### PR TITLE
Delay referencing packr managed resources

### DIFF
--- a/resource_service.go
+++ b/resource_service.go
@@ -110,7 +110,7 @@ func resourceService() *schema.Resource {
 				DiffSuppressFunc: emptyObjectDiffSuppressFunc,
 				Elem: &schema.Resource{
 					Schema: GenerateTerraformUserConfigSchema(
-						userConfigSchemas["service"]["cassandra"].(map[string]interface{})),
+						GetUserConfigSchema("service")["cassandra"].(map[string]interface{})),
 				},
 			},
 			"elasticsearch": {
@@ -138,7 +138,7 @@ func resourceService() *schema.Resource {
 				DiffSuppressFunc: emptyObjectDiffSuppressFunc,
 				Elem: &schema.Resource{
 					Schema: GenerateTerraformUserConfigSchema(
-						userConfigSchemas["service"]["elasticsearch"].(map[string]interface{})),
+						GetUserConfigSchema("service")["elasticsearch"].(map[string]interface{})),
 				},
 			},
 			"grafana": {
@@ -159,7 +159,7 @@ func resourceService() *schema.Resource {
 				DiffSuppressFunc: emptyObjectDiffSuppressFunc,
 				Elem: &schema.Resource{
 					Schema: GenerateTerraformUserConfigSchema(
-						userConfigSchemas["service"]["grafana"].(map[string]interface{})),
+						GetUserConfigSchema("service")["grafana"].(map[string]interface{})),
 				},
 			},
 			"influxdb": {
@@ -186,7 +186,7 @@ func resourceService() *schema.Resource {
 				DiffSuppressFunc: emptyObjectDiffSuppressFunc,
 				Elem: &schema.Resource{
 					Schema: GenerateTerraformUserConfigSchema(
-						userConfigSchemas["service"]["influxdb"].(map[string]interface{})),
+						GetUserConfigSchema("service")["influxdb"].(map[string]interface{})),
 				},
 			},
 			"kafka": {
@@ -240,7 +240,7 @@ func resourceService() *schema.Resource {
 				DiffSuppressFunc: emptyObjectDiffSuppressFunc,
 				Elem: &schema.Resource{
 					Schema: GenerateTerraformUserConfigSchema(
-						userConfigSchemas["service"]["kafka"].(map[string]interface{})),
+						GetUserConfigSchema("service")["kafka"].(map[string]interface{})),
 				},
 			},
 			"pg": {
@@ -306,7 +306,7 @@ func resourceService() *schema.Resource {
 				DiffSuppressFunc: emptyObjectDiffSuppressFunc,
 				Elem: &schema.Resource{
 					Schema: GenerateTerraformUserConfigSchema(
-						userConfigSchemas["service"]["pg"].(map[string]interface{})),
+						GetUserConfigSchema("service")["pg"].(map[string]interface{})),
 				},
 			},
 			"redis": {
@@ -327,7 +327,7 @@ func resourceService() *schema.Resource {
 				DiffSuppressFunc: emptyObjectDiffSuppressFunc,
 				Elem: &schema.Resource{
 					Schema: GenerateTerraformUserConfigSchema(
-						userConfigSchemas["service"]["redis"].(map[string]interface{})),
+						GetUserConfigSchema("service")["redis"].(map[string]interface{})),
 				},
 			},
 		},

--- a/resource_service_integration.go
+++ b/resource_service_integration.go
@@ -43,7 +43,7 @@ func resourceServiceIntegration() *schema.Resource {
 				Description: "Log integration specific user configurable settings",
 				Elem: &schema.Resource{
 					Schema: GenerateTerraformUserConfigSchema(
-						userConfigSchemas["integration"]["logs"].(map[string]interface{})),
+						GetUserConfigSchema("integration")["logs"].(map[string]interface{})),
 				},
 				MaxItems: 1,
 				Optional: true,
@@ -53,7 +53,7 @@ func resourceServiceIntegration() *schema.Resource {
 				Description: "Mirrormaker integration specific user configurable settings",
 				Elem: &schema.Resource{
 					Schema: GenerateTerraformUserConfigSchema(
-						userConfigSchemas["integration"]["mirrormaker"].(map[string]interface{})),
+						GetUserConfigSchema("integration")["mirrormaker"].(map[string]interface{})),
 				},
 				MaxItems: 1,
 				Optional: true,

--- a/resource_service_integration_endpoint.go
+++ b/resource_service_integration_endpoint.go
@@ -43,7 +43,7 @@ func resourceServiceIntegrationEndpoint() *schema.Resource {
 				Description: "Datadog specific user configurable settings",
 				Elem: &schema.Resource{
 					Schema: GenerateTerraformUserConfigSchema(
-						userConfigSchemas["endpoint"]["datadog"].(map[string]interface{})),
+						GetUserConfigSchema("endpoint")["datadog"].(map[string]interface{})),
 				},
 				MaxItems: 1,
 				Optional: true,


### PR DESCRIPTION
Files must not be referenced from global context because the init
function that makes embedded files available has not yet been run.