### PR TITLE
Add support for service termination protection

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -2,11 +2,11 @@
 
 
 [[projects]]
-  digest = "1:dedb0f251c9e52cff6f4a6b4e5ff4cbcbd9b6bc275648e0bc17b8b5c1a695744"
+  digest = "1:e7d639ec86898de9f66871353d23d3ffa7a10851c8f482e13e465ba189095863"
   name = "github.com/aiven/aiven-go-client"
   packages = ["."]
   pruneopts = "UT"
-  revision = "03b96f7bece55f0d98ad7e5a86461ea1da497236"
+  revision = "ec0871c583db5c4c154c68d814099fedacfc8ba5"
   source = "github.com/aiven/aiven-go-client"
 
 [[projects]]

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -13,7 +13,7 @@
 
 [[constraint]]
   name = "github.com/aiven/aiven-go-client"
-  revision = "03b96f7bece55f0d98ad7e5a86461ea1da497236"
+  revision = "ec0871c583db5c4c154c68d814099fedacfc8ba5"
   source = "github.com/aiven/aiven-go-client"
 
 [prune]

--- a/README.md
+++ b/README.md
@@ -19,6 +19,16 @@ These properties include such as the project a service is associated with, the n
 service, etc. Unless the system contains no relevant data, such changes must not be
 performed.
 
+To allow mitigating this problem, the service resource supports
+``termination_protection`` property. It is recommended to set this property to ``true``
+for all production services to avoid them being accidentally deleted. With this setting
+enabled service deletion, both intentional and unintentional, will fail until an explicit
+update is done to change the setting to ``false``. Note that while this does prevent the
+service itself from being deleted, any databases, topics or such that have been configured
+with Terraform can still be deleted and they will be deleted before the service itself is
+attempted to be deleted so even with this setting enabled you need to be very careful
+with the changes that are to be applied.
+
 ## Sample project
 
 There is a [sample project](sample.tf) which sets up a project, defines Kafka,
@@ -116,6 +126,7 @@ resource "aiven_service" "myservice" {
     service_name = "<SERVICE_NAME>"
     service_type = "pg"
     project_vpc_id = "${aiven_project_vpc.vpc_gcp_europe_west1.id}"
+    termination_protection = true
     pg_user_config {
         ip_filter = ["0.0.0.0/0"]
         pg_version = "10"
@@ -158,6 +169,12 @@ reference as shown above to set up dependencies correctly and the VPC must be in
 cloud and region as the service itself. Project can be freely moved to and from VPC after
 creation but doing so triggers migration to new servers so the operation can take
 significant amount of time to complete if the service has a lot of data.
+
+``termination_protection`` prevents the service from being deleted. It is recommended to
+set this to ``true`` for all production services to prevent unintentional service
+deletions. This does not shield against deleting databases or topics but for services
+with backups much of the content can at least be restored from backup in case accidental
+deletion is done.
 
 ``x_user_config`` defines service specific additional configuration options. These
 options can be found from the [JSON schema description](templates/service_user_config_schema.json).

--- a/resource_service.go
+++ b/resource_service.go
@@ -56,6 +56,11 @@ func resourceService() *schema.Resource {
 				Optional:    true,
 				Description: "Identifier of the VPC the service should be in, if any",
 			},
+			"termination_protection": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Description: "Prevent service from being deleted. It is recommended to have this enabled for all services.",
+			},
 			"service_uri": {
 				Type:        schema.TypeString,
 				Computed:    true,
@@ -342,12 +347,13 @@ func resourceServiceCreate(d *schema.ResourceData, m interface{}) error {
 	service, err := client.Services.Create(
 		d.Get("project").(string),
 		aiven.CreateServiceRequest{
-			Cloud:        d.Get("cloud_name").(string),
-			Plan:         d.Get("plan").(string),
-			ProjectVPCID: vpcIDPointer,
-			ServiceName:  d.Get("service_name").(string),
-			ServiceType:  serviceType,
-			UserConfig:   userConfig,
+			Cloud:                 d.Get("cloud_name").(string),
+			Plan:                  d.Get("plan").(string),
+			ProjectVPCID:          vpcIDPointer,
+			ServiceName:           d.Get("service_name").(string),
+			ServiceType:           serviceType,
+			TerminationProtection: d.Get("termination_protection").(bool),
+			UserConfig:            userConfig,
 		},
 	)
 
@@ -393,11 +399,12 @@ func resourceServiceUpdate(d *schema.ResourceData, m interface{}) error {
 		projectName,
 		serviceName,
 		aiven.UpdateServiceRequest{
-			Cloud:        d.Get("cloud_name").(string),
-			Plan:         d.Get("plan").(string),
-			ProjectVPCID: vpcIDPointer,
-			Powered:      true,
-			UserConfig:   userConfig,
+			Cloud:                 d.Get("cloud_name").(string),
+			Plan:                  d.Get("plan").(string),
+			ProjectVPCID:          vpcIDPointer,
+			Powered:               true,
+			TerminationProtection: d.Get("termination_protection").(bool),
+			UserConfig:            userConfig,
 		},
 	)
 	if err != nil {
@@ -475,6 +482,7 @@ func copyServicePropertiesFromAPIResponseToTerraform(
 	d.Set("state", service.State)
 	d.Set("plan", service.Plan)
 	d.Set("service_type", service.Type)
+	d.Set("termination_protection", service.TerminationProtection)
 	d.Set("service_uri", service.URI)
 	d.Set("project", project)
 	if service.ProjectVPCID != nil {


### PR DESCRIPTION
Termination protection can be useful for preventing accidental deletion
of production services. Because it only prevents deletion of the service
itself and not any sub resources one must still be extremely careful
with the diffs when applying changes but at least it will ensure that
backups are not lost for services that do keep backups.