### PR TITLE
golangci-lint disable unused checks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,7 +62,7 @@ sweep:
 	go test -v ./... -sweep=global -timeout 60m
 
 lint: vendor
-	golangci-lint run  -D errcheck -E gofmt --no-config --issues-exit-code=0 --timeout=30m ./...
+	golangci-lint run  -D errcheck -D unused -E gofmt --no-config --issues-exit-code=0 --timeout=30m ./...
 
 clean:
 	packr2 clean


### PR DESCRIPTION
Disable golangci-lint `unused` checks. 

**Motivation:**
Aiven in-house Jenkins build job fails from time to time with the following error:
```
golangci-lint run  -D errcheck --no-config --issues-exit-code=0 ./...
level=warning msg="[runner] Can't run linter goanalysis_metalinter: fact_deprecated: failed prerequisites: fact_deprecated@github.com/hashicorp/go-plugin"
level=error msg="Running error: fact_deprecated: failed prerequisites: fact_deprecated@github.com/hashicorp/go-plugin"
```

It looks like it is somehow related to these issues:
- https://github.com/golangci/golangci-lint/issues/885
- https://github.com/golangci/golangci-lint/issues/827

And the remedy for this problem could be to temporary disable `unused` checks.  