### PR TITLE
Fix caching nil pointer dereference

### DIFF
--- a/pkg/cache/kafka_acl_cache.go
+++ b/pkg/cache/kafka_acl_cache.go
@@ -32,8 +32,9 @@ func (a ACLCache) Read(project, service, aclID string, client *aiven.Client) (ac
 			// cache miss, try to get the ACL from the Aiven API instead
 			log.Printf("Cache miss on ACL: %s, going live to Aiven API", aclID)
 			var liveACL *aiven.KafkaACL
-			liveACL, err = client.KafkaACLs.Get(project, service, aclID)
-			acl = *liveACL
+			if liveACL, err = client.KafkaACLs.Get(project, service, aclID); err == nil {
+				acl = *liveACL
+			}
 		}
 	} else {
 		//TODO: returning a 404 here provides no extra value, as the ACL is then treated as if it

--- a/pkg/cache/kafka_topic_cache.go
+++ b/pkg/cache/kafka_topic_cache.go
@@ -60,9 +60,9 @@ func (t TopicCache) Read(project, service, topicName string, client *aiven.Clien
 	if cachedService, ok := topics[project+service]; ok {
 		if topic, ok = cachedService[topicName]; !ok {
 			// cache miss, return a 404 so it can be cleaned up later
-			err = aiven.Error{
-				Status:  404,
-				Message: fmt.Sprintf("Cache miss on project/service/topic: %s/%s/%s", project, service, topicName),
+			var liveTopic *aiven.KafkaTopic
+			if liveTopic, err = client.KafkaTopics.Get(project, service, topicName); err == nil {
+				topic = *liveTopic
 			}
 		}
 	} else {


### PR DESCRIPTION
this code was causing a nil pointer dereference when `liveACL` was nil:

```
liveACL, err = client.KafkaACLs.Get(project, service, aclID)
acl = *liveACL
```

..so I added a nil check.

I also changed the topic cache to return the error that `client.KafkaTopics.Get()` returns instead of creating its own (this also has a nil check).