### PR TITLE
Support all Aiven resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+## [1.0.0] - 2018-09-27
+Support all Aiven resource types. Also large changes to previously
+supported resource types, such as full support for all user config
+options.
+
+**NOTE**: This version is not backwards compatible with older versions.

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -147,10 +147,10 @@
   revision = "d1caa6c97c9fc1cc9e83bbe34d0603f9ff0ce8bd"
 
 [[projects]]
-  name = "github.com/jelmersnoeck/aiven"
+  name = "github.com/aiven/aiven-go-client"
   packages = ["."]
   revision = "99972dc23eb361d3d5227e1f5790a0bf80e90af0"
-  source = "github.com/jelmersnoeck/aiven"
+  source = "github.com/aiven/aiven-go-client"
 
 [[projects]]
   name = "github.com/jmespath/go-jmespath"

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -2,11 +2,22 @@
 
 
 [[projects]]
+  digest = "1:dedb0f251c9e52cff6f4a6b4e5ff4cbcbd9b6bc275648e0bc17b8b5c1a695744"
+  name = "github.com/aiven/aiven-go-client"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "03b96f7bece55f0d98ad7e5a86461ea1da497236"
+  source = "github.com/aiven/aiven-go-client"
+
+[[projects]]
+  digest = "1:672133929e2786ef49ada5ea7476fa154e251d04da8fa79ae0be0694562ef94e"
   name = "github.com/apparentlymart/go-cidr"
   packages = ["cidr"]
+  pruneopts = "UT"
   revision = "a3ebdb999b831ecb6ab8a226e31b07b2b9061c47"
 
 [[projects]]
+  digest = "1:f9ad6ffdf261fa78b099a66bb64bbc4ab1e4da1d61084fb30603c7b68343d6ec"
   name = "github.com/aws/aws-sdk-go"
   packages = [
     "aws",
@@ -33,63 +44,91 @@
     "private/protocol/xml/xmlutil",
     "private/waiter",
     "service/s3",
-    "service/sts"
+    "service/sts",
   ]
+  pruneopts = "UT"
   revision = "b2852089fcfd0794d25d57f193e15121ab8a6d9e"
   version = "v1.6.25"
 
 [[projects]]
   branch = "master"
+  digest = "1:37011b20a70e205b93ebea5287e1afa5618db54bf3998c36ff5a8e4b146a170a"
   name = "github.com/bgentry/go-netrc"
   packages = ["netrc"]
+  pruneopts = "UT"
   revision = "9fd32a8b3d3d3f9d43c341bfe098430e07609480"
 
 [[projects]]
+  digest = "1:a2c1d0e43bd3baaa071d1b9ed72c27d78169b2b269f71c105ac4ba34b1be4a39"
   name = "github.com/davecgh/go-spew"
   packages = ["spew"]
+  pruneopts = "UT"
   revision = "346938d642f2ec3594ed81d874461961cd0faa76"
   version = "v1.1.0"
 
 [[projects]]
+  digest = "1:b9a5ac645f8e4e8c735163872cb686592ce6d999dcd66e0a70d7eadce4fbd26b"
   name = "github.com/go-ini/ini"
   packages = ["."]
+  pruneopts = "UT"
   revision = "e3c2d47c61e5333f9aa2974695dd94396eb69c75"
   version = "v1.24.0"
 
 [[projects]]
+  digest = "1:c8ad4ba32ae8b71ef2bf5e1bad402aeb99ce77a1240f9b684db8b1ff5353e7ab"
+  name = "github.com/gobuffalo/packr"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "5a2cbb54c4e7d482e3f518c56f1f86f133d5204f"
+  version = "v1.13.7"
+
+[[projects]]
+  digest = "1:07671f8997086ed115824d1974507d2b147d1e0463675ea5dbf3be89b1c2c563"
   name = "github.com/hashicorp/errwrap"
   packages = ["."]
+  pruneopts = "UT"
   revision = "7554cd9344cec97297fa6649b055a8c98c2a1e55"
 
 [[projects]]
+  digest = "1:a1648e42765e943bb08464a126ad141413ac423a00f827b4273b2fa6b29274a0"
   name = "github.com/hashicorp/go-getter"
   packages = [
     ".",
-    "helper/url"
+    "helper/url",
   ]
+  pruneopts = "UT"
   revision = "c3d66e76678dce180a7b452653472f949aedfbcd"
 
 [[projects]]
+  digest = "1:70058d557ddb53af1a35dd41b748ae8032901e407c7c60f6ff3638c8145be5fb"
   name = "github.com/hashicorp/go-multierror"
   packages = ["."]
+  pruneopts = "UT"
   revision = "ed905158d87462226a13fe39ddf685ea65f1c11f"
 
 [[projects]]
+  digest = "1:ad93e756332b116b1f63e523f233082c1316bc183bbb6d8f3c0bef8beb92416c"
   name = "github.com/hashicorp/go-plugin"
   packages = ["."]
+  pruneopts = "UT"
   revision = "f72692aebca2008343a9deb06ddb4b17f7051c15"
 
 [[projects]]
+  digest = "1:b8edba99399cf7b4140dd74c9b942ab65155f02f08cccf2cf8246eb692bc5d4b"
   name = "github.com/hashicorp/go-uuid"
   packages = ["."]
+  pruneopts = "UT"
   revision = "64130c7a86d732268a38cb04cfbaf0cc987fda98"
 
 [[projects]]
+  digest = "1:826df03282c5a336f1d23a07ce0ec0a26c7230e1a5d5a79a8ea4b68c0c8462b3"
   name = "github.com/hashicorp/go-version"
   packages = ["."]
+  pruneopts = "UT"
   revision = "03c5bf6be031b6dd45afec16b1cf94fc8938bc77"
 
 [[projects]]
+  digest = "1:2f7a294353f5e7ff51ae26df3a844cb699c7ed3585ff9208a29ab28de960efcd"
   name = "github.com/hashicorp/hcl"
   packages = [
     ".",
@@ -100,27 +139,33 @@
     "hcl/token",
     "json/parser",
     "json/scanner",
-    "json/token"
+    "json/token",
   ]
+  pruneopts = "UT"
   revision = "630949a3c5fa3c613328e1b8256052cbc2327c9b"
 
 [[projects]]
+  digest = "1:73ee4fb45f1d87037acaa1e62e362c8a52cb53a60d0a3f77df2a682790abea71"
   name = "github.com/hashicorp/hil"
   packages = [
     ".",
     "ast",
     "parser",
-    "scanner"
+    "scanner",
   ]
+  pruneopts = "UT"
   revision = "5b8d13c8c5c2753e109fab25392a1dbfa2db93d2"
 
 [[projects]]
   branch = "master"
+  digest = "1:ce3f7860fd68bd2dd4c3735e2aed8c9de7c7d05bd6ad7d97a6bedcf4fe7b84fb"
   name = "github.com/hashicorp/logutils"
   packages = ["."]
+  pruneopts = "UT"
   revision = "0dc08b1671f34c4250ce212759ebd880f743d883"
 
 [[projects]]
+  digest = "1:4666423a40098b6803b34c4d4607c57e76f6136f4524a134f9c1840db5964fcf"
   name = "github.com/hashicorp/terraform"
   packages = [
     "config",
@@ -136,61 +181,98 @@
     "helper/schema",
     "helper/shadow",
     "plugin",
-    "terraform"
+    "terraform",
   ]
-  revision = "5bd194faa6fe5ee9ac304b7fe12e1579500be59e"
-  version = "v0.9.0"
+  pruneopts = "UT"
+  revision = "efca455c35d0d218a9bfee835a8ec3ef8d4d1c8c"
+  version = "v0.9.11"
 
 [[projects]]
+  digest = "1:f70324149a251e89d03333d2b627cb87bf360d1c576b218d8e8649c925316fe8"
   name = "github.com/hashicorp/yamux"
   packages = ["."]
+  pruneopts = "UT"
   revision = "d1caa6c97c9fc1cc9e83bbe34d0603f9ff0ce8bd"
 
 [[projects]]
-  name = "github.com/aiven/aiven-go-client"
-  packages = ["."]
-  revision = "99972dc23eb361d3d5227e1f5790a0bf80e90af0"
-  source = "github.com/aiven/aiven-go-client"
-
-[[projects]]
+  digest = "1:777a19f55da89883fe86477b3ffcaaebece9a20efa6e9d161c08beb4b3bd83be"
   name = "github.com/jmespath/go-jmespath"
   packages = ["."]
+  pruneopts = "UT"
   revision = "bd40a432e4c76585ef6b72d3fd96fb9b6dc7b68d"
 
 [[projects]]
+  digest = "1:fa20c5befe61ffcce412048bbb2251d236cd847610e2d37162c234ff2fe00ff2"
   name = "github.com/mitchellh/copystructure"
   packages = ["."]
+  pruneopts = "UT"
   revision = "f81071c9d77b7931f78c90b416a074ecdc50e959"
 
 [[projects]]
+  digest = "1:12ae6210bdbdad658a9a67fd95cd9c99f7fdbf12f6d36eaf0af704e69dacf4f5"
   name = "github.com/mitchellh/go-homedir"
   packages = ["."]
+  pruneopts = "UT"
   revision = "b8bc1bf767474819792c23f32d8286a45736f1c6"
 
 [[projects]]
+  digest = "1:3b6bb6060d008e84abb4d3d2dd2c50df391c4479056d66e2b4a22e5b0c83255c"
   name = "github.com/mitchellh/hashstructure"
   packages = ["."]
+  pruneopts = "UT"
   revision = "ab25296c0f51f1022f01cd99dfb45f1775de8799"
 
 [[projects]]
+  digest = "1:ce8a529f61eb119be5e84417a77e71fe380d09ddcd8b69b1372d9261a27f9539"
   name = "github.com/mitchellh/mapstructure"
   packages = ["."]
+  pruneopts = "UT"
   revision = "db1efb556f84b25a0a13a04aad883943538ad2e0"
 
 [[projects]]
+  digest = "1:1df968c4c20f1e0fa1c88e9b7d86a4cea6ca45e5f133f11bfc3bb3f251ddf21e"
   name = "github.com/mitchellh/reflectwalk"
   packages = ["."]
+  pruneopts = "UT"
   revision = "417edcfd99a4d472c262e58f22b4bfe97580f03e"
 
 [[projects]]
+  digest = "1:40e195917a951a8bf867cd05de2a46aaf1806c50cf92eebf4c16f78cd196f747"
+  name = "github.com/pkg/errors"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "645ef00459ed84a119197bfb8d8205042c6df63d"
+  version = "v0.8.0"
+
+[[projects]]
+  digest = "1:274f67cb6fed9588ea2521ecdac05a6d62a8c51c074c1fccc6a49a40ba80e925"
   name = "github.com/satori/go.uuid"
   packages = ["."]
-  revision = "879c5887cd475cd7864858769793b2ceb0d44feb"
-  version = "v1.1.0"
+  pruneopts = "UT"
+  revision = "f58768cc1a7a7e77a3bd49e98cdd21419399b6a3"
+  version = "v1.2.0"
+
+[[projects]]
+  branch = "master"
+  digest = "1:1ecf2a49df33be51e757d0033d5d51d5f784f35f68e5a38f797b2d3f03357d71"
+  name = "golang.org/x/crypto"
+  packages = [
+    "bcrypt",
+    "blowfish",
+  ]
+  pruneopts = "UT"
+  revision = "0e37d006457bf46f9e6692014ba72ef82c33022c"
 
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "a45aced9e5cb5b9baae44e8436419894894b3c352e5bf529dd3a4a475b88a888"
+  input-imports = [
+    "github.com/aiven/aiven-go-client",
+    "github.com/gobuffalo/packr",
+    "github.com/hashicorp/terraform/helper/resource",
+    "github.com/hashicorp/terraform/helper/schema",
+    "github.com/hashicorp/terraform/plugin",
+    "github.com/hashicorp/terraform/terraform",
+  ]
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -2,28 +2,10 @@
 #
 # Refer to https://github.com/golang/dep/blob/master/docs/Gopkg.toml.md
 # for detailed Gopkg.toml documentation.
-#
-# required = ["github.com/user/thing/cmd/thing"]
-# ignored = ["github.com/user/project/pkgX", "bitbucket.org/user/project/pkgA/pkgY"]
-#
-# [[constraint]]
-#   name = "github.com/user/project"
-#   version = "1.0.0"
-#
-# [[constraint]]
-#   name = "github.com/user/project2"
-#   branch = "dev"
-#   source = "github.com/myfork/project2"
-#
-# [[override]]
-#   name = "github.com/x/y"
-#   version = "2.4.0"
-#
-# [prune]
-#   non-go = false
-#   go-tests = true
-#   unused-packages = true
 
+[[constraint]]
+  name = "github.com/gobuffalo/packr"
+  version = "1.13.7"
 
 [[constraint]]
   name = "github.com/hashicorp/terraform"
@@ -31,7 +13,7 @@
 
 [[constraint]]
   name = "github.com/aiven/aiven-go-client"
-  revision = "99972dc23eb361d3d5227e1f5790a0bf80e90af0"
+  revision = "03b96f7bece55f0d98ad7e5a86461ea1da497236"
   source = "github.com/aiven/aiven-go-client"
 
 [prune]

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -30,9 +30,9 @@
   version = "0.9.0"
 
 [[constraint]]
-  name = "github.com/jelmersnoeck/aiven"
+  name = "github.com/aiven/aiven-go-client"
   revision = "99972dc23eb361d3d5227e1f5790a0bf80e90af0"
-  source = "github.com/jelmersnoeck/aiven"
+  source = "github.com/aiven/aiven-go-client"
 
 [prune]
   go-tests = true

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,7 @@
 The MIT License (MIT)
 
 Copyright (c) 2017 jelmersnoeck
+Copyright (c) 2018 Aiven, Helsinki, Finland. https://aiven.io/
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,8 @@ ci: lint bins
 #################################################
 BOOTSTRAP=\
 	github.com/golang/dep/cmd/dep \
-	github.com/alecthomas/gometalinter
+	github.com/alecthomas/gometalinter \
+	github.com/gobuffalo/packr/...
 
 $(BOOTSTRAP):
 	go get -u $@
@@ -26,7 +27,7 @@ update-vendor:
 #################################################
 
 bins: vendor
-	go build -o terraform-provider-aiven .
+	packr build -o terraform-provider-aiven .
 
 #################################################
 # Testing and linting

--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ resource "aiven_service" "myservice" {
     plan = "business-8"
     service_name = "<SERVICE_NAME>"
     service_type = "pg"
+    project_vpc_id = "${aiven_project_vpc.vpc_gcp_europe_west1.id}"
     pg_user_config {
         ip_filter = ["0.0.0.0/0"]
         pg_version = "10"
@@ -143,6 +144,13 @@ intended service usage rather than current attributes.
 ``service_type`` is the actual service that is being provided. Currently available
 options are ``cassadra``, ``elasticsearch``, ``grafana``, ``influxdb``, ``kafka``,
  ``pg`` (PostreSQL) and ``redis``. This value cannot be changed after service creation.
+
+``project_vpc_id`` optionally specifies the VPC the service should run in. If the value
+is not set the service is not run inside a VPC. When set, the value should be given as a
+reference as shown above to set up dependencies correctly and the VPC must be in the same
+cloud and region as the service itself. Project can be freely moved to and from VPC after
+creation but doing so triggers migration to new servers so the operation can take
+significant amount of time to complete if the service has a lot of data.
 
 ``x_user_config`` defines service specific additional configuration options. These
 options can be found from the [JSON schema description](templates/service_user_config_schema.json).

--- a/README.md
+++ b/README.md
@@ -162,8 +162,31 @@ significant amount of time to complete if the service has a lot of data.
 ``x_user_config`` defines service specific additional configuration options. These
 options can be found from the [JSON schema description](templates/service_user_config_schema.json).
 
-Note that some (very few) of the user configuration options have a dot (``.``) in their
-name. That is not supported by Terraform so the provider converts any literal dots to the
+For services that support different versions the version information must be specified in
+the user configuration. By the time of writing these services are Elasticsearch, Kafka
+and PostgreSQL. These services should have configuration like
+
+```
+elasticsearch_user_config {
+    elasticsearch_version = "6"
+}
+```
+
+```
+kafka_user_config {
+    kafka_version = "2.0"
+}
+```
+
+```
+pg_user_config {
+    pg_version = "10"
+}
+```
+
+
+Some (very few) of the user configuration options have a dot (``.``) in their name.
+That is not supported by Terraform so the provider converts any literal dots to the
 text string ``__dot__``. So if you want to set ``foo.bar = "abc"`` you need to instead
 set ``foo__dot__bar = "abc"``.
 

--- a/README.md
+++ b/README.md
@@ -91,7 +91,14 @@ project, including all sub-resources.
 
 ``card_id`` is either the full card UUID or the last 4 digits of the card. As the full
 UUID is not shown in the UI it is typically easier to use the last 4 digits to identify
-the card.
+the card. This can be omitted if ``copy_from_project`` is used to copy billing info from
+another project.
+
+``copy_from_project`` is the name of another project used to copy billing information and
+some other project attributes like technical contacts from. This is mostly relevant when
+an existing project has billing type set to invoice and that needs to be copied over to a
+new project. (Setting billing is otherwise not allowed over the API.) This only has
+effect when the project is created.
 
 ``ca_cert`` is a computed property that can be used to read the CA certificate of the
 project. This is required for configuring clients that connect to certain services like

--- a/README.md
+++ b/README.md
@@ -218,6 +218,44 @@ Service users have several computed properties that cannot be set, only read:
 
 Aiven ID format when importing existing resource: ``<project_name>/<service_name>/<username>``
 
+### Resource Connection Pool
+
+```
+resource "aiven_connection_pool" "mytestpool" {
+    project = "${aiven_project.myproject.project}"
+    service_name = "${aiven_service.myservice.service_name}"
+    database_name = "${aiven_database.mydatabase.database_name}"
+    pool_mode = "transaction"
+    pool_name = "mypool"
+    pool_size = 10
+    username = "${aiven_service_user.myserviceuser.username}"
+}
+```
+
+``project`` and ``service_name`` define the project and service the connection pool
+belongs to. They should be defined using reference as shown above to set up dependencies
+correctly. These properties cannot be changed once the service is created. Doing so will
+result in the connection pool being deleted and new one created instead.
+
+``database_name`` is the name of the database the pool connects to. This should be
+defined using reference as shown above to set up dependencies correctly.
+
+``pool_mode`` is the mode the pool operates in (session, transaction, statement).
+
+``pool_name`` is the name of the pool.
+
+``pool_size`` is the number of connections the pool may create towards the backend
+server. This does not affect the number of incoming connections, which is always a much
+larger number.
+
+``username`` is the name of the service user used to connect to the database. This should
+be defined using reference as shown above to set up dependencies correctly.
+
+``connection_uri`` is a computed property that tells the URI for connecting to the pool.
+This value cannot be set, only read.
+
+Aiven ID format when importing existing resource: ``<project_name>/<service_name>/<pool_name>``
+
 ### Resource Kafka Topic
 
 ```

--- a/README.md
+++ b/README.md
@@ -155,6 +155,11 @@ significant amount of time to complete if the service has a lot of data.
 ``x_user_config`` defines service specific additional configuration options. These
 options can be found from the [JSON schema description](templates/service_user_config_schema.json).
 
+Note that some (very few) of the user configuration options have a dot (``.``) in their
+name. That is not supported by Terraform so the provider converts any literal dots to the
+text string ``__dot__``. So if you want to set ``foo.bar = "abc"`` you need to instead
+set ``foo__dot__bar = "abc"``.
+
 ``service_(uri|host|port|username|password)`` are computed properties that define the
 URI for connecting to the service and the same info split into various parts. These
 values cannot be set, only read.

--- a/README.md
+++ b/README.md
@@ -1,85 +1,388 @@
 # Terraform Aiven
 
-[Terraform](https://www.terraform.io/) provider resources for [Aiven.io](https://aiven.io/).
+[Terraform](https://www.terraform.io/) provider for [Aiven.io](https://aiven.io/). This
+provider allows you to conveniently manage all resources for Aiven.
+
+**A word of caution**: While Terraform is an extremely powerful tool that can make
+managing your infrastructure a breeze, great care must be taken when comparing the
+changes that are about to applied to your infrastructure. When it comes to stateful
+services, you cannot just re-create a resource and have it in the original state;
+deleting a service deletes all data associated with it and there's often no way to
+recover the data later. Whenever the Terraform plan indicates that a service, database,
+topic or other such central construct is about to be deleted, something catastrophic is
+quite possibly about to happen unless you're dealing with some throwaway test
+environments or are deliberately retiring the service/database/topic.
+
+There are many properties that cannot be changed after a resource is created and changing
+those values later is handled by deleting the original resource and creating a new one.
+These properties include such as the project a service is associated with, the name of a
+service, etc. Unless the system contains no relevant data, such changes must not be
+performed.
 
 ## Sample project
 
-There is a [sample project](sample.tf) which sets up a new project, adds a new service,
-creates a new database and sets up a new user for the service.
+There is a [sample project](sample.tf) which sets up a project, defines Kafka,
+PostgreSQL, InfluxDB and Grafana services, one PG database and user, one Kafka topic and
+user, and metrics and dashboard integration for the Kafka and PG databases.
 
-Make sure you have a look at the [variables](terraform.tfvars.sample) and copy
-it over to `terraform.tfvars` with your own credentials.
+Make sure you have a look at the [variables](terraform.tfvars.sample) and copy it over to
+`terraform.tfvars` with your own settings.
+
+## Importing existing infrastructure
+
+All resources support importing so if you have already manually created an Aiven
+environment using the web console or otherwise, it is possible to import all resources
+and start managing them using Terraform. The documentation below mentions the ID format
+for each resource but typically it is ``<project_name>/<resource_name>`` for resources
+that are directly under project level and ``<project_name>/<service_name>/<resource_name>``
+for resources that belong to specific service. E.g. to import a database called ``mydb``
+belonging to service ``myservice`` in project ``myproject`` you'd do something like
+
+```
+terraform import aiven_database.mydb myproject/myservice/mydb
+```
+
+In some cases the internal identifiers are not shown in the Aiven web console. In such
+cases the easiest way to obtain identifiers is typically to check network requests and
+responses with your browser's debugging tools, as the raw responses do contain the IDs.
+
+Note that as Terraform does not support creating configuration automatically you will
+still need to manually create the Terraform configuration files. The import will just
+match the existing resources with the ones defined in the configuration.
 
 ## Options
+
+This section describes all the different resources that can be managed with this provider.
+The list of options in this document is not comprehensive. For most part the options map
+directly to [Aiven REST API](https://api.aiven.io/doc/) properties and that can be
+consulted for details. For various objects called x_user_config the exact configuration
+options are available in [Service User Config](templates/service_user_config_schema.json),
+[Integration User Config](templates/integrations_user_config_schema.json) and in
+[Integration Endpoint User Config](templates/integration_endpoints_user_config_schema.json).
 
 ### Provider
 
 ```
 provider "aiven" {
-    email = "<AIVEN_EMAIL>"
-    password = "<AIVEN_PASSWORD>"
+    api_token = "<AIVEN_API_TOKEN>"
 }
 ```
+
+The Aiven provider currently only supports a single configuration option, ``api_token``.
+The Aiven web console can be used to create named, never expiring API tokens that should
+be used for this kind of purposes. If Terraform is used for managing existing project(s),
+the API token must belong to a user with admin privileges for those project(s). For new
+projects the user will be automatically granted admin role. For projects with credit card
+billing this account must be the one in possession with the credit card used to pay for
+the services.
 
 ### Resource Project
 
-**Note**: it is currently not possible to automatically set up a new card for a project. If you already have a card linked to your account, you can get the card id and use it to set up this project.
-
 ```
-resource "aiven_service" "my-project" {
+resource "aiven_project" "myproject" {
     project = "<PROJECT_NAME>"
-    card_id = "<CARD_ID>"
-    cloud = "google-europe-west1"
+    card_id = "<FULL_CARD_ID/LAST4_DIGITS>"
 }
 ```
+
+``project`` defines the name of the project. Name must be globally unique (between all
+Aiven customers) and cannot be changed later without destroying and re-creating the
+project, including all sub-resources.
+
+``card_id`` is either the full card UUID or the last 4 digits of the card. As the full
+UUID is not shown in the UI it is typically easier to use the last 4 digits to identify
+the card.
+
+``ca_cert`` is a computed property that can be used to read the CA certificate of the
+project. This is required for configuring clients that connect to certain services like
+Kafka. This value cannot be set, only read.
+
+Aiven ID format when importing existing resource: name of the project as is.
 
 ### Resource Service
 
-**Note**: to make a new service, you'll have to have set up a project with a valid billing plan.
-
 ```
-resource "aiven_service" "my-service" {
-    project = "<PROJECT_NAME>"
-    group_name = "my-group"
-    cloud = "google-europe-west1"
-    plan = "business-16"
+resource "aiven_service" "myservice" {
+    project = "${aiven_project.myproject.project}"
+    cloud_name = "google-europe-west1"
+    plan = "business-8"
     service_name = "<SERVICE_NAME>"
     service_type = "pg"
+    pg_user_config {
+        ip_filter = ["0.0.0.0/0"]
+        pg_version = "10"
+    }
 }
 ```
+
+``project`` identifies the project the service belongs to. To set up proper dependency
+between the project and the service, refer to the project as shown in the above example.
+Project cannot be changed later without destroying and re-creating the service.
+
+``cloud_name`` defines where the cloud provider and region where the service is hosted
+in. This can be changed freely after service is created. Changing the value will trigger
+a potentially lenghty migration process for the service. Format is cloud provider name
+(``aws``, ``azure``, ``do`` ``google``, ``upcloud``, etc.), dash, and the cloud provider
+specific region name. These are documented on each Cloud provider's own support articles,
+like [here for Google](https://cloud.google.com/compute/docs/regions-zones/) and
+[here for AWS](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Concepts.RegionsAndAvailabilityZones.html).
+
+``plan`` defines what kind of computing resources are allocated for the service. It can
+be changed after creation, though there are some restrictions when going to a smaller
+plan such as the new plan must have sufficient amount of disk space to store all current
+data and switching to a plan with fewer nodes might not be supported. The basic plan
+names are ``hobbyist``, ``startup-x``, ``business-x`` and ``premium-x`` where ``x`` is
+(roughly) the amount of memory on each node (also other attributes like number of CPUs
+and amount of disk space varies but naming is based on memory). The exact options can be
+seen from the Aiven web console's Create Service dialog.
+
+``service_name`` specifies the actual name of the service. The name cannot be changed
+later without destroying and re-creating the service so name should be picked based on
+intended service usage rather than current attributes.
+
+``service_type`` is the actual service that is being provided. Currently available
+options are ``cassadra``, ``elasticsearch``, ``grafana``, ``influxdb``, ``kafka``,
+ ``pg`` (PostreSQL) and ``redis``. This value cannot be changed after service creation.
+
+``x_user_config`` defines service specific additional configuration options. These
+options can be found from the [JSON schema description](templates/service_user_config_schema.json).
+
+``service_(uri|host|port|username|password)`` are computed properties that define the
+URI for connecting to the service and the same info split into various parts. These
+values cannot be set, only read.
+
+``x`` defines service specific additional computed values for connecting to the service
+(where ``x`` is the type of the service). E.g. ``elasticsearch.0.kibana_uri`` specifies
+the Kibana URI for Elasticsearch service (while ``service_uri`` at main level is the
+connection URI for the actual Elasticsearch service itself). Note the need for using
+`.0` when accessing the values due to Terraform's restrictions in defining nested
+schematized values. These values cannot be set, only read.
+
+Aiven ID format when importing existing resource: ``<project_name>/<service_name>``.
 
 ### Resource Database
 
 ```
-resource "aiven_database" "my-database" {
-    project = "<PROJECT_NAME>"
-    service_name = "<SERVICE_NAME>"
-    database = "<DATABASE_NAME>"
+resource "aiven_database" "mydatabase" {
+    project = "${aiven_project.myproject.project}"
+    service_name = "${aiven_service.myservice.service_name}"
+    database_name = "<DATABASE_NAME>"
 }
 ```
 
-### Resource ServiceUser
+``project`` and ``service_name`` define the project and service the database belongs to.
+They should be defined using reference as shown above to set up dependencies correctly.
+
+``database_name`` is the actual name of the database.
+
+None of the database properties can currently be changed after creation. Doing so will
+result in the old database getting dropped and a new database created.
+
+Aiven ID format when importing existing resource: ``<project_name>/<service_name>/<database_name>``
+
+### Resource Service User
 
 ```
-resource "aiven_service_user" "my-service-user" {
-    project = "<PROJECT_NAME>"
-    service_name = "<SERVICE_NAME>"
+resource "aiven_service_user" "myserviceuser" {
+    project = "${aiven_project.myproject.project}"
+    service_name = "${aiven_service.myservice.service_name}"
     username = "<USERNAME>"
 }
 ```
 
+``project`` and ``service_name`` define the project and service the user belongs to.
+They should be defined using reference as shown above to set up dependencies correctly.
+
+``username`` is the actual name of the user account.
+
+None of the service user properties can currently be changed after creation. Doing so
+will result in the old database getting dropped and a new database created.
+
+Service users have several computed properties that cannot be set, only read:
+
+``password`` is the password of the user (not applicable for all services).
+
+``access_cert`` is the access certificate of the user (not applicable for all services).
+
+``access_key`` is the access key of the user (not applicable for all services).
+
+``type`` tells whether the user is primary account or regular account.
+
+Aiven ID format when importing existing resource: ``<project_name>/<service_name>/<username>``
+
 ### Resource Kafka Topic
 
 ```
-resource "aiven_kafka_topic" "rob-test" {
-    project = "<PROJECT_NAME>"
-    service_name = "<SERVICE_NAME>"
-    topic = "<TOPIC_NAME>"
+resource "aiven_kafka_topic" "mytesttopic" {
+    project = "${aiven_project.myproject.project}"
+    service_name = "${aiven_service.myservice.service_name}"
+    topic_name = "<TOPIC_NAME>"
     partitions = 5
-    replication = 1
+    replication = 3
     retention_bytes = -1
     retention_hours = 72
-    minimum_in_sync_replicas = 1
+    minimum_in_sync_replicas = 2
     cleanup_policy = "delete"
 }
 ```
+
+``project`` and ``service_name`` define the project and service the topic belongs to.
+They should be defined using reference as shown above to set up dependencies correctly.
+These properties cannot be changed once the service is created. Doing so will result in
+the topic being deleted and new one created instead.
+
+``topic_name`` is the actual name of the topic account. This propery cannot be changed
+once the service is created. Doing so will result in the topic being deleted and new one
+created instead.
+
+Other properties should be self-explanatory. They can be changed after the topic has been
+created.
+
+Aiven ID format when importing existing resource: ``<project_name>/<service_name>/<topic_name>``
+
+### Resource Service Integration Endpoint
+
+Service Integration Endpoint is an external endpoint that can be used as a source or
+destination for a Service Integration. These are only defined for non-Aiven resources.
+
+```
+resource "aiven_service_integration_endpoint" "myendpoint" {
+    project = "${aiven_project.myproject.project}"
+    endpoint_name = "<ENDPOINT_NAME>"
+    endpoint_type = "datadog"
+    datadog_user_config = {
+        datadog_api_key = "<DATADOG_API_KEY>"
+    }
+}
+```
+
+``project`` defines the project the endpoint is associated with.
+
+``endpoint_name`` is the name of the endpoint. This value has no effect beyond being used
+to identify different integration endpoints.
+
+``endpoint_type`` is the type of the external service this endpoint is associated with.
+By the time of writing the only available option is ``datadog``.
+
+``x_user_config`` defines endpoint type specific configuration. ``x`` is the type of the
+endpoint. The available configuration options are documented in
+[this JSON file](templates/integration_endpoints_user_config_schema.json)
+
+Aiven ID format when importing existing resource: ``<project_name>/<endpoint_id>``. The
+endpoint identifier (UUID) is not directly visible in the Aiven web console.
+
+### Resource Service Integration
+
+Service Integration defines an integration between two Aiven services or between Aiven
+service and an external integration endpoint. Integration could be for example sending
+metrics from Kafka service to an InfluxDB service, getting metrics from an InfluxDB
+service to a Grafana service to show dashboards, sending logs from any service to
+Elasticsearch, etc.
+
+```
+resource "aiven_service_integration" "myintegration" {
+    project = "${aiven_project.myproject.project}"
+    destination_endpoint_id = "${aiven_service_integration_endpoint.myendpoint.id}"
+    destination_service_name = ""
+    integration_type = "datadog"
+    source_endpoint_id = ""
+    source_service_name = "${aiven_service.testkafka.service_name}"
+}
+```
+
+``project`` defines the project the integration belongs to.
+
+``destination_endpoint_id`` or ``destination_service_name`` identifies the target side of
+the integration. Only either endpoint identifier or service name must be specified. In
+either case the target needs to be defined using the reference syntax described above to
+set up the dependency correctly.
+
+``integration_type`` identifies the type of integration that is set up. Possible values
+include ``dashboard``, ``datadog``, ``logs``, ``metrics`` and ``mirrormaker``.
+
+``source_endpoint_id`` or ``source_service_name`` identifies the source side of the
+integration. Only either endpoint identifier or service name must be specified. In either
+case the source needs to be defined using the reference syntax described above to set up
+the dependency correctly.
+
+``x_user_config`` defines integration specific configuration. ``x`` is the type of the
+integration. The available configuration options are documented in
+[this JSON file](templates/integrations_user_config_schema.json). Not all integration
+types have any configurable settings.
+
+Aiven ID format when importing existing resource: ``<project_name>/<integration_id>``.
+The integration identifier (UUID) is not directly visible in the Aiven web console.
+
+### Resource Project User
+
+```
+resource "aiven_project_user" "mytestuser" {
+    project = "${aiven_project.myproject.project}"
+    email = "john.doe@example.com"
+    member_type = "admin"
+}
+```
+
+``project`` defines the project the user is a member of.
+
+``email`` identifies the email address of the user.
+
+``member_type`` defines the access level the user has to the project.
+
+Computed property ``accepted`` tells whether the user has accepted the request to join
+the project; adding user to a project sends an invitation to the target user and the
+actual membership is only created once the user accepts the invitation. This property
+cannot be set, only read.
+
+Aiven ID format when importing existing resource: ``<project_name>/<email>``
+
+### Resource Project VPC
+
+```
+resource "aiven_project_vpc" "myvpc" {
+    project = "${aiven_project.myproject.project}"
+    cloud_name = "google-europe-west1"
+    network_cidr = "192.168.0.1/24"
+}
+```
+
+``project`` defines the project the VPC belongs to.
+
+``cloud_name`` defines where the cloud provider and region where the service is hosted
+in. See the Service resource for additional information.
+
+``network_cidr`` defines the network CIDR of the VPC.
+
+Computed property ``state`` tells the current state of the VPC. This property cannot be
+set, only read.
+
+Aiven ID format when importing existing resource: ``<project_name>/<VPC_UUID>``. The UUID
+is not directly visible in the Aiven web console.
+
+### Resource VPC Peering Connection
+
+```
+resource "aiven_vpc_peering_connection" "mypeeringconnection" {
+    vpc_id = "${aiven_project.myproject.myvpc.id}"
+    peer_cloud_account = "<PEER_ACCOUNT_ID>"
+    peer_vpc = "<PEER_VPC_ID/NAME>"
+}
+```
+
+``vpc_id`` is the Aiven VPC the peering connection is associated with.
+
+``peer_cloud_account`` defines the identifier of the cloud account the VPC is being
+peered with.
+
+``peer_vpc`` defines the identifier or name of the remote VPC.
+
+Computed property ``state`` tells the current state of the VPC. This property cannot be
+set, only read.
+
+Aiven ID format when importing existing resource: ``<project_name>/<VPC_UUID>/<peer_cloud_account>/<peer_vpc>``.
+The UUID is not directly visible in the Aiven web console.
+
+## Credits
+
+The original version of the Aiven Terraform provider was written and maintained by
+Jelmer Snoeck (https://github.com/jelmersnoeck).

--- a/README.md
+++ b/README.md
@@ -248,6 +248,33 @@ created.
 
 Aiven ID format when importing existing resource: ``<project_name>/<service_name>/<topic_name>``
 
+### Resource Kafka ACL
+
+```
+resource "aiven_kafka_acl" "mytestacl" {
+    project = "${aiven_project.myproject.project}"
+    service_name = "${aiven_service.myservice.service_name}"
+    topic = "<TOPIC_NAME_PATTERN>"
+    permission = "admin"
+    username = "<USERNAME_PATTERN>"
+}
+```
+
+``project`` and ``service_name`` define the project and service the ACL belongs to.
+They should be defined using reference as shown above to set up dependencies correctly.
+These properties cannot be changed once the service is created. Doing so will result in
+the topic being deleted and new one created instead.
+
+``topic`` is a topic name pattern the ACL entry matches to.
+
+``permission`` is the level of permission the matching users are given to the matching
+topics (admin, read, readwrite, write).
+
+``username`` is a username pattern the ACL entry matches to.
+
+Aiven ID format when importing existing resource: ``<project_name>/<service_name>/<acl_id>``.
+The ACL ID is not directly visible in the Aiven web console.
+
 ### Resource Service Integration Endpoint
 
 Service Integration Endpoint is an external endpoint that can be used as a source or

--- a/generate_templates.sh
+++ b/generate_templates.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/bash
+avn service types -v --json | jq '[to_entries[] | {"key": .key, "value": .value.user_config_schema}] | from_entries' > templates/service_user_config_schema.json
+avn service integration-endpoint-types-list --project test --json | jq 'map({(.endpoint_type): .user_config_schema}) | add' > templates/integration_endpoints_user_config_schema.json
+avn service integration-types-list --project test --json | jq 'map({(.integration_type): .user_config_schema}) | add' > templates/integrations_user_config_schema.json

--- a/kafka_topic_change.go
+++ b/kafka_topic_change.go
@@ -4,8 +4,8 @@ import (
 	"log"
 	"time"
 
+	"github.com/aiven/aiven-go-client"
 	"github.com/hashicorp/terraform/helper/resource"
-	"github.com/jelmersnoeck/aiven"
 )
 
 // KafkaTopicChangeWaiter is used to refresh the Aiven Kafka Topic endpoints when

--- a/kafka_topic_change.go
+++ b/kafka_topic_change.go
@@ -14,7 +14,7 @@ type KafkaTopicChangeWaiter struct {
 	Client      *aiven.Client
 	Project     string
 	ServiceName string
-	Topic       string
+	TopicName   string
 }
 
 // RefreshFunc will call the Aiven client and refresh it's state.
@@ -23,7 +23,7 @@ func (w *KafkaTopicChangeWaiter) RefreshFunc() resource.StateRefreshFunc {
 		topic, err := w.Client.KafkaTopics.Get(
 			w.Project,
 			w.ServiceName,
-			w.Topic,
+			w.TopicName,
 		)
 
 		if err != nil {

--- a/main.go
+++ b/main.go
@@ -1,3 +1,4 @@
+// Copyright (c) 2017 jelmersnoeck
 package main
 
 import (

--- a/provider.go
+++ b/provider.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"errors"
+	"net/url"
+	"strings"
 
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/jelmersnoeck/aiven"
@@ -42,11 +44,12 @@ func Provider() *schema.Provider {
 		},
 
 		ResourcesMap: map[string]*schema.Resource{
-			"aiven_project":      resourceProject(),
-			"aiven_service":      resourceService(),
-			"aiven_database":     resourceDatabase(),
-			"aiven_service_user": resourceServiceUser(),
-			"aiven_kafka_topic":  resourceKafkaTopic(),
+			"aiven_project":                      resourceProject(),
+			"aiven_service":                      resourceService(),
+			"aiven_service_integration_endpoint": resourceServiceIntegrationEndpoint(),
+			"aiven_database":                     resourceDatabase(),
+			"aiven_service_user":                 resourceServiceUser(),
+			"aiven_kafka_topic":                  resourceKafkaTopic(),
 		},
 
 		ConfigureFunc: func(d *schema.ResourceData) (interface{}, error) {
@@ -89,4 +92,31 @@ func optionalIntPointer(d *schema.ResourceData, key string) *int {
 		return nil
 	}
 	return &val
+}
+
+func buildResourceID(parts ...string) string {
+	finalParts := make([]string, len(parts))
+	for idx, part := range parts {
+		finalParts[idx] = url.PathEscape(part)
+	}
+	return strings.Join(finalParts, "/")
+}
+
+func splitResourceID(resourceID string, n int) []string {
+	parts := strings.SplitN(resourceID, "/", n)
+	for idx, part := range parts {
+		part, _ := url.PathUnescape(part)
+		parts[idx] = part
+	}
+	return parts
+}
+
+func splitResourceID2(resourceID string) (string, string) {
+	parts := splitResourceID(resourceID, 2)
+	return parts[0], parts[1]
+}
+
+func splitResourceID3(resourceID string) (string, string, string) {
+	parts := splitResourceID(resourceID, 3)
+	return parts[0], parts[1], parts[2]
 }

--- a/provider.go
+++ b/provider.go
@@ -127,14 +127,11 @@ func resourceExists(err error) (bool, error) {
 }
 
 func createOnlyDiffSuppressFunc(k, old, new string, d *schema.ResourceData) bool {
-	if len(d.Id()) > 0 {
-		return true
-	}
-	return false
+	return len(d.Id()) > 0
 }
 
 // When a map inside a list contains only default values without explicit values set by
-// the user Terraform inteprets the map as not being present and the array lenght being
+// the user Terraform inteprets the map as not being present and the array length being
 // zero, resulting in bogus update that does nothing. Allow ignoring those.
 func emptyObjectDiffSuppressFunc(k, old, new string, d *schema.ResourceData) bool {
 	return old == "1" && new == "0" && strings.HasSuffix(k, ".#")

--- a/provider.go
+++ b/provider.go
@@ -23,6 +23,7 @@ func Provider() *schema.Provider {
 		},
 
 		ResourcesMap: map[string]*schema.Resource{
+			"aiven_connection_pool":              resourceConnectionPool(),
 			"aiven_database":                     resourceDatabase(),
 			"aiven_kafka_acl":                    resourceKafkaACL(),
 			"aiven_kafka_topic":                  resourceKafkaTopic(),

--- a/provider.go
+++ b/provider.go
@@ -46,6 +46,7 @@ func Provider() *schema.Provider {
 		ResourcesMap: map[string]*schema.Resource{
 			"aiven_project":                      resourceProject(),
 			"aiven_service":                      resourceService(),
+			"aiven_service_integration":          resourceServiceIntegration(),
 			"aiven_service_integration_endpoint": resourceServiceIntegrationEndpoint(),
 			"aiven_database":                     resourceDatabase(),
 			"aiven_service_user":                 resourceServiceUser(),
@@ -79,7 +80,11 @@ func optionalString(d *schema.ResourceData, key string) string {
 }
 
 func optionalStringPointer(d *schema.ResourceData, key string) *string {
-	str, ok := d.Get(key).(string)
+	val, ok := d.GetOk(key)
+	if !ok {
+		return nil
+	}
+	str, ok := val.(string)
 	if !ok {
 		return nil
 	}
@@ -87,11 +92,15 @@ func optionalStringPointer(d *schema.ResourceData, key string) *string {
 }
 
 func optionalIntPointer(d *schema.ResourceData, key string) *int {
-	val, ok := d.Get(key).(int)
+	val, ok := d.GetOk(key)
 	if !ok {
 		return nil
 	}
-	return &val
+	intValue, ok := val.(int)
+	if !ok {
+		return nil
+	}
+	return &intValue
 }
 
 func buildResourceID(parts ...string) string {

--- a/provider.go
+++ b/provider.go
@@ -125,3 +125,10 @@ func resourceExists(err error) (bool, error) {
 	}
 	return true, nil
 }
+
+func createOnlyDiffSuppressFunc(k, old, new string, d *schema.ResourceData) bool {
+	if len(d.Id()) > 0 {
+		return true
+	}
+	return false
+}

--- a/provider.go
+++ b/provider.go
@@ -49,6 +49,7 @@ func Provider() *schema.Provider {
 			"aiven_project":                      resourceProject(),
 			"aiven_project_user":                 resourceProjectUser(),
 			"aiven_project_vpc":                  resourceProjectVPC(),
+			"aiven_vpc_peering_connection":       resourceVPCPeeringConnection(),
 			"aiven_service":                      resourceService(),
 			"aiven_service_integration":          resourceServiceIntegration(),
 			"aiven_service_integration_endpoint": resourceServiceIntegrationEndpoint(),
@@ -130,6 +131,11 @@ func splitResourceID2(resourceID string) (string, string) {
 func splitResourceID3(resourceID string) (string, string, string) {
 	parts := splitResourceID(resourceID, 3)
 	return parts[0], parts[1], parts[2]
+}
+
+func splitResourceID4(resourceID string) (string, string, string, string) {
+	parts := splitResourceID(resourceID, 4)
+	return parts[0], parts[1], parts[2], parts[3]
 }
 
 func resourceExists(err error) (bool, error) {

--- a/provider.go
+++ b/provider.go
@@ -24,6 +24,7 @@ func Provider() *schema.Provider {
 
 		ResourcesMap: map[string]*schema.Resource{
 			"aiven_database":                     resourceDatabase(),
+			"aiven_kafka_acl":                    resourceKafkaACL(),
 			"aiven_kafka_topic":                  resourceKafkaTopic(),
 			"aiven_project":                      resourceProject(),
 			"aiven_project_user":                 resourceProjectUser(),

--- a/provider.go
+++ b/provider.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"errors"
 	"net/url"
 	"strings"
 
@@ -13,33 +12,11 @@ import (
 func Provider() *schema.Provider {
 	return &schema.Provider{
 		Schema: map[string]*schema.Schema{
-			"email": {
-				Type:        schema.TypeString,
-				Optional:    true,
-				Sensitive:   true,
-				Description: "Aiven email address",
-				Default:     "",
-			},
-			"otp": {
-				Type:        schema.TypeString,
-				Optional:    true,
-				Sensitive:   true,
-				Description: "Aiven One-Time password",
-				Default:     "",
-			},
-			"password": {
-				Type:        schema.TypeString,
-				Optional:    true,
-				Sensitive:   true,
-				Description: "Aiven password",
-				Default:     "",
-			},
 			"api_token": {
 				Type:        schema.TypeString,
-				Optional:    true,
+				Required:    true,
 				Sensitive:   true,
 				Description: "Aiven Authentication Token",
-				Default:     "",
 			},
 		},
 
@@ -57,19 +34,7 @@ func Provider() *schema.Provider {
 		},
 
 		ConfigureFunc: func(d *schema.ResourceData) (interface{}, error) {
-			if d.Get("api_token") == "" && (d.Get("email") == "" || d.Get("password") == "") {
-				return nil, errors.New("Must provide an API Token or email and password")
-			}
-			if d.Get("api_token") != "" {
-				return aiven.NewTokenClient(
-					d.Get("api_token").(string),
-				)
-			}
-			return aiven.NewMFAUserClient(
-				d.Get("email").(string),
-				d.Get("otp").(string),
-				d.Get("password").(string),
-			)
+			return aiven.NewTokenClient(d.Get("api_token").(string))
 		},
 	}
 }

--- a/provider.go
+++ b/provider.go
@@ -129,3 +129,22 @@ func splitResourceID3(resourceID string) (string, string, string) {
 	parts := splitResourceID(resourceID, 3)
 	return parts[0], parts[1], parts[2]
 }
+
+func resourceExists(err error) (bool, error) {
+	if err == nil {
+		return true, nil
+	}
+
+	aivenError, ok := err.(aiven.Error)
+	if !ok {
+		return true, err
+	}
+
+	if aivenError.Status == 404 {
+		return false, nil
+	}
+	if aivenError.Status < 200 || aivenError.Status >= 300 {
+		return true, err
+	}
+	return true, nil
+}

--- a/provider.go
+++ b/provider.go
@@ -4,8 +4,8 @@ import (
 	"net/url"
 	"strings"
 
+	"github.com/aiven/aiven-go-client"
 	"github.com/hashicorp/terraform/helper/schema"
-	"github.com/jelmersnoeck/aiven"
 )
 
 // Provider returns the Terraform Aiven Provider configuration object.

--- a/provider.go
+++ b/provider.go
@@ -44,13 +44,14 @@ func Provider() *schema.Provider {
 		},
 
 		ResourcesMap: map[string]*schema.Resource{
+			"aiven_database":                     resourceDatabase(),
+			"aiven_kafka_topic":                  resourceKafkaTopic(),
 			"aiven_project":                      resourceProject(),
+			"aiven_project_user":                 resourceProjectUser(),
 			"aiven_service":                      resourceService(),
 			"aiven_service_integration":          resourceServiceIntegration(),
 			"aiven_service_integration_endpoint": resourceServiceIntegrationEndpoint(),
-			"aiven_database":                     resourceDatabase(),
 			"aiven_service_user":                 resourceServiceUser(),
-			"aiven_kafka_topic":                  resourceKafkaTopic(),
 		},
 
 		ConfigureFunc: func(d *schema.ResourceData) (interface{}, error) {

--- a/provider.go
+++ b/provider.go
@@ -1,3 +1,5 @@
+// Copyright (c) 2017 jelmersnoeck
+// Copyright (c) 2018 Aiven, Helsinki, Finland. https://aiven.io/
 package main
 
 import (

--- a/provider.go
+++ b/provider.go
@@ -48,6 +48,7 @@ func Provider() *schema.Provider {
 			"aiven_kafka_topic":                  resourceKafkaTopic(),
 			"aiven_project":                      resourceProject(),
 			"aiven_project_user":                 resourceProjectUser(),
+			"aiven_project_vpc":                  resourceProjectVPC(),
 			"aiven_service":                      resourceService(),
 			"aiven_service_integration":          resourceServiceIntegration(),
 			"aiven_service_integration_endpoint": resourceServiceIntegrationEndpoint(),

--- a/provider.go
+++ b/provider.go
@@ -132,3 +132,22 @@ func createOnlyDiffSuppressFunc(k, old, new string, d *schema.ResourceData) bool
 	}
 	return false
 }
+
+// When a map inside a list contains only default values without explicit values set by
+// the user Terraform inteprets the map as not being present and the array lenght being
+// zero, resulting in bogus update that does nothing. Allow ignoring those.
+func emptyObjectDiffSuppressFunc(k, old, new string, d *schema.ResourceData) bool {
+	return old == "1" && new == "0" && strings.HasSuffix(k, ".#")
+}
+
+// Terraform does not allow default values for arrays but the IP filter user config value
+// has default. We don't want to force users to always define explicit value just because
+// of the Terraform restriction so suppress the change from default to empty (which would
+// be nonsensical operation anyway)
+func ipFilterArrayDiffSuppressFunc(k, old, new string, d *schema.ResourceData) bool {
+	return old == "1" && new == "0" && strings.HasSuffix(k, ".ip_filter.#")
+}
+
+func ipFilterValueDiffSuppressFunc(k, old, new string, d *schema.ResourceData) bool {
+	return old == "0.0.0.0/0" && new == "" && strings.HasSuffix(k, ".ip_filter.0")
+}

--- a/resource_connection_pool.go
+++ b/resource_connection_pool.go
@@ -1,0 +1,178 @@
+// Copyright (c) 2018 Aiven, Helsinki, Finland. https://aiven.io/
+package main
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/aiven/aiven-go-client"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func resourceConnectionPool() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceConnectionPoolCreate,
+		Read:   resourceConnectionPoolRead,
+		Update: resourceConnectionPoolUpdate,
+		Delete: resourceConnectionPoolDelete,
+		Exists: resourceConnectionPoolExists,
+		Importer: &schema.ResourceImporter{
+			State: resourceConnectionPoolState,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"project": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "Project to link the connection pool to",
+				ForceNew:    true,
+			},
+			"service_name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "Service to link the connection pool to",
+				ForceNew:    true,
+			},
+			"database_name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "Name of the database the pool connects to",
+				ForceNew:    true,
+			},
+			"pool_mode": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Default:     "transaction",
+				Description: "Mode the pool operates in (session, transaction, statement)",
+			},
+			"pool_name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "Name of the pool",
+				ForceNew:    true,
+			},
+			"pool_size": {
+				Type:        schema.TypeInt,
+				Optional:    true,
+				Default:     10,
+				Description: "Number of connections the pool may create towards the backend server",
+			},
+			"username": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "Name of the service user used to connect to the database",
+			},
+			"connection_uri": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "URI for connecting to the pool",
+				Sensitive:   true,
+			},
+		},
+	}
+}
+
+func resourceConnectionPoolCreate(d *schema.ResourceData, m interface{}) error {
+	client := m.(*aiven.Client)
+
+	project := d.Get("project").(string)
+	serviceName := d.Get("service_name").(string)
+	poolName := d.Get("pool_name").(string)
+	pool, err := client.ConnectionPools.Create(
+		project,
+		serviceName,
+		aiven.CreateConnectionPoolRequest{
+			Database: d.Get("database_name").(string),
+			PoolMode: d.Get("pool_mode").(string),
+			PoolName: poolName,
+			PoolSize: d.Get("pool_size").(int),
+			Username: d.Get("username").(string),
+		},
+	)
+	if err != nil {
+		return err
+	}
+
+	d.SetId(buildResourceID(project, serviceName, poolName))
+	return copyConnectionPoolPropertiesFromAPIResponseToTerraform(d, pool, project, serviceName)
+}
+
+func resourceConnectionPoolRead(d *schema.ResourceData, m interface{}) error {
+	client := m.(*aiven.Client)
+
+	project, serviceName, poolName := splitResourceID3(d.Id())
+	pool, err := client.ConnectionPools.Get(project, serviceName, poolName)
+	if err != nil {
+		return err
+	}
+
+	return copyConnectionPoolPropertiesFromAPIResponseToTerraform(d, pool, project, serviceName)
+}
+
+func resourceConnectionPoolUpdate(d *schema.ResourceData, m interface{}) error {
+	client := m.(*aiven.Client)
+
+	project, serviceName, poolName := splitResourceID3(d.Id())
+	pool, err := client.ConnectionPools.Update(
+		project,
+		serviceName,
+		poolName,
+		aiven.UpdateConnectionPoolRequest{
+			Database: d.Get("database_name").(string),
+			PoolMode: d.Get("pool_mode").(string),
+			PoolSize: d.Get("pool_size").(int),
+			Username: d.Get("username").(string),
+		},
+	)
+	if err != nil {
+		return err
+	}
+
+	return copyConnectionPoolPropertiesFromAPIResponseToTerraform(d, pool, project, serviceName)
+}
+
+func resourceConnectionPoolDelete(d *schema.ResourceData, m interface{}) error {
+	client := m.(*aiven.Client)
+
+	projectName, serviceName, poolName := splitResourceID3(d.Id())
+	return client.ConnectionPools.Delete(projectName, serviceName, poolName)
+}
+
+func resourceConnectionPoolExists(d *schema.ResourceData, m interface{}) (bool, error) {
+	client := m.(*aiven.Client)
+
+	projectName, serviceName, poolName := splitResourceID3(d.Id())
+	_, err := client.ConnectionPools.Get(projectName, serviceName, poolName)
+	return resourceExists(err)
+}
+
+func resourceConnectionPoolState(d *schema.ResourceData, m interface{}) ([]*schema.ResourceData, error) {
+	if len(strings.Split(d.Id(), "/")) != 3 {
+		return nil, fmt.Errorf("Invalid identifier %v, expected <project_name>/<service_name>/<pool_name>", d.Id())
+	}
+
+	err := resourceConnectionPoolRead(d, m)
+	if err != nil {
+		return nil, err
+	}
+
+	return []*schema.ResourceData{d}, nil
+}
+
+func copyConnectionPoolPropertiesFromAPIResponseToTerraform(
+	d *schema.ResourceData,
+	pool *aiven.ConnectionPool,
+	project string,
+	serviceName string,
+) error {
+	d.Set("project", project)
+	d.Set("service_name", serviceName)
+	d.Set("connection_uri", pool.ConnectionURI)
+	d.Set("database_name", pool.Database)
+	d.Set("pool_mode", pool.PoolMode)
+	d.Set("pool_name", pool.PoolName)
+	d.Set("pool_size", pool.PoolSize)
+	d.Set("username", pool.Username)
+
+	return nil
+}

--- a/resource_database.go
+++ b/resource_database.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/aiven/aiven-go-client"
 	"github.com/hashicorp/terraform/helper/schema"
-	"github.com/jelmersnoeck/aiven"
 )
 
 func resourceDatabase() *schema.Resource {

--- a/resource_database.go
+++ b/resource_database.go
@@ -1,3 +1,5 @@
+// Copyright (c) 2017 jelmersnoeck
+// Copyright (c) 2018 Aiven, Helsinki, Finland. https://aiven.io/
 package main
 
 import (

--- a/resource_database.go
+++ b/resource_database.go
@@ -32,7 +32,7 @@ func resourceDatabase() *schema.Resource {
 				Description: "Service to link the database to",
 				ForceNew:    true,
 			},
-			"database": {
+			"database_name": {
 				Type:        schema.TypeString,
 				Required:    true,
 				Description: "Service database name",
@@ -61,7 +61,7 @@ func resourceDatabaseCreate(d *schema.ResourceData, m interface{}) error {
 
 	projectName := d.Get("project").(string)
 	serviceName := d.Get("service_name").(string)
-	databaseName := d.Get("database").(string)
+	databaseName := d.Get("database_name").(string)
 	_, err := client.Databases.Create(
 		projectName,
 		serviceName,
@@ -88,7 +88,7 @@ func resourceDatabaseRead(d *schema.ResourceData, m interface{}) error {
 		return err
 	}
 
-	d.Set("database", database.DatabaseName)
+	d.Set("database_name", database.DatabaseName)
 	d.Set("lc_collate", database.LcCollate)
 	d.Set("lc_ctype", database.LcType)
 	return nil

--- a/resource_kafka_acl.go
+++ b/resource_kafka_acl.go
@@ -1,0 +1,133 @@
+// Copyright (c) 2018 Aiven, Helsinki, Finland. https://aiven.io/
+package main
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/aiven/aiven-go-client"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func resourceKafkaACL() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceKafkaACLCreate,
+		Read:   resourceKafkaACLRead,
+		Delete: resourceKafkaACLDelete,
+		Exists: resourceKafkaACLExists,
+		Importer: &schema.ResourceImporter{
+			State: resourceKafkaACLState,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"project": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "Project to link the Kafka ACL to",
+				ForceNew:    true,
+			},
+			"service_name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "Service to link the Kafka ACL to",
+				ForceNew:    true,
+			},
+			"permission": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "Kafka permission to grant (admin, read, readwrite, write)",
+				ForceNew:    true,
+			},
+			"topic": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "Topic name pattern for the ACL entry",
+				ForceNew:    true,
+			},
+			"username": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "Username pattern for the ACL entry",
+				ForceNew:    true,
+			},
+		},
+	}
+}
+
+func resourceKafkaACLCreate(d *schema.ResourceData, m interface{}) error {
+	client := m.(*aiven.Client)
+
+	project := d.Get("project").(string)
+	serviceName := d.Get("service_name").(string)
+
+	acl, err := client.KafkaACLs.Create(
+		project,
+		serviceName,
+		aiven.CreateKafkaACLRequest{
+			Permission: d.Get("permission").(string),
+			Topic:      d.Get("topic").(string),
+			Username:   d.Get("username").(string),
+		},
+	)
+	if err != nil {
+		return err
+	}
+
+	d.SetId(buildResourceID(project, serviceName, acl.ID))
+	return copyKafkaACLPropertiesFromAPIResponseToTerraform(d, acl, project, serviceName)
+}
+
+func resourceKafkaACLRead(d *schema.ResourceData, m interface{}) error {
+	client := m.(*aiven.Client)
+
+	project, serviceName, aclID := splitResourceID3(d.Id())
+	acl, err := client.KafkaACLs.Get(project, serviceName, aclID)
+	if err != nil {
+		return err
+	}
+
+	return copyKafkaACLPropertiesFromAPIResponseToTerraform(d, acl, project, serviceName)
+}
+
+func resourceKafkaACLDelete(d *schema.ResourceData, m interface{}) error {
+	client := m.(*aiven.Client)
+
+	projectName, serviceName, aclID := splitResourceID3(d.Id())
+	return client.KafkaACLs.Delete(projectName, serviceName, aclID)
+}
+
+func resourceKafkaACLExists(d *schema.ResourceData, m interface{}) (bool, error) {
+	client := m.(*aiven.Client)
+
+	projectName, serviceName, aclID := splitResourceID3(d.Id())
+	_, err := client.KafkaACLs.Get(projectName, serviceName, aclID)
+	return resourceExists(err)
+}
+
+func resourceKafkaACLState(d *schema.ResourceData, m interface{}) ([]*schema.ResourceData, error) {
+	if len(strings.Split(d.Id(), "/")) != 3 {
+		return nil, fmt.Errorf("Invalid identifier %v, expected <project_name>/<service_name>/<acl_id>", d.Id())
+	}
+
+	err := resourceKafkaACLRead(d, m)
+	if err != nil {
+		return nil, err
+	}
+
+	return []*schema.ResourceData{d}, nil
+}
+
+func copyKafkaACLPropertiesFromAPIResponseToTerraform(
+	d *schema.ResourceData,
+	acl *aiven.KafkaACL,
+	project string,
+	serviceName string,
+) error {
+	d.Set("project", project)
+	d.Set("service_name", serviceName)
+	d.Set("topic", acl.Topic)
+	d.Set("permission", acl.Permission)
+	d.Set("username", acl.Username)
+
+	return nil
+}

--- a/resource_kafka_topic.go
+++ b/resource_kafka_topic.go
@@ -32,7 +32,7 @@ func resourceKafkaTopic() *schema.Resource {
 				Description: "Service to link the kafka topic to",
 				ForceNew:    true,
 			},
-			"topic": {
+			"topic_name": {
 				Type:        schema.TypeString,
 				Required:    true,
 				Description: "Topic name",
@@ -82,7 +82,7 @@ func resourceKafkaTopicCreate(d *schema.ResourceData, m interface{}) error {
 
 	project := d.Get("project").(string)
 	serviceName := d.Get("service_name").(string)
-	topic := d.Get("topic").(string)
+	topicName := d.Get("topic_name").(string)
 	partitions := d.Get("partitions").(int)
 	replication := d.Get("replication").(int)
 
@@ -96,7 +96,7 @@ func resourceKafkaTopicCreate(d *schema.ResourceData, m interface{}) error {
 			Replication:           &replication,
 			RetentionBytes:        optionalIntPointer(d, "retention_bytes"),
 			RetentionHours:        optionalIntPointer(d, "retention_hours"),
-			TopicName:             topic,
+			TopicName:             topicName,
 		},
 	)
 	if err != nil {
@@ -109,7 +109,7 @@ func resourceKafkaTopicCreate(d *schema.ResourceData, m interface{}) error {
 		return err
 	}
 
-	d.SetId(buildResourceID(project, serviceName, topic))
+	d.SetId(buildResourceID(project, serviceName, topicName))
 
 	return resourceKafkaTopicRead(d, m)
 }
@@ -125,7 +125,7 @@ func resourceKafkaTopicRead(d *schema.ResourceData, m interface{}) error {
 
 	d.Set("project", project)
 	d.Set("service_name", serviceName)
-	d.Set("topic", topic.TopicName)
+	d.Set("topic_name", topic.TopicName)
 	d.Set("state", topic.State)
 	d.Set("partitions", len(topic.Partitions))
 	d.Set("replication", topic.Replication)
@@ -199,7 +199,7 @@ func resourceKafkaTopicWait(d *schema.ResourceData, m interface{}) error {
 		Client:      m.(*aiven.Client),
 		Project:     d.Get("project").(string),
 		ServiceName: d.Get("service_name").(string),
-		Topic:       d.Get("topic").(string),
+		TopicName:   d.Get("topic_name").(string),
 	}
 
 	_, err := w.Conf().WaitForState()

--- a/resource_kafka_topic.go
+++ b/resource_kafka_topic.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/aiven/aiven-go-client"
 	"github.com/hashicorp/terraform/helper/schema"
-	"github.com/jelmersnoeck/aiven"
 )
 
 func resourceKafkaTopic() *schema.Resource {

--- a/resource_kafka_topic.go
+++ b/resource_kafka_topic.go
@@ -1,3 +1,5 @@
+// Copyright (c) 2017 jelmersnoeck
+// Copyright (c) 2018 Aiven, Helsinki, Finland. https://aiven.io/
 package main
 
 import (

--- a/resource_project.go
+++ b/resource_project.go
@@ -11,6 +11,7 @@ func resourceProject() *schema.Resource {
 		Read:   resourceProjectRead,
 		Update: resourceProjectUpdate,
 		Delete: resourceProjectDelete,
+		Exists: resourceProjectExists,
 		Importer: &schema.ResourceImporter{
 			State: resourceProjectState,
 		},
@@ -88,6 +89,13 @@ func resourceProjectDelete(d *schema.ResourceData, m interface{}) error {
 	client := m.(*aiven.Client)
 
 	return client.Projects.Delete(d.Id())
+}
+
+func resourceProjectExists(d *schema.ResourceData, m interface{}) (bool, error) {
+	client := m.(*aiven.Client)
+
+	_, err := client.Projects.Get(d.Get("project").(string))
+	return resourceExists(err)
 }
 
 func resourceProjectState(d *schema.ResourceData, m interface{}) ([]*schema.ResourceData, error) {

--- a/resource_project.go
+++ b/resource_project.go
@@ -207,14 +207,12 @@ func contactEmailListForAPI(d *schema.ResourceData, field string, newResource bo
 
 func contactEmailListForTerraform(d *schema.ResourceData, field string, contactEmails []*aiven.ContactEmail) {
 	_, existsBefore := d.GetOk(field)
-	if !existsBefore && (contactEmails == nil || len(contactEmails) == 0) {
+	if !existsBefore && len(contactEmails) == 0 {
 		return
 	}
 	results := []string{}
-	if contactEmails != nil {
-		for _, contactEmail := range contactEmails {
-			results = append(results, contactEmail.Email)
-		}
+	for _, contactEmail := range contactEmails {
+		results = append(results, contactEmail.Email)
 	}
 	d.Set(field, results)
 }

--- a/resource_project.go
+++ b/resource_project.go
@@ -30,6 +30,12 @@ func resourceProject() *schema.Resource {
 				Optional:    true,
 				Description: "Credit card ID",
 			},
+			"copy_from_project": {
+				Type:             schema.TypeString,
+				Optional:         true,
+				Description:      "Copy properties from another project. Only has effect when a new project is created.",
+				DiffSuppressFunc: createOnlyDiffSuppressFunc,
+			},
 			"project": {
 				Type:        schema.TypeString,
 				Required:    true,
@@ -48,8 +54,9 @@ func resourceProjectCreate(d *schema.ResourceData, m interface{}) error {
 	projectName := d.Get("project").(string)
 	project, err := client.Projects.Create(
 		aiven.CreateProjectRequest{
-			CardID:  cardID,
-			Project: projectName,
+			CardID:          cardID,
+			CopyFromProject: d.Get("copy_from_project").(string),
+			Project:         projectName,
 		},
 	)
 	if err != nil {

--- a/resource_project.go
+++ b/resource_project.go
@@ -1,3 +1,5 @@
+// Copyright (c) 2017 jelmersnoeck
+// Copyright (c) 2018 Aiven, Helsinki, Finland. https://aiven.io/
 package main
 
 import (

--- a/resource_project.go
+++ b/resource_project.go
@@ -1,8 +1,8 @@
 package main
 
 import (
+	"github.com/aiven/aiven-go-client"
 	"github.com/hashicorp/terraform/helper/schema"
-	"github.com/jelmersnoeck/aiven"
 )
 
 func resourceProject() *schema.Resource {

--- a/resource_project.go
+++ b/resource_project.go
@@ -19,6 +19,17 @@ func resourceProject() *schema.Resource {
 		},
 
 		Schema: map[string]*schema.Schema{
+			"billing_address": {
+				Type:        schema.TypeString,
+				Description: "Billing name and address of the project",
+				Optional:    true,
+			},
+			"billing_emails": {
+				Type:        schema.TypeSet,
+				Description: "Billing contact emails of the project",
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Optional:    true,
+			},
 			"ca_cert": {
 				Type:        schema.TypeString,
 				Computed:    true,
@@ -36,10 +47,21 @@ func resourceProject() *schema.Resource {
 				Description:      "Copy properties from another project. Only has effect when a new project is created.",
 				DiffSuppressFunc: createOnlyDiffSuppressFunc,
 			},
+			"country_code": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "Billing country code of the project",
+			},
 			"project": {
 				Type:        schema.TypeString,
 				Required:    true,
 				Description: "Project name",
+			},
+			"technical_emails": {
+				Type:        schema.TypeSet,
+				Description: "Technical contact emails of the project",
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Optional:    true,
 			},
 		},
 	}
@@ -54,9 +76,13 @@ func resourceProjectCreate(d *schema.ResourceData, m interface{}) error {
 	projectName := d.Get("project").(string)
 	project, err := client.Projects.Create(
 		aiven.CreateProjectRequest{
+			BillingAddress:  optionalStringPointer(d, "billing_address"),
+			BillingEmails:   contactEmailListForAPI(d, "billing_emails", true),
 			CardID:          cardID,
 			CopyFromProject: d.Get("copy_from_project").(string),
+			CountryCode:     optionalStringPointer(d, "country_code"),
 			Project:         projectName,
+			TechnicalEmails: contactEmailListForAPI(d, "technical_emails", true),
 		},
 	)
 	if err != nil {
@@ -76,13 +102,12 @@ func resourceProjectRead(d *schema.ResourceData, m interface{}) error {
 		return err
 	}
 
-	d.Set("project", project.Name)
 	// Don't set card id unconditionally to prevent converting short card id format to long
 	currentCardID, err := getLongCardID(client, d.Get("card_id").(string))
 	if err != nil || currentCardID != project.Card.CardID {
 		d.Set("card_id", project.Card.CardID)
 	}
-	resourceProjectGetCACert(project.Name, client, d)
+	setProjectTerraformProperties(d, client, project)
 	return nil
 }
 
@@ -93,10 +118,16 @@ func resourceProjectUpdate(d *schema.ResourceData, m interface{}) error {
 	if err != nil {
 		return err
 	}
+	billingAddress := d.Get("billing_address").(string)
+	countryCode := d.Get("country_code").(string)
 	project, err := client.Projects.Update(
 		d.Get("project").(string),
 		aiven.UpdateProjectRequest{
-			CardID: cardID,
+			BillingAddress:  &billingAddress,
+			BillingEmails:   contactEmailListForAPI(d, "billing_emails", false),
+			CardID:          cardID,
+			CountryCode:     &countryCode,
+			TechnicalEmails: contactEmailListForAPI(d, "technical_emails", false),
 		},
 	)
 	if err != nil {
@@ -128,9 +159,8 @@ func resourceProjectState(d *schema.ResourceData, m interface{}) ([]*schema.Reso
 		return nil, err
 	}
 
-	d.Set("project", project.Name)
 	d.Set("card_id", project.Card.CardID)
-	resourceProjectGetCACert(project.Name, client, d)
+	setProjectTerraformProperties(d, client, project)
 
 	return []*schema.ResourceData{d}, nil
 }
@@ -151,4 +181,49 @@ func getLongCardID(client *aiven.Client, cardID string) (string, error) {
 		return card.CardID, nil
 	}
 	return cardID, nil
+}
+
+func contactEmailListForAPI(d *schema.ResourceData, field string, newResource bool) *[]*aiven.ContactEmail {
+	var results []*aiven.ContactEmail
+	// We don't want to send empty list for new resource if data is copied from other
+	// project to prevent accidental override of the emails being copied. Empty array
+	// should be sent if user has explicitly defined that even when copy_from_project
+	// is set but Terraform does not support checking that; d.GetOkExists returns false
+	// even if the value is set (to empty).
+	if len(d.Get("copy_from_project").(string)) == 0 || !newResource {
+		results = []*aiven.ContactEmail{}
+	}
+	valuesInterface, ok := d.GetOk(field)
+	if ok && valuesInterface != nil {
+		for _, emailInterface := range valuesInterface.(*schema.Set).List() {
+			results = append(results, &aiven.ContactEmail{Email: emailInterface.(string)})
+		}
+	}
+	if results == nil {
+		return nil
+	}
+	return &results
+}
+
+func contactEmailListForTerraform(d *schema.ResourceData, field string, contactEmails []*aiven.ContactEmail) {
+	_, existsBefore := d.GetOk(field)
+	if !existsBefore && (contactEmails == nil || len(contactEmails) == 0) {
+		return
+	}
+	results := []string{}
+	if contactEmails != nil {
+		for _, contactEmail := range contactEmails {
+			results = append(results, contactEmail.Email)
+		}
+	}
+	d.Set(field, results)
+}
+
+func setProjectTerraformProperties(d *schema.ResourceData, client *aiven.Client, project *aiven.Project) {
+	d.Set("billing_address", project.BillingAddress)
+	contactEmailListForTerraform(d, "billing_emails", project.BillingEmails)
+	d.Set("country_code", project.CountryCode)
+	d.Set("project", project.Name)
+	contactEmailListForTerraform(d, "technical_emails", project.TechnicalEmails)
+	resourceProjectGetCACert(project.Name, client, d)
 }

--- a/resource_project_user.go
+++ b/resource_project_user.go
@@ -1,3 +1,4 @@
+// Copyright (c) 2018 Aiven, Helsinki, Finland. https://aiven.io/
 package main
 
 import (

--- a/resource_project_user.go
+++ b/resource_project_user.go
@@ -33,7 +33,7 @@ func resourceProjectUser() *schema.Resource {
 				Type:        schema.TypeString,
 			},
 			"member_type": {
-				Description: "Project membership type",
+				Description: "Project membership type. One of: admin, developer, operator",
 				Required:    true,
 				Type:        schema.TypeString,
 			},

--- a/resource_project_user.go
+++ b/resource_project_user.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/aiven/aiven-go-client"
 	"github.com/hashicorp/terraform/helper/schema"
-	"github.com/jelmersnoeck/aiven"
 )
 
 func resourceProjectUser() *schema.Resource {

--- a/resource_project_user.go
+++ b/resource_project_user.go
@@ -1,0 +1,131 @@
+package main
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/jelmersnoeck/aiven"
+)
+
+func resourceProjectUser() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceProjectUserCreate,
+		Read:   resourceProjectUserRead,
+		Update: resourceProjectUserUpdate,
+		Delete: resourceProjectUserDelete,
+		Exists: resourceProjectUserExists,
+		Importer: &schema.ResourceImporter{
+			State: resourceProjectUserState,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"project": {
+				Description: "The project the user belongs to",
+				ForceNew:    true,
+				Required:    true,
+				Type:        schema.TypeString,
+			},
+			"email": {
+				Description: "Email address of the user",
+				ForceNew:    true,
+				Required:    true,
+				Type:        schema.TypeString,
+			},
+			"member_type": {
+				Description: "Project membership type",
+				Required:    true,
+				Type:        schema.TypeString,
+			},
+			"accepted": {
+				Computed:    true,
+				Description: "Whether the user has accepted project membership or not",
+				Type:        schema.TypeBool,
+			},
+		},
+	}
+}
+
+func resourceProjectUserCreate(d *schema.ResourceData, m interface{}) error {
+	client := m.(*aiven.Client)
+	projectName := d.Get("project").(string)
+	email := d.Get("email").(string)
+	err := client.ProjectUsers.Invite(
+		projectName,
+		aiven.CreateProjectInvitationRequest{
+			UserEmail:  email,
+			MemberType: d.Get("member_type").(string),
+		},
+	)
+
+	if err != nil {
+		return err
+	}
+
+	d.SetId(buildResourceID(projectName, email))
+	d.Set("accepted", false)
+	return nil
+}
+
+func resourceProjectUserRead(d *schema.ResourceData, m interface{}) error {
+	client := m.(*aiven.Client)
+
+	projectName, email := splitResourceID2(d.Id())
+	user, invitation, err := client.ProjectUsers.Get(projectName, email)
+	if err != nil {
+		return err
+	}
+
+	d.Set("project", projectName)
+	d.Set("email", email)
+	if user != nil {
+		d.Set("member_type", user.MemberType)
+		d.Set("accepted", true)
+	} else {
+		d.Set("member_type", invitation.MemberType)
+		d.Set("accepted", false)
+	}
+	return nil
+}
+
+func resourceProjectUserUpdate(d *schema.ResourceData, m interface{}) error {
+	client := m.(*aiven.Client)
+
+	projectName, email := splitResourceID2(d.Id())
+	memberType := d.Get("member_type").(string)
+	return client.ProjectUsers.UpdateUserOrInvitation(
+		projectName,
+		email,
+		aiven.UpdateProjectUserOrInvitationRequest{
+			MemberType: memberType,
+		},
+	)
+}
+
+func resourceProjectUserDelete(d *schema.ResourceData, m interface{}) error {
+	client := m.(*aiven.Client)
+
+	projectName, email := splitResourceID2(d.Id())
+	return client.ProjectUsers.DeleteUserOrInvitation(projectName, email)
+}
+
+func resourceProjectUserExists(d *schema.ResourceData, m interface{}) (bool, error) {
+	client := m.(*aiven.Client)
+
+	projectName, email := splitResourceID2(d.Id())
+	_, _, err := client.ProjectUsers.Get(projectName, email)
+	return resourceExists(err)
+}
+
+func resourceProjectUserState(d *schema.ResourceData, m interface{}) ([]*schema.ResourceData, error) {
+	if len(strings.Split(d.Id(), "/")) != 2 {
+		return nil, fmt.Errorf("Invalid identifier %v, expected <project_name>/<email>", d.Id())
+	}
+
+	err := resourceProjectUserRead(d, m)
+	if err != nil {
+		return nil, err
+	}
+
+	return []*schema.ResourceData{d}, nil
+}

--- a/resource_project_vpc.go
+++ b/resource_project_vpc.go
@@ -1,3 +1,4 @@
+// Copyright (c) 2018 Aiven, Helsinki, Finland. https://aiven.io/
 package main
 
 import (

--- a/resource_project_vpc.go
+++ b/resource_project_vpc.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/aiven/aiven-go-client"
 	"github.com/hashicorp/terraform/helper/schema"
-	"github.com/jelmersnoeck/aiven"
 )
 
 func resourceProjectVPC() *schema.Resource {

--- a/resource_project_vpc.go
+++ b/resource_project_vpc.go
@@ -1,0 +1,115 @@
+package main
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/jelmersnoeck/aiven"
+)
+
+func resourceProjectVPC() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceProjectVPCCreate,
+		Read:   resourceProjectVPCRead,
+		Delete: resourceProjectVPCDelete,
+		Exists: resourceProjectVPCExists,
+		Importer: &schema.ResourceImporter{
+			State: resourceProjectVPCState,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"project": {
+				Description: "The project the VPC belongs to",
+				ForceNew:    true,
+				Required:    true,
+				Type:        schema.TypeString,
+			},
+			"cloud_name": {
+				Description: "Cloud the VPC is in",
+				ForceNew:    true,
+				Required:    true,
+				Type:        schema.TypeString,
+			},
+			"network_cidr": {
+				Description: "Network address range used by the VPC like 192.168.0.0/24",
+				ForceNew:    true,
+				Required:    true,
+				Type:        schema.TypeString,
+			},
+			"state": {
+				Computed:    true,
+				Description: "State of the VPC (APPROVED, ACTIVE, DELETING, DELETED)",
+				Type:        schema.TypeString,
+			},
+		},
+	}
+}
+
+func resourceProjectVPCCreate(d *schema.ResourceData, m interface{}) error {
+	client := m.(*aiven.Client)
+	projectName := d.Get("project").(string)
+	vpc, err := client.VPCs.Create(
+		projectName,
+		aiven.CreateVPCRequest{
+			CloudName:   d.Get("cloud_name").(string),
+			NetworkCIDR: d.Get("network_cidr").(string),
+		},
+	)
+
+	if err != nil {
+		return err
+	}
+
+	d.SetId(buildResourceID(projectName, vpc.ProjectVPCID))
+	return copyVPCPropertiesFromAPIResponseToTerraform(d, vpc, projectName)
+}
+
+func resourceProjectVPCRead(d *schema.ResourceData, m interface{}) error {
+	client := m.(*aiven.Client)
+
+	projectName, vpcID := splitResourceID2(d.Id())
+	vpc, err := client.VPCs.Get(projectName, vpcID)
+	if err != nil {
+		return err
+	}
+
+	return copyVPCPropertiesFromAPIResponseToTerraform(d, vpc, projectName)
+}
+
+func resourceProjectVPCDelete(d *schema.ResourceData, m interface{}) error {
+	client := m.(*aiven.Client)
+
+	projectName, vpcID := splitResourceID2(d.Id())
+	return client.VPCs.Delete(projectName, vpcID)
+}
+
+func resourceProjectVPCExists(d *schema.ResourceData, m interface{}) (bool, error) {
+	client := m.(*aiven.Client)
+
+	projectName, vpcID := splitResourceID2(d.Id())
+	_, err := client.VPCs.Get(projectName, vpcID)
+	return resourceExists(err)
+}
+
+func resourceProjectVPCState(d *schema.ResourceData, m interface{}) ([]*schema.ResourceData, error) {
+	if len(strings.Split(d.Id(), "/")) != 2 {
+		return nil, fmt.Errorf("Invalid identifier %v, expected <project_name>/<vpc_id>", d.Id())
+	}
+
+	err := resourceProjectVPCRead(d, m)
+	if err != nil {
+		return nil, err
+	}
+
+	return []*schema.ResourceData{d}, nil
+}
+
+func copyVPCPropertiesFromAPIResponseToTerraform(d *schema.ResourceData, vpc *aiven.VPC, project string) error {
+	d.Set("project", project)
+	d.Set("cloud_name", vpc.CloudName)
+	d.Set("network_cidr", vpc.NetworkCIDR)
+	d.Set("state", vpc.State)
+
+	return nil
+}

--- a/resource_service.go
+++ b/resource_service.go
@@ -98,10 +98,11 @@ func resourceService() *schema.Resource {
 				},
 			},
 			"cassandra_user_config": {
-				Type:        schema.TypeList,
-				MaxItems:    1,
-				Optional:    true,
-				Description: "Cassandra specific user configurable settings",
+				Type:             schema.TypeList,
+				MaxItems:         1,
+				Optional:         true,
+				Description:      "Cassandra specific user configurable settings",
+				DiffSuppressFunc: emptyObjectDiffSuppressFunc,
 				Elem: &schema.Resource{
 					Schema: GenerateTerraformUserConfigSchema(
 						userConfigSchemas["service"]["cassandra"].(map[string]interface{})),
@@ -125,10 +126,11 @@ func resourceService() *schema.Resource {
 				},
 			},
 			"elasticsearch_user_config": {
-				Type:        schema.TypeList,
-				MaxItems:    1,
-				Optional:    true,
-				Description: "Elasticsearch specific user configurable settings",
+				Type:             schema.TypeList,
+				MaxItems:         1,
+				Optional:         true,
+				Description:      "Elasticsearch specific user configurable settings",
+				DiffSuppressFunc: emptyObjectDiffSuppressFunc,
 				Elem: &schema.Resource{
 					Schema: GenerateTerraformUserConfigSchema(
 						userConfigSchemas["service"]["elasticsearch"].(map[string]interface{})),
@@ -145,10 +147,11 @@ func resourceService() *schema.Resource {
 				},
 			},
 			"grafana_user_config": {
-				Type:        schema.TypeList,
-				MaxItems:    1,
-				Optional:    true,
-				Description: "Grafana specific user configurable settings",
+				Type:             schema.TypeList,
+				MaxItems:         1,
+				Optional:         true,
+				Description:      "Grafana specific user configurable settings",
+				DiffSuppressFunc: emptyObjectDiffSuppressFunc,
 				Elem: &schema.Resource{
 					Schema: GenerateTerraformUserConfigSchema(
 						userConfigSchemas["service"]["grafana"].(map[string]interface{})),
@@ -171,10 +174,11 @@ func resourceService() *schema.Resource {
 				},
 			},
 			"influxdb_user_config": {
-				Type:        schema.TypeList,
-				MaxItems:    1,
-				Optional:    true,
-				Description: "InfluxDB specific user configurable settings",
+				Type:             schema.TypeList,
+				MaxItems:         1,
+				Optional:         true,
+				Description:      "InfluxDB specific user configurable settings",
+				DiffSuppressFunc: emptyObjectDiffSuppressFunc,
 				Elem: &schema.Resource{
 					Schema: GenerateTerraformUserConfigSchema(
 						userConfigSchemas["service"]["influxdb"].(map[string]interface{})),
@@ -224,10 +228,11 @@ func resourceService() *schema.Resource {
 				},
 			},
 			"kafka_user_config": {
-				Type:        schema.TypeList,
-				MaxItems:    1,
-				Optional:    true,
-				Description: "Kafka specific user configurable settings",
+				Type:             schema.TypeList,
+				MaxItems:         1,
+				Optional:         true,
+				Description:      "Kafka specific user configurable settings",
+				DiffSuppressFunc: emptyObjectDiffSuppressFunc,
 				Elem: &schema.Resource{
 					Schema: GenerateTerraformUserConfigSchema(
 						userConfigSchemas["service"]["kafka"].(map[string]interface{})),
@@ -289,10 +294,11 @@ func resourceService() *schema.Resource {
 				},
 			},
 			"pg_user_config": {
-				Type:        schema.TypeList,
-				MaxItems:    1,
-				Optional:    true,
-				Description: "PostgreSQL specific user configurable settings",
+				Type:             schema.TypeList,
+				MaxItems:         1,
+				Optional:         true,
+				Description:      "PostgreSQL specific user configurable settings",
+				DiffSuppressFunc: emptyObjectDiffSuppressFunc,
 				Elem: &schema.Resource{
 					Schema: GenerateTerraformUserConfigSchema(
 						userConfigSchemas["service"]["pg"].(map[string]interface{})),
@@ -309,10 +315,11 @@ func resourceService() *schema.Resource {
 				},
 			},
 			"redis_user_config": {
-				Type:        schema.TypeList,
-				MaxItems:    1,
-				Optional:    true,
-				Description: "Redis specific user configurable settings",
+				Type:             schema.TypeList,
+				MaxItems:         1,
+				Optional:         true,
+				Description:      "Redis specific user configurable settings",
+				DiffSuppressFunc: emptyObjectDiffSuppressFunc,
 				Elem: &schema.Resource{
 					Schema: GenerateTerraformUserConfigSchema(
 						userConfigSchemas["service"]["redis"].(map[string]interface{})),

--- a/resource_service.go
+++ b/resource_service.go
@@ -325,7 +325,7 @@ func resourceService() *schema.Resource {
 func resourceServiceCreate(d *schema.ResourceData, m interface{}) error {
 	client := m.(*aiven.Client)
 	serviceType := d.Get("service_type").(string)
-	userConfig := ConvertTerraformUserConfigToAPICompatibleFormat("service", serviceType, d)
+	userConfig := ConvertTerraformUserConfigToAPICompatibleFormat("service", serviceType, true, d)
 	vpcID := d.Get("project_vpc_id").(string)
 	var vpcIDPointer *string
 	if len(vpcID) > 0 {
@@ -375,7 +375,7 @@ func resourceServiceUpdate(d *schema.ResourceData, m interface{}) error {
 	client := m.(*aiven.Client)
 
 	projectName, serviceName := splitResourceID2(d.Id())
-	userConfig := ConvertTerraformUserConfigToAPICompatibleFormat("service", d.Get("service_type").(string), d)
+	userConfig := ConvertTerraformUserConfigToAPICompatibleFormat("service", d.Get("service_type").(string), false, d)
 	vpcID := d.Get("project_vpc_id").(string)
 	var vpcIDPointer *string
 	if len(vpcID) > 0 {

--- a/resource_service.go
+++ b/resource_service.go
@@ -27,7 +27,7 @@ func resourceService() *schema.Resource {
 				Description: "Target project",
 				ForceNew:    true,
 			},
-			"cloud": {
+			"cloud_name": {
 				Type:        schema.TypeString,
 				Optional:    true,
 				Description: "Cloud the service runs in",
@@ -200,7 +200,7 @@ func resourceServiceCreate(d *schema.ResourceData, m interface{}) error {
 	service, err := client.Services.Create(
 		d.Get("project").(string),
 		aiven.CreateServiceRequest{
-			Cloud:       d.Get("cloud").(string),
+			Cloud:       d.Get("cloud_name").(string),
 			Plan:        d.Get("plan").(string),
 			ServiceName: d.Get("service_name").(string),
 			ServiceType: serviceType,
@@ -244,7 +244,7 @@ func resourceServiceUpdate(d *schema.ResourceData, m interface{}) error {
 		projectName,
 		serviceName,
 		aiven.UpdateServiceRequest{
-			Cloud:      d.Get("cloud").(string),
+			Cloud:      d.Get("cloud_name").(string),
 			Plan:       d.Get("plan").(string),
 			Powered:    true,
 			UserConfig: userConfig,
@@ -320,7 +320,7 @@ func copyServicePropertiesFromAPIResponseToTerraform(
 	service *aiven.Service,
 	project string,
 ) error {
-	d.Set("cloud", service.CloudName)
+	d.Set("cloud_name", service.CloudName)
 	d.Set("service_name", service.Name)
 	d.Set("state", service.State)
 	d.Set("plan", service.Plan)

--- a/resource_service.go
+++ b/resource_service.go
@@ -120,7 +120,8 @@ func resourceService() *schema.Resource {
 				Optional:    true,
 				Description: "Kafka specific user configurable settings",
 				Elem: &schema.Resource{
-					Schema: GenerateTerraformUserConfigSchema(userConfigSchemas["service"]["kafka"].(map[string]interface{})),
+					Schema: GenerateTerraformUserConfigSchema(
+						userConfigSchemas["service"]["kafka"].(map[string]interface{})),
 				},
 			},
 			"pg": {
@@ -184,7 +185,8 @@ func resourceService() *schema.Resource {
 				Optional:    true,
 				Description: "PostgreSQL specific user configurable settings",
 				Elem: &schema.Resource{
-					Schema: GenerateTerraformUserConfigSchema(userConfigSchemas["service"]["pg"].(map[string]interface{})),
+					Schema: GenerateTerraformUserConfigSchema(
+						userConfigSchemas["service"]["pg"].(map[string]interface{})),
 				},
 			},
 		},
@@ -343,7 +345,11 @@ func copyServicePropertiesFromAPIResponseToTerraform(
 	return nil
 }
 
-func copyConnectionInfoFromAPIResponseToTerraform(d *schema.ResourceData, serviceType string, connectionInfo aiven.ConnectionInfo) {
+func copyConnectionInfoFromAPIResponseToTerraform(
+	d *schema.ResourceData,
+	serviceType string,
+	connectionInfo aiven.ConnectionInfo,
+) {
 	// Need to set empty value for all services or all Terraform keeps on showing there's
 	// a change in the computed values that don't match actual service type
 	d.Set("kafka", []map[string]interface{}{})

--- a/resource_service.go
+++ b/resource_service.go
@@ -1,3 +1,5 @@
+// Copyright (c) 2017 jelmersnoeck
+// Copyright (c) 2018 Aiven, Helsinki, Finland. https://aiven.io/
 package main
 
 import (

--- a/resource_service.go
+++ b/resource_service.go
@@ -209,7 +209,7 @@ func resourceServiceCreate(d *schema.ResourceData, m interface{}) error {
 		return err
 	}
 
-	err = resourceServiceWait(d, m)
+	err = resourceServiceWait(d, m, "create")
 
 	if err != nil {
 		return err
@@ -251,7 +251,7 @@ func resourceServiceUpdate(d *schema.ResourceData, m interface{}) error {
 		return err
 	}
 
-	err = resourceServiceWait(d, m)
+	err = resourceServiceWait(d, m, "update")
 
 	if err != nil {
 		return err
@@ -288,9 +288,10 @@ func resourceServiceState(d *schema.ResourceData, m interface{}) ([]*schema.Reso
 	return []*schema.ResourceData{d}, nil
 }
 
-func resourceServiceWait(d *schema.ResourceData, m interface{}) error {
+func resourceServiceWait(d *schema.ResourceData, m interface{}, operation string) error {
 	w := &ServiceChangeWaiter{
 		Client:      m.(*aiven.Client),
+		Operation:   operation,
 		Project:     d.Get("project").(string),
 		ServiceName: d.Get("service_name").(string),
 	}

--- a/resource_service.go
+++ b/resource_service.go
@@ -5,8 +5,8 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/aiven/aiven-go-client"
 	"github.com/hashicorp/terraform/helper/schema"
-	"github.com/jelmersnoeck/aiven"
 )
 
 func resourceService() *schema.Resource {

--- a/resource_service.go
+++ b/resource_service.go
@@ -15,6 +15,7 @@ func resourceService() *schema.Resource {
 		Read:   resourceServiceRead,
 		Update: resourceServiceUpdate,
 		Delete: resourceServiceDelete,
+		Exists: resourceServiceExists,
 		Importer: &schema.ResourceImporter{
 			State: resourceServiceState,
 		},
@@ -265,6 +266,14 @@ func resourceServiceDelete(d *schema.ResourceData, m interface{}) error {
 
 	projectName, serviceName := splitResourceID2(d.Id())
 	return client.Services.Delete(projectName, serviceName)
+}
+
+func resourceServiceExists(d *schema.ResourceData, m interface{}) (bool, error) {
+	client := m.(*aiven.Client)
+
+	projectName, serviceName := splitResourceID2(d.Id())
+	_, err := client.Services.Get(projectName, serviceName)
+	return resourceExists(err)
 }
 
 func resourceServiceState(d *schema.ResourceData, m interface{}) ([]*schema.ResourceData, error) {

--- a/resource_service_integration.go
+++ b/resource_service_integration.go
@@ -1,3 +1,4 @@
+// Copyright (c) 2018 Aiven, Helsinki, Finland. https://aiven.io/
 package main
 
 import (

--- a/resource_service_integration.go
+++ b/resource_service_integration.go
@@ -1,0 +1,199 @@
+package main
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/jelmersnoeck/aiven"
+)
+
+func resourceServiceIntegration() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceServiceIntegrationCreate,
+		Read:   resourceServiceIntegrationRead,
+		Update: resourceServiceIntegrationUpdate,
+		Delete: resourceServiceIntegrationDelete,
+		Importer: &schema.ResourceImporter{
+			State: resourceServiceIntegrationState,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"destination_endpoint_id": {
+				Description: "Destination endpoint for the integration (if any)",
+				ForceNew:    true,
+				Optional:    true,
+				Type:        schema.TypeString,
+			},
+			"destination_service_name": {
+				Description: "Destination service for the integration (if any)",
+				ForceNew:    true,
+				Optional:    true,
+				Type:        schema.TypeString,
+			},
+			"integration_type": {
+				Description: "Type of the service integration",
+				ForceNew:    true,
+				Required:    true,
+				Type:        schema.TypeString,
+			},
+			"logs_user_config": {
+				Description: "Log integration specific user configurable settings",
+				Elem: &schema.Resource{
+					Schema: GenerateTerraformUserConfigSchema(
+						userConfigSchemas["integration"]["logs"].(map[string]interface{})),
+				},
+				MaxItems: 1,
+				Optional: true,
+				Type:     schema.TypeList,
+			},
+			"mirrormaker_user_config": {
+				Description: "Mirrormaker integration specific user configurable settings",
+				Elem: &schema.Resource{
+					Schema: GenerateTerraformUserConfigSchema(
+						userConfigSchemas["integration"]["mirrormaker"].(map[string]interface{})),
+				},
+				MaxItems: 1,
+				Optional: true,
+				Type:     schema.TypeList,
+			},
+			"project": {
+				Description: "Project the integration belongs to",
+				ForceNew:    true,
+				Required:    true,
+				Type:        schema.TypeString,
+			},
+			"source_endpoint_id": {
+				Description: "Source endpoint for the integration (if any)",
+				ForceNew:    true,
+				Optional:    true,
+				Type:        schema.TypeString,
+			},
+			"source_service_name": {
+				Description: "Source service for the integration (if any)",
+				ForceNew:    true,
+				Optional:    true,
+				Type:        schema.TypeString,
+			},
+		},
+	}
+}
+
+func plainEndpointID(fullEndpointID *string) *string {
+	if fullEndpointID == nil {
+		return nil
+	}
+	_, endpointID := splitResourceID2(*fullEndpointID)
+	return &endpointID
+}
+
+func resourceServiceIntegrationCreate(d *schema.ResourceData, m interface{}) error {
+	client := m.(*aiven.Client)
+	projectName := d.Get("project").(string)
+	integrationType := d.Get("integration_type").(string)
+	userConfig := ConvertTerraformUserConfigToAPICompatibleFormat("integration", integrationType, d)
+	integration, err := client.ServiceIntegrations.Create(
+		projectName,
+		aiven.CreateServiceIntegrationRequest{
+			DestinationEndpointID: plainEndpointID(optionalStringPointer(d, "destination_endpoint_id")),
+			DestinationService:    optionalStringPointer(d, "destination_service_name"),
+			IntegrationType:       integrationType,
+			SourceEndpointID:      plainEndpointID(optionalStringPointer(d, "source_endpoint_id")),
+			SourceService:         optionalStringPointer(d, "source_service_name"),
+			UserConfig:            userConfig,
+		},
+	)
+
+	if err != nil {
+		return err
+	}
+
+	d.SetId(buildResourceID(projectName, integration.ServiceIntegrationID))
+	return copyServiceIntegrationPropertiesFromAPIResponseToTerraform(d, integration, projectName)
+}
+
+func resourceServiceIntegrationRead(d *schema.ResourceData, m interface{}) error {
+	client := m.(*aiven.Client)
+
+	projectName, integrationID := splitResourceID2(d.Id())
+	integration, err := client.ServiceIntegrations.Get(projectName, integrationID)
+	if err != nil {
+		return err
+	}
+
+	return copyServiceIntegrationPropertiesFromAPIResponseToTerraform(d, integration, projectName)
+}
+
+func resourceServiceIntegrationUpdate(d *schema.ResourceData, m interface{}) error {
+	client := m.(*aiven.Client)
+
+	projectName, integrationID := splitResourceID2(d.Id())
+	integrationType := d.Get("integration_type").(string)
+	userConfig := ConvertTerraformUserConfigToAPICompatibleFormat("integration", integrationType, d)
+	integration, err := client.ServiceIntegrations.Update(
+		projectName,
+		integrationID,
+		aiven.UpdateServiceIntegrationRequest{
+			UserConfig: userConfig,
+		},
+	)
+	if err != nil {
+		return err
+	}
+
+	return copyServiceIntegrationPropertiesFromAPIResponseToTerraform(d, integration, projectName)
+}
+
+func resourceServiceIntegrationDelete(d *schema.ResourceData, m interface{}) error {
+	client := m.(*aiven.Client)
+
+	projectName, integrationID := splitResourceID2(d.Id())
+	return client.ServiceIntegrations.Delete(projectName, integrationID)
+}
+
+func resourceServiceIntegrationState(d *schema.ResourceData, m interface{}) ([]*schema.ResourceData, error) {
+	client := m.(*aiven.Client)
+
+	if len(strings.Split(d.Id(), "/")) != 2 {
+		return nil, fmt.Errorf("Invalid identifier %v, expected <project_name>/<integration_id>", d.Id())
+	}
+
+	projectName, integrationID := splitResourceID2(d.Id())
+	integration, err := client.ServiceIntegrations.Get(projectName, integrationID)
+	if err != nil {
+		return nil, err
+	}
+
+	err = copyServiceIntegrationPropertiesFromAPIResponseToTerraform(d, integration, projectName)
+	if err != nil {
+		return nil, err
+	}
+
+	return []*schema.ResourceData{d}, nil
+}
+
+func copyServiceIntegrationPropertiesFromAPIResponseToTerraform(
+	d *schema.ResourceData,
+	integration *aiven.ServiceIntegration,
+	project string,
+) error {
+	d.Set("project", project)
+	if integration.DestinationEndpointID != nil {
+		d.Set("destination_endpoint_id", buildResourceID(project, *integration.DestinationEndpointID))
+	} else if integration.DestinationService != nil {
+		d.Set("destination_service_name", *integration.DestinationService)
+	}
+	if integration.SourceEndpointID != nil {
+		d.Set("source_endpoint_id", buildResourceID(project, *integration.SourceEndpointID))
+	} else if integration.SourceService != nil {
+		d.Set("source_service_name", *integration.SourceService)
+	}
+	integrationType := integration.IntegrationType
+	d.Set("integration_type", integrationType)
+	userConfig := ConvertAPIUserConfigToTerraformCompatibleFormat("integration", integrationType, integration.UserConfig)
+	if userConfig != nil && len(userConfig) > 0 {
+		d.Set(integrationType+"_user_config", userConfig)
+	}
+
+	return nil
+}

--- a/resource_service_integration.go
+++ b/resource_service_integration.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/aiven/aiven-go-client"
 	"github.com/hashicorp/terraform/helper/schema"
-	"github.com/jelmersnoeck/aiven"
 )
 
 func resourceServiceIntegration() *schema.Resource {

--- a/resource_service_integration.go
+++ b/resource_service_integration.go
@@ -93,7 +93,7 @@ func resourceServiceIntegrationCreate(d *schema.ResourceData, m interface{}) err
 	client := m.(*aiven.Client)
 	projectName := d.Get("project").(string)
 	integrationType := d.Get("integration_type").(string)
-	userConfig := ConvertTerraformUserConfigToAPICompatibleFormat("integration", integrationType, d)
+	userConfig := ConvertTerraformUserConfigToAPICompatibleFormat("integration", integrationType, true, d)
 	integration, err := client.ServiceIntegrations.Create(
 		projectName,
 		aiven.CreateServiceIntegrationRequest{
@@ -131,7 +131,7 @@ func resourceServiceIntegrationUpdate(d *schema.ResourceData, m interface{}) err
 
 	projectName, integrationID := splitResourceID2(d.Id())
 	integrationType := d.Get("integration_type").(string)
-	userConfig := ConvertTerraformUserConfigToAPICompatibleFormat("integration", integrationType, d)
+	userConfig := ConvertTerraformUserConfigToAPICompatibleFormat("integration", integrationType, false, d)
 	integration, err := client.ServiceIntegrations.Update(
 		projectName,
 		integrationID,

--- a/resource_service_integration.go
+++ b/resource_service_integration.go
@@ -199,7 +199,11 @@ func copyServiceIntegrationPropertiesFromAPIResponseToTerraform(
 	}
 	integrationType := integration.IntegrationType
 	d.Set("integration_type", integrationType)
-	userConfig := ConvertAPIUserConfigToTerraformCompatibleFormat("integration", integrationType, integration.UserConfig)
+	userConfig := ConvertAPIUserConfigToTerraformCompatibleFormat(
+		"integration",
+		integrationType,
+		integration.UserConfig,
+	)
 	if userConfig != nil && len(userConfig) > 0 {
 		d.Set(integrationType+"_user_config", userConfig)
 	}

--- a/resource_service_integration.go
+++ b/resource_service_integration.go
@@ -14,6 +14,7 @@ func resourceServiceIntegration() *schema.Resource {
 		Read:   resourceServiceIntegrationRead,
 		Update: resourceServiceIntegrationUpdate,
 		Delete: resourceServiceIntegrationDelete,
+		Exists: resourceServiceIntegrationExists,
 		Importer: &schema.ResourceImporter{
 			State: resourceServiceIntegrationState,
 		},
@@ -149,6 +150,14 @@ func resourceServiceIntegrationDelete(d *schema.ResourceData, m interface{}) err
 
 	projectName, integrationID := splitResourceID2(d.Id())
 	return client.ServiceIntegrations.Delete(projectName, integrationID)
+}
+
+func resourceServiceIntegrationExists(d *schema.ResourceData, m interface{}) (bool, error) {
+	client := m.(*aiven.Client)
+
+	projectName, integrationID := splitResourceID2(d.Id())
+	_, err := client.ServiceIntegrations.Get(projectName, integrationID)
+	return resourceExists(err)
 }
 
 func resourceServiceIntegrationState(d *schema.ResourceData, m interface{}) ([]*schema.ResourceData, error) {

--- a/resource_service_integration.go
+++ b/resource_service_integration.go
@@ -205,7 +205,7 @@ func copyServiceIntegrationPropertiesFromAPIResponseToTerraform(
 		integrationType,
 		integration.UserConfig,
 	)
-	if userConfig != nil && len(userConfig) > 0 {
+	if len(userConfig) > 0 {
 		d.Set(integrationType+"_user_config", userConfig)
 	}
 

--- a/resource_service_integration_endpoint.go
+++ b/resource_service_integration_endpoint.go
@@ -1,3 +1,4 @@
+// Copyright (c) 2018 Aiven, Helsinki, Finland. https://aiven.io/
 package main
 
 import (

--- a/resource_service_integration_endpoint.go
+++ b/resource_service_integration_endpoint.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/aiven/aiven-go-client"
 	"github.com/hashicorp/terraform/helper/schema"
-	"github.com/jelmersnoeck/aiven"
 )
 
 func resourceServiceIntegrationEndpoint() *schema.Resource {

--- a/resource_service_integration_endpoint.go
+++ b/resource_service_integration_endpoint.go
@@ -143,7 +143,9 @@ func copyServiceIntegrationEndpointPropertiesFromAPIResponseToTerraform(
 	endpointType := endpoint.EndpointType
 	d.Set("endpoint_type", endpointType)
 	userConfig := ConvertAPIUserConfigToTerraformCompatibleFormat("endpoint", endpointType, endpoint.UserConfig)
-	d.Set(endpointType+"_user_config", userConfig)
+	if userConfig != nil && len(userConfig) > 0 {
+		d.Set(endpointType+"_user_config", userConfig)
+	}
 
 	return nil
 }

--- a/resource_service_integration_endpoint.go
+++ b/resource_service_integration_endpoint.go
@@ -1,0 +1,149 @@
+package main
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/jelmersnoeck/aiven"
+)
+
+func resourceServiceIntegrationEndpoint() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceServiceIntegrationEndpointCreate,
+		Read:   resourceServiceIntegrationEndpointRead,
+		Update: resourceServiceIntegrationEndpointUpdate,
+		Delete: resourceServiceIntegrationEndpointDelete,
+		Importer: &schema.ResourceImporter{
+			State: resourceServiceIntegrationEndpointState,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"project": {
+				Description: "Project the service integration endpoint belongs to",
+				ForceNew:    true,
+				Required:    true,
+				Type:        schema.TypeString,
+			},
+			"endpoint_name": {
+				ForceNew:    true,
+				Description: "Name of the service integration endpoint",
+				Required:    true,
+				Type:        schema.TypeString,
+			},
+			"endpoint_type": {
+				Description: "Type of the service integration endpoint",
+				ForceNew:    true,
+				Required:    true,
+				Type:        schema.TypeString,
+			},
+			"datadog_user_config": {
+				Description: "Datadog specific user configurable settings",
+				Elem: &schema.Resource{
+					Schema: GenerateTerraformUserConfigSchema(
+						userConfigSchemas["endpoint"]["datadog"].(map[string]interface{})),
+				},
+				MaxItems: 1,
+				Optional: true,
+				Type:     schema.TypeList,
+			},
+		},
+	}
+}
+
+func resourceServiceIntegrationEndpointCreate(d *schema.ResourceData, m interface{}) error {
+	client := m.(*aiven.Client)
+	projectName := d.Get("project").(string)
+	endpointType := d.Get("endpoint_type").(string)
+	userConfig := ConvertTerraformUserConfigToAPICompatibleFormat("endpoint", endpointType, d)
+	endpoint, err := client.ServiceIntegrationEndpoints.Create(
+		projectName,
+		aiven.CreateServiceIntegrationEndpointRequest{
+			EndpointName: d.Get("endpoint_name").(string),
+			EndpointType: endpointType,
+			UserConfig:   userConfig,
+		},
+	)
+
+	if err != nil {
+		return err
+	}
+
+	d.SetId(buildResourceID(projectName, endpoint.EndpointID))
+	return copyServiceIntegrationEndpointPropertiesFromAPIResponseToTerraform(d, endpoint, projectName)
+}
+
+func resourceServiceIntegrationEndpointRead(d *schema.ResourceData, m interface{}) error {
+	client := m.(*aiven.Client)
+
+	projectName, endpointID := splitResourceID2(d.Id())
+	endpoint, err := client.ServiceIntegrationEndpoints.Get(projectName, endpointID)
+	if err != nil {
+		return err
+	}
+
+	return copyServiceIntegrationEndpointPropertiesFromAPIResponseToTerraform(d, endpoint, projectName)
+}
+
+func resourceServiceIntegrationEndpointUpdate(d *schema.ResourceData, m interface{}) error {
+	client := m.(*aiven.Client)
+
+	projectName, endpointID := splitResourceID2(d.Id())
+	endpointType := d.Get("endpoint_type").(string)
+	userConfig := ConvertTerraformUserConfigToAPICompatibleFormat("endpoint", endpointType, d)
+	endpoint, err := client.ServiceIntegrationEndpoints.Update(
+		projectName,
+		endpointID,
+		aiven.UpdateServiceIntegrationEndpointRequest{
+			UserConfig: userConfig,
+		},
+	)
+	if err != nil {
+		return err
+	}
+
+	return copyServiceIntegrationEndpointPropertiesFromAPIResponseToTerraform(d, endpoint, projectName)
+}
+
+func resourceServiceIntegrationEndpointDelete(d *schema.ResourceData, m interface{}) error {
+	client := m.(*aiven.Client)
+
+	projectName, endpointID := splitResourceID2(d.Id())
+	return client.ServiceIntegrationEndpoints.Delete(projectName, endpointID)
+}
+
+func resourceServiceIntegrationEndpointState(d *schema.ResourceData, m interface{}) ([]*schema.ResourceData, error) {
+	client := m.(*aiven.Client)
+
+	if len(strings.Split(d.Id(), "/")) != 2 {
+		return nil, fmt.Errorf("Invalid identifier %v, expected <project_name>/<endpoint_id>", d.Id())
+	}
+
+	projectName, endpointID := splitResourceID2(d.Id())
+	endpoint, err := client.ServiceIntegrationEndpoints.Get(projectName, endpointID)
+	if err != nil {
+		return nil, err
+	}
+
+	err = copyServiceIntegrationEndpointPropertiesFromAPIResponseToTerraform(d, endpoint, projectName)
+	if err != nil {
+		return nil, err
+	}
+
+	return []*schema.ResourceData{d}, nil
+}
+
+func copyServiceIntegrationEndpointPropertiesFromAPIResponseToTerraform(
+	d *schema.ResourceData,
+	endpoint *aiven.ServiceIntegrationEndpoint,
+	project string,
+) error {
+	d.Set("project", project)
+	d.Set("endpoint_name", endpoint.EndpointName)
+	endpointType := endpoint.EndpointType
+	d.Set("endpoint_type", endpointType)
+	userConfig := ConvertAPIUserConfigToTerraformCompatibleFormat("endpoint", endpointType, endpoint.UserConfig)
+	d.Set(endpointType+"_user_config", userConfig)
+
+	return nil
+}

--- a/resource_service_integration_endpoint.go
+++ b/resource_service_integration_endpoint.go
@@ -14,6 +14,7 @@ func resourceServiceIntegrationEndpoint() *schema.Resource {
 		Read:   resourceServiceIntegrationEndpointRead,
 		Update: resourceServiceIntegrationEndpointUpdate,
 		Delete: resourceServiceIntegrationEndpointDelete,
+		Exists: resourceServiceIntegrationEndpointExists,
 		Importer: &schema.ResourceImporter{
 			State: resourceServiceIntegrationEndpointState,
 		},
@@ -110,6 +111,14 @@ func resourceServiceIntegrationEndpointDelete(d *schema.ResourceData, m interfac
 
 	projectName, endpointID := splitResourceID2(d.Id())
 	return client.ServiceIntegrationEndpoints.Delete(projectName, endpointID)
+}
+
+func resourceServiceIntegrationEndpointExists(d *schema.ResourceData, m interface{}) (bool, error) {
+	client := m.(*aiven.Client)
+
+	projectName, endpointID := splitResourceID2(d.Id())
+	_, err := client.ServiceIntegrationEndpoints.Get(projectName, endpointID)
+	return resourceExists(err)
 }
 
 func resourceServiceIntegrationEndpointState(d *schema.ResourceData, m interface{}) ([]*schema.ResourceData, error) {

--- a/resource_service_integration_endpoint.go
+++ b/resource_service_integration_endpoint.go
@@ -153,7 +153,7 @@ func copyServiceIntegrationEndpointPropertiesFromAPIResponseToTerraform(
 	endpointType := endpoint.EndpointType
 	d.Set("endpoint_type", endpointType)
 	userConfig := ConvertAPIUserConfigToTerraformCompatibleFormat("endpoint", endpointType, endpoint.UserConfig)
-	if userConfig != nil && len(userConfig) > 0 {
+	if len(userConfig) > 0 {
 		d.Set(endpointType+"_user_config", userConfig)
 	}
 

--- a/resource_service_integration_endpoint.go
+++ b/resource_service_integration_endpoint.go
@@ -57,7 +57,7 @@ func resourceServiceIntegrationEndpointCreate(d *schema.ResourceData, m interfac
 	client := m.(*aiven.Client)
 	projectName := d.Get("project").(string)
 	endpointType := d.Get("endpoint_type").(string)
-	userConfig := ConvertTerraformUserConfigToAPICompatibleFormat("endpoint", endpointType, d)
+	userConfig := ConvertTerraformUserConfigToAPICompatibleFormat("endpoint", endpointType, true, d)
 	endpoint, err := client.ServiceIntegrationEndpoints.Create(
 		projectName,
 		aiven.CreateServiceIntegrationEndpointRequest{
@@ -92,7 +92,7 @@ func resourceServiceIntegrationEndpointUpdate(d *schema.ResourceData, m interfac
 
 	projectName, endpointID := splitResourceID2(d.Id())
 	endpointType := d.Get("endpoint_type").(string)
-	userConfig := ConvertTerraformUserConfigToAPICompatibleFormat("endpoint", endpointType, d)
+	userConfig := ConvertTerraformUserConfigToAPICompatibleFormat("endpoint", endpointType, false, d)
 	endpoint, err := client.ServiceIntegrationEndpoints.Update(
 		projectName,
 		endpointID,

--- a/resource_service_user.go
+++ b/resource_service_user.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/aiven/aiven-go-client"
 	"github.com/hashicorp/terraform/helper/schema"
-	"github.com/jelmersnoeck/aiven"
 )
 
 func resourceServiceUser() *schema.Resource {

--- a/resource_service_user.go
+++ b/resource_service_user.go
@@ -1,3 +1,5 @@
+// Copyright (c) 2017 jelmersnoeck
+// Copyright (c) 2018 Aiven, Helsinki, Finland. https://aiven.io/
 package main
 
 import (

--- a/resource_service_user.go
+++ b/resource_service_user.go
@@ -1,7 +1,8 @@
 package main
 
 import (
-	"errors"
+	"fmt"
+	"strings"
 
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/jelmersnoeck/aiven"
@@ -12,6 +13,10 @@ func resourceServiceUser() *schema.Resource {
 		Create: resourceServiceUserCreate,
 		Read:   resourceServiceUserRead,
 		Delete: resourceServiceUserDelete,
+		Exists: resourceServiceUserExists,
+		Importer: &schema.ResourceImporter{
+			State: resourceServiceUserState,
+		},
 
 		Schema: map[string]*schema.Schema{
 			"project": {
@@ -29,27 +34,31 @@ func resourceServiceUser() *schema.Resource {
 			"username": {
 				Type:        schema.TypeString,
 				Required:    true,
-				Description: "Service username",
+				Description: "Name of the user account",
 				ForceNew:    true,
 			},
 			"type": {
-				Type:     schema.TypeString,
-				Computed: true,
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Type of the user account",
 			},
 			"password": {
-				Type:      schema.TypeString,
-				Sensitive: true,
-				Computed:  true,
+				Type:        schema.TypeString,
+				Sensitive:   true,
+				Computed:    true,
+				Description: "Password of the user",
 			},
 			"access_cert": {
-				Type:      schema.TypeString,
-				Sensitive: true,
-				Computed:  true,
+				Type:        schema.TypeString,
+				Sensitive:   true,
+				Computed:    true,
+				Description: "Access certificate for the user if applicable for the service in question",
 			},
 			"access_key": {
-				Type:      schema.TypeString,
-				Sensitive: true,
-				Computed:  true,
+				Type:        schema.TypeString,
+				Sensitive:   true,
+				Computed:    true,
+				Description: "Access certificate key for the user if applicable for the service in question",
 			},
 		},
 	}
@@ -58,61 +67,84 @@ func resourceServiceUser() *schema.Resource {
 func resourceServiceUserCreate(d *schema.ResourceData, m interface{}) error {
 	client := m.(*aiven.Client)
 
+	projectName := d.Get("project").(string)
+	serviceName := d.Get("service_name").(string)
+	username := d.Get("username").(string)
 	user, err := client.ServiceUsers.Create(
-		d.Get("project").(string),
-		d.Get("service_name").(string),
+		projectName,
+		serviceName,
 		aiven.CreateServiceUserRequest{
-			Username: d.Get("username").(string),
+			Username: username,
 		},
 	)
 	if err != nil {
-		d.SetId("")
 		return err
 	}
 
-	d.SetId(user.Username + "!")
+	d.SetId(buildResourceID(projectName, serviceName, username))
+	return copyServiceUserPropertiesFromAPIResponseToTerraform(d, user, projectName, serviceName)
+}
 
+func copyServiceUserPropertiesFromAPIResponseToTerraform(
+	d *schema.ResourceData,
+	user *aiven.ServiceUser,
+	projectName string,
+	serviceName string,
+) error {
+	d.Set("project", projectName)
+	d.Set("service_name", serviceName)
 	d.Set("username", user.Username)
 	d.Set("password", user.Password)
 	d.Set("type", user.Type)
 	d.Set("access_cert", user.AccessCert)
 	d.Set("access_key", user.AccessKey)
-
 	return nil
 }
 
 func resourceServiceUserRead(d *schema.ResourceData, m interface{}) error {
 	client := m.(*aiven.Client)
 
-	service, err := client.Services.Get(
-		d.Get("project").(string),
-		d.Get("service_name").(string),
-	)
+	projectName, serviceName, username := splitResourceID3(d.Id())
+	user, err := client.ServiceUsers.Get(projectName, serviceName, username)
 	if err != nil {
 		return err
 	}
 
-	username := d.Get("username").(string)
-	for _, user := range service.Users {
-		if user.Username == username {
-			d.Set("username", user.Username)
-			d.Set("password", user.Password)
-			d.Set("type", user.Type)
-			d.Set("access_cert", user.AccessCert)
-			d.Set("access_key", user.AccessKey)
-			return nil
-		}
-	}
-
-	return errors.New("User not found")
+	return copyServiceUserPropertiesFromAPIResponseToTerraform(d, user, projectName, serviceName)
 }
 
 func resourceServiceUserDelete(d *schema.ResourceData, m interface{}) error {
 	client := m.(*aiven.Client)
 
-	return client.ServiceUsers.Delete(
-		d.Get("project").(string),
-		d.Get("service_name").(string),
-		d.Get("username").(string),
-	)
+	projectName, serviceName, username := splitResourceID3(d.Id())
+	return client.ServiceUsers.Delete(projectName, serviceName, username)
+}
+
+func resourceServiceUserExists(d *schema.ResourceData, m interface{}) (bool, error) {
+	client := m.(*aiven.Client)
+
+	projectName, serviceName, username := splitResourceID3(d.Id())
+	_, err := client.ServiceUsers.Get(projectName, serviceName, username)
+	return resourceExists(err)
+}
+
+func resourceServiceUserState(d *schema.ResourceData, m interface{}) ([]*schema.ResourceData, error) {
+	client := m.(*aiven.Client)
+
+	if len(strings.Split(d.Id(), "/")) != 3 {
+		return nil, fmt.Errorf("Invalid identifier %v, expected <project_name>/<service_name>/<username>", d.Id())
+	}
+
+	projectName, serviceName, username := splitResourceID3(d.Id())
+	user, err := client.ServiceUsers.Get(projectName, serviceName, username)
+	if err != nil {
+		return nil, err
+	}
+
+	err = copyServiceUserPropertiesFromAPIResponseToTerraform(d, user, projectName, serviceName)
+	if err != nil {
+		return nil, err
+	}
+
+	return []*schema.ResourceData{d}, nil
 }

--- a/resource_vpc_peering_connection.go
+++ b/resource_vpc_peering_connection.go
@@ -1,3 +1,4 @@
+// Copyright (c) 2018 Aiven, Helsinki, Finland. https://aiven.io/
 package main
 
 import (

--- a/resource_vpc_peering_connection.go
+++ b/resource_vpc_peering_connection.go
@@ -1,0 +1,121 @@
+package main
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/jelmersnoeck/aiven"
+)
+
+func resourceVPCPeeringConnection() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceVPCPeeringConnectionCreate,
+		Read:   resourceVPCPeeringConnectionRead,
+		Delete: resourceVPCPeeringConnectionDelete,
+		Exists: resourceVPCPeeringConnectionExists,
+		Importer: &schema.ResourceImporter{
+			State: resourceVPCPeeringConnectionState,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"vpc_id": {
+				Description: "The VPC the peering connection belongs to",
+				ForceNew:    true,
+				Required:    true,
+				Type:        schema.TypeString,
+			},
+			"peer_cloud_account": {
+				Description: "AWS account ID or GCP project ID of the peered VPC",
+				ForceNew:    true,
+				Required:    true,
+				Type:        schema.TypeString,
+			},
+			"peer_vpc": {
+				Description: "AWS VPC ID or GCP VPC network name of the peered VPC",
+				ForceNew:    true,
+				Required:    true,
+				Type:        schema.TypeString,
+			},
+			"state": {
+				Computed:    true,
+				Description: "State of the peering connection",
+				Type:        schema.TypeString,
+			},
+		},
+	}
+}
+
+func resourceVPCPeeringConnectionCreate(d *schema.ResourceData, m interface{}) error {
+	client := m.(*aiven.Client)
+	projectName, vpcID := splitResourceID2(d.Get("vpc_id").(string))
+	pc, err := client.VPCPeeringConnections.Create(
+		projectName,
+		vpcID,
+		aiven.CreateVPCPeeringConnectionRequest{
+			PeerCloudAccount: d.Get("peer_cloud_account").(string),
+			PeerVPC:          d.Get("peer_vpc").(string),
+		},
+	)
+
+	if err != nil {
+		return err
+	}
+
+	d.SetId(buildResourceID(projectName, vpcID, pc.PeerCloudAccount, pc.PeerVPC))
+	return copyVPCPeeringConnectionPropertiesFromAPIResponseToTerraform(d, pc, projectName, vpcID)
+}
+
+func resourceVPCPeeringConnectionRead(d *schema.ResourceData, m interface{}) error {
+	client := m.(*aiven.Client)
+
+	projectName, vpcID, peerCloudAccount, peerVPC := splitResourceID4(d.Id())
+	pc, err := client.VPCPeeringConnections.Get(projectName, vpcID, peerCloudAccount, peerVPC)
+	if err != nil {
+		return err
+	}
+
+	return copyVPCPeeringConnectionPropertiesFromAPIResponseToTerraform(d, pc, projectName, vpcID)
+}
+
+func resourceVPCPeeringConnectionDelete(d *schema.ResourceData, m interface{}) error {
+	client := m.(*aiven.Client)
+
+	projectName, vpcID, peerCloudAccount, peerVPC := splitResourceID4(d.Id())
+	return client.VPCPeeringConnections.Delete(projectName, vpcID, peerCloudAccount, peerVPC)
+}
+
+func resourceVPCPeeringConnectionExists(d *schema.ResourceData, m interface{}) (bool, error) {
+	client := m.(*aiven.Client)
+
+	projectName, vpcID, peerCloudAccount, peerVPC := splitResourceID4(d.Id())
+	_, err := client.VPCPeeringConnections.Get(projectName, vpcID, peerCloudAccount, peerVPC)
+	return resourceExists(err)
+}
+
+func resourceVPCPeeringConnectionState(d *schema.ResourceData, m interface{}) ([]*schema.ResourceData, error) {
+	if len(strings.Split(d.Id(), "/")) != 4 {
+		return nil, fmt.Errorf("Invalid identifier %v, expected <project_name>/<vpc_id>", d.Id())
+	}
+
+	err := resourceVPCPeeringConnectionRead(d, m)
+	if err != nil {
+		return nil, err
+	}
+
+	return []*schema.ResourceData{d}, nil
+}
+
+func copyVPCPeeringConnectionPropertiesFromAPIResponseToTerraform(
+	d *schema.ResourceData,
+	peeringConnection *aiven.VPCPeeringConnection,
+	project string,
+	vpcID string,
+) error {
+	d.Set("vpc_id", buildResourceID(project, vpcID))
+	d.Set("peer_cloud_account", peeringConnection.PeerCloudAccount)
+	d.Set("peer_vpc", peeringConnection.PeerVPC)
+	d.Set("state", peeringConnection.State)
+
+	return nil
+}

--- a/resource_vpc_peering_connection.go
+++ b/resource_vpc_peering_connection.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/aiven/aiven-go-client"
 	"github.com/hashicorp/terraform/helper/schema"
-	"github.com/jelmersnoeck/aiven"
 )
 
 func resourceVPCPeeringConnection() *schema.Resource {

--- a/sample.tf
+++ b/sample.tf
@@ -29,7 +29,6 @@ resource "aiven_service" "samplekafka" {
 	service_name = "samplekafka"
 	service_type = "kafka"
 	kafka_user_config {
-		ip_filter = ["0.0.0.0/0"]
 		kafka_connect = true
 		kafka_rest = true
 		kafka_version = "2.0"
@@ -94,14 +93,10 @@ resource "aiven_service" "samplepg" {
 	service_name = "samplepg"
 	service_type = "pg"
 	pg_user_config {
-		ip_filter = ["0.0.0.0/0"]
 		pg {
 			idle_in_transaction_session_timeout = 900
 		}
 		pg_version = "10"
-		pglookout {
-			max_failover_replication_time_lag = 60
-		}
 	}
 }
 

--- a/sample.tf
+++ b/sample.tf
@@ -57,6 +57,15 @@ resource "aiven_service_user" "kafka_a" {
 	username = "kafka_a"
 }
 
+# ACL for Kafka
+resource "aiven_kafka_acl" "sample_acl" {
+	project = "${aiven_project.sample.project}"
+        service_name = "${aiven_service.samplekafka.service_name}"
+	username = "kafka_*"
+	permission = "read"
+	topic = "*"
+}
+
 # InfluxDB service
 resource "aiven_service" "sampleinflux" {
 	project = "${aiven_project.sample.project}"

--- a/sample.tf
+++ b/sample.tf
@@ -127,6 +127,15 @@ resource "aiven_service_user" "sample_user" {
 	username = "sampleuser"
 }
 
+# PostgreSQL connection pool
+resource "aiven_connection_pool" "sample_pool" {
+	project = "${aiven_project.sample.project}"
+	service_name = "${aiven_service.samplepg.service_name}"
+	database_name = "${aiven_database.sample_db.database_name}"
+	pool_name = "samplepool"
+	username = "${aiven_service_user.sample_user.username}"
+}
+
 # Grafana service
 resource "aiven_service" "samplegrafana" {
 	project = "${aiven_project.sample.project}"

--- a/sample.tf
+++ b/sample.tf
@@ -1,35 +1,139 @@
-variable "aiven_email" {}
-variable "aiven_password" {}
+variable "aiven_api_token" {}
 variable "aiven_card_id" {}
+variable "aiven_project_name" {}
 
+# Initialize provider. No other config options than api_token
 provider "aiven" {
-	email       = "${var.aiven_email}"
-	password    = "${var.aiven_password}"
+	api_token = "${var.aiven_api_token}"
 }
 
+# Project
 resource "aiven_project" "sample" {
-    project = "sample"
+    project = "${var.aiven_project_name}"
     card_id = "${var.aiven_card_id}"
-    cloud = "google-europe-west1"
 }
 
-resource "aiven_service" "postgresql" {
+# VPC for the project in AWS ap-south-1 region. Should also
+# define peering connection(s) to make this useful.
+resource "aiven_project_vpc" "vpc_aws_ap_south_1" {
 	project = "${aiven_project.sample.project}"
-	group_name = "test"
-    cloud = "google-europe-west1"
-	plan = "hobbyist"
-	service_name = "test-postgresql"
+	cloud_name = "aws-ap-south-1"
+	network_cidr = "192.168.0.0/24"
+}
+
+# Kafka service
+resource "aiven_service" "samplekafka" {
+	project = "${aiven_project.sample.project}"
+	cloud_name = "google-europe-west1"
+	plan = "business-4"
+	service_name = "samplekafka"
+	service_type = "kafka"
+	kafka_user_config {
+		ip_filter = ["0.0.0.0/0"]
+		kafka_connect = true
+		kafka_rest = true
+		kafka_version = "2.0"
+		kafka {
+			group_max_session_timeout_ms = 70000
+			log_retention_bytes = 1000000000
+		}
+	}
+}
+
+# Topic for Kafka
+resource "aiven_kafka_topic" "sample_topic" {
+	project = "${aiven_project.sample.project}"
+	service_name = "${aiven_service.samplekafka.service_name}"
+	topic_name = "sample_topic"
+	partitions = 3
+	replication = 2
+	retention_bytes = 1000000000
+}
+
+# User for Kafka
+resource "aiven_service_user" "kafka_a" {
+	project = "${aiven_project.sample.project}"
+	service_name = "${aiven_service.samplekafka.service_name}"
+	username = "kafka_a"
+}
+
+# InfluxDB service
+resource "aiven_service" "sampleinflux" {
+	project = "${aiven_project.sample.project}"
+	cloud_name = "google-europe-west1"
+	plan = "startup-4"
+	service_name = "sampleinflux"
+	service_type = "influxdb"
+	influxdb_user_config {
+		ip_filter = ["0.0.0.0/0"]
+	}
+}
+
+# Send metrics from Kafka to InfluxDB
+resource "aiven_service_integration" "samplekafka_metrics" {
+	project = "${aiven_project.sample.project}"
+	integration_type = "metrics"
+	source_service_name = "${aiven_service.samplekafka.service_name}"
+	destination_service_name = "${aiven_service.sampleinflux.service_name}"
+}
+
+# PostreSQL service
+resource "aiven_service" "samplepg" {
+	project = "${aiven_project.sample.project}"
+	cloud_name = "google-europe-west1"
+	plan = "business-4"
+	service_name = "samplepg"
 	service_type = "pg"
+	pg_user_config {
+		ip_filter = ["0.0.0.0/0"]
+		pg {
+			idle_in_transaction_session_timeout = 900
+		}
+		pg_version = "10"
+		pglookout {
+			max_failover_replication_time_lag = 60
+		}
+	}
 }
 
-resource "aiven_database" "postgresql" {
-	project = "${aiven_service.postgresql.project}"
-	service_name = "${aiven_service.postgresql.service_name}"
-	database = "coda"
+# Send metrics from PostgreSQL to InfluxDB
+resource "aiven_service_integration" "samplepg_metrics" {
+	project = "${aiven_project.sample.project}"
+	integration_type = "metrics"
+	source_service_name = "${aiven_service.samplepg.service_name}"
+	destination_service_name = "${aiven_service.sampleinflux.service_name}"
 }
 
-resource "aiven_service_user" "postgresql" {
-	project = "${aiven_service.postgresql.project}"
-	service_name = "${aiven_database.postgresql.service_name}"
-	username = "codabox"
+# PostgreSQL database
+resource "aiven_database" "sample_db" {
+	project = "${aiven_project.sample.project}"
+	service_name = "${aiven_service.samplepg.service_name}"
+	database_name = "sample_db"
+}
+
+# PostgreSQL user
+resource "aiven_service_user" "sample_user" {
+	project = "${aiven_project.sample.project}"
+	service_name = "${aiven_service.samplepg.service_name}"
+	username = "sampleuser"
+}
+
+# Grafana service
+resource "aiven_service" "samplegrafana" {
+	project = "${aiven_project.sample.project}"
+	cloud_name = "google-europe-west1"
+	plan = "startup-4"
+	service_name = "samplegrafana"
+	service_type = "grafana"
+	grafana_user_config {
+		ip_filter = ["0.0.0.0/0"]
+	}
+}
+
+# Dashboards for Kafka and PostgreSQL services
+resource "aiven_service_integration" "samplegrafana_dashboards" {
+	project = "${aiven_project.sample.project}"
+	integration_type = "dashboard"
+	source_service_name = "${aiven_service.samplegrafana.service_name}"
+	destination_service_name = "${aiven_service.sampleinflux.service_name}"
 }

--- a/service_change.go
+++ b/service_change.go
@@ -95,7 +95,7 @@ func (w *ServiceChangeWaiter) Conf() *resource.StateChangeConf {
 		Refresh: w.RefreshFunc(),
 	}
 	state.Delay = 10 * time.Second
-	state.Timeout = 10 * time.Minute
+	state.Timeout = 20 * time.Minute
 	state.MinTimeout = 2 * time.Second
 
 	return state

--- a/service_change.go
+++ b/service_change.go
@@ -78,7 +78,8 @@ func kafkaServicesReady(service *aiven.Service) bool {
 }
 
 func backupsReady(service *aiven.Service) bool {
-	if service.Type != "pg" {
+	if service.Type != "pg" && service.Type != "elasticsearch" &&
+		service.Type != "redis" && service.Type != "influxdb" {
 		return true
 	}
 

--- a/service_change.go
+++ b/service_change.go
@@ -5,8 +5,8 @@ import (
 
 	"net/http"
 
+	"github.com/aiven/aiven-go-client"
 	"github.com/hashicorp/terraform/helper/resource"
-	"github.com/jelmersnoeck/aiven"
 )
 
 // ServiceChangeWaiter is used to refresh the Aiven Service endpoints when

--- a/service_change.go
+++ b/service_change.go
@@ -1,3 +1,5 @@
+// Copyright (c) 2017 jelmersnoeck
+// Copyright (c) 2018 Aiven, Helsinki, Finland. https://aiven.io/
 package main
 
 import (

--- a/service_change.go
+++ b/service_change.go
@@ -3,10 +3,11 @@ package main
 import (
 	"time"
 
-	"github.com/hashicorp/terraform/helper/resource"
-	"github.com/jelmersnoeck/aiven"
 	"log"
 	"net/http"
+
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/jelmersnoeck/aiven"
 )
 
 // ServiceChangeWaiter is used to refresh the Aiven Service endpoints when
@@ -57,7 +58,7 @@ func kafkaServicesReady(service *aiven.Service) bool {
 		return false
 	}
 
-	userConfig := service.UserConfig.(map[string]interface{})
+	userConfig := service.UserConfig
 
 	ready := true
 	if enabled, ok := userConfig["kafka_rest"]; ok && enabled.(bool) {

--- a/templates/integration_endpoints_user_config_schema.json
+++ b/templates/integration_endpoints_user_config_schema.json
@@ -1,0 +1,30 @@
+{
+  "datadog": {
+    "additionalProperties": false,
+    "properties": {
+      "datadog_api_key": {
+        "example": "848f30907c15c55d601fe45487cce9b6",
+        "maxLength": 32,
+        "minLength": 32,
+        "title": "Datadog API key",
+        "type": "string"
+      },
+      "disable_consumer_stats": {
+        "example": true,
+        "title": "Disable consumer group metrics",
+        "type": "boolean"
+      },
+      "max_partition_contexts": {
+        "example": 32000,
+        "maximum": 200000,
+        "minimum": 200,
+        "title": "Maximum number of partition contexts to send",
+        "type": "integer"
+      }
+    },
+    "required": [
+      "datadog_api_key"
+    ],
+    "type": "object"
+  }
+}

--- a/templates/integrations_user_config_schema.json
+++ b/templates/integrations_user_config_schema.json
@@ -1,0 +1,53 @@
+{
+  "dashboard": {
+    "additionalProperties": true,
+    "title": "Integration user config",
+    "type": "object"
+  },
+  "datadog": {
+    "additionalProperties": true,
+    "title": "Integration user config",
+    "type": "object"
+  },
+  "logs": {
+    "additionalProperties": false,
+    "properties": {
+      "elasticsearch_index_days_max": {
+        "default": 3,
+        "example": 5,
+        "maximum": 100,
+        "minimum": 1,
+        "title": "Elasticsearch index retention limit",
+        "type": "integer"
+      },
+      "elasticsearch_index_prefix": {
+        "default": "logs",
+        "example": "logs",
+        "maxLength": 1000,
+        "minLength": 1,
+        "title": "Elasticsearch index prefix",
+        "type": "string"
+      }
+    },
+    "type": "object"
+  },
+  "metrics": {
+    "additionalProperties": true,
+    "title": "Integration user config",
+    "type": "object"
+  },
+  "mirrormaker": {
+    "additionalProperties": false,
+    "properties": {
+      "mirrormaker_whitelist": {
+        "default": ".*",
+        "example": ".*",
+        "maxLength": 1000,
+        "minLength": 1,
+        "title": "Mirrormaker topic whitelist",
+        "type": "string"
+      }
+    },
+    "type": "object"
+  }
+}

--- a/templates/service_user_config_schema.json
+++ b/templates/service_user_config_schema.json
@@ -1,0 +1,982 @@
+{
+  "cassandra": {
+    "additionalProperties": false,
+    "properties": {
+      "ip_filter": {
+        "default": [
+          "0.0.0.0/0"
+        ],
+        "items": {
+          "example": "10.20.0.0/16",
+          "title": "CIDR address block",
+          "type": "string"
+        },
+        "maxItems": 100,
+        "title": "Allow incoming connections from CIDR address block, e.g. '10.20.0.0/16'",
+        "type": "array"
+      }
+    },
+    "type": "object"
+  },
+  "elasticsearch": {
+    "additionalProperties": false,
+    "properties": {
+      "custom_domain": {
+        "default": null,
+        "example": "grafana.example.org",
+        "title": "Serve the web frontend using a custom CNAME pointing to the Aiven DNS name",
+        "type": [
+          "string",
+          "null"
+        ]
+      },
+      "elasticsearch_version": {
+        "enum": [
+          "2",
+          "5",
+          "6"
+        ],
+        "title": "Elasticsearch major version",
+        "type": [
+          "string",
+          "null"
+        ]
+      },
+      "ip_filter": {
+        "default": [
+          "0.0.0.0/0"
+        ],
+        "items": {
+          "example": "10.20.0.0/16",
+          "title": "CIDR address block",
+          "type": "string"
+        },
+        "maxItems": 100,
+        "title": "Allow incoming connections from CIDR address block, e.g. '10.20.0.0/16'",
+        "type": "array"
+      },
+      "max_index_count": {
+        "default": 0,
+        "maximum": 9223372036854776000,
+        "minimum": 0,
+        "title": "Maximum number of indexes to keep before deleting the oldest one",
+        "type": "integer"
+      }
+    },
+    "type": "object"
+  },
+  "grafana": {
+    "additionalProperties": false,
+    "properties": {
+      "auth_github": {
+        "additionalProperties": false,
+        "properties": {
+          "allow_sign_up": {
+            "example": false,
+            "title": "Automatically sign-up users on successful sign-in",
+            "type": "boolean"
+          },
+          "allowed_organizations": {
+            "items": {
+              "example": "aiven",
+              "pattern": "^[a-z0-9-]+$",
+              "title": "Organization name",
+              "type": "string"
+            },
+            "title": "Require users to belong to one of given organizations",
+            "type": "array"
+          },
+          "client_id": {
+            "example": "b1ba0bf54a4c2c0a1c29",
+            "pattern": "^[a-zA-Z0-9-/=\\.]+$",
+            "title": "Client ID from provider",
+            "type": "string"
+          },
+          "client_secret": {
+            "example": "bfa6gea4f129076761dcba8ce5e1e406bd83af7b",
+            "pattern": "^[a-zA-Z0-9-/=]+$",
+            "title": "Client secret from provider",
+            "type": "string"
+          },
+          "team_ids": {
+            "items": {
+              "example": 150,
+              "maximum": 9223372036854776000,
+              "minimum": 1,
+              "title": "Team ID",
+              "type": "integer"
+            },
+            "title": "Require users to belong to one of given team IDs",
+            "type": "array"
+          }
+        },
+        "required": [
+          "client_id",
+          "client_secret"
+        ],
+        "title": "Github Auth integration",
+        "type": "object"
+      },
+      "auth_gitlab": {
+        "additionalProperties": false,
+        "properties": {
+          "allow_sign_up": {
+            "example": false,
+            "title": "Automatically sign-up users on successful sign-in",
+            "type": "boolean"
+          },
+          "allowed_groups": {
+            "items": {
+              "example": "aiven/developers",
+              "pattern": "^[a-z0-9-_/]+$",
+              "title": "Group or subgroup name",
+              "type": "string"
+            },
+            "title": "Require users to belong to one of given groups",
+            "type": "array"
+          },
+          "client_id": {
+            "example": "b1ba0bf54a4c2c0a1c29",
+            "pattern": "^[a-zA-Z0-9-/=\\.]+$",
+            "title": "Client ID from provider",
+            "type": "string"
+          },
+          "client_secret": {
+            "example": "bfa6gea4f129076761dcba8ce5e1e406bd83af7b",
+            "pattern": "^[a-zA-Z0-9-/=]+$",
+            "title": "Client secret from provider",
+            "type": "string"
+          }
+        },
+        "required": [
+          "client_id",
+          "client_secret",
+          "allowed_groups"
+        ],
+        "title": "GitLab Auth integration",
+        "type": "object"
+      },
+      "auth_google": {
+        "additionalProperties": false,
+        "properties": {
+          "allow_sign_up": {
+            "example": false,
+            "title": "Automatically sign-up users on successful sign-in",
+            "type": "boolean"
+          },
+          "allowed_domains": {
+            "items": {
+              "example": "aiven.io",
+              "pattern": "^(\\w+(-\\w+)*\\.)+([a-zA-Z]{2,}|xn--[a-zA-Z0-9]+)$",
+              "title": "Domain",
+              "type": "string"
+            },
+            "title": "Domains allowed to sign-in to this Grafana",
+            "type": "array"
+          },
+          "client_id": {
+            "example": "b1ba0bf54a4c2c0a1c29",
+            "pattern": "^[a-zA-Z0-9-/=\\.]+$",
+            "title": "Client ID from provider",
+            "type": "string"
+          },
+          "client_secret": {
+            "example": "bfa6gea4f129076761dcba8ce5e1e406bd83af7b",
+            "pattern": "^[a-zA-Z0-9-/=]+$",
+            "title": "Client secret from provider",
+            "type": "string"
+          }
+        },
+        "required": [
+          "client_id",
+          "client_secret",
+          "allowed_domains"
+        ],
+        "title": "Google Auth integration",
+        "type": "object"
+      },
+      "custom_domain": {
+        "default": null,
+        "example": "grafana.example.org",
+        "title": "Serve the web frontend using a custom CNAME pointing to the Aiven DNS name",
+        "type": [
+          "string",
+          "null"
+        ]
+      },
+      "external_image_storage": {
+        "additionalProperties": false,
+        "properties": {
+          "access_key": {
+            "example": "AAAAAAAAAAAAAAAAAAAA",
+            "title": "S3 access key. Requires permissions to the S3 bucket for the s3:PutObject and s3:PutObjectAcl actions",
+            "type": "string"
+          },
+          "bucket_url": {
+            "example": "https://grafana.s3-ap-southeast-2.amazonaws.com/",
+            "title": "Bucket URL for S3",
+            "type": "string"
+          },
+          "provider": {
+            "enum": [
+              "s3"
+            ],
+            "title": "Provider type",
+            "type": "string"
+          },
+          "secret_key": {
+            "example": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+            "title": "S3 secret key",
+            "type": "string"
+          }
+        },
+        "required": [
+          "provider",
+          "bucket_url",
+          "access_key",
+          "secret_key"
+        ],
+        "title": "External image store settings",
+        "type": "object"
+      },
+      "google_analytics_ua_id": {
+        "example": "UA-123456-4",
+        "title": "Google Analytics Universal Analytics ID for tracking Grafana usage",
+        "type": [
+          "string",
+          "null"
+        ]
+      },
+      "ip_filter": {
+        "default": [
+          "0.0.0.0/0"
+        ],
+        "items": {
+          "example": "10.20.0.0/16",
+          "title": "CIDR address block",
+          "type": "string"
+        },
+        "maxItems": 100,
+        "title": "Allow incoming connections from CIDR address block, e.g. '10.20.0.0/16'",
+        "type": "array"
+      },
+      "smtp_server": {
+        "additionalproperties": false,
+        "properties": {
+          "from_address": {
+            "example": "yourgrafanauser@yourdomain.example.com",
+            "pattern": "^[^@\\s,]+@(\\w+(-\\w+)*\\.)+([a-zA-Z]{2,}|xn--[a-zA-Z0-9]+)$",
+            "title": "Address used for sending emails",
+            "type": "string"
+          },
+          "from_name": {
+            "example": "Company Grafana",
+            "title": "Name used in outgoing emails, defaults to Grafana",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "host": {
+            "example": "smtp.example.com",
+            "title": "Server hostname or IP",
+            "type": "string"
+          },
+          "password": {
+            "example": "ein0eemeev5eeth3Ahfu",
+            "title": "Password for SMTP authentication",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "port": {
+            "example": 25,
+            "maximum": 65535,
+            "minimum": 1,
+            "title": "SMTP server port",
+            "type": "integer"
+          },
+          "skip_verify": {
+            "example": "false",
+            "title": "Skip verifying server certificate. Defaults to false",
+            "type": "boolean"
+          },
+          "username": {
+            "example": "smtpuser",
+            "title": "Username for SMTP authentication",
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "host",
+          "port",
+          "from_address"
+        ],
+        "title": "SMTP server settings",
+        "type": "object"
+      }
+    },
+    "type": "object"
+  },
+  "influxdb": {
+    "additionalProperties": false,
+    "properties": {
+      "custom_domain": {
+        "default": null,
+        "example": "grafana.example.org",
+        "title": "Serve the web frontend using a custom CNAME pointing to the Aiven DNS name",
+        "type": [
+          "string",
+          "null"
+        ]
+      },
+      "ip_filter": {
+        "default": [
+          "0.0.0.0/0"
+        ],
+        "items": {
+          "example": "10.20.0.0/16",
+          "title": "CIDR address block",
+          "type": "string"
+        },
+        "maxItems": 100,
+        "title": "Allow incoming connections from CIDR address block, e.g. '10.20.0.0/16'",
+        "type": "array"
+      },
+      "service_to_fork_from": {
+        "default": null,
+        "example": "anotherservicename",
+        "title": "Name of another service to fork from",
+        "type": [
+          "string",
+          "null"
+        ]
+      }
+    },
+    "type": "object"
+  },
+  "kafka": {
+    "additionalProperties": false,
+    "properties": {
+      "custom_domain": {
+        "default": null,
+        "example": "grafana.example.org",
+        "title": "Serve the web frontend using a custom CNAME pointing to the Aiven DNS name",
+        "type": [
+          "string",
+          "null"
+        ]
+      },
+      "ip_filter": {
+        "default": [
+          "0.0.0.0/0"
+        ],
+        "items": {
+          "example": "10.20.0.0/16",
+          "title": "CIDR address block",
+          "type": "string"
+        },
+        "maxItems": 100,
+        "title": "Allow incoming connections from CIDR address block, e.g. '10.20.0.0/16'",
+        "type": "array"
+      },
+      "kafka": {
+        "additionalProperties": false,
+        "default": {
+          "group_max_session_timeout_ms": 300000,
+          "group_min_session_timeout_ms": 6000,
+          "message_max_bytes": 1000012
+        },
+        "properties": {
+          "auto_create_topics_enable": {
+            "example": true,
+            "title": "Enable auto creation of topics",
+            "type": "boolean"
+          },
+          "default_replication_factor": {
+            "maximum": 10,
+            "minimum": 1,
+            "title": "Replication factor for autocreated topics",
+            "type": "integer"
+          },
+          "group_max_session_timeout_ms": {
+            "default": 300000,
+            "maximum": 1800000,
+            "minimum": 0,
+            "title": "The maximum allowed session timeout for registered consumers. Longer timeouts give consumers more time to process messages in between heartbeats at the cost of a longer time to detect failures.",
+            "type": "integer"
+          },
+          "group_min_session_timeout_ms": {
+            "default": 6000,
+            "maximum": 60000,
+            "minimum": 0,
+            "title": "The minimum allowed session timeout for registered consumers. Longer timeouts give consumers more time to process messages in between heartbeats at the cost of a longer time to detect failures.",
+            "type": "integer"
+          },
+          "log_message_timestamp_difference_max_ms": {
+            "maximum": 9223372036854776000,
+            "minimum": 0,
+            "title": "The maximum difference allowed between the timestamp when a broker receives a message and the timestamp specified in the message",
+            "type": "integer"
+          },
+          "log_message_timestamp_type": {
+            "enum": [
+              "CreateTime",
+              "LogAppendTime"
+            ],
+            "title": "Define whether the timestamp in the message is message create time or log append time.",
+            "type": "string"
+          },
+          "log_retention_bytes": {
+            "maximum": 9223372036854776000,
+            "minimum": -1,
+            "title": "The maximum size of the log before deleting messages",
+            "type": "integer"
+          },
+          "log_retention_hours": {
+            "maximum": 9223372036854776000,
+            "minimum": -1,
+            "title": "The number of hours to keep a log file before deleting it",
+            "type": "integer"
+          },
+          "message_max_bytes": {
+            "default": 1000012,
+            "maximum": 100001200,
+            "minimum": 0,
+            "title": "The maximum size of message that the server can receive.",
+            "type": "integer"
+          },
+          "num_partitions": {
+            "maximum": 1000,
+            "minimum": 1,
+            "title": "Number of partitions for autocreated topics",
+            "type": "integer"
+          },
+          "offsets_retention_minutes": {
+            "default": 1440,
+            "maximum": 14400,
+            "minimum": 1,
+            "title": "Log retention window in minutes for offsets topic",
+            "type": "integer"
+          }
+        },
+        "title": "Kafka broker configuration values",
+        "type": "object"
+      },
+      "kafka_connect": {
+        "default": false,
+        "title": "Enable Kafka Connect service",
+        "type": "boolean"
+      },
+      "kafka_rest": {
+        "default": false,
+        "title": "Enable Kafka-REST service",
+        "type": "boolean"
+      },
+      "kafka_version": {
+        "enum": [
+          "1.0",
+          "1.1",
+          "2.0"
+        ],
+        "title": "Kafka major version",
+        "type": [
+          "string",
+          "null"
+        ]
+      },
+      "schema_registry": {
+        "default": false,
+        "title": "Enable Schema-Registry service",
+        "type": "boolean"
+      }
+    },
+    "type": "object"
+  },
+  "pg": {
+    "additionalProperties": false,
+    "properties": {
+      "admin_password": {
+        "default": null,
+        "example": "z66o9QXqKM",
+        "title": "Custom password for admin user. Defaults to random string.",
+        "type": [
+          "string",
+          "null"
+        ]
+      },
+      "admin_username": {
+        "default": "avnadmin",
+        "example": "avnadmin",
+        "title": "Custom username for admin user",
+        "type": [
+          "string",
+          "null"
+        ]
+      },
+      "ip_filter": {
+        "default": [
+          "0.0.0.0/0"
+        ],
+        "items": {
+          "example": "10.20.0.0/16",
+          "title": "CIDR address block",
+          "type": "string"
+        },
+        "maxItems": 100,
+        "title": "Allow incoming connections from CIDR address block, e.g. '10.20.0.0/16'",
+        "type": "array"
+      },
+      "pg": {
+        "additionalProperties": false,
+        "properties": {
+          "autovacuum_analyze_scale_factor": {
+            "maximum": 1,
+            "minimum": 0,
+            "title": "Specifies a fraction of the table size to add to autovacuum_analyze_threshold when deciding whether to trigger an ANALYZE. The default is 0.2 (20% of table size)",
+            "type": "number"
+          },
+          "autovacuum_analyze_threshold": {
+            "maximum": 2147483647,
+            "minimum": 0,
+            "title": "Specifies the minimum number of inserted, updated or deleted tuples needed to trigger an  ANALYZE in any one table. The default is 50 tuples.",
+            "type": "integer"
+          },
+          "autovacuum_max_workers": {
+            "maximum": 20,
+            "minimum": 1,
+            "title": "Specifies the maximum number of autovacuum processes (other than the autovacuum launcher) that may be running at any one time. The default is three. This parameter can only be set at server start.",
+            "type": "integer"
+          },
+          "autovacuum_naptime": {
+            "maximum": 86400,
+            "minimum": 0,
+            "title": "Specifies the minimum delay between autovacuum runs on any given database. The delay is measured in seconds, and the default is one minute",
+            "type": "integer"
+          },
+          "autovacuum_vacuum_cost_delay": {
+            "maximum": 2147483647,
+            "minimum": -1,
+            "title": "Specifies the cost delay value that will be used in automatic VACUUM operations. If -1 is specified, the regular vacuum_cost_delay value will be used. The default value is 20 milliseconds",
+            "type": "integer"
+          },
+          "autovacuum_vacuum_cost_limit": {
+            "maximum": 2147483647,
+            "minimum": -1,
+            "title": "Specifies the cost limit value that will be used in automatic VACUUM operations. If -1 is specified (which is the default), the regular vacuum_cost_limit value will be used.",
+            "type": "integer"
+          },
+          "autovacuum_vacuum_scale_factor": {
+            "maximum": 1,
+            "minimum": 0,
+            "title": "Specifies a fraction of the table size to add to autovacuum_vacuum_threshold when deciding whether to trigger a VACUUM. The default is 0.2 (20% of table size)",
+            "type": "number"
+          },
+          "autovacuum_vacuum_threshold": {
+            "maximum": 2147483647,
+            "minimum": 0,
+            "title": "Specifies the minimum number of updated or deleted tuples needed to trigger a VACUUM in any one table. The default is 50 tuples",
+            "type": "integer"
+          },
+          "idle_in_transaction_session_timeout": {
+            "maximum": 86400000,
+            "minimum": 0,
+            "title": "Time out sessions with open transactions after this number of milliseconds",
+            "type": "integer"
+          },
+          "log_autovacuum_min_duration": {
+            "maximum": 2147483647,
+            "minimum": -1,
+            "title": "Causes each action executed by autovacuum to be logged if it ran for at least the specified number of milliseconds. Setting this to zero logs all autovacuum actions. Minus-one (the default) disables logging autovacuum actions.",
+            "type": "integer"
+          },
+          "log_error_verbosity": {
+            "enum": [
+              "TERSE",
+              "DEFAULT",
+              "VERBOSE"
+            ],
+            "title": "Controls the amount of detail written in the server log for each message that is logged.",
+            "type": "string"
+          },
+          "log_min_duration_statement": {
+            "maximum": 86400000,
+            "minimum": -1,
+            "title": "Log statements that take more than this number of milliseconds to run, -1 disables",
+            "type": "integer"
+          },
+          "max_locks_per_transaction": {
+            "maximum": 640,
+            "minimum": 64,
+            "title": "PostgreSQL maximum locks per transaction",
+            "type": "integer"
+          },
+          "max_parallel_workers": {
+            "maximum": 96,
+            "minimum": 0,
+            "title": "Sets the maximum number of workers that the system can support for parallel queries",
+            "type": "integer"
+          },
+          "max_parallel_workers_per_gather": {
+            "maximum": 96,
+            "minimum": 0,
+            "title": "Sets the maximum number of workers that can be started by a single Gather or Gather Merge node",
+            "type": "integer"
+          },
+          "max_pred_locks_per_transaction": {
+            "maximum": 640,
+            "minimum": 64,
+            "title": "PostgreSQL maximum predicate locks per transaction",
+            "type": "integer"
+          },
+          "max_prepared_transactions": {
+            "maximum": 10000,
+            "minimum": 0,
+            "title": "PostgreSQL maximum prepared transactions",
+            "type": "integer"
+          },
+          "max_standby_archive_delay": {
+            "maximum": 43200000,
+            "minimum": 1,
+            "title": "Max standby archive delay in milliseconds",
+            "type": "integer"
+          },
+          "max_standby_streaming_delay": {
+            "maximum": 43200000,
+            "minimum": 1,
+            "title": "Max standby streaming delay in milliseconds",
+            "type": "integer"
+          },
+          "max_worker_processes": {
+            "maximum": 96,
+            "minimum": 8,
+            "title": "Sets the maximum number of background processes that the system can support",
+            "type": "integer"
+          },
+          "pg_stat_statements.track": {
+            "enum": [
+              "all",
+              "top",
+              "none"
+            ],
+            "title": "Controls which statements are counted. Specify top to track top-level statements (those issued directly by clients), all to also track nested statements (such as statements invoked within functions), or none to disable statement statistics collection. The default value is top.",
+            "type": [
+              "string"
+            ]
+          },
+          "temp_file_limit": {
+            "example": 5000000,
+            "maximum": 2147483647,
+            "minimum": -1,
+            "title": "PostgreSQL temporary file limit in KiB, -1 for unlimited",
+            "type": "integer"
+          },
+          "timezone": {
+            "example": "Europe/Helsinki",
+            "title": "PostgreSQL service timezone",
+            "type": "string"
+          },
+          "track_activity_query_size": {
+            "example": 1024,
+            "maximum": 10240,
+            "minimum": 1024,
+            "title": "Specifies the number of bytes reserved to track the currently executing command for each active session.",
+            "type": "integer"
+          },
+          "track_functions": {
+            "enum": [
+              "all",
+              "pl",
+              "none"
+            ],
+            "title": "Enables tracking of function call counts and time used.",
+            "type": "string"
+          }
+        },
+        "title": "postgresql.conf configuration values",
+        "type": "object"
+      },
+      "pg_read_replica": {
+        "default": null,
+        "example": true,
+        "title": "Should the service which is being forked be a read replica",
+        "type": [
+          "boolean",
+          "null"
+        ]
+      },
+      "pg_service_to_fork_from": {
+        "default": null,
+        "example": "anotherservicename",
+        "title": "Name of the PG Service from which to fork (deprecated, use service_to_fork_from)",
+        "type": [
+          "string",
+          "null"
+        ]
+      },
+      "pg_version": {
+        "enum": [
+          "9.3",
+          "9.5",
+          "9.6",
+          "10"
+        ],
+        "title": "PostgreSQL major version",
+        "type": [
+          "string",
+          "null"
+        ]
+      },
+      "pglookout": {
+        "additionalProperties": false,
+        "default": {
+          "max_failover_replication_time_lag": 60
+        },
+        "properties": {
+          "max_failover_replication_time_lag": {
+            "default": 60,
+            "maximum": 9223372036854776000,
+            "minimum": 10,
+            "title": "Number of seconds of master unavailability before triggering database failover to standby",
+            "type": "integer"
+          }
+        },
+        "title": "PGLookout settings",
+        "type": "object"
+      },
+      "recovery_target_time": {
+        "default": null,
+        "example": "2010-01-01 23:34:45",
+        "format": "date-time",
+        "title": "PostgreSQL recovery_target_time",
+        "type": [
+          "string",
+          "null"
+        ]
+      },
+      "service_to_fork_from": {
+        "default": null,
+        "example": "anotherservicename",
+        "title": "Name of another service to fork from",
+        "type": [
+          "string",
+          "null"
+        ]
+      }
+    },
+    "type": "object"
+  },
+  "redis": {
+    "additionalProperties": false,
+    "properties": {
+      "ip_filter": {
+        "default": [
+          "0.0.0.0/0"
+        ],
+        "items": {
+          "example": "10.20.0.0/16",
+          "title": "CIDR address block",
+          "type": "string"
+        },
+        "maxItems": 100,
+        "title": "Allow incoming connections from CIDR address block, e.g. '10.20.0.0/16'",
+        "type": "array"
+      },
+      "redis_maxmemory_policy": {
+        "default": "noeviction",
+        "enum": [
+          "noeviction",
+          "allkeys-lru",
+          "volatile-lru",
+          "allkeys-random",
+          "volatile-random",
+          "volatile-ttl"
+        ],
+        "title": "Redis maxmemory-policy",
+        "type": [
+          "string",
+          "null"
+        ]
+      },
+      "redis_ssl": {
+        "default": true,
+        "title": "Require SSL to access Redis",
+        "type": "boolean"
+      },
+      "redis_timeout": {
+        "default": 300,
+        "maximum": 31536000,
+        "minimum": 0,
+        "title": "Redis idle connection timeout",
+        "type": "integer"
+      }
+    },
+    "type": "object"
+  },
+  "sw": {
+    "additionalProperties": false,
+    "properties": {
+      "env": {
+        "additionalProperties": false,
+        "default": {},
+        "patternProperties": {
+          "^[a-zA-Z_]+[a-zA-Z0-9_]*$": {
+            "default": null,
+            "title": "Assigned value",
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "title": "Environmental variables",
+        "type": "object"
+      },
+      "ip_filter": {
+        "default": [
+          "0.0.0.0/0"
+        ],
+        "items": {
+          "example": "10.20.0.0/16",
+          "title": "CIDR address block",
+          "type": "string"
+        },
+        "maxItems": 100,
+        "title": "Allow incoming connections from CIDR address block, e.g. '10.20.0.0/16'",
+        "type": "array"
+      },
+      "project_file": {
+        "default": null,
+        "example": "aiven-gw-services-1.7.0-277-ge830b49.tar",
+        "title": "Project file name to use for software container initialization",
+        "type": [
+          "string",
+          "null"
+        ]
+      },
+      "proxy_definitions": {
+        "items": {
+          "patternProperties": {
+            "^[a-zA-Z_]+[a-zA-Z0-9_]*$": {
+              "properties": {
+                "password": {
+                  "example": "abc123",
+                  "title": "User password",
+                  "type": "string"
+                },
+                "port": {
+                  "maximum": 32000,
+                  "minimum": 1024,
+                  "title": "TCP/IP port",
+                  "type": "integer"
+                },
+                "username": {
+                  "example": "id-e11v3n",
+                  "pattern": "^[a-z][-a-z0-9]{0,39}$",
+                  "title": "ID",
+                  "type": "string",
+                  "user_error": "Must consist of lower-case alpha-numeric characters and dashes, max 40 characters"
+                }
+              },
+              "required": [
+                "host",
+                "password",
+                "port"
+              ],
+              "type": "object"
+            }
+          }
+        },
+        "title": "Proxy definitions",
+        "type": "object"
+      },
+      "tcp_port": {
+        "default": 10800,
+        "maximum": 32000,
+        "minimum": 1024,
+        "title": "Port on which a TCP service is exposed",
+        "type": [
+          "integer",
+          "null"
+        ]
+      },
+      "web": {
+        "additionalProperties": {
+          "properties": {
+            "port": {
+              "default": null,
+              "maximum": 32000,
+              "minimum": 80,
+              "title": "Port on which web service is exposed",
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "redirect": {
+              "default": null,
+              "example": "https://127.0.0.1:9999",
+              "title": "Redirect traffic on this port to another URL",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "ssl": {
+              "default": null,
+              "example": "",
+              "title": "__system__ to use Aiven internal certificates or a hostname for Let's Encrypt",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "verify": {
+              "default": null,
+              "example": "",
+              "title": "__system__ to use Aiven internal CA certificates or null",
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          },
+          "title": "Dummy title",
+          "type": "object"
+        },
+        "default": {},
+        "title": "Aiven Web service settings",
+        "type": "object"
+      }
+    },
+    "type": "object"
+  },
+  "zookeeper": {
+    "additionalProperties": false,
+    "properties": {
+      "ip_filter": {
+        "default": [
+          "0.0.0.0/0"
+        ],
+        "items": {
+          "example": "10.20.0.0/16",
+          "title": "CIDR address block",
+          "type": "string"
+        },
+        "maxItems": 100,
+        "title": "Allow incoming connections from CIDR address block, e.g. '10.20.0.0/16'",
+        "type": "array"
+      },
+      "zookeeper_ssl": {
+        "default": true,
+        "title": "Require SSL to access ZooKeeper",
+        "type": "boolean"
+      }
+    },
+    "type": "object"
+  }
+}

--- a/templates/service_user_config_schema.json
+++ b/templates/service_user_config_schema.json
@@ -30,6 +30,14 @@
           "null"
         ]
       },
+      "disable_replication_factor_adjustment": {
+        "example": false,
+        "title": "Disable automatic replication factor adjustment for multi-node services. By default, Aiven ensures all indexes are replicated at least to two nodes. Note: setting this to true increases a risk of data loss in case of virtual machine failure.",
+        "type": [
+          "boolean",
+          "null"
+        ]
+      },
       "elasticsearch_version": {
         "enum": [
           "2",
@@ -318,6 +326,27 @@
         ],
         "title": "SMTP server settings",
         "type": "object"
+      },
+      "user_auto_assign_org": {
+        "example": false,
+        "title": "Auto-assign new users on signup to main organization. Defaults to false",
+        "type": [
+          "boolean",
+          "null"
+        ]
+      },
+      "user_auto_assign_org_role": {
+        "enum": [
+          "Viewer",
+          "Admin",
+          "Editor"
+        ],
+        "example": "Viewer",
+        "title": "Set role for new signups. Defaults to Viewer",
+        "type": [
+          "string",
+          "null"
+        ]
       }
     },
     "type": "object"
@@ -348,6 +377,7 @@
         "type": "array"
       },
       "service_to_fork_from": {
+        "createOnly": true,
         "default": null,
         "example": "anotherservicename",
         "title": "Name of another service to fork from",
@@ -501,6 +531,7 @@
     "additionalProperties": false,
     "properties": {
       "admin_password": {
+        "createOnly": true,
         "default": null,
         "example": "z66o9QXqKM",
         "title": "Custom password for admin user. Defaults to random string.",
@@ -510,6 +541,7 @@
         ]
       },
       "admin_username": {
+        "createOnly": true,
         "default": "avnadmin",
         "example": "avnadmin",
         "title": "Custom username for admin user",
@@ -710,6 +742,7 @@
         ]
       },
       "pg_service_to_fork_from": {
+        "createOnly": true,
         "default": null,
         "example": "anotherservicename",
         "title": "Name of the PG Service from which to fork (deprecated, use service_to_fork_from)",
@@ -749,6 +782,7 @@
         "type": "object"
       },
       "recovery_target_time": {
+        "createOnly": true,
         "default": null,
         "example": "2010-01-01 23:34:45",
         "format": "date-time",
@@ -759,6 +793,7 @@
         ]
       },
       "service_to_fork_from": {
+        "createOnly": true,
         "default": null,
         "example": "anotherservicename",
         "title": "Name of another service to fork from",

--- a/templates/service_user_config_schema.json
+++ b/templates/service_user_config_schema.json
@@ -380,7 +380,7 @@
         "createOnly": true,
         "default": null,
         "example": "anotherservicename",
-        "title": "Name of another service to fork from",
+        "title": "Name of another service to fork from. This has effect only when a new service is being created.",
         "type": [
           "string",
           "null"
@@ -534,7 +534,7 @@
         "createOnly": true,
         "default": null,
         "example": "z66o9QXqKM",
-        "title": "Custom password for admin user. Defaults to random string.",
+        "title": "Custom password for admin user. Defaults to random string. This must be set only when a new service is being created.",
         "type": [
           "string",
           "null"
@@ -544,7 +544,7 @@
         "createOnly": true,
         "default": "avnadmin",
         "example": "avnadmin",
-        "title": "Custom username for admin user",
+        "title": "Custom username for admin user. This must be set only when a new service is being created.",
         "type": [
           "string",
           "null"
@@ -745,7 +745,7 @@
         "createOnly": true,
         "default": null,
         "example": "anotherservicename",
-        "title": "Name of the PG Service from which to fork (deprecated, use service_to_fork_from)",
+        "title": "Name of the PG Service from which to fork (deprecated, use service_to_fork_from). This has effect only when a new service is being created.",
         "type": [
           "string",
           "null"
@@ -786,7 +786,7 @@
         "default": null,
         "example": "2010-01-01 23:34:45",
         "format": "date-time",
-        "title": "PostgreSQL recovery_target_time",
+        "title": "PostgreSQL recovery_target_time. This has effect only when a new service is being created.",
         "type": [
           "string",
           "null"
@@ -796,7 +796,7 @@
         "createOnly": true,
         "default": null,
         "example": "anotherservicename",
-        "title": "Name of another service to fork from",
+        "title": "Name of another service to fork from. This has effect only when a new service is being created.",
         "type": [
           "string",
           "null"

--- a/terraform.tfvars.sample
+++ b/terraform.tfvars.sample
@@ -1,3 +1,3 @@
-aiven_email = ""
-aiven_password = ""
+aiven_api_token = ""
 aiven_card_id = ""
+aiven_project_name = ""

--- a/user_config.go
+++ b/user_config.go
@@ -1,3 +1,4 @@
+// Copyright (c) 2018 Aiven, Helsinki, Finland. https://aiven.io/
 package main
 
 import (

--- a/user_config.go
+++ b/user_config.go
@@ -119,10 +119,15 @@ func generateTerraformUserConfigSchema(key string, definition map[string]interfa
 		default:
 			panic(fmt.Sprintf("Unexpected user config schema array item type: %T / %v", typeString, typeString))
 		}
+		maxItemsVal, maxItemsFound := definition["maxItems"]
+		maxItems := 0
+		if maxItemsFound {
+			maxItems = int(maxItemsVal.(float64))
+		}
 		return &schema.Schema{
 			Description: title,
 			Elem:        &schema.Schema{Type: itemType},
-			MaxItems:    int(definition["maxItems"].(float64)),
+			MaxItems:    maxItems,
 			Optional:    true,
 			Sensitive:   sensitive,
 			Type:        schema.TypeList,

--- a/user_config.go
+++ b/user_config.go
@@ -198,7 +198,7 @@ func ConvertAPIUserConfigToTerraformCompatibleFormat(
 	entryType string,
 	userConfig map[string]interface{},
 ) []map[string]interface{} {
-	if userConfig == nil || len(userConfig) == 0 {
+	if len(userConfig) == 0 {
 		return []map[string]interface{}{}
 	}
 

--- a/user_config.go
+++ b/user_config.go
@@ -273,7 +273,8 @@ func convertTerraformUserConfigToAPICompatibleFormat(
 			continue
 		}
 		definition := definitionRaw.(map[string]interface{})
-		convertedValue, omit := convertTerraformUserConfigValueToAPICompatibleFormat(serviceType, key, value, definition)
+		convertedValue, omit := convertTerraformUserConfigValueToAPICompatibleFormat(
+			serviceType, key, value, definition)
 		if !omit {
 			apiConfig[key] = convertedValue
 		}

--- a/user_config.go
+++ b/user_config.go
@@ -342,13 +342,18 @@ func convertTerraformUserConfigValueToAPICompatibleFormat(
 			default:
 				panic(fmt.Sprintf("Invalid %v user config key type %T for %v, expected map", serviceType, value, key))
 			}
-			asMap := value.([]interface{})[0].(map[string]interface{})
-			if len(asMap) == 0 {
+			asList := value.([]interface{})
+			if len(asList) == 0 {
 				omit = true
 			} else {
-				convertedValue = convertTerraformUserConfigToAPICompatibleFormat(
-					serviceType, asMap, definition["properties"].(map[string]interface{}),
-				)
+				asMap := asList[0].(map[string]interface{})
+				if len(asMap) == 0 {
+					omit = true
+				} else {
+					convertedValue = convertTerraformUserConfigToAPICompatibleFormat(
+						serviceType, asMap, definition["properties"].(map[string]interface{}),
+					)
+				}
 			}
 		}
 	case "array":

--- a/user_config.go
+++ b/user_config.go
@@ -1,0 +1,390 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/gobuffalo/packr"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func readUserConfigJSONSchema(name string) map[string]interface{} {
+	box := packr.NewBox("./templates")
+	data, err := box.MustBytes(name)
+	if err != nil {
+		panic(fmt.Sprintf("Failed to read %v: %v", name, err))
+	}
+	var jsonObject interface{}
+	err = json.Unmarshal(data, &jsonObject)
+	if err != nil {
+		panic(fmt.Sprintf("Failed to unmarshal %v: %v", name, err))
+	}
+	return jsonObject.(map[string]interface{})
+}
+
+var userConfigSchemas = map[string]map[string]interface{}{
+	"endpoint":    readUserConfigJSONSchema("integration_endpoints_user_config_schema.json"),
+	"integration": readUserConfigJSONSchema("integrations_user_config_schema.json"),
+	"service":     readUserConfigJSONSchema("service_user_config_schema.json"),
+}
+
+// GenerateTerraformUserConfigSchema creates Terraform schema definition for user config based
+// on user config JSON schema definition.
+func GenerateTerraformUserConfigSchema(data map[string]interface{}) map[string]*schema.Schema {
+	properties := data["properties"].(map[string]interface{})
+	terraformSchema := make(map[string]*schema.Schema)
+	for name, definitionRaw := range properties {
+		definition := definitionRaw.(map[string]interface{})
+		terraformSchema[encodeKeyName(name)] = generateTerraformUserConfigSchema(name, definition)
+	}
+	return terraformSchema
+}
+
+func generateTerraformUserConfigSchema(key string, definition map[string]interface{}) *schema.Schema {
+	valueType, _ := getAivenSchemaType(definition["type"])
+	sensitive := false
+	if strings.Contains(key, "api_key") || strings.Contains(key, "password") {
+		sensitive = true
+	}
+	defaultValue, ok := definition["default"]
+	title := definition["title"].(string)
+	switch valueType {
+	case "number":
+		if !ok {
+			defaultValue = -1.0
+		}
+		return &schema.Schema{
+			Default:     defaultValue,
+			Description: title,
+			Optional:    true,
+			Sensitive:   sensitive,
+			Type:        schema.TypeFloat,
+		}
+	case "integer":
+		if !ok {
+			defaultValue = -1.0
+		}
+		return &schema.Schema{
+			Default:     int(defaultValue.(float64)),
+			Description: title,
+			Optional:    true,
+			Sensitive:   sensitive,
+			Type:        schema.TypeInt,
+		}
+	case "boolean":
+		if !ok || defaultValue == nil {
+			defaultValue = false
+		}
+		return &schema.Schema{
+			Default:     defaultValue,
+			Description: title,
+			Optional:    true,
+			Sensitive:   sensitive,
+			Type:        schema.TypeBool,
+		}
+	case "string":
+		if !ok || defaultValue == nil {
+			// Terraform has no way of indicating unset values.
+			// Convert "<<value not set>>" to unset when handling request
+			defaultValue = "<<value not set>>"
+		}
+		return &schema.Schema{
+			Default:     defaultValue,
+			Description: title,
+			Optional:    true,
+			Sensitive:   sensitive,
+			Type:        schema.TypeString,
+		}
+	case "object":
+		return &schema.Schema{
+			Description: title,
+			Elem:        &schema.Resource{Schema: GenerateTerraformUserConfigSchema(definition)},
+			MaxItems:    1,
+			Optional:    true,
+			Type:        schema.TypeList,
+		}
+	case "array":
+		var itemType schema.ValueType
+		typeString := definition["items"].(map[string]interface{})["type"].(string)
+		switch typeString {
+		case "number":
+			itemType = schema.TypeFloat
+		case "integer":
+			itemType = schema.TypeInt
+		case "boolean":
+			itemType = schema.TypeBool
+		case "string":
+			itemType = schema.TypeString
+		default:
+			panic(fmt.Sprintf("Unexpected user config schema array item type: %T / %v", typeString, typeString))
+		}
+		return &schema.Schema{
+			Description: title,
+			Elem:        &schema.Schema{Type: itemType},
+			MaxItems:    int(definition["maxItems"].(float64)),
+			Optional:    true,
+			Sensitive:   sensitive,
+			Type:        schema.TypeList,
+		}
+	default:
+		panic(fmt.Sprintf("Unexpected user config schema type: %T / %v", valueType, valueType))
+	}
+}
+
+func getAivenSchemaType(value interface{}) (string, bool) {
+	switch value.(type) {
+	case string:
+		return value.(string), false
+	case []interface{}:
+		optional := false
+		typeString := ""
+		for _, typeOrNullRaw := range value.([]interface{}) {
+			typeOrNull := typeOrNullRaw.(string)
+			if typeOrNull == "null" {
+				optional = true
+			} else {
+				typeString = typeOrNull
+			}
+		}
+		return typeString, optional
+	default:
+		panic(fmt.Sprintf("Unexpected user config schema type: %T / %v", value, value))
+	}
+}
+
+// ConvertAPIUserConfigToTerraformCompatibleFormat converts API response to a format that is
+// accepted by Terraform; intermediary lists are added as necessary, default values are provided
+// for missing keys and type conversions are performed if necessary.
+func ConvertAPIUserConfigToTerraformCompatibleFormat(
+	configType string,
+	entryType string,
+	userConfig map[string]interface{},
+) []map[string]interface{} {
+	if userConfig == nil || len(userConfig) == 0 {
+		return []map[string]interface{}{}
+	}
+
+	entrySchema := userConfigSchemas[configType][entryType].(map[string]interface{})
+	entrySchemaProps := entrySchema["properties"].(map[string]interface{})
+	return []map[string]interface{}{convertAPIUserConfigToTerraformCompatibleFormat(userConfig, entrySchemaProps)}
+}
+
+func convertAPIUserConfigToTerraformCompatibleFormat(
+	apiUserConfig map[string]interface{},
+	jsonSchema map[string]interface{},
+) map[string]interface{} {
+	terraformConfig := make(map[string]interface{})
+	for key, schemaDefinitionRaw := range jsonSchema {
+		schemaDefinition := schemaDefinitionRaw.(map[string]interface{})
+		valueType, _ := getAivenSchemaType(schemaDefinition["type"])
+		apiValue, ok := apiUserConfig[key]
+		key = encodeKeyName(key)
+		if !ok || apiValue == nil {
+			// To avoid undesired "changes" for values that are not explicitly defined return
+			// default values for anything that is not returned in the API response
+			switch valueType {
+			case "object":
+				terraformConfig[key] = map[string]interface{}{}
+			case "array":
+				terraformConfig[key] = []interface{}{}
+			case "number":
+				terraformConfig[key] = -1.0
+			case "integer":
+				terraformConfig[key] = -1
+			case "boolean":
+				terraformConfig[key] = false
+			case "string":
+				terraformConfig[key] = "<<value not set>>"
+			}
+			continue
+		}
+		switch valueType {
+		case "object":
+			res := convertAPIUserConfigToTerraformCompatibleFormat(
+				apiValue.(map[string]interface{}), schemaDefinition["properties"].(map[string]interface{}),
+			)
+			terraformConfig[key] = []map[string]interface{}{res}
+		case "integer":
+			switch apiValue.(type) {
+			case float64:
+				terraformConfig[key] = int(apiValue.(float64))
+			case float32:
+				terraformConfig[key] = int(apiValue.(float32))
+			case int64:
+				terraformConfig[key] = int(apiValue.(int64))
+			case int32:
+				terraformConfig[key] = int(apiValue.(int32))
+			default:
+				panic(fmt.Sprintf("Unexpected value type for '%v': %v / %T", key, apiValue, apiValue))
+			}
+		case "number":
+			switch apiValue.(type) {
+			case float64:
+				terraformConfig[key] = apiValue.(float64)
+			case float32:
+				terraformConfig[key] = float64(apiValue.(float32))
+			case int64:
+				terraformConfig[key] = float64(apiValue.(int64))
+			case int32:
+				terraformConfig[key] = float64(apiValue.(int32))
+			default:
+				panic(fmt.Sprintf("Unexpected value type for '%v': %v / %T", key, apiValue, apiValue))
+			}
+		default:
+			terraformConfig[key] = apiValue
+		}
+	}
+	return terraformConfig
+}
+
+// ConvertTerraformUserConfigToAPICompatibleFormat converts Terraform user configuration to API compatible
+// format; Schema-based Terraform configuration requires using TypeList, which adds one extra layer of lists
+// that need to be dropped. Also need to drop dummy "unset" replacement values
+func ConvertTerraformUserConfigToAPICompatibleFormat(
+	configType string,
+	entryType string,
+	d *schema.ResourceData,
+) map[string]interface{} {
+	mainKey := entryType + "_user_config"
+	userConfigsRaw, ok := d.GetOk(mainKey)
+	if !ok || userConfigsRaw == nil {
+		return nil
+	}
+	entrySchema := userConfigSchemas[configType][entryType].(map[string]interface{})
+	entrySchemaProps := entrySchema["properties"].(map[string]interface{})
+	return convertTerraformUserConfigToAPICompatibleFormat(
+		entryType, userConfigsRaw.([]interface{})[0].(map[string]interface{}), entrySchemaProps)
+}
+
+func convertTerraformUserConfigToAPICompatibleFormat(
+	serviceType string,
+	userConfig map[string]interface{},
+	configSchema map[string]interface{},
+) map[string]interface{} {
+	apiConfig := make(map[string]interface{})
+	for key, value := range userConfig {
+		key = decodeKeyName(key)
+		definitionRaw, ok := configSchema[key]
+		if !ok {
+			panic(fmt.Sprintf("Unsupported %v user config key %v", serviceType, key))
+		}
+		if definitionRaw == nil {
+			continue
+		}
+		definition := definitionRaw.(map[string]interface{})
+		convertedValue, omit := convertTerraformUserConfigValueToAPICompatibleFormat(serviceType, key, value, definition)
+		if !omit {
+			apiConfig[key] = convertedValue
+		}
+	}
+	return apiConfig
+}
+
+func convertTerraformUserConfigValueToAPICompatibleFormat(
+	serviceType string,
+	key string,
+	value interface{},
+	definition map[string]interface{},
+) (interface{}, bool) {
+	convertedValue := value
+	omit := false
+	valueType, _ := getAivenSchemaType(definition["type"])
+	switch valueType {
+	case "integer":
+		switch value.(type) {
+		case int:
+		case int64:
+			convertedValue = int(value.(int64))
+		case int32:
+			convertedValue = int(value.(int32))
+		default:
+			panic(fmt.Sprintf("Invalid %v user config key type %T for %v, expected integer", serviceType, value, key))
+		}
+		minimum, hasMin := definition["minimum"]
+		if hasMin && value.(int) < int(minimum.(float64)) {
+			omit = true
+		}
+	case "number":
+		switch value.(type) {
+		case float64:
+		case float32:
+			convertedValue = float64(value.(float32))
+		case int64:
+			convertedValue = float64(value.(int64))
+		case int32:
+			convertedValue = float64(value.(int32))
+		case int:
+			convertedValue = float64(value.(int))
+		default:
+			panic(fmt.Sprintf("Invalid %v user config key type %T for %v, expected float", serviceType, value, key))
+		}
+		minimum, hasMin := definition["minimum"]
+		if hasMin && value.(float64) < minimum.(float64) {
+			omit = true
+		}
+	case "boolean":
+	case "string":
+		switch value.(type) {
+		case string:
+			if value == "<<value not set>>" {
+				omit = true
+			}
+		default:
+			panic(fmt.Sprintf("Invalid %v user config key type %T for %v, expected string", serviceType, value, key))
+		}
+	case "object":
+		if value == nil {
+			omit = true
+		} else {
+			switch value.(type) {
+			case []interface{}:
+			default:
+				panic(fmt.Sprintf("Invalid %v user config key type %T for %v, expected map", serviceType, value, key))
+			}
+			asMap := value.([]interface{})[0].(map[string]interface{})
+			if len(asMap) == 0 {
+				omit = true
+			} else {
+				convertedValue = convertTerraformUserConfigToAPICompatibleFormat(
+					serviceType, asMap, definition["properties"].(map[string]interface{}),
+				)
+			}
+		}
+	case "array":
+		if value == nil {
+			omit = true
+		} else {
+			switch value.(type) {
+			case []interface{}:
+			default:
+				panic(fmt.Sprintf("Invalid %v user config key type %T for %v, expected list", serviceType, value, key))
+			}
+			asArray := value.([]interface{})
+			if len(asArray) == 0 {
+				omit = true
+			} else {
+				values := make([]interface{}, len(value.([]interface{})))
+				itemDefinition := definition["items"].(map[string]interface{})
+				for idx, arrValue := range asArray {
+					arrValueConverted, _ := convertTerraformUserConfigValueToAPICompatibleFormat(
+						serviceType, key, arrValue, itemDefinition)
+					values[idx] = arrValueConverted
+				}
+				convertedValue = values
+			}
+		}
+	default:
+		panic(fmt.Sprintf("Unsupported value type %v for %v user config key %v", definition["type"], serviceType, key))
+	}
+	return convertedValue, omit
+}
+
+func encodeKeyName(key string) string {
+	// Terraform does not accept dots in key names but Aiven API has those at least in PG user config
+	return strings.Replace(key, ".", "__dot__", -1)
+}
+
+func decodeKeyName(key string) string {
+	return strings.Replace(key, "__dot__", ".", -1)
+}


### PR DESCRIPTION
Note: This change is not backwards compatible. Things like identifier format and names of some parameters have changed and existing Terraform scripts do not work with this version. For most part the changes are fairly straightforward and discarding existing `terraform.tfstate` and importing the resources after minor changes to .tf files should work.