### PR TITLE
Add topic and acl caching

### DIFF
--- a/aiven/kafka_topic_change.go
+++ b/aiven/kafka_topic_change.go
@@ -5,6 +5,8 @@ import (
 	"time"
 
 	"github.com/aiven/aiven-go-client"
+	"github.com/aiven/terraform-provider-aiven/pkg/cache"
+
 	"github.com/hashicorp/terraform/helper/resource"
 )
 
@@ -20,11 +22,11 @@ type KafkaTopicChangeWaiter struct {
 // RefreshFunc will call the Aiven client and refresh it's state.
 func (w *KafkaTopicChangeWaiter) RefreshFunc() resource.StateRefreshFunc {
 	return func() (interface{}, string, error) {
-		topic, err := w.Client.KafkaTopics.Get(
-			w.Project,
-			w.ServiceName,
-			w.TopicName,
-		)
+		var topic aiven.KafkaTopic
+		var err error
+		topicCache := cache.TopicCache{}
+		topicCache.Refresh(w.Project, w.ServiceName, w.Client)
+		topic, err = topicCache.Read(w.Project, w.ServiceName, w.TopicName, w.Client)
 
 		if err != nil {
 			aivenError, ok := err.(aiven.Error)

--- a/aiven/resource_kafka_acl.go
+++ b/aiven/resource_kafka_acl.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/aiven/terraform-provider-aiven/pkg/cache"
+
 	"github.com/aiven/aiven-go-client"
 	"github.com/hashicorp/terraform/helper/schema"
 )
@@ -83,12 +85,12 @@ func resourceKafkaACLRead(d *schema.ResourceData, m interface{}) error {
 	client := m.(*aiven.Client)
 
 	project, serviceName, aclID := splitResourceID3(d.Id())
-	acl, err := client.KafkaACLs.Get(project, serviceName, aclID)
+	acl, err := cache.ACLCache{}.Read(project, serviceName, aclID, client)
 	if err != nil {
 		return err
 	}
 
-	return copyKafkaACLPropertiesFromAPIResponseToTerraform(d, acl, project, serviceName)
+	return copyKafkaACLPropertiesFromAPIResponseToTerraform(d, &acl, project, serviceName)
 }
 
 func resourceKafkaACLDelete(d *schema.ResourceData, m interface{}) error {
@@ -102,7 +104,7 @@ func resourceKafkaACLExists(d *schema.ResourceData, m interface{}) (bool, error)
 	client := m.(*aiven.Client)
 
 	projectName, serviceName, aclID := splitResourceID3(d.Id())
-	_, err := client.KafkaACLs.Get(projectName, serviceName, aclID)
+	_, err := cache.ACLCache{}.Read(projectName, serviceName, aclID, client)
 	return resourceExists(err)
 }
 

--- a/go.mod
+++ b/go.mod
@@ -10,4 +10,5 @@ require (
 	github.com/hashicorp/hcl v1.0.0 // indirect
 	github.com/hashicorp/terraform v0.12.0
 	github.com/mitchellh/go-homedir v1.1.0 // indirect
+	github.com/spf13/pflag v1.0.3 // indirect
 )

--- a/pkg/cache/kafka_acl_cache.go
+++ b/pkg/cache/kafka_acl_cache.go
@@ -1,0 +1,79 @@
+package cache
+
+import (
+	"fmt"
+	"log"
+	"sync"
+
+	aiven "github.com/aiven/aiven-go-client"
+)
+
+var (
+	acls         = make(map[string]map[string]aiven.KafkaACL)
+	aclCacheLock sync.Mutex
+)
+
+//ACLCache type
+type ACLCache struct {
+}
+
+//Read populates the cache if it doesn't exist, and reads the required acl. An aiven.Error with status
+//404 is returned upon cache miss
+func (a ACLCache) Read(project, service, aclID string, client *aiven.Client) (acl aiven.KafkaACL, err error) {
+	aclCacheLock.Lock()
+	defer aclCacheLock.Unlock()
+	if _, ok := acls[project+service]; !ok {
+		if err = a.populateACLCache(project, service, client); err != nil {
+			return
+		}
+	}
+	if cachedService, ok := acls[project+service]; ok {
+		if acl, ok = cachedService[aclID]; !ok {
+			// cache miss, try to get the ACL from the Aiven API instead
+			log.Printf("Cache miss on ACL: %s, going live to Aiven API", aclID)
+			var liveACL *aiven.KafkaACL
+			liveACL, err = client.KafkaACLs.Get(project, service, aclID)
+			acl = *liveACL
+		}
+	} else {
+		//TODO: returning a 404 here provides no extra value, as the ACL is then treated as if it
+		// doesn't exist (which may not be the case here).
+		err = aiven.Error{
+			Status:  404,
+			Message: fmt.Sprintf("Cache miss on project/service: %s/%s", project, service),
+		}
+	}
+
+	return
+}
+
+//write writes the specified ACL to the cache
+func (a ACLCache) write(project, service string, acl *aiven.KafkaACL) (err error) {
+	var cachedService map[string]aiven.KafkaACL
+	var ok bool
+	if cachedService, ok = acls[project+service]; !ok {
+		cachedService = make(map[string]aiven.KafkaACL)
+	}
+
+	cachedService[acl.ID] = *acl
+	acls[project+service] = cachedService
+	return
+}
+
+//Refresh refreshes the ACL cache
+func (a ACLCache) Refresh(project, service string, client *aiven.Client) error {
+	aclCacheLock.Lock()
+	defer aclCacheLock.Unlock()
+	return a.populateACLCache(project, service, client)
+}
+
+//populateACLCache makes a call to Aiven to list kafka ACLs, and upserts into the cache
+func (a ACLCache) populateACLCache(project, service string, client *aiven.Client) (err error) {
+	var acls []*aiven.KafkaACL
+	if acls, err = client.KafkaACLs.List(project, service); err == nil {
+		for _, acl := range acls {
+			a.write(project, service, acl)
+		}
+	}
+	return
+}

--- a/pkg/cache/kafka_topic_cache.go
+++ b/pkg/cache/kafka_topic_cache.go
@@ -1,0 +1,88 @@
+package cache
+
+import (
+	"fmt"
+
+	aiven "github.com/aiven/aiven-go-client"
+)
+
+var (
+	topics = make(map[string]map[string]aiven.KafkaTopic)
+)
+
+//TopicCache type
+type TopicCache struct {
+}
+
+//write writes the specified topic to the cache
+func (t TopicCache) write(project, service string, topic *aiven.KafkaListTopic) (err error) {
+	var cachedService map[string]aiven.KafkaTopic
+	var ok bool
+	if cachedService, ok = topics[project+service]; !ok {
+		cachedService = make(map[string]aiven.KafkaTopic)
+	}
+
+	topicForCache := aiven.KafkaTopic{
+		MinimumInSyncReplicas: topic.MinimumInSyncReplicas,
+		Partitions:            partitions(topic.Partitions),
+		Replication:           topic.Replication,
+		RetentionBytes:        topic.RetentionBytes,
+		RetentionHours:        topic.RetentionHours,
+		State:                 topic.State,
+		TopicName:             topic.TopicName,
+		CleanupPolicy:         topic.CleanupPolicy}
+
+	cachedService[topic.TopicName] = topicForCache
+	topics[project+service] = cachedService
+	return
+}
+
+//Refresh refreshes the Topic cache
+func (t TopicCache) Refresh(project, service string, client *aiven.Client) error {
+	return t.populateTopicCache(project, service, client)
+}
+
+//Read populates the cache if it doesn't exist, and reads the required topic. An aiven.Error with status
+//404 is returned upon cache miss
+func (t TopicCache) Read(project, service, topicName string, client *aiven.Client) (topic aiven.KafkaTopic, err error) {
+	if _, ok := topics[project+service]; !ok {
+		if err = t.populateTopicCache(project, service, client); err != nil {
+			return
+		}
+	}
+	if cachedService, ok := topics[project+service]; ok {
+		if topic, ok = cachedService[topicName]; !ok {
+			// cache miss, return a 404 so it can be cleaned up later
+			err = aiven.Error{
+				Status:  404,
+				Message: fmt.Sprintf("Cache miss on project/service/topic: %s/%s/%s", project, service, topicName),
+			}
+		}
+	} else {
+		err = aiven.Error{
+			Status:  404,
+			Message: fmt.Sprintf("Cache miss on project/service: %s/%s", project, service),
+		}
+	}
+
+	return
+}
+
+//partitions returns a slice, of empty aiven.Partition, of specified size
+func partitions(numPartitions int) (partitions []*aiven.Partition) {
+	for i := 0; i < numPartitions; i++ {
+		partitions = append(partitions, &aiven.Partition{})
+	}
+	return
+}
+
+//populateTopicCache makes a call to Aiven to list kafka topics, and upserts into the cache
+func (t TopicCache) populateTopicCache(project, service string, client *aiven.Client) (err error) {
+	var topics []*aiven.KafkaListTopic
+	if topics, err = client.KafkaTopics.List(project, service); err == nil {
+		for _, topic := range topics {
+			t.write(project, service, topic)
+		}
+	}
+	return
+}


### PR DESCRIPTION
Cc @mteiste 

Apologies it took me so long to get this PR in..

For anyone checking this, the TL;DR is that we have a large number (thousands) of resources in Aiven that we've Terraformed in a single GitHub repo. Running `tf plan` and `tf apply` commands are taking an extremely long time for Topics and ACLs due to an API call being made for each.

This change introduces an ACL and a Topic cache, which are populated using a single List API call for each. It's cut our tf plan/applies down to sub-2mins, and I hope it could reduce the impact on your API too?

We also added a sleep into each resource, as without them we were seeing most plan/applies failing with a gRPC error: `Error: rpc error: code = Canceled desc = context canceled`. Unfortunately we don't have much gRPC expertise currently, so we've not been able to track down the route cause yet, but adding sleeps seemed to reduce the frequency of the failures.