### PR TITLE
Add support for Kafka Connect service

### DIFF
--- a/aiven/resource_service.go
+++ b/aiven/resource_service.go
@@ -272,6 +272,16 @@ var aivenServiceSchema = map[string]*schema.Schema{
 				GetUserConfigSchema("service")["kafka"].(map[string]interface{})),
 		},
 	},
+	"kafka_connect": {
+		Type: schema.TypeList,
+		MaxItems: 1,
+		Computed: true,
+		Description: "Kafka Connect specific server provided values",
+		Optional: true,
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{},
+		},
+	},
 	"mysql": {
 		Type:        schema.TypeList,
 		MaxItems:    1,
@@ -617,6 +627,7 @@ func copyConnectionInfoFromAPIResponseToTerraform(
 	d.Set("mysql", []map[string]interface{}{})
 	d.Set("pg", []map[string]interface{}{})
 	d.Set("redis", []map[string]interface{}{})
+	d.Set("kafka_connect", []map[string]interface{}{})
 
 	props := make(map[string]interface{})
 	switch serviceType {
@@ -651,6 +662,7 @@ func copyConnectionInfoFromAPIResponseToTerraform(
 		}
 		props["replica_uri"] = connectionInfo.PostgresReplicaURI
 	case "redis":
+	case "kafka_connect":
 	default:
 		panic(fmt.Sprintf("Unsupported service type %v", serviceType))
 	}

--- a/aiven/resource_service.go
+++ b/aiven/resource_service.go
@@ -272,14 +272,15 @@ var aivenServiceSchema = map[string]*schema.Schema{
 				GetUserConfigSchema("service")["kafka"].(map[string]interface{})),
 		},
 	},
-	"kafka_connect": {
-		Type: schema.TypeList,
-		MaxItems: 1,
-		Computed: true,
-		Description: "Kafka Connect specific server provided values",
-		Optional: true,
+	"kafka_connect_user_config": {
+		Type:             schema.TypeList,
+		MaxItems:         1,
+		Description:      "Kafka Connect specific user configurable settings",
+		Optional:         true,
+		DiffSuppressFunc: emptyObjectDiffSuppressFunc,
 		Elem: &schema.Resource{
-			Schema: map[string]*schema.Schema{},
+			Schema: GenerateTerraformUserConfigSchema(
+				GetUserConfigSchema("service")["kafka_connect"].(map[string]interface{})),
 		},
 	},
 	"mysql": {

--- a/aiven/templates/service_user_config_schema.json
+++ b/aiven/templates/service_user_config_schema.json
@@ -1478,5 +1478,29 @@
       }
     },
     "type": "object"
+  },
+  "kafka_connect": {
+    "additionalProperties": false,
+    "properties": {
+      "kafka_connect": {
+        "additionalProperties": false,
+        "default": {
+          "consumer_isolation_level": "read_uncommitted"
+        },
+        "properties": {
+          "consumer_isolation_level": {
+            "title": "Transaction read isolation level",
+            "type": "string",
+            "enum": [
+              "read_committed",
+              "read_uncommitted"
+            ]
+          }
+        },
+        "type": "object",
+        "title": "Kafka Connect configuration values"
+      }
+    },
+    "type": "object"
   }
 }


### PR DESCRIPTION
This is for creating separate Kafka Connect services. For example

```terraform
resource "aiven_service" "kafka_connect" {
  project                 = var.project
  cloud_name              = var.cloud
  plan                    = var.plan
  service_name            = var.service_name
  service_type            = "kafka_connect"
  project_vpc_id          = var.vpc_id
  termination_protection  = true
  maintenance_window_dow  = var.maintenance_window_dow
  maintenance_window_time = var.maintenance_window_time
}

resource "aiven_service_integration" "kafka_connect" {
  project                  = var.project
  integration_type         = "kafka_connect"
  source_service_name      = var.source_service_name
  destination_service_name = aiven_service.kafka_connect.service_name
}
```