### PR TITLE
testacc: Add service type specific tests

### DIFF
--- a/aiven/resource_project_user_test.go
+++ b/aiven/resource_project_user_test.go
@@ -6,7 +6,6 @@ import (
 	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
-	"log"
 	"testing"
 )
 
@@ -26,7 +25,7 @@ func TestAccAivenProjectUser_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAivenProjectUserAttributes("data.aiven_project_user.user"),
 					resource.TestCheckResourceAttr(resourceName, "project", fmt.Sprintf("test-acc-pr-%s", rName)),
-					resource.TestCheckResourceAttr(resourceName, "email", fmt.Sprintf("user%s@aiven.fi", rName)),
+					resource.TestCheckResourceAttr(resourceName, "email", fmt.Sprintf("savciuci+%s@aiven.fi", rName)),
 					resource.TestCheckResourceAttr(resourceName, "member_type", "admin"),
 				),
 			},
@@ -71,7 +70,7 @@ func testAccProjectUserResource(name string) string {
 
 		resource "aiven_project_user" "bar" {
 			project = aiven_project.foo.project
-			email = "user%s@aiven.fi"
+			email = "savciuci+%s@aiven.fi"
 			member_type = "admin"
 		}
 
@@ -86,8 +85,6 @@ func testAccCheckAivenProjectUserAttributes(n string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		r := s.RootModule().Resources[n]
 		a := r.Primary.Attributes
-
-		log.Printf("[DEBUG] project user attributes %v", a)
 
 		if a["project"] == "" {
 			return fmt.Errorf("expected to get a project name from Aiven")

--- a/aiven/resource_service_cassandra_test.go
+++ b/aiven/resource_service_cassandra_test.go
@@ -1,0 +1,98 @@
+package aiven
+
+import (
+	"fmt"
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+	"os"
+	"testing"
+)
+
+// Cassandra service tests
+func TestAccAivenService_cassandra(t *testing.T) {
+	t.Parallel()
+	resourceName := "aiven_service.bar"
+	rName := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAivenServiceResourceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCassandraServiceResource(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAivenServiceCommonAttributes("data.aiven_service.service"),
+					testAccCheckAivenServiceCassandraAttributes("data.aiven_service.service"),
+					resource.TestCheckResourceAttr(resourceName, "service_name", fmt.Sprintf("test-acc-sr-%s", rName)),
+					resource.TestCheckResourceAttr(resourceName, "state", "RUNNING"),
+					resource.TestCheckResourceAttr(resourceName, "project", fmt.Sprintf("test-acc-pr-%s", rName)),
+					resource.TestCheckResourceAttr(resourceName, "service_type", "cassandra"),
+					resource.TestCheckResourceAttr(resourceName, "cloud_name", "google-europe-west1"),
+					resource.TestCheckResourceAttr(resourceName, "maintenance_window_dow", "monday"),
+					resource.TestCheckResourceAttr(resourceName, "maintenance_window_time", "10:00:00"),
+					resource.TestCheckResourceAttr(resourceName, "state", "RUNNING"),
+					resource.TestCheckResourceAttr(resourceName, "termination_protection", "false"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCassandraServiceResource(name string) string {
+	return fmt.Sprintf(`
+		resource "aiven_project" "foo" {
+			project = "test-acc-pr-%s"
+			card_id="%s"	
+		}
+		
+		resource "aiven_service" "bar" {
+			project = aiven_project.foo.project
+			cloud_name = "google-europe-west1"
+			plan = "startup-4"
+			service_name = "test-acc-sr-%s"
+			service_type = "cassandra"
+			maintenance_window_dow = "monday"
+			maintenance_window_time = "10:00:00"
+			
+			cassandra_user_config {
+				migrate_sstableloader = true		
+	
+				public_access {
+					prometheus = true
+				}
+			}
+		}
+		
+		data "aiven_service" "service" {
+			service_name = aiven_service.bar.service_name
+			project = aiven_project.foo.project
+		}
+		`, name, os.Getenv("AIVEN_CARD_ID"), name)
+}
+
+func testAccCheckAivenServiceCassandraAttributes(n string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		r := s.RootModule().Resources[n]
+		a := r.Primary.Attributes
+
+		if a["service_type"] != "cassandra" {
+			return fmt.Errorf("expected to get a correct service type from Aiven, got :%s", a["service_type"])
+		}
+
+		if a["cassandra_user_config.0.public_access.0.prometheus"] != "true" {
+			return fmt.Errorf("expected to get a correct public_access.prometheus from Aiven")
+		}
+
+		if a["cassandra_user_config.0.service_to_fork_from"] != "<<value not set>>" {
+			return fmt.Errorf("expected to get a correct public_access.service_to_fork_from from Aiven")
+		}
+
+		if a["cassandra_user_config.0.migrate_sstableloader"] != "true" {
+			return fmt.Errorf("expected to get a correct migrate_sstableloader from Aiven")
+		}
+
+		return nil
+	}
+}

--- a/aiven/resource_service_influxdb_test.go
+++ b/aiven/resource_service_influxdb_test.go
@@ -1,0 +1,88 @@
+package aiven
+
+import (
+	"fmt"
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+	"os"
+	"testing"
+)
+
+// InfluxDB service tests
+func TestAccAivenService_influxdb(t *testing.T) {
+	t.Parallel()
+	resourceName := "aiven_service.bar"
+	rName := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAivenServiceResourceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccInfluxdbServiceResource(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAivenServiceCommonAttributes("data.aiven_service.service"),
+					testAccCheckAivenServiceInfluxdbAttributes("data.aiven_service.service"),
+					resource.TestCheckResourceAttr(resourceName, "service_name", fmt.Sprintf("test-acc-sr-%s", rName)),
+					resource.TestCheckResourceAttr(resourceName, "state", "RUNNING"),
+					resource.TestCheckResourceAttr(resourceName, "project", fmt.Sprintf("test-acc-pr-%s", rName)),
+					resource.TestCheckResourceAttr(resourceName, "service_type", "influxdb"),
+					resource.TestCheckResourceAttr(resourceName, "cloud_name", "google-europe-west1"),
+					resource.TestCheckResourceAttr(resourceName, "maintenance_window_dow", "monday"),
+					resource.TestCheckResourceAttr(resourceName, "maintenance_window_time", "10:00:00"),
+					resource.TestCheckResourceAttr(resourceName, "state", "RUNNING"),
+					resource.TestCheckResourceAttr(resourceName, "termination_protection", "false"),
+				),
+			},
+		},
+	})
+}
+
+func testAccInfluxdbServiceResource(name string) string {
+	return fmt.Sprintf(`
+		resource "aiven_project" "foo" {
+			project = "test-acc-pr-%s"
+			card_id="%s"	
+		}
+		
+		resource "aiven_service" "bar" {
+			project = aiven_project.foo.project
+			cloud_name = "google-europe-west1"
+			plan = "startup-4"
+			service_name = "test-acc-sr-%s"
+			service_type = "influxdb"
+			maintenance_window_dow = "monday"
+			maintenance_window_time = "10:00:00"
+			
+			influxdb_user_config {
+				public_access {
+					influxdb = true
+				}
+			}
+		}
+		
+		data "aiven_service" "service" {
+			service_name = aiven_service.bar.service_name
+			project = aiven_project.foo.project
+		}
+		`, name, os.Getenv("AIVEN_CARD_ID"), name)
+}
+
+func testAccCheckAivenServiceInfluxdbAttributes(n string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		r := s.RootModule().Resources[n]
+		a := r.Primary.Attributes
+
+		if a["service_type"] != "influxdb" {
+			return fmt.Errorf("expected to get a correct service type from Aiven, got :%s", a["service_type"])
+		}
+
+		if a["influxdb_user_config.0.public_access.0.influxdb"] != "true" {
+			return fmt.Errorf("expected to get a correct public_access.influxdb from Aiven")
+		}
+
+		return nil
+	}
+}

--- a/aiven/resource_service_kafka_connect_test.go
+++ b/aiven/resource_service_kafka_connect_test.go
@@ -1,0 +1,108 @@
+package aiven
+
+import (
+	"fmt"
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+	"os"
+	"testing"
+)
+
+// Kafka Connect service tests
+func TestAccAivenService_kafkaconnect(t *testing.T) {
+	t.Parallel()
+	resourceName := "aiven_service.bar"
+	rName := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAivenServiceResourceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccKafkaConnectServiceResource(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAivenServiceCommonAttributes("data.aiven_service.service"),
+					testAccCheckAivenServiceKafkaConnectAttributes("data.aiven_service.service"),
+					resource.TestCheckResourceAttr(resourceName, "service_name", fmt.Sprintf("test-acc-sr-%s", rName)),
+					resource.TestCheckResourceAttr(resourceName, "state", "RUNNING"),
+					resource.TestCheckResourceAttr(resourceName, "project", fmt.Sprintf("test-acc-pr-%s", rName)),
+					resource.TestCheckResourceAttr(resourceName, "service_type", "kafka_connect"),
+					resource.TestCheckResourceAttr(resourceName, "cloud_name", "google-europe-west1"),
+					resource.TestCheckResourceAttr(resourceName, "maintenance_window_dow", "monday"),
+					resource.TestCheckResourceAttr(resourceName, "maintenance_window_time", "10:00:00"),
+					resource.TestCheckResourceAttr(resourceName, "state", "RUNNING"),
+					resource.TestCheckResourceAttr(resourceName, "termination_protection", "false"),
+				),
+			},
+		},
+	})
+}
+
+func testAccKafkaConnectServiceResource(name string) string {
+	return fmt.Sprintf(`
+		resource "aiven_project" "foo" {
+			project = "test-acc-pr-%s"
+			card_id="%s"	
+		}
+		
+		resource "aiven_service" "bar" {
+			project = aiven_project.foo.project
+			cloud_name = "google-europe-west1"
+			plan = "startup-4"
+			service_name = "test-acc-sr-%s"
+			service_type = "kafka_connect"
+			maintenance_window_dow = "monday"
+			maintenance_window_time = "10:00:00"
+			
+			kafka_connect_user_config {
+				kafka_connect {
+					consumer_isolation_level = "read_committed"
+				}
+		
+				public_access {
+					kafka_connect = true
+				}
+			}
+		}
+		
+		data "aiven_service" "service" {
+			service_name = aiven_service.bar.service_name
+			project = aiven_project.foo.project
+		}
+		`, name, os.Getenv("AIVEN_CARD_ID"), name)
+}
+
+func testAccCheckAivenServiceKafkaConnectAttributes(n string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		r := s.RootModule().Resources[n]
+		a := r.Primary.Attributes
+
+		if a["service_type"] != "kafka_connect" {
+			return fmt.Errorf("expected to get a correct service type from Aiven, got :%s", a["service_type"])
+		}
+
+		if a["kafka_connect_user_config.0.kafka_connect.0.consumer_isolation_level"] != "read_committed" {
+			return fmt.Errorf("expected to get a correct consumer_isolation_level from Aiven")
+		}
+
+		if a["kafka_connect_user_config.0.kafka_connect.0.consumer_max_poll_records"] != "-1" {
+			return fmt.Errorf("expected to get a correct consumer_max_poll_records from Aiven")
+		}
+
+		if a["kafka_connect_user_config.0.kafka_connect.0.offset_flush_interval_ms"] != "-1" {
+			return fmt.Errorf("expected to get a correct offset_flush_interval_ms from Aiven")
+		}
+
+		if a["kafka_connect_user_config.0.public_access.0.kafka_connect"] != "true" {
+			return fmt.Errorf("expected to get a correct public_access.kafka_connect from Aiven")
+		}
+
+		if a["kafka_connect_user_config.0.public_access.0.prometheus"] != "<<value not set>>" {
+			return fmt.Errorf("expected to get a correct public_access.prometheus from Aiven")
+		}
+
+		return nil
+	}
+}

--- a/aiven/resource_service_redis_test.go
+++ b/aiven/resource_service_redis_test.go
@@ -1,0 +1,98 @@
+package aiven
+
+import (
+	"fmt"
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+	"os"
+	"testing"
+)
+
+// Redis service tests
+func TestAccAivenService_redis(t *testing.T) {
+	t.Parallel()
+	resourceName := "aiven_service.bar"
+	rName := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAivenServiceResourceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccRedisServiceResource(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAivenServiceCommonAttributes("data.aiven_service.service"),
+					testAccCheckAivenServiceRedisAttributes("data.aiven_service.service"),
+					resource.TestCheckResourceAttr(resourceName, "service_name", fmt.Sprintf("test-acc-sr-%s", rName)),
+					resource.TestCheckResourceAttr(resourceName, "state", "RUNNING"),
+					resource.TestCheckResourceAttr(resourceName, "project", fmt.Sprintf("test-acc-pr-%s", rName)),
+					resource.TestCheckResourceAttr(resourceName, "service_type", "redis"),
+					resource.TestCheckResourceAttr(resourceName, "cloud_name", "google-europe-west1"),
+					resource.TestCheckResourceAttr(resourceName, "maintenance_window_dow", "monday"),
+					resource.TestCheckResourceAttr(resourceName, "maintenance_window_time", "10:00:00"),
+					resource.TestCheckResourceAttr(resourceName, "state", "RUNNING"),
+					resource.TestCheckResourceAttr(resourceName, "termination_protection", "false"),
+				),
+			},
+		},
+	})
+}
+
+func testAccRedisServiceResource(name string) string {
+	return fmt.Sprintf(`
+		resource "aiven_project" "foo" {
+			project = "test-acc-pr-%s"
+			card_id="%s"	
+		}
+		
+		resource "aiven_service" "bar" {
+			project = aiven_project.foo.project
+			cloud_name = "google-europe-west1"
+			plan = "business-4"
+			service_name = "test-acc-sr-%s"
+			service_type = "redis"
+			maintenance_window_dow = "monday"
+			maintenance_window_time = "10:00:00"
+			
+			redis_user_config {
+				redis_maxmemory_policy = "allkeys-random"		
+	
+				public_access {
+					redis = true
+				}
+			}
+		}
+		
+		data "aiven_service" "service" {
+			service_name = aiven_service.bar.service_name
+			project = aiven_project.foo.project
+		}
+		`, name, os.Getenv("AIVEN_CARD_ID"), name)
+}
+
+func testAccCheckAivenServiceRedisAttributes(n string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		r := s.RootModule().Resources[n]
+		a := r.Primary.Attributes
+
+		if a["service_type"] != "redis" {
+			return fmt.Errorf("expected to get a correct service type from Aiven, got :%s", a["service_type"])
+		}
+
+		if a["redis_user_config.0.redis_maxmemory_policy"] != "allkeys-random" {
+			return fmt.Errorf("expected to get a correct redis_maxmemory_policy from Aiven")
+		}
+
+		if a["redis_user_config.0.public_access.0.redis"] != "true" {
+			return fmt.Errorf("expected to get a correct public_access.redis from Aiven")
+		}
+
+		if a["redis_user_config.0.public_access.0.prometheus"] != "<<value not set>>" {
+			return fmt.Errorf("expected to get a correct public_access.prometheus from Aiven")
+		}
+
+		return nil
+	}
+}


### PR DESCRIPTION
Add service type-specific tests
Covers Cassandra, InfluxDB, Kafka Connect and Redis