### PR TITLE
Kafka topic old TF state backwards compatibility

### DIFF
--- a/aiven/resource_kafka_topic.go
+++ b/aiven/resource_kafka_topic.go
@@ -122,7 +122,7 @@ func resourceKafkaTopicCreate(d *schema.ResourceData, m interface{}) error {
 }
 
 func resourceKafkaTopicRead(d *schema.ResourceData, m interface{}) error {
-	project, serviceName, _ := splitResourceID3(d.Id())
+	project, serviceName, topicName := splitResourceID3(d.Id())
 	topic, err := getTopic(d, m)
 	if err != nil {
 		return err
@@ -134,7 +134,7 @@ func resourceKafkaTopicRead(d *schema.ResourceData, m interface{}) error {
 	if err := d.Set("service_name", serviceName); err != nil {
 		return err
 	}
-	if err := d.Set("topic_name", topic.TopicName); err != nil {
+	if err := d.Set("topic_name", topicName); err != nil {
 		return err
 	}
 	if err := d.Set("partitions", len(topic.Partitions)); err != nil {
@@ -163,11 +163,13 @@ func resourceKafkaTopicRead(d *schema.ResourceData, m interface{}) error {
 }
 
 func getTopic(d *schema.ResourceData, m interface{}) (aiven.KafkaTopic, error) {
+	project, serviceName, topicName := splitResourceID3(d.Id())
+
 	w := &KafkaTopicAvailabilityWaiter{
 		Client:      m.(*aiven.Client),
-		Project:     d.Get("project").(string),
-		ServiceName: d.Get("service_name").(string),
-		TopicName:   d.Get("topic_name").(string),
+		Project:     project,
+		ServiceName: serviceName,
+		TopicName:   topicName,
 	}
 
 	topic, err := w.Conf().WaitForState()

--- a/pkg/cache/kafka_topic_cache.go
+++ b/pkg/cache/kafka_topic_cache.go
@@ -61,6 +61,8 @@ func (t *TopicCache) LoadByTopicName(projectName, serviceName, topicName string)
 
 	result, ok := topics[topicName]
 
+	log.Printf("[TRACE] retrienve from a topic cache `%+#v` for a topic name `%s`", result, topicName)
+
 	return result, ok
 }
 


### PR DESCRIPTION
- Will solve a situation when a user has an old TF state file created before Kafka `topic` field was renamed to `topic_name`.
- Extra debug and trace logging for Kafka Topic cache and waiter layers 