### PR TITLE
Adjust provider schema to make api_token optional

### DIFF
--- a/aiven/provider.go
+++ b/aiven/provider.go
@@ -22,7 +22,6 @@ func Provider() terraform.ResourceProvider {
 			"api_token": {
 				Type:        schema.TypeString,
 				Optional:    true,
-				Default:     "",
 				Sensitive:   true,
 				DefaultFunc: schema.EnvDefaultFunc("AIVEN_TOKEN", nil),
 				Description: "Aiven Authentication Token",

--- a/aiven/provider.go
+++ b/aiven/provider.go
@@ -21,7 +21,8 @@ func Provider() terraform.ResourceProvider {
 		Schema: map[string]*schema.Schema{
 			"api_token": {
 				Type:        schema.TypeString,
-				Required:    true,
+				Optional:    true,
+				Default:     "",
 				Sensitive:   true,
 				DefaultFunc: schema.EnvDefaultFunc("AIVEN_TOKEN", nil),
 				Description: "Aiven Authentication Token",


### PR DESCRIPTION
Terraform hinting in VSCode indicates that when you leave off the `api_token` field that it's invalid.  Because there's a `DefaultFunc`, this will get read in from the environment variable `AIVEN_TOKEN` executed successfully regardless of the hinting, but this fixes that hinting.

Tested with `make test` and by running my terraform code.