### PR TITLE
WIP: exclude golint from Jenkins build task

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ version = $(shell git describe --long --tags 2>/dev/null || echo unknown-g`git d
 short_version = $(shell echo $(version) | sed 's/-.*//')
 
 .PHONY: ci
-ci: lint bins release
+ci: bins release
 
 #################################################
 # Bootstrapping for base golang package deps
@@ -66,4 +66,4 @@ clean:
 	rm -rf plugins
 	rm -f terraform-provider-aiven.tar.gz
 
-.PHONY: test lint vendor bootstrap
+.PHONY: test vendor bootstrap


### PR DESCRIPTION
We have the following error been observed on CI:

```
go: extracting github.com/googleapis/gax-go/v2 v2.0.3
golangci-lint run --no-config --issues-exit-code=0 ./...
level=warning msg="[runner] Can't run linter goanalysis_metalinter: ctrlflow: failed prerequisites: inspect@github.com/hashicorp/go-plugin"
level=error msg="Running error: ctrlflow: failed prerequisites: inspect@github.com/hashicorp/go-plugin"
make: *** [Makefile:61: lint] Error 3
Build step 'Execute shell' marked build as failure
Archiving artifacts
Finished: FAILURE
```

Which seems to be a GoLint bug which appears randomly from time to time https://github.com/golangci/golangci-lint/issues/827.

Initial idea was to disable GoLint from Jenkins CI to make builds work again and at the same time code is not compliant with all default GoLint checks.

Then together with @mteiste we decided to try this PR first https://github.com/aiven/terraform-provider-aiven/pull/126 and observe it this error will appear again then we would need to temporary disable GoLit from Jenkins CI. Another proposed solution is to use  https://golangci.com/  instead of running GoLit ourselves, that would probably save us in the future from errors like the one from above. 

Please ignore this PR for now