### PR TITLE
speed up kafka topic availability waiter

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,4 +11,5 @@ require (
 	github.com/hashicorp/terraform v0.12.0
 	github.com/mitchellh/go-homedir v1.1.0 // indirect
 	github.com/stretchr/testify v1.3.0
+	golang.org/x/sync v0.0.0-20190423024810-112230192c58
 )

--- a/pkg/cache/kafka_topic_cache.go
+++ b/pkg/cache/kafka_topic_cache.go
@@ -56,10 +56,13 @@ func (t *TopicCache) LoadByTopicName(projectName, serviceName, topicName string)
 
 	topics, ok := t.internal[projectName+serviceName]
 	if !ok {
-		return aiven.KafkaTopic{}, false
+		return aiven.KafkaTopic{State: "CONFIGURING"}, false
 	}
 
 	result, ok := topics[topicName]
+	if !ok {
+		result.State = "CONFIGURING"
+	}
 
 	log.Printf("[TRACE] retrienve from a topic cache `%+#v` for a topic name `%s`", result, topicName)
 

--- a/pkg/cache/kafka_topic_cache_test.go
+++ b/pkg/cache/kafka_topic_cache_test.go
@@ -174,7 +174,9 @@ func TestTopicCache_LoadByTopicName(t1 *testing.T) {
 				serviceName: "test-sr1",
 				topicName:   "topic-1",
 			},
-			aiven.KafkaTopic{},
+			aiven.KafkaTopic{
+				State: "CONFIGURING",
+			},
 			false,
 		},
 		{


### PR DESCRIPTION
Improve Kafka Topic availability performance:
- remove waiter delay which sets TF timeout before start checking availability
- avoid multiple calls to Aiven API to refresh Topic Cache, since TF calls multiple waiters at the same time solution would be to make the first waiter refresh cache and put all others in the waiting position.

https://github.com/aiven/terraform-provider-aiven/issues/212