### PR TITLE
fix aiven_database resource importing

### DIFF
--- a/resource_database.go
+++ b/resource_database.go
@@ -103,6 +103,8 @@ func resourceDatabaseRead(d *schema.ResourceData, m interface{}) error {
 	}
 
 	d.Set("database_name", database.DatabaseName)
+	d.Set("project", projectName)
+	d.Set("service_name", serviceName)
 	d.Set("lc_collate", database.LcCollate)
 	d.Set("lc_ctype", database.LcType)
 


### PR DESCRIPTION
Fixes #76

resourceDatabaseRead() did not fill the project and service_name
resulting in partial import that then later trigger recreation
of the database.

Previously imported database resources having this issue will have
to be removed from the state and reimported.