### PR TITLE
test-acc: project

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,10 +55,11 @@ test: vendor
 	CGO_ENABLED=0 go test -v ./...
 
 testacc: vendor
-	TF_ACC=1 CGO_ENABLED=0 go test -v --cover ./...
+	TF_ACC=1 CGO_ENABLED=0 go test -v --cover ./... -timeout 120m
 
-fmt: vendor
-	! go fmt ./... 2>&1 | read
+sweep:
+	@echo "WARNING: This will destroy infrastructure. Use only in development accounts."
+	go test -v ./... -sweep=global -timeout 60m
 
 lint: vendor
 	golangci-lint run  -D errcheck -E gofmt --no-config --issues-exit-code=0 --timeout=30m ./...

--- a/Makefile
+++ b/Makefile
@@ -54,6 +54,12 @@ release: bins
 test: vendor
 	CGO_ENABLED=0 go test -v ./...
 
+testacc: vendor
+	TF_ACC=1 CGO_ENABLED=0 go test -v --cover ./...
+
+fmt: vendor
+	! go fmt ./... 2>&1 | read
+
 lint: vendor
 	golangci-lint run  -D errcheck -E gofmt --no-config --issues-exit-code=0 --timeout=30m ./...
 

--- a/aiven/aiven_sweeper_test.go
+++ b/aiven/aiven_sweeper_test.go
@@ -1,0 +1,28 @@
+package aiven
+
+import (
+	"fmt"
+	"github.com/aiven/aiven-go-client"
+	"github.com/hashicorp/terraform/helper/resource"
+	"os"
+	"testing"
+)
+
+func TestMain(m *testing.M) {
+	resource.TestMain(m)
+}
+
+// sharedClient returns a common Aiven Client setup needed for the sweeper
+func sharedClient(region string) (interface{}, error) {
+	if os.Getenv("AIVEN_TOKEN") == "" {
+		return nil, fmt.Errorf("must provide environment variable AIVEN_TOKEN ")
+	}
+
+	// configures a default client, using the above env var
+	client, err := aiven.NewTokenClient(os.Getenv("AIVEN_TOKEN"), "terraform-provider-aiven-acc/")
+	if err != nil {
+		return nil, fmt.Errorf("error getting Aiven client")
+	}
+
+	return client, nil
+}

--- a/aiven/provider_test.go
+++ b/aiven/provider_test.go
@@ -1,0 +1,37 @@
+package aiven
+
+import (
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform/terraform"
+	"os"
+	"testing"
+)
+
+var (
+	testAccProviders map[string]terraform.ResourceProvider
+	testAccProvider  *schema.Provider
+)
+
+func init() {
+	testAccProvider = Provider().(*schema.Provider)
+	testAccProviders = map[string]terraform.ResourceProvider{
+		"aiven": testAccProvider,
+	}
+}
+
+func TestProvider(t *testing.T) {
+	if err := Provider().(*schema.Provider).InternalValidate(); err != nil {
+		t.Fatalf("err: %s", err)
+	}
+}
+
+func TestProviderImpl(t *testing.T) {
+	var _ terraform.ResourceProvider = Provider()
+}
+
+func testAccPreCheck(t *testing.T) {
+	if v := os.Getenv("AIVEN_TOKEN"); v == "" {
+		t.Log(v)
+		t.Fatal("AIVEN_TOKEN must be set for acceptance tests")
+	}
+}

--- a/aiven/resource_project_test.go
+++ b/aiven/resource_project_test.go
@@ -1,0 +1,116 @@
+package aiven
+
+import (
+	"fmt"
+	"github.com/aiven/aiven-go-client"
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+	"strings"
+	"testing"
+)
+
+func init() {
+	resource.AddTestSweepers("aiven_project", &resource.Sweeper{
+		Name: "aiven_project",
+		F:    sweepProjects,
+	})
+}
+
+func sweepProjects(region string) error {
+
+	client, err := sharedClient(region)
+	if err != nil {
+		return fmt.Errorf("error getting client: %s", err)
+	}
+
+	conn := client.(*aiven.Client)
+
+	projects, err := conn.Projects.List()
+	if err != nil {
+		return fmt.Errorf("error retrieving a list of projects : %s", err)
+	}
+
+	for _, project := range projects {
+		if strings.Contains(project.Name, "test-acc-pr") {
+			if err := conn.Projects.Delete(project.Name); err != nil {
+				return fmt.Errorf("error destroying project %s during sweep: %s", project.Name, err)
+			}
+		}
+	}
+
+	return nil
+}
+
+func TestAccAivenProject_basic(t *testing.T) {
+	resourceName := "aiven_project.foo"
+	rName := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAivenProjectResourceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccProjectResource(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAivenProjectAttributes("data.aiven_project.project"),
+					resource.TestCheckResourceAttr(resourceName, "project", fmt.Sprintf("pr-%s", rName)),
+				),
+			},
+		},
+	})
+}
+
+func testAccProjectResource(name string) string {
+	return fmt.Sprintf(`
+		resource "aiven_project" "foo" {
+			project = "test-acc-pr-%s"
+		}
+
+		data "aiven_project" "project" {
+			project = aiven_project.foo.project
+		}
+		`, name)
+}
+
+func testAccCheckAivenProjectAttributes(n string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		r := s.RootModule().Resources[n]
+		a := r.Primary.Attributes
+
+		if a["project"] == "" {
+			return fmt.Errorf("expected to get a project name from Aiven")
+		}
+
+		if a["ca_cert"] == "" {
+			return fmt.Errorf("expected to get an ca_cert from Aiven")
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckAivenProjectResourceDestroy(s *terraform.State) error {
+	c := testAccProvider.Meta().(*aiven.Client)
+
+	// loop through the resources in state, verifying each project is destroyed
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "project" {
+			continue
+		}
+
+		p, err := c.Projects.Get(rs.Primary.ID)
+		if err != nil {
+			if err.(aiven.Error).Status != 404 {
+				return err
+			}
+		}
+
+		if p != nil {
+			return fmt.Errorf("porject (%s) still exists", rs.Primary.ID)
+		}
+	}
+
+	return nil
+}


### PR DESCRIPTION
use `make testacc` to run the acceptance tests

`AIVEN_TOKEN` environment variable is required and should contain a valid Aiven API token