### PR TITLE
fix kafka acl datasource

### DIFF
--- a/aiven/datasource_kafka_acl.go
+++ b/aiven/datasource_kafka_acl.go
@@ -10,8 +10,9 @@ import (
 
 func datasourceKafkaACL() *schema.Resource {
 	return &schema.Resource{
-		Read:   datasourceKafkaACLRead,
-		Schema: resourceSchemaAsDatasourceSchema(aivenKafkaACLSchema, "project", "service_name", "topic", "username"),
+		Read: datasourceKafkaACLRead,
+		Schema: resourceSchemaAsDatasourceSchema(aivenKafkaACLSchema,
+			"project", "service_name", "topic", "username", "permission"),
 	}
 }
 
@@ -22,6 +23,7 @@ func datasourceKafkaACLRead(d *schema.ResourceData, m interface{}) error {
 	serviceName := d.Get("service_name").(string)
 	topic := d.Get("topic").(string)
 	userName := d.Get("username").(string)
+	permission := d.Get("permission").(string)
 
 	acls, err := client.KafkaACLs.List(projectName, serviceName)
 	if err != nil {
@@ -29,7 +31,7 @@ func datasourceKafkaACLRead(d *schema.ResourceData, m interface{}) error {
 	}
 
 	for _, acl := range acls {
-		if acl.Topic == topic && acl.Username == userName {
+		if acl.Topic == topic && acl.Username == userName && acl.Permission == permission {
 			d.SetId(buildResourceID(projectName, serviceName, acl.ID))
 			return resourceKafkaACLRead(d, m)
 		}

--- a/aiven/resource_kafka_acl_test.go
+++ b/aiven/resource_kafka_acl_test.go
@@ -181,6 +181,7 @@ func testAccKafkaACLResource(name string) string {
 			service_name = aiven_kafka_acl.foo.service_name
 			topic = aiven_kafka_acl.foo.topic
 			username = aiven_kafka_acl.foo.username
+			permission = aiven_kafka_acl.foo.permission
 		}
 		`, name, os.Getenv("AIVEN_CARD_ID"), name, name, name)
 }


### PR DESCRIPTION
It is possible to create multiple Kafka ACL's for the same topic/username in a project for multiple roles, added permission as a required field. 