### PR TITLE
Wait for VPC to become active before completing creation

### DIFF
--- a/resource_service.go
+++ b/resource_service.go
@@ -420,12 +420,6 @@ func resourceServiceCreate(d *schema.ResourceData, m interface{}) error {
 	if len(vpcID) > 0 {
 		_, vpcID := splitResourceID2(vpcID)
 		vpcIDPointer = &vpcID
-		// Make sure the VPC is active before trying to create the service. Service creation will fail otherwise
-		waiter := ProjectVPCActiveWaiter{Client: client, Project: project, VPCID: vpcID}
-		_, vpcError := waiter.Conf().WaitForState()
-		if vpcError != nil {
-			return fmt.Errorf("error waiting for Aiven project VPC to be ACTIVE: %s", vpcError)
-		}
 	}
 	_, err := client.Services.Create(
 		project,


### PR DESCRIPTION
State will always automatically change from APPROVED to ACTIVE (unless
there's some error in configuration) so instead of handling waiting in
places where the VPC is used, just always wait during creation. Fixes
case where new VPC is created and existing service moved to that VPC
during the same apply and also some other issues.

Also increased timeout from 2 two 4 minutes since in some cases the
cloud provider APIs can be slow enough for 2 minutes to be enough.

Fixes https://github.com/aiven/terraform-provider-aiven/issues/54