### PR TITLE
added variant to the schema definition to enable timescale support

### DIFF
--- a/aiven/templates/service_user_config_schema.json
+++ b/aiven/templates/service_user_config_schema.json
@@ -1292,6 +1292,11 @@
         "title": "PostgreSQL major version",
         "type": ["string", "null"]
       },
+      "variant": {
+        "enum": ["aiven", "timescale"],
+        "title": "Service variant",
+        "type": ["string", "null"]
+      },
       "pgbouncer": {
         "properties": {
           "server_reset_query_always": {


### PR DESCRIPTION
This addresses #104 (Timescale Cloud Support).

Allows variant of type "timescale" or "aiven" in the `aiven_service` resource.