### PR TITLE
Github Pages support and static docs generation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,8 @@ packrd/
 
 # Artefacts directories
 plugins/
+
+# Github Pages
+_site/
+Gemfile
+Gemfile.lock

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
-# Changelog
+---
+title: Changelog
+parent: README
+nav_order: 1
+---# Changelog
 
 ## [1.2.4] - 2020-05-07
 - Speed up kafka topic availability waiter

--- a/Makefile
+++ b/Makefile
@@ -71,3 +71,15 @@ clean:
 	rm -f terraform-provider-aiven.tar.gz
 
 .PHONY: test lint vendor bootstrap
+
+#################################################
+# Documentation
+#################################################
+# TODO Run schema json output command on build
+doc:
+	cat scripts/template_all.md > docs/index.md
+	cat scripts/template_ds.md > docs/data-sources/index.md
+	cat scripts/template_re.md > docs/resources/index.md
+	python scripts/docgen.py scripts/schema.json ALL >> docs/index.md
+	python scripts/docgen.py scripts/schema.json DATASOURCES >> docs/data-sources/index.md
+	python scripts/docgen.py scripts/schema.json RESOURCES >> docs/resources/index.md

--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
+---
+title: README
+nav_order: 1
+has_children: true
+---
+
 # Terraform Aiven
 
 [Terraform](https://www.terraform.io/) provider for [Aiven.io](https://aiven.io/). This

--- a/_config.yml
+++ b/_config.yml
@@ -1,0 +1,12 @@
+plugins:
+  - jekyll-relative-links
+relative_links:
+  enabled: true
+  collections: true
+remote_theme: pmarsceill/just-the-docs
+email: support@aiven.io 
+title: Aiven Terraform Provider
+Description: The Aiven Terraform Provider is a way to access all of your Aiven services within Terraform. Use this provider to set up and teardown services and test out configurations. Any issues, please email support@aiven.io
+search_enabled: true
+exclude:
+  - scripts/

--- a/docs/data-sources/index.md
+++ b/docs/data-sources/index.md
@@ -1,0 +1,228 @@
+---
+title: Datasources
+has_children: true
+nav_order: 2
+description: |-
+  The Aiven Terraform Provider is a way to access all of your Aiven services within Terraform. Use this provider to set up and teardown services and test out configurations. Any issues, please email support@aiven.io
+---
+## Data-sources 
+### aiven_kafka_schema_configuration 
+#### Required 
+* **service_name** _Service to link the Kafka Schema to_ 
+* **project** _Project to link the Kafka Schema to_ 
+#### Optional 
+* **subject_name** _Kafka Schema Subject name_ 
+* **schema** _Kafka Schema configuration should be a valid Avro Schema JSON format_ 
+##### Computed 
+* **version** _Kafka Schema configuration version_ 
+* **id**  
+### aiven_kafka_connector 
+#### Required 
+* **service_name** _Service to link the kafka connector to_ 
+* **project** _Project to link the kafka connector to_ 
+* **connector_name** _Kafka connector name_ 
+#### Optional 
+* **config** _Kafka Connector configuration parameters_ 
+##### Computed 
+* **plugin_version** _Kafka connector version_ 
+* **plugin_class** _Kafka connector Java class_ 
+* **plugin_title** _Kafka connector title_ 
+* **plugin_doc_url** _Kafka connector documentation URL_ 
+* **plugin_author** _Kafka connector author_ 
+* **id**  
+* **plugin_type** _Kafka connector type_ 
+### aiven_service 
+#### Required 
+* **service_name** _Service name_ 
+* **project** _Target project_ 
+#### Optional 
+* **maintenance_window_dow** _Day of week when maintenance operations should be performed. One monday, tuesday, wednesday, etc._ 
+* **termination_protection** _Prevent service from being deleted. It is recommended to have this enabled for all services._ 
+* **maintenance_window_time** _Time of day when maintenance operations should be performed. UTC time in HH:mm:ss format._ 
+* **cloud_name** _Cloud the service runs in_ 
+* **project_vpc_id** _Identifier of the VPC the service should be in, if any_ 
+* **plan** _Subscription plan_ 
+* **service_type** _Service type code_ 
+##### Computed 
+* **service_uri** _URI for connecting to the service. Service specific info is under "kafka", "pg", etc._ 
+* **service_password** _Password used for connecting to the service, if applicable_ 
+* **state** _Service state_ 
+* **service_port** _Service port_ 
+* **service_username** _Username used for connecting to the service, if applicable_ 
+* **id**  
+* **service_host** _Service hostname_ 
+### aiven_elasticsearch_acl 
+#### Required 
+* **project** _Project to link the Elasticsearch ACLs to_ 
+* **service_name** _Service to link the Elasticsearch ACLs to_ 
+#### Optional 
+* **enabled** _Enable Elasticsearch ACLs. When disabled authenticated service users have unrestricted access_ 
+* **extended_acl** _Index rules can be applied in a limited fashion to the _mget, _msearch and _bulk APIs (and only those) by enabling the ExtendedAcl option for the service. When it is enabled, users can use these APIs as long as all operations only target indexes they have been granted access to_ 
+##### Computed 
+* **id**  
+### aiven_account 
+#### Required 
+* **name** _Account name_ 
+##### Computed 
+* **update_time** _Time of last update_ 
+* **account_id** _Account id_ 
+* **tenant_id** _Tenant id_ 
+* **owner_team_id** _Owner team id_ 
+* **create_time** _Time of creation_ 
+* **id**  
+### aiven_project_user 
+#### Required 
+* **project** _The project the user belongs to_ 
+* **email** _Email address of the user_ 
+#### Optional 
+* **member_type** _Project membership type. One of: admin, developer, operator_ 
+##### Computed 
+* **accepted** _Whether the user has accepted project membership or not_ 
+* **id**  
+### aiven_account_team_project 
+#### Required 
+* **team_id** _Account team id_ 
+* **project_name** _Account team project name_ 
+* **account_id** _Account id_ 
+#### Optional 
+* **team_type** _Account team project type, can one of the following values: admin, developer, operator and read_only_ 
+##### Computed 
+* **id**  
+### aiven_connection_pool 
+#### Required 
+* **pool_name** _Name of the pool_ 
+* **service_name** _Service to link the connection pool to_ 
+* **project** _Project to link the connection pool to_ 
+#### Optional 
+* **username** _Name of the service user used to connect to the database_ 
+* **pool_mode** _Mode the pool operates in (session, transaction, statement)_ 
+* **database_name** _Name of the database the pool connects to_ 
+* **pool_size** _Number of connections the pool may create towards the backend server_ 
+##### Computed 
+* **connection_uri** _URI for connecting to the pool_ 
+* **id**  
+### aiven_account_team_member 
+#### Required 
+* **account_id** _Account id_ 
+* **team_id** _Account team id_ 
+* **user_email** _Team invite user email_ 
+##### Computed 
+* **create_time** _Time of creation_ 
+* **invited_by_user_email** _Team invited by user email_ 
+* **accepted** _Team member invitation status_ 
+* **id**  
+### aiven_kafka_schema 
+#### Required 
+* **service_name** _Service to link the Kafka Schema to_ 
+* **subject_name** _Kafka Schema Subject name_ 
+* **project** _Project to link the Kafka Schema to_ 
+#### Optional 
+* **schema** _Kafka Schema configuration should be a valid Avro Schema JSON format_ 
+##### Computed 
+* **version** _Kafka Schema configuration version_ 
+* **id**  
+### aiven_service_user 
+#### Required 
+* **username** _Name of the user account_ 
+* **service_name** _Service to link the user to_ 
+* **project** _Project to link the user to_ 
+##### Computed 
+* **access_key** _Access certificate key for the user if applicable for the service in question_ 
+* **access_cert** _Access certificate for the user if applicable for the service in question_ 
+* **password** _Password of the user_ 
+* **type** _Type of the user account_ 
+* **id**  
+### aiven_account_team 
+#### Required 
+* **account_id** _Account id_ 
+* **name** _Account team name_ 
+##### Computed 
+* **update_time** _Time of last update_ 
+* **team_id** _Account team id_ 
+* **create_time** _Time of creation_ 
+* **id**  
+### aiven_project 
+#### Required 
+* **project** _Project name_ 
+#### Optional 
+* **billing_address** _Billing name and address of the project_ 
+* **account_id** _Account ID_ 
+* **card_id** _Credit card ID_ 
+* **billing_emails** _Billing contact emails of the project_ 
+* **country_code** _Billing country code of the project_ 
+* **technical_emails** _Technical contact emails of the project_ 
+* **copy_from_project** _Copy properties from another project. Only has effect when a new project is created._ 
+##### Computed 
+* **ca_cert** _Project root CA. This is used by some services like Kafka to sign service certificate_ 
+* **id**  
+### aiven_kafka_topic 
+#### Required 
+* **service_name** _Service to link the kafka topic to_ 
+* **topic_name** _Topic name_ 
+* **project** _Project to link the kafka topic to_ 
+#### Optional 
+* **minimum_in_sync_replicas** _Minimum required nodes in-sync replicas (ISR) to produce to a partition_ 
+* **retention_hours** _Retention period (hours)_ 
+* **replication** _Replication factor for the topic_ 
+* **termination_protection** _It is a Terraform client-side deletion protection, which prevents a Kafka 
+			topic from being deleted. It is recommended to enable this for any production Kafka 
+			topic containing critical data._ 
+* **retention_bytes** _Retention bytes_ 
+* **cleanup_policy** _Topic cleanup policy. Allowed values: delete, compact_ 
+* **partitions** _Number of partitions to create in the topic_ 
+##### Computed 
+* **id**  
+### aiven_kafka_acl 
+#### Required 
+* **username** _Username pattern for the ACL entry_ 
+* **topic** _Topic name pattern for the ACL entry_ 
+* **service_name** _Service to link the Kafka ACL to_ 
+* **project** _Project to link the Kafka ACL to_ 
+#### Optional 
+* **permission** _Kafka permission to grant (admin, read, readwrite, write)_ 
+##### Computed 
+* **id**  
+### aiven_vpc_peering_connection 
+#### Required 
+* **peer_vpc** _AWS VPC ID or GCP VPC network name of the peered VPC_ 
+* **vpc_id** _The VPC the peering connection belongs to_ 
+* **peer_cloud_account** _AWS account ID or GCP project ID of the peered VPC_ 
+#### Optional 
+* **peer_region** _AWS region of the peered VPC (if not in the same region as Aiven VPC)_ 
+##### Computed 
+* **state_info** _State-specific help or error information_ 
+* **state** _State of the peering connection_ 
+* **peering_connection_id** _Cloud provider identifier for the peering connection if available_ 
+* **id**  
+### aiven_service_integration_endpoint 
+#### Required 
+* **project** _Project the service integration endpoint belongs to_ 
+* **endpoint_name** _Name of the service integration endpoint_ 
+#### Optional 
+* **endpoint_type** _Type of the service integration endpoint_ 
+##### Computed 
+* **endpoint_config** _Integration endpoint specific backend configuration_ 
+* **id**  
+### aiven_project_vpc 
+#### Required 
+* **project** _The project the VPC belongs to_ 
+* **cloud_name** _Cloud the VPC is in_ 
+#### Optional 
+* **network_cidr** _Network address range used by the VPC like 192.168.0.0/24_ 
+##### Computed 
+* **state** _State of the VPC (APPROVED, ACTIVE, DELETING, DELETED)_ 
+* **id**  
+### aiven_database 
+#### Required 
+* **service_name** _Service to link the database to_ 
+* **database_name** _Service database name_ 
+* **project** _Project to link the database to_ 
+#### Optional 
+* **lc_ctype** _Default character classification (LC_CTYPE) of the database. Default value: en_US.UTF-8_ 
+* **termination_protection** _It is a Terraform client-side deletion protections, which prevents the database
+			from being deleted by Terraform. It is recommended to enable this for any production
+			databases containing critical data._ 
+* **lc_collate** _Default string sort order (LC_COLLATE) of the database. Default value: en_US.UTF-8_ 
+##### Computed 
+* **id**  
+

--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -1,0 +1,88 @@
+---
+parent: Guides
+title: "Getting Started"
+sidebar_current: "docs-aiven-getting-started"
+description: |-
+  The Aiven Terraform Provider is a way to access all of your Aiven services within Terraform. Use this provider to set up and teardown services and test out configurations. Any issues, please email support@aiven.io
+---
+
+## Installing the Aiven Provider
+
+`go get -u github.com/aiven/terraform-provider-aiven`
+
+### Locally
+
+```
+$ mkdir -p $PWD/terraform.d/plugins/<OS_ARCH> # i.e. ~/.terraform.d/plugins/linux_amd64
+$ cp $GOPATH/bin/terraform-provider-aiven $PWD/terraform.d/plugins/linux_amd64/terraform-provider-aiven_v1.2.4 # Change to release ver
+```
+### Globally
+
+```
+$ mkdir -p ~/.terraform.d/plugins/<OS_ARCH> # i.e. ~/.terraform.d/plugins/linux_amd64
+$ cp $GOPATH/bin/terraform-provider-aiven ~/.terraform.d/plugins/<OS_ARCH>/terraform-provider-aiven-v1.2.4
+```
+
+#### TIP: Using with Terraform Cloud
+
+Terraform Cloud will also need the provider. In this case, it is best to install it locally and make sure you copy it to `linux_amd64` inside the plugins directory.
+
+## Set up
+
+You will need an API token from your account, which you can get through the [Aiven Web Console](https://console.aiven.io/profile/auth) or the [Aiven CLI](https://github.com/aiven/aiven-cli)
+
+## Your first run
+
+`$ terraform init`
+`$ terraform version`
+
+You should now see terraform and terraform-provider-aiven with the version number as output.
+
+### Hello World
+
+It is difficult to make an Open Source Database Management Service say Hello World, so maybe we will just setup a project and deploy Postgres.
+
+```
+terraform {
+  required_providers {
+    aiven = "1.2.4"
+  }
+}
+
+variable "aiven_api_token" {
+  type = string
+}
+
+provider "aiven" {
+  api_token = var.aiven_api_token
+}
+
+resource "aiven_project" "hello" {
+  project = "hello-project"
+}
+
+resource "aiven_service" "world" {
+	project = "${aiven_project.hello.project}"
+	cloud_name = "google-europe-west1"
+	plan = "business-4"
+	service_name = "world-pg"
+	service_type = "pg"
+	maintenance_window_dow = "monday"
+	maintenance_window_time = "12:00:00"
+	pg_user_config {
+		pg {
+			idle_in_transaction_session_timeout = 900
+		}
+		pg_version = "10"
+	}
+}
+
+```
+
+Save this as `getting-started.tf`
+
+`$ terraform plan # This will show you what Terraform thinks you want to do and you can confirm it before applying`
+
+`$ terraform apply # Now we really do it`
+
+`$ terraform destroy # When you want to sound cool and undo all the things in the script`

--- a/docs/guides/index.md
+++ b/docs/guides/index.md
@@ -1,0 +1,5 @@
+---
+title: Guides
+has_children: true
+nav_order: 4
+---

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,453 @@
+---
+title: "Schema"
+nav_order: 1
+has_children: true
+description: |-
+  The Aiven Terraform Provider is a way to access all of your Aiven services within Terraform. Use this provider to set up and teardown services and test out configurations. Any issues, please email support@aiven.io
+---
+## Resources 
+### aiven_kafka_schema_configuration 
+#### Required 
+* **project** _Project to link the Kafka Schemas Configuration to_ 
+* **service_name** _Service to link the Kafka Schemas Configuration to_ 
+* **compatibility_level** _Kafka Schemas compatibility level_ 
+##### Computed 
+* **id**  
+### aiven_kafka_connector 
+#### Required 
+* **service_name** _Service to link the kafka connector to_ 
+* **project** _Project to link the kafka connector to_ 
+* **connector_name** _Kafka connector name_ 
+* **config** _Kafka Connector configuration parameters_ 
+##### Computed 
+* **task** _List of tasks of a connector_ 
+* **plugin_version** _Kafka connector version_ 
+* **plugin_class** _Kafka connector Java class_ 
+* **plugin_title** _Kafka connector title_ 
+* **plugin_doc_url** _Kafka connector documentation URL_ 
+* **plugin_author** _Kafka connector author_ 
+* **id**  
+* **plugin_type** _Kafka connector type_ 
+### aiven_service 
+#### Required 
+* **service_name** _Service name_ 
+* **project** _Target project_ 
+* **service_type** _Service type code_ 
+#### Optional 
+* **maintenance_window_dow** _Day of week when maintenance operations should be performed. One monday, tuesday, wednesday, etc._ 
+* **termination_protection** _Prevent service from being deleted. It is recommended to have this enabled for all services._ 
+* **maintenance_window_time** _Time of day when maintenance operations should be performed. UTC time in HH:mm:ss format._ 
+* **cloud_name** _Cloud the service runs in_ 
+* **project_vpc_id** _Identifier of the VPC the service should be in, if any_ 
+* **plan** _Subscription plan_ 
+##### Computed 
+* **service_uri** _URI for connecting to the service. Service specific info is under "kafka", "pg", etc._ 
+* **service_password** _Password used for connecting to the service, if applicable_ 
+* **state** _Service state_ 
+* **components** _Service component information objects_ 
+* **service_port** _Service port_ 
+* **service_username** _Username used for connecting to the service, if applicable_ 
+* **id**  
+* **service_host** _Service hostname_ 
+### aiven_elasticsearch_acl 
+#### Required 
+* **project** _Project to link the Elasticsearch ACLs to_ 
+* **service_name** _Service to link the Elasticsearch ACLs to_ 
+#### Optional 
+* **enabled** _Enable Elasticsearch ACLs. When disabled authenticated service users have unrestricted access_ 
+* **extended_acl** _Index rules can be applied in a limited fashion to the _mget, _msearch and _bulk APIs (and only those) by enabling the ExtendedAcl option for the service. When it is enabled, users can use these APIs as long as all operations only target indexes they have been granted access to_ 
+##### Computed 
+* **id**  
+### aiven_account 
+#### Required 
+* **name** _Account name_ 
+##### Computed 
+* **update_time** _Time of last update_ 
+* **account_id** _Account id_ 
+* **tenant_id** _Tenant id_ 
+* **owner_team_id** _Owner team id_ 
+* **create_time** _Time of creation_ 
+* **id**  
+### aiven_project_user 
+#### Required 
+* **project** _The project the user belongs to_ 
+* **email** _Email address of the user_ 
+* **member_type** _Project membership type. One of: admin, developer, operator_ 
+##### Computed 
+* **accepted** _Whether the user has accepted project membership or not_ 
+* **id**  
+### aiven_vpc_peering_connection 
+#### Required 
+* **peer_vpc** _AWS VPC ID or GCP VPC network name of the peered VPC_ 
+* **vpc_id** _The VPC the peering connection belongs to_ 
+* **peer_cloud_account** _AWS account ID or GCP project ID of the peered VPC_ 
+#### Optional 
+* **peer_region** _AWS region of the peered VPC (if not in the same region as Aiven VPC)_ 
+##### Computed 
+* **state_info** _State-specific help or error information_ 
+* **state** _State of the peering connection_ 
+* **peering_connection_id** _Cloud provider identifier for the peering connection if available_ 
+* **id**  
+### aiven_account_team_project 
+#### Required 
+* **team_id** _Account team id_ 
+* **account_id** _Account id_ 
+#### Optional 
+* **team_type** _Account team project type, can one of the following values: admin, developer, operator and read_only_ 
+* **project_name** _Account team project name_ 
+##### Computed 
+* **id**  
+### aiven_connection_pool 
+#### Required 
+* **username** _Name of the service user used to connect to the database_ 
+* **pool_name** _Name of the pool_ 
+* **service_name** _Service to link the connection pool to_ 
+* **database_name** _Name of the database the pool connects to_ 
+* **project** _Project to link the connection pool to_ 
+#### Optional 
+* **pool_mode** _Mode the pool operates in (session, transaction, statement)_ 
+* **pool_size** _Number of connections the pool may create towards the backend server_ 
+##### Computed 
+* **connection_uri** _URI for connecting to the pool_ 
+* **id**  
+### aiven_account_team_member 
+#### Required 
+* **account_id** _Account id_ 
+* **team_id** _Account team id_ 
+* **user_email** _Team invite user email_ 
+##### Computed 
+* **create_time** _Time of creation_ 
+* **invited_by_user_email** _Team invited by user email_ 
+* **accepted** _Team member invitation status_ 
+* **id**  
+### aiven_kafka_schema 
+#### Required 
+* **service_name** _Service to link the Kafka Schema to_ 
+* **subject_name** _Kafka Schema Subject name_ 
+* **project** _Project to link the Kafka Schema to_ 
+* **schema** _Kafka Schema configuration should be a valid Avro Schema JSON format_ 
+##### Computed 
+* **version** _Kafka Schema configuration version_ 
+* **id**  
+### aiven_service_user 
+#### Required 
+* **username** _Name of the user account_ 
+* **service_name** _Service to link the user to_ 
+* **project** _Project to link the user to_ 
+##### Computed 
+* **access_key** _Access certificate key for the user if applicable for the service in question_ 
+* **access_cert** _Access certificate for the user if applicable for the service in question_ 
+* **password** _Password of the user_ 
+* **type** _Type of the user account_ 
+* **id**  
+### aiven_account_team 
+#### Required 
+* **account_id** _Account id_ 
+* **name** _Account team name_ 
+##### Computed 
+* **update_time** _Time of last update_ 
+* **team_id** _Account team id_ 
+* **create_time** _Time of creation_ 
+* **id**  
+### aiven_project 
+#### Required 
+* **project** _Project name_ 
+#### Optional 
+* **billing_address** _Billing name and address of the project_ 
+* **account_id** _Account ID_ 
+* **card_id** _Credit card ID_ 
+* **billing_emails** _Billing contact emails of the project_ 
+* **country_code** _Billing country code of the project_ 
+* **technical_emails** _Technical contact emails of the project_ 
+* **copy_from_project** _Copy properties from another project. Only has effect when a new project is created._ 
+##### Computed 
+* **ca_cert** _Project root CA. This is used by some services like Kafka to sign service certificate_ 
+* **id**  
+### aiven_kafka_topic 
+#### Required 
+* **service_name** _Service to link the kafka topic to_ 
+* **topic_name** _Topic name_ 
+* **project** _Project to link the kafka topic to_ 
+* **replication** _Replication factor for the topic_ 
+* **partitions** _Number of partitions to create in the topic_ 
+#### Optional 
+* **minimum_in_sync_replicas** _Minimum required nodes in-sync replicas (ISR) to produce to a partition_ 
+* **retention_hours** _Retention period (hours)_ 
+* **termination_protection** _It is a Terraform client-side deletion protection, which prevents a Kafka 
+			topic from being deleted. It is recommended to enable this for any production Kafka 
+			topic containing critical data._ 
+* **retention_bytes** _Retention bytes_ 
+* **cleanup_policy** _Topic cleanup policy. Allowed values: delete, compact_ 
+##### Computed 
+* **id**  
+### aiven_kafka_acl 
+#### Required 
+* **username** _Username pattern for the ACL entry_ 
+* **topic** _Topic name pattern for the ACL entry_ 
+* **permission** _Kafka permission to grant (admin, read, readwrite, write)_ 
+* **service_name** _Service to link the Kafka ACL to_ 
+* **project** _Project to link the Kafka ACL to_ 
+##### Computed 
+* **id**  
+### aiven_service_integration 
+#### Required 
+* **integration_type** _Type of the service integration_ 
+* **project** _Project the integration belongs to_ 
+#### Optional 
+* **source_endpoint_id** _Source endpoint for the integration (if any)_ 
+* **source_service_name** _Source service for the integration (if any)_ 
+* **destination_service_name** _Destination service for the integration (if any)_ 
+* **destination_endpoint_id** _Destination endpoint for the integration (if any)_ 
+##### Computed 
+* **id**  
+### aiven_service_integration_endpoint 
+#### Required 
+* **project** _Project the service integration endpoint belongs to_ 
+* **endpoint_type** _Type of the service integration endpoint_ 
+* **endpoint_name** _Name of the service integration endpoint_ 
+##### Computed 
+* **endpoint_config** _Integration endpoint specific backend configuration_ 
+* **id**  
+### aiven_project_vpc 
+#### Required 
+* **project** _The project the VPC belongs to_ 
+* **cloud_name** _Cloud the VPC is in_ 
+* **network_cidr** _Network address range used by the VPC like 192.168.0.0/24_ 
+##### Computed 
+* **state** _State of the VPC (APPROVED, ACTIVE, DELETING, DELETED)_ 
+* **id**  
+### aiven_database 
+#### Required 
+* **service_name** _Service to link the database to_ 
+* **database_name** _Service database name_ 
+* **project** _Project to link the database to_ 
+#### Optional 
+* **lc_ctype** _Default character classification (LC_CTYPE) of the database. Default value: en_US.UTF-8_ 
+* **termination_protection** _It is a Terraform client-side deletion protections, which prevents the database
+			from being deleted by Terraform. It is recommended to enable this for any production
+			databases containing critical data._ 
+* **lc_collate** _Default string sort order (LC_COLLATE) of the database. Default value: en_US.UTF-8_ 
+##### Computed 
+* **id**  
+--- 
+## Data-sources 
+### aiven_kafka_schema_configuration 
+#### Required 
+* **service_name** _Service to link the Kafka Schema to_ 
+* **project** _Project to link the Kafka Schema to_ 
+#### Optional 
+* **subject_name** _Kafka Schema Subject name_ 
+* **schema** _Kafka Schema configuration should be a valid Avro Schema JSON format_ 
+##### Computed 
+* **version** _Kafka Schema configuration version_ 
+* **id**  
+### aiven_kafka_connector 
+#### Required 
+* **service_name** _Service to link the kafka connector to_ 
+* **project** _Project to link the kafka connector to_ 
+* **connector_name** _Kafka connector name_ 
+#### Optional 
+* **config** _Kafka Connector configuration parameters_ 
+##### Computed 
+* **plugin_version** _Kafka connector version_ 
+* **plugin_class** _Kafka connector Java class_ 
+* **plugin_title** _Kafka connector title_ 
+* **plugin_doc_url** _Kafka connector documentation URL_ 
+* **plugin_author** _Kafka connector author_ 
+* **id**  
+* **plugin_type** _Kafka connector type_ 
+### aiven_service 
+#### Required 
+* **service_name** _Service name_ 
+* **project** _Target project_ 
+#### Optional 
+* **maintenance_window_dow** _Day of week when maintenance operations should be performed. One monday, tuesday, wednesday, etc._ 
+* **termination_protection** _Prevent service from being deleted. It is recommended to have this enabled for all services._ 
+* **maintenance_window_time** _Time of day when maintenance operations should be performed. UTC time in HH:mm:ss format._ 
+* **cloud_name** _Cloud the service runs in_ 
+* **project_vpc_id** _Identifier of the VPC the service should be in, if any_ 
+* **plan** _Subscription plan_ 
+* **service_type** _Service type code_ 
+##### Computed 
+* **service_uri** _URI for connecting to the service. Service specific info is under "kafka", "pg", etc._ 
+* **service_password** _Password used for connecting to the service, if applicable_ 
+* **state** _Service state_ 
+* **service_port** _Service port_ 
+* **service_username** _Username used for connecting to the service, if applicable_ 
+* **id**  
+* **service_host** _Service hostname_ 
+### aiven_elasticsearch_acl 
+#### Required 
+* **project** _Project to link the Elasticsearch ACLs to_ 
+* **service_name** _Service to link the Elasticsearch ACLs to_ 
+#### Optional 
+* **enabled** _Enable Elasticsearch ACLs. When disabled authenticated service users have unrestricted access_ 
+* **extended_acl** _Index rules can be applied in a limited fashion to the _mget, _msearch and _bulk APIs (and only those) by enabling the ExtendedAcl option for the service. When it is enabled, users can use these APIs as long as all operations only target indexes they have been granted access to_ 
+##### Computed 
+* **id**  
+### aiven_account 
+#### Required 
+* **name** _Account name_ 
+##### Computed 
+* **update_time** _Time of last update_ 
+* **account_id** _Account id_ 
+* **tenant_id** _Tenant id_ 
+* **owner_team_id** _Owner team id_ 
+* **create_time** _Time of creation_ 
+* **id**  
+### aiven_project_user 
+#### Required 
+* **project** _The project the user belongs to_ 
+* **email** _Email address of the user_ 
+#### Optional 
+* **member_type** _Project membership type. One of: admin, developer, operator_ 
+##### Computed 
+* **accepted** _Whether the user has accepted project membership or not_ 
+* **id**  
+### aiven_account_team_project 
+#### Required 
+* **team_id** _Account team id_ 
+* **project_name** _Account team project name_ 
+* **account_id** _Account id_ 
+#### Optional 
+* **team_type** _Account team project type, can one of the following values: admin, developer, operator and read_only_ 
+##### Computed 
+* **id**  
+### aiven_connection_pool 
+#### Required 
+* **pool_name** _Name of the pool_ 
+* **service_name** _Service to link the connection pool to_ 
+* **project** _Project to link the connection pool to_ 
+#### Optional 
+* **username** _Name of the service user used to connect to the database_ 
+* **pool_mode** _Mode the pool operates in (session, transaction, statement)_ 
+* **database_name** _Name of the database the pool connects to_ 
+* **pool_size** _Number of connections the pool may create towards the backend server_ 
+##### Computed 
+* **connection_uri** _URI for connecting to the pool_ 
+* **id**  
+### aiven_account_team_member 
+#### Required 
+* **account_id** _Account id_ 
+* **team_id** _Account team id_ 
+* **user_email** _Team invite user email_ 
+##### Computed 
+* **create_time** _Time of creation_ 
+* **invited_by_user_email** _Team invited by user email_ 
+* **accepted** _Team member invitation status_ 
+* **id**  
+### aiven_kafka_schema 
+#### Required 
+* **service_name** _Service to link the Kafka Schema to_ 
+* **subject_name** _Kafka Schema Subject name_ 
+* **project** _Project to link the Kafka Schema to_ 
+#### Optional 
+* **schema** _Kafka Schema configuration should be a valid Avro Schema JSON format_ 
+##### Computed 
+* **version** _Kafka Schema configuration version_ 
+* **id**  
+### aiven_service_user 
+#### Required 
+* **username** _Name of the user account_ 
+* **service_name** _Service to link the user to_ 
+* **project** _Project to link the user to_ 
+##### Computed 
+* **access_key** _Access certificate key for the user if applicable for the service in question_ 
+* **access_cert** _Access certificate for the user if applicable for the service in question_ 
+* **password** _Password of the user_ 
+* **type** _Type of the user account_ 
+* **id**  
+### aiven_account_team 
+#### Required 
+* **account_id** _Account id_ 
+* **name** _Account team name_ 
+##### Computed 
+* **update_time** _Time of last update_ 
+* **team_id** _Account team id_ 
+* **create_time** _Time of creation_ 
+* **id**  
+### aiven_project 
+#### Required 
+* **project** _Project name_ 
+#### Optional 
+* **billing_address** _Billing name and address of the project_ 
+* **account_id** _Account ID_ 
+* **card_id** _Credit card ID_ 
+* **billing_emails** _Billing contact emails of the project_ 
+* **country_code** _Billing country code of the project_ 
+* **technical_emails** _Technical contact emails of the project_ 
+* **copy_from_project** _Copy properties from another project. Only has effect when a new project is created._ 
+##### Computed 
+* **ca_cert** _Project root CA. This is used by some services like Kafka to sign service certificate_ 
+* **id**  
+### aiven_kafka_topic 
+#### Required 
+* **service_name** _Service to link the kafka topic to_ 
+* **topic_name** _Topic name_ 
+* **project** _Project to link the kafka topic to_ 
+#### Optional 
+* **minimum_in_sync_replicas** _Minimum required nodes in-sync replicas (ISR) to produce to a partition_ 
+* **retention_hours** _Retention period (hours)_ 
+* **replication** _Replication factor for the topic_ 
+* **termination_protection** _It is a Terraform client-side deletion protection, which prevents a Kafka 
+			topic from being deleted. It is recommended to enable this for any production Kafka 
+			topic containing critical data._ 
+* **retention_bytes** _Retention bytes_ 
+* **cleanup_policy** _Topic cleanup policy. Allowed values: delete, compact_ 
+* **partitions** _Number of partitions to create in the topic_ 
+##### Computed 
+* **id**  
+### aiven_kafka_acl 
+#### Required 
+* **username** _Username pattern for the ACL entry_ 
+* **topic** _Topic name pattern for the ACL entry_ 
+* **service_name** _Service to link the Kafka ACL to_ 
+* **project** _Project to link the Kafka ACL to_ 
+#### Optional 
+* **permission** _Kafka permission to grant (admin, read, readwrite, write)_ 
+##### Computed 
+* **id**  
+### aiven_vpc_peering_connection 
+#### Required 
+* **peer_vpc** _AWS VPC ID or GCP VPC network name of the peered VPC_ 
+* **vpc_id** _The VPC the peering connection belongs to_ 
+* **peer_cloud_account** _AWS account ID or GCP project ID of the peered VPC_ 
+#### Optional 
+* **peer_region** _AWS region of the peered VPC (if not in the same region as Aiven VPC)_ 
+##### Computed 
+* **state_info** _State-specific help or error information_ 
+* **state** _State of the peering connection_ 
+* **peering_connection_id** _Cloud provider identifier for the peering connection if available_ 
+* **id**  
+### aiven_service_integration_endpoint 
+#### Required 
+* **project** _Project the service integration endpoint belongs to_ 
+* **endpoint_name** _Name of the service integration endpoint_ 
+#### Optional 
+* **endpoint_type** _Type of the service integration endpoint_ 
+##### Computed 
+* **endpoint_config** _Integration endpoint specific backend configuration_ 
+* **id**  
+### aiven_project_vpc 
+#### Required 
+* **project** _The project the VPC belongs to_ 
+* **cloud_name** _Cloud the VPC is in_ 
+#### Optional 
+* **network_cidr** _Network address range used by the VPC like 192.168.0.0/24_ 
+##### Computed 
+* **state** _State of the VPC (APPROVED, ACTIVE, DELETING, DELETED)_ 
+* **id**  
+### aiven_database 
+#### Required 
+* **service_name** _Service to link the database to_ 
+* **database_name** _Service database name_ 
+* **project** _Project to link the database to_ 
+#### Optional 
+* **lc_ctype** _Default character classification (LC_CTYPE) of the database. Default value: en_US.UTF-8_ 
+* **termination_protection** _It is a Terraform client-side deletion protections, which prevents the database
+			from being deleted by Terraform. It is recommended to enable this for any production
+			databases containing critical data._ 
+* **lc_collate** _Default string sort order (LC_COLLATE) of the database. Default value: en_US.UTF-8_ 
+##### Computed 
+* **id**  
+

--- a/docs/resources/index.md
+++ b/docs/resources/index.md
@@ -1,0 +1,233 @@
+---
+title: Resources
+has_children: true
+nav_order: 3
+description: |-
+  The Aiven Terraform Provider is a way to access all of your Aiven services within Terraform. Use this provider to set up and teardown services and test out configurations. Any issues, please email support@aiven.io
+---
+## Resources 
+### aiven_kafka_schema_configuration 
+#### Required 
+* **project** _Project to link the Kafka Schemas Configuration to_ 
+* **service_name** _Service to link the Kafka Schemas Configuration to_ 
+* **compatibility_level** _Kafka Schemas compatibility level_ 
+##### Computed 
+* **id**  
+### aiven_kafka_connector 
+#### Required 
+* **service_name** _Service to link the kafka connector to_ 
+* **project** _Project to link the kafka connector to_ 
+* **connector_name** _Kafka connector name_ 
+* **config** _Kafka Connector configuration parameters_ 
+##### Computed 
+* **task** _List of tasks of a connector_ 
+* **plugin_version** _Kafka connector version_ 
+* **plugin_class** _Kafka connector Java class_ 
+* **plugin_title** _Kafka connector title_ 
+* **plugin_doc_url** _Kafka connector documentation URL_ 
+* **plugin_author** _Kafka connector author_ 
+* **id**  
+* **plugin_type** _Kafka connector type_ 
+### aiven_service 
+#### Required 
+* **service_name** _Service name_ 
+* **project** _Target project_ 
+* **service_type** _Service type code_ 
+#### Optional 
+* **maintenance_window_dow** _Day of week when maintenance operations should be performed. One monday, tuesday, wednesday, etc._ 
+* **termination_protection** _Prevent service from being deleted. It is recommended to have this enabled for all services._ 
+* **maintenance_window_time** _Time of day when maintenance operations should be performed. UTC time in HH:mm:ss format._ 
+* **cloud_name** _Cloud the service runs in_ 
+* **project_vpc_id** _Identifier of the VPC the service should be in, if any_ 
+* **plan** _Subscription plan_ 
+##### Computed 
+* **service_uri** _URI for connecting to the service. Service specific info is under "kafka", "pg", etc._ 
+* **service_password** _Password used for connecting to the service, if applicable_ 
+* **state** _Service state_ 
+* **components** _Service component information objects_ 
+* **service_port** _Service port_ 
+* **service_username** _Username used for connecting to the service, if applicable_ 
+* **id**  
+* **service_host** _Service hostname_ 
+### aiven_elasticsearch_acl 
+#### Required 
+* **project** _Project to link the Elasticsearch ACLs to_ 
+* **service_name** _Service to link the Elasticsearch ACLs to_ 
+#### Optional 
+* **enabled** _Enable Elasticsearch ACLs. When disabled authenticated service users have unrestricted access_ 
+* **extended_acl** _Index rules can be applied in a limited fashion to the _mget, _msearch and _bulk APIs (and only those) by enabling the ExtendedAcl option for the service. When it is enabled, users can use these APIs as long as all operations only target indexes they have been granted access to_ 
+##### Computed 
+* **id**  
+### aiven_account 
+#### Required 
+* **name** _Account name_ 
+##### Computed 
+* **update_time** _Time of last update_ 
+* **account_id** _Account id_ 
+* **tenant_id** _Tenant id_ 
+* **owner_team_id** _Owner team id_ 
+* **create_time** _Time of creation_ 
+* **id**  
+### aiven_project_user 
+#### Required 
+* **project** _The project the user belongs to_ 
+* **email** _Email address of the user_ 
+* **member_type** _Project membership type. One of: admin, developer, operator_ 
+##### Computed 
+* **accepted** _Whether the user has accepted project membership or not_ 
+* **id**  
+### aiven_vpc_peering_connection 
+#### Required 
+* **peer_vpc** _AWS VPC ID or GCP VPC network name of the peered VPC_ 
+* **vpc_id** _The VPC the peering connection belongs to_ 
+* **peer_cloud_account** _AWS account ID or GCP project ID of the peered VPC_ 
+#### Optional 
+* **peer_region** _AWS region of the peered VPC (if not in the same region as Aiven VPC)_ 
+##### Computed 
+* **state_info** _State-specific help or error information_ 
+* **state** _State of the peering connection_ 
+* **peering_connection_id** _Cloud provider identifier for the peering connection if available_ 
+* **id**  
+### aiven_account_team_project 
+#### Required 
+* **team_id** _Account team id_ 
+* **account_id** _Account id_ 
+#### Optional 
+* **team_type** _Account team project type, can one of the following values: admin, developer, operator and read_only_ 
+* **project_name** _Account team project name_ 
+##### Computed 
+* **id**  
+### aiven_connection_pool 
+#### Required 
+* **username** _Name of the service user used to connect to the database_ 
+* **pool_name** _Name of the pool_ 
+* **service_name** _Service to link the connection pool to_ 
+* **database_name** _Name of the database the pool connects to_ 
+* **project** _Project to link the connection pool to_ 
+#### Optional 
+* **pool_mode** _Mode the pool operates in (session, transaction, statement)_ 
+* **pool_size** _Number of connections the pool may create towards the backend server_ 
+##### Computed 
+* **connection_uri** _URI for connecting to the pool_ 
+* **id**  
+### aiven_account_team_member 
+#### Required 
+* **account_id** _Account id_ 
+* **team_id** _Account team id_ 
+* **user_email** _Team invite user email_ 
+##### Computed 
+* **create_time** _Time of creation_ 
+* **invited_by_user_email** _Team invited by user email_ 
+* **accepted** _Team member invitation status_ 
+* **id**  
+### aiven_kafka_schema 
+#### Required 
+* **service_name** _Service to link the Kafka Schema to_ 
+* **subject_name** _Kafka Schema Subject name_ 
+* **project** _Project to link the Kafka Schema to_ 
+* **schema** _Kafka Schema configuration should be a valid Avro Schema JSON format_ 
+##### Computed 
+* **version** _Kafka Schema configuration version_ 
+* **id**  
+### aiven_service_user 
+#### Required 
+* **username** _Name of the user account_ 
+* **service_name** _Service to link the user to_ 
+* **project** _Project to link the user to_ 
+##### Computed 
+* **access_key** _Access certificate key for the user if applicable for the service in question_ 
+* **access_cert** _Access certificate for the user if applicable for the service in question_ 
+* **password** _Password of the user_ 
+* **type** _Type of the user account_ 
+* **id**  
+### aiven_account_team 
+#### Required 
+* **account_id** _Account id_ 
+* **name** _Account team name_ 
+##### Computed 
+* **update_time** _Time of last update_ 
+* **team_id** _Account team id_ 
+* **create_time** _Time of creation_ 
+* **id**  
+### aiven_project 
+#### Required 
+* **project** _Project name_ 
+#### Optional 
+* **billing_address** _Billing name and address of the project_ 
+* **account_id** _Account ID_ 
+* **card_id** _Credit card ID_ 
+* **billing_emails** _Billing contact emails of the project_ 
+* **country_code** _Billing country code of the project_ 
+* **technical_emails** _Technical contact emails of the project_ 
+* **copy_from_project** _Copy properties from another project. Only has effect when a new project is created._ 
+##### Computed 
+* **ca_cert** _Project root CA. This is used by some services like Kafka to sign service certificate_ 
+* **id**  
+### aiven_kafka_topic 
+#### Required 
+* **service_name** _Service to link the kafka topic to_ 
+* **topic_name** _Topic name_ 
+* **project** _Project to link the kafka topic to_ 
+* **replication** _Replication factor for the topic_ 
+* **partitions** _Number of partitions to create in the topic_ 
+#### Optional 
+* **minimum_in_sync_replicas** _Minimum required nodes in-sync replicas (ISR) to produce to a partition_ 
+* **retention_hours** _Retention period (hours)_ 
+* **termination_protection** _It is a Terraform client-side deletion protection, which prevents a Kafka 
+			topic from being deleted. It is recommended to enable this for any production Kafka 
+			topic containing critical data._ 
+* **retention_bytes** _Retention bytes_ 
+* **cleanup_policy** _Topic cleanup policy. Allowed values: delete, compact_ 
+##### Computed 
+* **id**  
+### aiven_kafka_acl 
+#### Required 
+* **username** _Username pattern for the ACL entry_ 
+* **topic** _Topic name pattern for the ACL entry_ 
+* **permission** _Kafka permission to grant (admin, read, readwrite, write)_ 
+* **service_name** _Service to link the Kafka ACL to_ 
+* **project** _Project to link the Kafka ACL to_ 
+##### Computed 
+* **id**  
+### aiven_service_integration 
+#### Required 
+* **integration_type** _Type of the service integration_ 
+* **project** _Project the integration belongs to_ 
+#### Optional 
+* **source_endpoint_id** _Source endpoint for the integration (if any)_ 
+* **source_service_name** _Source service for the integration (if any)_ 
+* **destination_service_name** _Destination service for the integration (if any)_ 
+* **destination_endpoint_id** _Destination endpoint for the integration (if any)_ 
+##### Computed 
+* **id**  
+### aiven_service_integration_endpoint 
+#### Required 
+* **project** _Project the service integration endpoint belongs to_ 
+* **endpoint_type** _Type of the service integration endpoint_ 
+* **endpoint_name** _Name of the service integration endpoint_ 
+##### Computed 
+* **endpoint_config** _Integration endpoint specific backend configuration_ 
+* **id**  
+### aiven_project_vpc 
+#### Required 
+* **project** _The project the VPC belongs to_ 
+* **cloud_name** _Cloud the VPC is in_ 
+* **network_cidr** _Network address range used by the VPC like 192.168.0.0/24_ 
+##### Computed 
+* **state** _State of the VPC (APPROVED, ACTIVE, DELETING, DELETED)_ 
+* **id**  
+### aiven_database 
+#### Required 
+* **service_name** _Service to link the database to_ 
+* **database_name** _Service database name_ 
+* **project** _Project to link the database to_ 
+#### Optional 
+* **lc_ctype** _Default character classification (LC_CTYPE) of the database. Default value: en_US.UTF-8_ 
+* **termination_protection** _It is a Terraform client-side deletion protections, which prevents the database
+			from being deleted by Terraform. It is recommended to enable this for any production
+			databases containing critical data._ 
+* **lc_collate** _Default string sort order (LC_COLLATE) of the database. Default value: en_US.UTF-8_ 
+##### Computed 
+* **id**  
+--- 
+

--- a/scripts/docgen.py
+++ b/scripts/docgen.py
@@ -1,0 +1,77 @@
+import json
+import sys
+
+
+class DocGen:
+
+    KEYS = ['provider', 'resource_schemas', 'datasource_schemas']
+
+    def __init__(self, schema = "scripts/schema.json", output = "ALLL"):
+        with open(schema) as source:
+            json_src = json.load(source)
+            md_str = []
+            if output is "ALL":
+                md_str.append("# terraform-provider-aiven \n")
+                c, r, o = self.get_attrs(json_src['provider'])
+                md_str += self.gen_attributes(c, r, o)
+                md_str.append('--- \n')
+            if output in ["ALL", "RESOURCES"]:
+                md_str.append('## Resources \n')
+                for k, v in json_src['resource_schemas'].items():
+                    c, r, o = self.get_attrs(v)
+                    md_str += self.gen_attributes(c, r, o, k)
+                md_str.append('--- \n')
+            if output in ["ALL", "DATASOURCES"]:
+                md_str.append('## Data-sources \n')
+                for k, v in json_src['data_source_schemas'].items():
+                    c, r, o = self.get_attrs(v)
+                    md_str += self.gen_attributes(c, r, o, k)
+
+            print(''.join(md_str))
+
+    def get_attrs(self, obj):
+        c = []
+        r = []
+        o = []
+        attrs = obj['block']['attributes']
+        for k, v in attrs.items():
+            desc = "_{}_".format(v['description']) if 'description' in v else ''
+            s = "**{}** {}".format(k, desc)
+            if 'computed' in v and v['computed']:
+                c.append(s)
+            elif 'required' in v and v['required']:
+                r.append(s)
+            elif 'optional' in v and v['optional']:
+                o.append(s)
+        return c, r, o
+
+
+    def gen_list(self, arr, section=False, numbered=False):
+        out = []
+        if len(arr) == 0:
+            return out
+        if section is not False:
+            out += section
+        for req in arr:
+            idx = '*'
+            out.append("{} {} \n".format(idx, req))
+        return out
+
+
+    def gen_attributes(self, c, r, o, section=False):
+        tmpl = []
+        if section is not False:
+            tmpl.append("### {} \n".format(section))
+        tmpl += self.gen_list(r, '#### Required \n')
+        tmpl += self.gen_list(o, '#### Optional \n')
+        tmpl += self.gen_list(c, '##### Computed \n')
+        return tmpl
+
+
+if __name__ == '__main__':
+    if len(sys.argv) == 3:
+        schema = sys.argv[1]
+        output = sys.argv[2]
+        d = DocGen(schema, output)
+    else:
+        print("Usage: docgen.py <PATH_TO_SCHEMA> <ALL | RESOURCES | DATASOURCES>")

--- a/scripts/schema.json
+++ b/scripts/schema.json
@@ -1,0 +1,6441 @@
+{
+  "provider": {
+    "version": 0,
+    "block": {
+      "attributes": {
+        "api_token": {
+          "type": "string",
+          "description": "Aiven Authentication Token",
+          "required": true,
+          "sensitive": true
+        }
+      }
+    }
+  },
+  "resource_schemas": {
+    "aiven_account": {
+      "version": 0,
+      "block": {
+        "attributes": {
+          "account_id": {
+            "type": "string",
+            "description": "Account id",
+            "computed": true
+          },
+          "create_time": {
+            "type": "string",
+            "description": "Time of creation",
+            "optional": true,
+            "computed": true
+          },
+          "id": {
+            "type": "string",
+            "optional": true,
+            "computed": true
+          },
+          "name": {
+            "type": "string",
+            "description": "Account name",
+            "required": true
+          },
+          "owner_team_id": {
+            "type": "string",
+            "description": "Owner team id",
+            "optional": true,
+            "computed": true
+          },
+          "tenant_id": {
+            "type": "string",
+            "description": "Tenant id",
+            "optional": true,
+            "computed": true
+          },
+          "update_time": {
+            "type": "string",
+            "description": "Time of last update",
+            "optional": true,
+            "computed": true
+          }
+        }
+      }
+    },
+    "aiven_account_team": {
+      "version": 0,
+      "block": {
+        "attributes": {
+          "account_id": {
+            "type": "string",
+            "description": "Account id",
+            "required": true
+          },
+          "create_time": {
+            "type": "string",
+            "description": "Time of creation",
+            "optional": true,
+            "computed": true
+          },
+          "id": {
+            "type": "string",
+            "optional": true,
+            "computed": true
+          },
+          "name": {
+            "type": "string",
+            "description": "Account team name",
+            "required": true
+          },
+          "team_id": {
+            "type": "string",
+            "description": "Account team id",
+            "computed": true
+          },
+          "update_time": {
+            "type": "string",
+            "description": "Time of last update",
+            "optional": true,
+            "computed": true
+          }
+        }
+      }
+    },
+    "aiven_account_team_member": {
+      "version": 0,
+      "block": {
+        "attributes": {
+          "accepted": {
+            "type": "bool",
+            "description": "Team member invitation status",
+            "optional": true,
+            "computed": true
+          },
+          "account_id": {
+            "type": "string",
+            "description": "Account id",
+            "required": true
+          },
+          "create_time": {
+            "type": "string",
+            "description": "Time of creation",
+            "optional": true,
+            "computed": true
+          },
+          "id": {
+            "type": "string",
+            "optional": true,
+            "computed": true
+          },
+          "invited_by_user_email": {
+            "type": "string",
+            "description": "Team invited by user email",
+            "optional": true,
+            "computed": true
+          },
+          "team_id": {
+            "type": "string",
+            "description": "Account team id",
+            "required": true
+          },
+          "user_email": {
+            "type": "string",
+            "description": "Team invite user email",
+            "required": true
+          }
+        }
+      }
+    },
+    "aiven_account_team_project": {
+      "version": 0,
+      "block": {
+        "attributes": {
+          "account_id": {
+            "type": "string",
+            "description": "Account id",
+            "required": true
+          },
+          "id": {
+            "type": "string",
+            "optional": true,
+            "computed": true
+          },
+          "project_name": {
+            "type": "string",
+            "description": "Account team project name",
+            "optional": true
+          },
+          "team_id": {
+            "type": "string",
+            "description": "Account team id",
+            "required": true
+          },
+          "team_type": {
+            "type": "string",
+            "description": "Account team project type, can one of the following values: admin, developer, operator and read_only",
+            "optional": true
+          }
+        }
+      }
+    },
+    "aiven_connection_pool": {
+      "version": 0,
+      "block": {
+        "attributes": {
+          "connection_uri": {
+            "type": "string",
+            "description": "URI for connecting to the pool",
+            "computed": true,
+            "sensitive": true
+          },
+          "database_name": {
+            "type": "string",
+            "description": "Name of the database the pool connects to",
+            "required": true
+          },
+          "id": {
+            "type": "string",
+            "optional": true,
+            "computed": true
+          },
+          "pool_mode": {
+            "type": "string",
+            "description": "Mode the pool operates in (session, transaction, statement)",
+            "optional": true
+          },
+          "pool_name": {
+            "type": "string",
+            "description": "Name of the pool",
+            "required": true
+          },
+          "pool_size": {
+            "type": "number",
+            "description": "Number of connections the pool may create towards the backend server",
+            "optional": true
+          },
+          "project": {
+            "type": "string",
+            "description": "Project to link the connection pool to",
+            "required": true
+          },
+          "service_name": {
+            "type": "string",
+            "description": "Service to link the connection pool to",
+            "required": true
+          },
+          "username": {
+            "type": "string",
+            "description": "Name of the service user used to connect to the database",
+            "required": true
+          }
+        }
+      }
+    },
+    "aiven_database": {
+      "version": 0,
+      "block": {
+        "attributes": {
+          "database_name": {
+            "type": "string",
+            "description": "Service database name",
+            "required": true
+          },
+          "id": {
+            "type": "string",
+            "optional": true,
+            "computed": true
+          },
+          "lc_collate": {
+            "type": "string",
+            "description": "Default string sort order (LC_COLLATE) of the database. Default value: en_US.UTF-8",
+            "optional": true
+          },
+          "lc_ctype": {
+            "type": "string",
+            "description": "Default character classification (LC_CTYPE) of the database. Default value: en_US.UTF-8",
+            "optional": true
+          },
+          "project": {
+            "type": "string",
+            "description": "Project to link the database to",
+            "required": true
+          },
+          "service_name": {
+            "type": "string",
+            "description": "Service to link the database to",
+            "required": true
+          },
+          "termination_protection": {
+            "type": "bool",
+            "description": "It is a Terraform client-side deletion protections, which prevents the database\n\t\t\tfrom being deleted by Terraform. It is recommended to enable this for any production\n\t\t\tdatabases containing critical data.",
+            "optional": true
+          }
+        }
+      }
+    },
+    "aiven_elasticsearch_acl": {
+      "version": 0,
+      "block": {
+        "attributes": {
+          "enabled": {
+            "type": "bool",
+            "description": "Enable Elasticsearch ACLs. When disabled authenticated service users have unrestricted access",
+            "optional": true
+          },
+          "extended_acl": {
+            "type": "bool",
+            "description": "Index rules can be applied in a limited fashion to the _mget, _msearch and _bulk APIs (and only those) by enabling the ExtendedAcl option for the service. When it is enabled, users can use these APIs as long as all operations only target indexes they have been granted access to",
+            "optional": true
+          },
+          "id": {
+            "type": "string",
+            "optional": true,
+            "computed": true
+          },
+          "project": {
+            "type": "string",
+            "description": "Project to link the Elasticsearch ACLs to",
+            "required": true
+          },
+          "service_name": {
+            "type": "string",
+            "description": "Service to link the Elasticsearch ACLs to",
+            "required": true
+          }
+        },
+        "block_types": {
+          "acl": {
+            "nesting_mode": "set",
+            "block": {
+              "attributes": {
+                "username": {
+                  "type": "string",
+                  "description": "Username for the ACL entry",
+                  "required": true
+                }
+              },
+              "block_types": {
+                "rule": {
+                  "nesting_mode": "set",
+                  "block": {
+                    "attributes": {
+                      "index": {
+                        "type": "string",
+                        "description": "Elasticsearch index pattern",
+                        "required": true
+                      },
+                      "permission": {
+                        "type": "string",
+                        "description": "Elasticsearch permission",
+                        "required": true
+                      }
+                    }
+                  },
+                  "min_items": 1
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "aiven_kafka_acl": {
+      "version": 0,
+      "block": {
+        "attributes": {
+          "id": {
+            "type": "string",
+            "optional": true,
+            "computed": true
+          },
+          "permission": {
+            "type": "string",
+            "description": "Kafka permission to grant (admin, read, readwrite, write)",
+            "required": true
+          },
+          "project": {
+            "type": "string",
+            "description": "Project to link the Kafka ACL to",
+            "required": true
+          },
+          "service_name": {
+            "type": "string",
+            "description": "Service to link the Kafka ACL to",
+            "required": true
+          },
+          "topic": {
+            "type": "string",
+            "description": "Topic name pattern for the ACL entry",
+            "required": true
+          },
+          "username": {
+            "type": "string",
+            "description": "Username pattern for the ACL entry",
+            "required": true
+          }
+        }
+      }
+    },
+    "aiven_kafka_connector": {
+      "version": 0,
+      "block": {
+        "attributes": {
+          "config": {
+            "type": [
+              "map",
+              "string"
+            ],
+            "description": "Kafka Connector configuration parameters",
+            "required": true
+          },
+          "connector_name": {
+            "type": "string",
+            "description": "Kafka connector name",
+            "required": true
+          },
+          "id": {
+            "type": "string",
+            "optional": true,
+            "computed": true
+          },
+          "plugin_author": {
+            "type": "string",
+            "description": "Kafka connector author",
+            "computed": true
+          },
+          "plugin_class": {
+            "type": "string",
+            "description": "Kafka connector Java class",
+            "computed": true
+          },
+          "plugin_doc_url": {
+            "type": "string",
+            "description": "Kafka connector documentation URL",
+            "computed": true
+          },
+          "plugin_title": {
+            "type": "string",
+            "description": "Kafka connector title",
+            "computed": true
+          },
+          "plugin_type": {
+            "type": "string",
+            "description": "Kafka connector type",
+            "computed": true
+          },
+          "plugin_version": {
+            "type": "string",
+            "description": "Kafka connector version",
+            "computed": true
+          },
+          "project": {
+            "type": "string",
+            "description": "Project to link the kafka connector to",
+            "required": true
+          },
+          "service_name": {
+            "type": "string",
+            "description": "Service to link the kafka connector to",
+            "required": true
+          },
+          "task": {
+            "type": [
+              "set",
+              [
+                "object",
+                {
+                  "connector": "string",
+                  "task": "number"
+                }
+              ]
+            ],
+            "description": "List of tasks of a connector",
+            "computed": true
+          }
+        }
+      }
+    },
+    "aiven_kafka_schema": {
+      "version": 0,
+      "block": {
+        "attributes": {
+          "id": {
+            "type": "string",
+            "optional": true,
+            "computed": true
+          },
+          "project": {
+            "type": "string",
+            "description": "Project to link the Kafka Schema to",
+            "required": true
+          },
+          "schema": {
+            "type": "string",
+            "description": "Kafka Schema configuration should be a valid Avro Schema JSON format",
+            "required": true
+          },
+          "service_name": {
+            "type": "string",
+            "description": "Service to link the Kafka Schema to",
+            "required": true
+          },
+          "subject_name": {
+            "type": "string",
+            "description": "Kafka Schema Subject name",
+            "required": true
+          },
+          "version": {
+            "type": "number",
+            "description": "Kafka Schema configuration version",
+            "computed": true
+          }
+        }
+      }
+    },
+    "aiven_kafka_schema_configuration": {
+      "version": 0,
+      "block": {
+        "attributes": {
+          "compatibility_level": {
+            "type": "string",
+            "description": "Kafka Schemas compatibility level",
+            "required": true
+          },
+          "id": {
+            "type": "string",
+            "optional": true,
+            "computed": true
+          },
+          "project": {
+            "type": "string",
+            "description": "Project to link the Kafka Schemas Configuration to",
+            "required": true
+          },
+          "service_name": {
+            "type": "string",
+            "description": "Service to link the Kafka Schemas Configuration to",
+            "required": true
+          }
+        }
+      }
+    },
+    "aiven_kafka_topic": {
+      "version": 0,
+      "block": {
+        "attributes": {
+          "cleanup_policy": {
+            "type": "string",
+            "description": "Topic cleanup policy. Allowed values: delete, compact",
+            "optional": true
+          },
+          "id": {
+            "type": "string",
+            "optional": true,
+            "computed": true
+          },
+          "minimum_in_sync_replicas": {
+            "type": "number",
+            "description": "Minimum required nodes in-sync replicas (ISR) to produce to a partition",
+            "optional": true
+          },
+          "partitions": {
+            "type": "number",
+            "description": "Number of partitions to create in the topic",
+            "required": true
+          },
+          "project": {
+            "type": "string",
+            "description": "Project to link the kafka topic to",
+            "required": true
+          },
+          "replication": {
+            "type": "number",
+            "description": "Replication factor for the topic",
+            "required": true
+          },
+          "retention_bytes": {
+            "type": "number",
+            "description": "Retention bytes",
+            "optional": true
+          },
+          "retention_hours": {
+            "type": "number",
+            "description": "Retention period (hours)",
+            "optional": true
+          },
+          "service_name": {
+            "type": "string",
+            "description": "Service to link the kafka topic to",
+            "required": true
+          },
+          "termination_protection": {
+            "type": "bool",
+            "description": "It is a Terraform client-side deletion protection, which prevents a Kafka \n\t\t\ttopic from being deleted. It is recommended to enable this for any production Kafka \n\t\t\ttopic containing critical data.",
+            "optional": true
+          },
+          "topic_name": {
+            "type": "string",
+            "description": "Topic name",
+            "required": true
+          }
+        },
+        "block_types": {
+          "client_timeout": {
+            "nesting_mode": "set",
+            "block": {
+              "attributes": {
+                "create": {
+                  "type": "string",
+                  "description": "create timeout",
+                  "optional": true
+                },
+                "read": {
+                  "type": "string",
+                  "description": "read timeout",
+                  "optional": true
+                }
+              }
+            },
+            "max_items": 1
+          }
+        }
+      }
+    },
+    "aiven_project": {
+      "version": 0,
+      "block": {
+        "attributes": {
+          "account_id": {
+            "type": "string",
+            "description": "Account ID",
+            "optional": true
+          },
+          "billing_address": {
+            "type": "string",
+            "description": "Billing name and address of the project",
+            "optional": true
+          },
+          "billing_emails": {
+            "type": [
+              "set",
+              "string"
+            ],
+            "description": "Billing contact emails of the project",
+            "optional": true
+          },
+          "ca_cert": {
+            "type": "string",
+            "description": "Project root CA. This is used by some services like Kafka to sign service certificate",
+            "optional": true,
+            "computed": true
+          },
+          "card_id": {
+            "type": "string",
+            "description": "Credit card ID",
+            "optional": true
+          },
+          "copy_from_project": {
+            "type": "string",
+            "description": "Copy properties from another project. Only has effect when a new project is created.",
+            "optional": true
+          },
+          "country_code": {
+            "type": "string",
+            "description": "Billing country code of the project",
+            "optional": true
+          },
+          "id": {
+            "type": "string",
+            "optional": true,
+            "computed": true
+          },
+          "project": {
+            "type": "string",
+            "description": "Project name",
+            "required": true
+          },
+          "technical_emails": {
+            "type": [
+              "set",
+              "string"
+            ],
+            "description": "Technical contact emails of the project",
+            "optional": true
+          }
+        }
+      }
+    },
+    "aiven_project_user": {
+      "version": 0,
+      "block": {
+        "attributes": {
+          "accepted": {
+            "type": "bool",
+            "description": "Whether the user has accepted project membership or not",
+            "computed": true
+          },
+          "email": {
+            "type": "string",
+            "description": "Email address of the user",
+            "required": true
+          },
+          "id": {
+            "type": "string",
+            "optional": true,
+            "computed": true
+          },
+          "member_type": {
+            "type": "string",
+            "description": "Project membership type. One of: admin, developer, operator",
+            "required": true
+          },
+          "project": {
+            "type": "string",
+            "description": "The project the user belongs to",
+            "required": true
+          }
+        }
+      }
+    },
+    "aiven_project_vpc": {
+      "version": 0,
+      "block": {
+        "attributes": {
+          "cloud_name": {
+            "type": "string",
+            "description": "Cloud the VPC is in",
+            "required": true
+          },
+          "id": {
+            "type": "string",
+            "optional": true,
+            "computed": true
+          },
+          "network_cidr": {
+            "type": "string",
+            "description": "Network address range used by the VPC like 192.168.0.0/24",
+            "required": true
+          },
+          "project": {
+            "type": "string",
+            "description": "The project the VPC belongs to",
+            "required": true
+          },
+          "state": {
+            "type": "string",
+            "description": "State of the VPC (APPROVED, ACTIVE, DELETING, DELETED)",
+            "computed": true
+          }
+        },
+        "block_types": {
+          "client_timeout": {
+            "nesting_mode": "set",
+            "block": {
+              "attributes": {
+                "create": {
+                  "type": "string",
+                  "description": "create timeout",
+                  "optional": true
+                },
+                "delete": {
+                  "type": "string",
+                  "description": "delete timeout",
+                  "optional": true
+                }
+              }
+            },
+            "max_items": 1
+          }
+        }
+      }
+    },
+    "aiven_service": {
+      "version": 0,
+      "block": {
+        "attributes": {
+          "cloud_name": {
+            "type": "string",
+            "description": "Cloud the service runs in",
+            "optional": true
+          },
+          "components": {
+            "type": [
+              "list",
+              [
+                "object",
+                {
+                  "component": "string",
+                  "host": "string",
+                  "kafka_authentication_method": "string",
+                  "port": "number",
+                  "route": "string",
+                  "ssl": "bool",
+                  "usage": "string"
+                }
+              ]
+            ],
+            "description": "Service component information objects",
+            "computed": true
+          },
+          "id": {
+            "type": "string",
+            "optional": true,
+            "computed": true
+          },
+          "maintenance_window_dow": {
+            "type": "string",
+            "description": "Day of week when maintenance operations should be performed. One monday, tuesday, wednesday, etc.",
+            "optional": true
+          },
+          "maintenance_window_time": {
+            "type": "string",
+            "description": "Time of day when maintenance operations should be performed. UTC time in HH:mm:ss format.",
+            "optional": true
+          },
+          "plan": {
+            "type": "string",
+            "description": "Subscription plan",
+            "optional": true
+          },
+          "project": {
+            "type": "string",
+            "description": "Target project",
+            "required": true
+          },
+          "project_vpc_id": {
+            "type": "string",
+            "description": "Identifier of the VPC the service should be in, if any",
+            "optional": true
+          },
+          "service_host": {
+            "type": "string",
+            "description": "Service hostname",
+            "computed": true
+          },
+          "service_name": {
+            "type": "string",
+            "description": "Service name",
+            "required": true
+          },
+          "service_password": {
+            "type": "string",
+            "description": "Password used for connecting to the service, if applicable",
+            "computed": true,
+            "sensitive": true
+          },
+          "service_port": {
+            "type": "number",
+            "description": "Service port",
+            "computed": true
+          },
+          "service_type": {
+            "type": "string",
+            "description": "Service type code",
+            "required": true
+          },
+          "service_uri": {
+            "type": "string",
+            "description": "URI for connecting to the service. Service specific info is under \"kafka\", \"pg\", etc.",
+            "computed": true,
+            "sensitive": true
+          },
+          "service_username": {
+            "type": "string",
+            "description": "Username used for connecting to the service, if applicable",
+            "computed": true
+          },
+          "state": {
+            "type": "string",
+            "description": "Service state",
+            "computed": true
+          },
+          "termination_protection": {
+            "type": "bool",
+            "description": "Prevent service from being deleted. It is recommended to have this enabled for all services.",
+            "optional": true
+          }
+        },
+        "block_types": {
+          "cassandra": {
+            "nesting_mode": "list",
+            "block": {},
+            "max_items": 1
+          },
+          "cassandra_user_config": {
+            "nesting_mode": "list",
+            "block": {
+              "attributes": {
+                "ip_filter": {
+                  "type": [
+                    "list",
+                    "string"
+                  ],
+                  "description": "IP filter",
+                  "optional": true
+                },
+                "migrate_sstableloader": {
+                  "type": "string",
+                  "description": "Migration mode for the sstableloader utility",
+                  "optional": true
+                },
+                "service_to_fork_from": {
+                  "type": "string",
+                  "description": "Name of another service to fork from. This has effect only when a new service is being created.",
+                  "optional": true
+                }
+              },
+              "block_types": {
+                "private_access": {
+                  "nesting_mode": "list",
+                  "block": {
+                    "attributes": {
+                      "prometheus": {
+                        "type": "string",
+                        "description": "Allow clients to connect to prometheus with a DNS name that always resolves to the service's private IP addresses. Only available in certain network locations",
+                        "optional": true
+                      }
+                    }
+                  },
+                  "max_items": 1
+                },
+                "public_access": {
+                  "nesting_mode": "list",
+                  "block": {
+                    "attributes": {
+                      "prometheus": {
+                        "type": "string",
+                        "description": "Allow clients to connect to prometheus from the public internet for service nodes that are in a project VPC or another type of private network",
+                        "optional": true
+                      }
+                    }
+                  },
+                  "max_items": 1
+                }
+              }
+            },
+            "max_items": 1
+          },
+          "client_timeout": {
+            "nesting_mode": "set",
+            "block": {
+              "attributes": {
+                "create": {
+                  "type": "string",
+                  "description": "create timeout",
+                  "optional": true
+                },
+                "update": {
+                  "type": "string",
+                  "description": "update timeout",
+                  "optional": true
+                }
+              }
+            },
+            "max_items": 1
+          },
+          "elasticsearch": {
+            "nesting_mode": "list",
+            "block": {
+              "attributes": {
+                "kibana_uri": {
+                  "type": "string",
+                  "description": "URI for Kibana frontend",
+                  "computed": true,
+                  "sensitive": true
+                }
+              }
+            },
+            "max_items": 1
+          },
+          "elasticsearch_user_config": {
+            "nesting_mode": "list",
+            "block": {
+              "attributes": {
+                "custom_domain": {
+                  "type": "string",
+                  "description": "Custom domain",
+                  "optional": true
+                },
+                "disable_replication_factor_adjustment": {
+                  "type": "string",
+                  "description": "Disable replication factor adjustment",
+                  "optional": true
+                },
+                "elasticsearch_version": {
+                  "type": "string",
+                  "description": "Elasticsearch major version",
+                  "optional": true
+                },
+                "ip_filter": {
+                  "type": [
+                    "list",
+                    "string"
+                  ],
+                  "description": "IP filter",
+                  "optional": true
+                },
+                "max_index_count": {
+                  "type": "number",
+                  "description": "Maximum index count",
+                  "optional": true
+                },
+                "recovery_basebackup_name": {
+                  "type": "string",
+                  "description": "Name of the basebackup to restore in forked service",
+                  "optional": true
+                },
+                "service_to_fork_from": {
+                  "type": "string",
+                  "description": "Name of another service to fork from. This has effect only when a new service is being created.",
+                  "optional": true
+                }
+              },
+              "block_types": {
+                "elasticsearch": {
+                  "nesting_mode": "list",
+                  "block": {
+                    "attributes": {
+                      "action_auto_create_index_enabled": {
+                        "type": "string",
+                        "description": "action.auto_create_index",
+                        "optional": true
+                      },
+                      "action_destructive_requires_name": {
+                        "type": "string",
+                        "description": "Require explicit index names when deleting",
+                        "optional": true
+                      },
+                      "http_max_content_length": {
+                        "type": "number",
+                        "description": "http.max_content_length",
+                        "optional": true
+                      },
+                      "http_max_header_size": {
+                        "type": "number",
+                        "description": "http.max_header_size",
+                        "optional": true
+                      },
+                      "http_max_initial_line_length": {
+                        "type": "number",
+                        "description": "http.max_initial_line_length",
+                        "optional": true
+                      },
+                      "indices_fielddata_cache_size": {
+                        "type": "number",
+                        "description": "indices.fielddata.cache.size",
+                        "optional": true
+                      },
+                      "indices_memory_index_buffer_size": {
+                        "type": "number",
+                        "description": "indices.memory.index_buffer_size",
+                        "optional": true
+                      },
+                      "indices_queries_cache_size": {
+                        "type": "number",
+                        "description": "indices.queries.cache.size",
+                        "optional": true
+                      },
+                      "indices_query_bool_max_clause_count": {
+                        "type": "number",
+                        "description": "indices.query.bool.max_clause_count",
+                        "optional": true
+                      },
+                      "reindex_remote_whitelist": {
+                        "type": [
+                          "list",
+                          "string"
+                        ],
+                        "description": "reindex_remote_whitelist",
+                        "optional": true
+                      },
+                      "thread_pool_analyze_queue_size": {
+                        "type": "number",
+                        "description": "analyze thread pool queue size",
+                        "optional": true
+                      },
+                      "thread_pool_analyze_size": {
+                        "type": "number",
+                        "description": "analyze thread pool size",
+                        "optional": true
+                      },
+                      "thread_pool_force_merge_size": {
+                        "type": "number",
+                        "description": "force_merge thread pool size",
+                        "optional": true
+                      },
+                      "thread_pool_get_queue_size": {
+                        "type": "number",
+                        "description": "get thread pool queue size",
+                        "optional": true
+                      },
+                      "thread_pool_get_size": {
+                        "type": "number",
+                        "description": "get thread pool size",
+                        "optional": true
+                      },
+                      "thread_pool_index_queue_size": {
+                        "type": "number",
+                        "description": "index thread pool queue size",
+                        "optional": true
+                      },
+                      "thread_pool_index_size": {
+                        "type": "number",
+                        "description": "index thread pool size",
+                        "optional": true
+                      },
+                      "thread_pool_search_queue_size": {
+                        "type": "number",
+                        "description": "search thread pool queue size",
+                        "optional": true
+                      },
+                      "thread_pool_search_size": {
+                        "type": "number",
+                        "description": "search thread pool size",
+                        "optional": true
+                      },
+                      "thread_pool_search_throttled_queue_size": {
+                        "type": "number",
+                        "description": "search_throttled thread pool queue size",
+                        "optional": true
+                      },
+                      "thread_pool_search_throttled_size": {
+                        "type": "number",
+                        "description": "search_throttled thread pool size",
+                        "optional": true
+                      },
+                      "thread_pool_write_queue_size": {
+                        "type": "number",
+                        "description": "write thread pool queue size",
+                        "optional": true
+                      },
+                      "thread_pool_write_size": {
+                        "type": "number",
+                        "description": "write thread pool size",
+                        "optional": true
+                      }
+                    }
+                  },
+                  "max_items": 1
+                },
+                "index_patterns": {
+                  "nesting_mode": "list",
+                  "block": {
+                    "attributes": {
+                      "max_index_count": {
+                        "type": "number",
+                        "description": "Maximum number of indexes to keep",
+                        "optional": true
+                      },
+                      "pattern": {
+                        "type": "string",
+                        "description": "fnmatch pattern",
+                        "optional": true
+                      }
+                    }
+                  },
+                  "max_items": 512
+                },
+                "kibana": {
+                  "nesting_mode": "list",
+                  "block": {
+                    "attributes": {
+                      "elasticsearch_request_timeout": {
+                        "type": "number",
+                        "description": "Timeout in milliseconds for requests made by Kibana towards Elasticsearch",
+                        "optional": true
+                      },
+                      "enabled": {
+                        "type": "bool",
+                        "description": "Enable or disable Kibana",
+                        "optional": true
+                      },
+                      "max_old_space_size": {
+                        "type": "number",
+                        "description": "max_old_space_size",
+                        "optional": true
+                      }
+                    }
+                  },
+                  "max_items": 1
+                },
+                "private_access": {
+                  "nesting_mode": "list",
+                  "block": {
+                    "attributes": {
+                      "elasticsearch": {
+                        "type": "string",
+                        "description": "Allow clients to connect to elasticsearch with a DNS name that always resolves to the service's private IP addresses. Only available in certain network locations",
+                        "optional": true
+                      },
+                      "kibana": {
+                        "type": "string",
+                        "description": "Allow clients to connect to kibana with a DNS name that always resolves to the service's private IP addresses. Only available in certain network locations",
+                        "optional": true
+                      },
+                      "prometheus": {
+                        "type": "string",
+                        "description": "Allow clients to connect to prometheus with a DNS name that always resolves to the service's private IP addresses. Only available in certain network locations",
+                        "optional": true
+                      }
+                    }
+                  },
+                  "max_items": 1
+                },
+                "public_access": {
+                  "nesting_mode": "list",
+                  "block": {
+                    "attributes": {
+                      "elasticsearch": {
+                        "type": "string",
+                        "description": "Allow clients to connect to elasticsearch from the public internet for service nodes that are in a project VPC or another type of private network",
+                        "optional": true
+                      },
+                      "kibana": {
+                        "type": "string",
+                        "description": "Allow clients to connect to kibana from the public internet for service nodes that are in a project VPC or another type of private network",
+                        "optional": true
+                      },
+                      "prometheus": {
+                        "type": "string",
+                        "description": "Allow clients to connect to prometheus from the public internet for service nodes that are in a project VPC or another type of private network",
+                        "optional": true
+                      }
+                    }
+                  },
+                  "max_items": 1
+                }
+              }
+            },
+            "max_items": 1
+          },
+          "grafana": {
+            "nesting_mode": "list",
+            "block": {},
+            "max_items": 1
+          },
+          "grafana_user_config": {
+            "nesting_mode": "list",
+            "block": {
+              "attributes": {
+                "alerting_enabled": {
+                  "type": "string",
+                  "description": "Enable or disable Grafana alerting functionality",
+                  "optional": true
+                },
+                "alerting_error_or_timeout": {
+                  "type": "string",
+                  "description": "Default error or timeout setting for new alerting rules",
+                  "optional": true
+                },
+                "alerting_nodata_or_nullvalues": {
+                  "type": "string",
+                  "description": "Default value for 'no data or null values' for new alerting rules",
+                  "optional": true
+                },
+                "allow_embedding": {
+                  "type": "string",
+                  "description": "Allow embedding Grafana dashboards with iframe/frame/object/embed tags. Disabled by default to limit impact of clickjacking",
+                  "optional": true
+                },
+                "auth_basic_enabled": {
+                  "type": "string",
+                  "description": "Enable or disable basic authentication form, used by Grafana built-in login",
+                  "optional": true
+                },
+                "cookie_samesite": {
+                  "type": "string",
+                  "description": "Cookie SameSite attribute: 'strict' prevents sending cookie for cross-site requests, effectively disabling direct linking from other sites to Grafana. 'lax' is the default value.",
+                  "optional": true
+                },
+                "custom_domain": {
+                  "type": "string",
+                  "description": "Custom domain",
+                  "optional": true
+                },
+                "dashboards_versions_to_keep": {
+                  "type": "number",
+                  "description": "Dashboard versions to keep per dashboard",
+                  "optional": true
+                },
+                "dataproxy_send_user_header": {
+                  "type": "string",
+                  "description": "Send 'X-Grafana-User' header to data source",
+                  "optional": true
+                },
+                "dataproxy_timeout": {
+                  "type": "number",
+                  "description": "Timeout for data proxy requests in seconds",
+                  "optional": true
+                },
+                "disable_gravatar": {
+                  "type": "string",
+                  "description": "Set to true to disable gravatar. Defaults to false (gravatar is enabled)",
+                  "optional": true
+                },
+                "editors_can_admin": {
+                  "type": "string",
+                  "description": "Editors can manage folders, teams and dashboards created by them",
+                  "optional": true
+                },
+                "google_analytics_ua_id": {
+                  "type": "string",
+                  "description": "Google Analytics Universal Analytics ID for tracking Grafana usage",
+                  "optional": true
+                },
+                "ip_filter": {
+                  "type": [
+                    "list",
+                    "string"
+                  ],
+                  "description": "IP filter",
+                  "optional": true
+                },
+                "metrics_enabled": {
+                  "type": "string",
+                  "description": "Enable Grafana /metrics endpoint",
+                  "optional": true
+                },
+                "user_auto_assign_org": {
+                  "type": "string",
+                  "description": "Auto-assign new users on signup to main organization. Defaults to false",
+                  "optional": true
+                },
+                "user_auto_assign_org_role": {
+                  "type": "string",
+                  "description": "Set role for new signups. Defaults to Viewer",
+                  "optional": true
+                },
+                "viewers_can_edit": {
+                  "type": "string",
+                  "description": "Users with view-only permission can edit but not save dashboards",
+                  "optional": true
+                }
+              },
+              "block_types": {
+                "auth_generic_oauth": {
+                  "nesting_mode": "list",
+                  "block": {
+                    "attributes": {
+                      "allow_sign_up": {
+                        "type": "string",
+                        "description": "Automatically sign-up users on successful sign-in",
+                        "optional": true
+                      },
+                      "allowed_domains": {
+                        "type": [
+                          "list",
+                          "string"
+                        ],
+                        "description": "Allowed domains",
+                        "optional": true
+                      },
+                      "allowed_organizations": {
+                        "type": [
+                          "list",
+                          "string"
+                        ],
+                        "description": "Require user to be member of one of the listed organizations",
+                        "optional": true
+                      },
+                      "api_url": {
+                        "type": "string",
+                        "description": "API URL",
+                        "optional": true
+                      },
+                      "auth_url": {
+                        "type": "string",
+                        "description": "Authorization URL",
+                        "optional": true
+                      },
+                      "client_id": {
+                        "type": "string",
+                        "description": "Client ID from provider",
+                        "optional": true
+                      },
+                      "client_secret": {
+                        "type": "string",
+                        "description": "Client secret from provider",
+                        "optional": true
+                      },
+                      "name": {
+                        "type": "string",
+                        "description": "Name of the OAuth integration",
+                        "optional": true
+                      },
+                      "scopes": {
+                        "type": [
+                          "list",
+                          "string"
+                        ],
+                        "description": "OAuth scopes",
+                        "optional": true
+                      },
+                      "token_url": {
+                        "type": "string",
+                        "description": "Token URL",
+                        "optional": true
+                      }
+                    }
+                  },
+                  "max_items": 1
+                },
+                "auth_github": {
+                  "nesting_mode": "list",
+                  "block": {
+                    "attributes": {
+                      "allow_sign_up": {
+                        "type": "string",
+                        "description": "Automatically sign-up users on successful sign-in",
+                        "optional": true
+                      },
+                      "allowed_organizations": {
+                        "type": [
+                          "list",
+                          "string"
+                        ],
+                        "description": "Require users to belong to one of given organizations",
+                        "optional": true
+                      },
+                      "client_id": {
+                        "type": "string",
+                        "description": "Client ID from provider",
+                        "optional": true
+                      },
+                      "client_secret": {
+                        "type": "string",
+                        "description": "Client secret from provider",
+                        "optional": true
+                      },
+                      "team_ids": {
+                        "type": [
+                          "list",
+                          "number"
+                        ],
+                        "description": "Require users to belong to one of given team IDs",
+                        "optional": true
+                      }
+                    }
+                  },
+                  "max_items": 1
+                },
+                "auth_gitlab": {
+                  "nesting_mode": "list",
+                  "block": {
+                    "attributes": {
+                      "allow_sign_up": {
+                        "type": "string",
+                        "description": "Automatically sign-up users on successful sign-in",
+                        "optional": true
+                      },
+                      "allowed_groups": {
+                        "type": [
+                          "list",
+                          "string"
+                        ],
+                        "description": "Require users to belong to one of given groups",
+                        "optional": true
+                      },
+                      "api_url": {
+                        "type": "string",
+                        "description": "API URL. This only needs to be set when using self hosted GitLab",
+                        "optional": true
+                      },
+                      "auth_url": {
+                        "type": "string",
+                        "description": "Authorization URL. This only needs to be set when using self hosted GitLab",
+                        "optional": true
+                      },
+                      "client_id": {
+                        "type": "string",
+                        "description": "Client ID from provider",
+                        "optional": true
+                      },
+                      "client_secret": {
+                        "type": "string",
+                        "description": "Client secret from provider",
+                        "optional": true
+                      },
+                      "token_url": {
+                        "type": "string",
+                        "description": "Token URL. This only needs to be set when using self hosted GitLab",
+                        "optional": true
+                      }
+                    }
+                  },
+                  "max_items": 1
+                },
+                "auth_google": {
+                  "nesting_mode": "list",
+                  "block": {
+                    "attributes": {
+                      "allow_sign_up": {
+                        "type": "string",
+                        "description": "Automatically sign-up users on successful sign-in",
+                        "optional": true
+                      },
+                      "allowed_domains": {
+                        "type": [
+                          "list",
+                          "string"
+                        ],
+                        "description": "Domains allowed to sign-in to this Grafana",
+                        "optional": true
+                      },
+                      "client_id": {
+                        "type": "string",
+                        "description": "Client ID from provider",
+                        "optional": true
+                      },
+                      "client_secret": {
+                        "type": "string",
+                        "description": "Client secret from provider",
+                        "optional": true
+                      }
+                    }
+                  },
+                  "max_items": 1
+                },
+                "external_image_storage": {
+                  "nesting_mode": "list",
+                  "block": {
+                    "attributes": {
+                      "access_key": {
+                        "type": "string",
+                        "description": "S3 access key. Requires permissions to the S3 bucket for the s3:PutObject and s3:PutObjectAcl actions",
+                        "optional": true
+                      },
+                      "bucket_url": {
+                        "type": "string",
+                        "description": "Bucket URL for S3",
+                        "optional": true
+                      },
+                      "provider": {
+                        "type": "string",
+                        "description": "Provider type",
+                        "optional": true
+                      },
+                      "secret_key": {
+                        "type": "string",
+                        "description": "S3 secret key",
+                        "optional": true
+                      }
+                    }
+                  },
+                  "max_items": 1
+                },
+                "private_access": {
+                  "nesting_mode": "list",
+                  "block": {
+                    "attributes": {
+                      "grafana": {
+                        "type": "string",
+                        "description": "Allow clients to connect to grafana with a DNS name that always resolves to the service's private IP addresses. Only available in certain network locations",
+                        "optional": true
+                      }
+                    }
+                  },
+                  "max_items": 1
+                },
+                "public_access": {
+                  "nesting_mode": "list",
+                  "block": {
+                    "attributes": {
+                      "grafana": {
+                        "type": "string",
+                        "description": "Allow clients to connect to grafana from the public internet for service nodes that are in a project VPC or another type of private network",
+                        "optional": true
+                      }
+                    }
+                  },
+                  "max_items": 1
+                },
+                "smtp_server": {
+                  "nesting_mode": "list",
+                  "block": {
+                    "attributes": {
+                      "from_address": {
+                        "type": "string",
+                        "description": "Address used for sending emails",
+                        "optional": true
+                      },
+                      "from_name": {
+                        "type": "string",
+                        "description": "Name used in outgoing emails, defaults to Grafana",
+                        "optional": true
+                      },
+                      "host": {
+                        "type": "string",
+                        "description": "Server hostname or IP",
+                        "optional": true
+                      },
+                      "password": {
+                        "type": "string",
+                        "description": "Password for SMTP authentication",
+                        "optional": true,
+                        "sensitive": true
+                      },
+                      "port": {
+                        "type": "number",
+                        "description": "SMTP server port",
+                        "optional": true
+                      },
+                      "skip_verify": {
+                        "type": "string",
+                        "description": "Skip verifying server certificate. Defaults to false",
+                        "optional": true
+                      },
+                      "username": {
+                        "type": "string",
+                        "description": "Username for SMTP authentication",
+                        "optional": true
+                      }
+                    }
+                  },
+                  "max_items": 1
+                }
+              }
+            },
+            "max_items": 1
+          },
+          "influxdb": {
+            "nesting_mode": "list",
+            "block": {
+              "attributes": {
+                "database_name": {
+                  "type": "string",
+                  "description": "Name of the default InfluxDB database",
+                  "computed": true
+                }
+              }
+            },
+            "max_items": 1
+          },
+          "influxdb_user_config": {
+            "nesting_mode": "list",
+            "block": {
+              "attributes": {
+                "custom_domain": {
+                  "type": "string",
+                  "description": "Custom domain",
+                  "optional": true
+                },
+                "ip_filter": {
+                  "type": [
+                    "list",
+                    "string"
+                  ],
+                  "description": "IP filter",
+                  "optional": true
+                },
+                "service_to_fork_from": {
+                  "type": "string",
+                  "description": "Name of another service to fork from. This has effect only when a new service is being created.",
+                  "optional": true
+                }
+              },
+              "block_types": {
+                "private_access": {
+                  "nesting_mode": "list",
+                  "block": {
+                    "attributes": {
+                      "influxdb": {
+                        "type": "string",
+                        "description": "Allow clients to connect to influxdb with a DNS name that always resolves to the service's private IP addresses. Only available in certain network locations",
+                        "optional": true
+                      }
+                    }
+                  },
+                  "max_items": 1
+                },
+                "public_access": {
+                  "nesting_mode": "list",
+                  "block": {
+                    "attributes": {
+                      "influxdb": {
+                        "type": "string",
+                        "description": "Allow clients to connect to influxdb from the public internet for service nodes that are in a project VPC or another type of private network",
+                        "optional": true
+                      }
+                    }
+                  },
+                  "max_items": 1
+                }
+              }
+            },
+            "max_items": 1
+          },
+          "kafka": {
+            "nesting_mode": "list",
+            "block": {
+              "attributes": {
+                "access_cert": {
+                  "type": "string",
+                  "description": "The Kafka client certificate",
+                  "optional": true,
+                  "computed": true,
+                  "sensitive": true
+                },
+                "access_key": {
+                  "type": "string",
+                  "description": "The Kafka client certificate key",
+                  "optional": true,
+                  "computed": true,
+                  "sensitive": true
+                },
+                "connect_uri": {
+                  "type": "string",
+                  "description": "The Kafka Connect URI, if any",
+                  "optional": true,
+                  "computed": true,
+                  "sensitive": true
+                },
+                "rest_uri": {
+                  "type": "string",
+                  "description": "The Kafka REST URI, if any",
+                  "optional": true,
+                  "computed": true,
+                  "sensitive": true
+                },
+                "schema_registry_uri": {
+                  "type": "string",
+                  "description": "The Schema Registry URI, if any",
+                  "optional": true,
+                  "computed": true,
+                  "sensitive": true
+                }
+              }
+            },
+            "max_items": 1
+          },
+          "kafka_connect": {
+            "nesting_mode": "list",
+            "block": {},
+            "max_items": 1
+          },
+          "kafka_connect_user_config": {
+            "nesting_mode": "list",
+            "block": {
+              "attributes": {
+                "ip_filter": {
+                  "type": [
+                    "list",
+                    "string"
+                  ],
+                  "description": "IP filter",
+                  "optional": true
+                }
+              },
+              "block_types": {
+                "kafka_connect": {
+                  "nesting_mode": "list",
+                  "block": {
+                    "attributes": {
+                      "consumer_isolation_level": {
+                        "type": "string",
+                        "description": "Consumer isolation level",
+                        "optional": true
+                      },
+                      "consumer_max_poll_records": {
+                        "type": "number",
+                        "description": "The maximum number of records returned by a single poll",
+                        "optional": true
+                      },
+                      "offset_flush_interval_ms": {
+                        "type": "number",
+                        "description": "The interval at which to try committing offsets for tasks",
+                        "optional": true
+                      }
+                    }
+                  },
+                  "max_items": 1
+                },
+                "private_access": {
+                  "nesting_mode": "list",
+                  "block": {
+                    "attributes": {
+                      "kafka_connect": {
+                        "type": "string",
+                        "description": "Allow clients to connect to kafka_connect with a DNS name that always resolves to the service's private IP addresses. Only available in certain network locations",
+                        "optional": true
+                      },
+                      "prometheus": {
+                        "type": "string",
+                        "description": "Allow clients to connect to prometheus with a DNS name that always resolves to the service's private IP addresses. Only available in certain network locations",
+                        "optional": true
+                      }
+                    }
+                  },
+                  "max_items": 1
+                },
+                "public_access": {
+                  "nesting_mode": "list",
+                  "block": {
+                    "attributes": {
+                      "kafka_connect": {
+                        "type": "string",
+                        "description": "Allow clients to connect to kafka_connect from the public internet for service nodes that are in a project VPC or another type of private network",
+                        "optional": true
+                      },
+                      "prometheus": {
+                        "type": "string",
+                        "description": "Allow clients to connect to prometheus from the public internet for service nodes that are in a project VPC or another type of private network",
+                        "optional": true
+                      }
+                    }
+                  },
+                  "max_items": 1
+                }
+              }
+            },
+            "max_items": 1
+          },
+          "kafka_mirrormaker": {
+            "nesting_mode": "list",
+            "block": {},
+            "max_items": 1
+          },
+          "kafka_mirrormaker_user_config": {
+            "nesting_mode": "list",
+            "block": {
+              "attributes": {
+                "ip_filter": {
+                  "type": [
+                    "list",
+                    "string"
+                  ],
+                  "description": "IP filter",
+                  "optional": true
+                }
+              },
+              "block_types": {
+                "kafka_mirrormaker": {
+                  "nesting_mode": "list",
+                  "block": {
+                    "attributes": {
+                      "refresh_groups_enabled": {
+                        "type": "string",
+                        "description": "Refresh consumer groups",
+                        "optional": true
+                      },
+                      "refresh_groups_interval_seconds": {
+                        "type": "number",
+                        "description": "Frequency of group refresh",
+                        "optional": true
+                      },
+                      "refresh_topics_enabled": {
+                        "type": "string",
+                        "description": "Refresh topics and partitions",
+                        "optional": true
+                      },
+                      "refresh_topics_interval_seconds": {
+                        "type": "number",
+                        "description": "Frequency of topic and partitions refresh",
+                        "optional": true
+                      }
+                    }
+                  },
+                  "max_items": 1
+                }
+              }
+            },
+            "max_items": 1
+          },
+          "kafka_user_config": {
+            "nesting_mode": "list",
+            "block": {
+              "attributes": {
+                "custom_domain": {
+                  "type": "string",
+                  "description": "Custom domain",
+                  "optional": true
+                },
+                "ip_filter": {
+                  "type": [
+                    "list",
+                    "string"
+                  ],
+                  "description": "IP filter",
+                  "optional": true
+                },
+                "kafka_connect": {
+                  "type": "bool",
+                  "description": "Enable Kafka Connect service",
+                  "optional": true
+                },
+                "kafka_rest": {
+                  "type": "bool",
+                  "description": "Enable Kafka-REST service",
+                  "optional": true
+                },
+                "kafka_version": {
+                  "type": "string",
+                  "description": "Kafka major version",
+                  "optional": true
+                },
+                "schema_registry": {
+                  "type": "bool",
+                  "description": "Enable Schema-Registry service",
+                  "optional": true
+                }
+              },
+              "block_types": {
+                "kafka": {
+                  "nesting_mode": "list",
+                  "block": {
+                    "attributes": {
+                      "auto_create_topics_enable": {
+                        "type": "string",
+                        "description": "auto.create.topics.enable",
+                        "optional": true
+                      },
+                      "compression_type": {
+                        "type": "string",
+                        "description": "compression.type",
+                        "optional": true
+                      },
+                      "connections_max_idle_ms": {
+                        "type": "number",
+                        "description": "connections.max.idle.ms",
+                        "optional": true
+                      },
+                      "default_replication_factor": {
+                        "type": "number",
+                        "description": "default.replication.factor",
+                        "optional": true
+                      },
+                      "group_max_session_timeout_ms": {
+                        "type": "number",
+                        "description": "group.max.session.timeout.ms",
+                        "optional": true
+                      },
+                      "group_min_session_timeout_ms": {
+                        "type": "number",
+                        "description": "group.min.session.timeout.ms",
+                        "optional": true
+                      },
+                      "log_cleaner_max_compaction_lag_ms": {
+                        "type": "number",
+                        "description": "log.cleaner.max.compaction.lag.ms",
+                        "optional": true
+                      },
+                      "log_cleaner_min_cleanable_ratio": {
+                        "type": "number",
+                        "description": "log.cleaner.min.cleanable.ratio",
+                        "optional": true
+                      },
+                      "log_cleaner_min_compaction_lag_ms": {
+                        "type": "number",
+                        "description": "log.cleaner.min.compaction.lag.ms",
+                        "optional": true
+                      },
+                      "log_cleanup_policy": {
+                        "type": "string",
+                        "description": "log.cleanup.policy",
+                        "optional": true
+                      },
+                      "log_message_timestamp_difference_max_ms": {
+                        "type": "number",
+                        "description": "log.message.timestamp.difference.max.ms",
+                        "optional": true
+                      },
+                      "log_message_timestamp_type": {
+                        "type": "string",
+                        "description": "log.message.timestamp.type",
+                        "optional": true
+                      },
+                      "log_retention_bytes": {
+                        "type": "number",
+                        "description": "log.retention.bytes",
+                        "optional": true
+                      },
+                      "log_retention_hours": {
+                        "type": "number",
+                        "description": "log.retention.hours",
+                        "optional": true
+                      },
+                      "log_segment_bytes": {
+                        "type": "number",
+                        "description": "log.segment.bytes",
+                        "optional": true
+                      },
+                      "max_connections_per_ip": {
+                        "type": "number",
+                        "description": "max.connections.per.ip",
+                        "optional": true
+                      },
+                      "message_max_bytes": {
+                        "type": "number",
+                        "description": "message.max.bytes",
+                        "optional": true
+                      },
+                      "num_partitions": {
+                        "type": "number",
+                        "description": "num.partitions",
+                        "optional": true
+                      },
+                      "offsets_retention_minutes": {
+                        "type": "number",
+                        "description": "offsets.retention.minutes",
+                        "optional": true
+                      },
+                      "producer_purgatory_purge_interval_requests": {
+                        "type": "number",
+                        "description": "producer.purgatory.purge.interval.requests",
+                        "optional": true
+                      },
+                      "replica_fetch_max_bytes": {
+                        "type": "number",
+                        "description": "replica.fetch.max.bytes",
+                        "optional": true
+                      },
+                      "replica_fetch_response_max_bytes": {
+                        "type": "number",
+                        "description": "replica.fetch.response.max.bytes",
+                        "optional": true
+                      },
+                      "socket_request_max_bytes": {
+                        "type": "number",
+                        "description": "socket.request.max.bytes",
+                        "optional": true
+                      }
+                    }
+                  },
+                  "max_items": 1
+                },
+                "kafka_authentication_methods": {
+                  "nesting_mode": "list",
+                  "block": {
+                    "attributes": {
+                      "certificate": {
+                        "type": "bool",
+                        "description": "Enable certificate/SSL authentication",
+                        "optional": true
+                      },
+                      "sasl": {
+                        "type": "bool",
+                        "description": "Enable SASL authentication",
+                        "optional": true
+                      }
+                    }
+                  },
+                  "max_items": 1
+                },
+                "kafka_connect_config": {
+                  "nesting_mode": "list",
+                  "block": {
+                    "attributes": {
+                      "consumer_isolation_level": {
+                        "type": "string",
+                        "description": "Consumer isolation level",
+                        "optional": true
+                      },
+                      "consumer_max_poll_records": {
+                        "type": "number",
+                        "description": "The maximum number of records returned by a single poll",
+                        "optional": true
+                      },
+                      "offset_flush_interval_ms": {
+                        "type": "number",
+                        "description": "The interval at which to try committing offsets for tasks",
+                        "optional": true
+                      }
+                    }
+                  },
+                  "max_items": 1
+                },
+                "kafka_rest_config": {
+                  "nesting_mode": "list",
+                  "block": {
+                    "attributes": {
+                      "consumer_enable_auto_commit": {
+                        "type": "bool",
+                        "description": "consumer.enable.auto.commit",
+                        "optional": true
+                      },
+                      "consumer_request_max_bytes": {
+                        "type": "number",
+                        "description": "consumer.request.max.bytes",
+                        "optional": true
+                      },
+                      "consumer_request_timeout_ms": {
+                        "type": "number",
+                        "description": "consumer.request.timeout.ms",
+                        "optional": true
+                      },
+                      "producer_acks": {
+                        "type": "string",
+                        "description": "producer.acks",
+                        "optional": true
+                      },
+                      "producer_linger_ms": {
+                        "type": "number",
+                        "description": "producer.linger.ms",
+                        "optional": true
+                      },
+                      "simpleconsumer_pool_size_max": {
+                        "type": "number",
+                        "description": "simpleconsumer.pool.size.max",
+                        "optional": true
+                      }
+                    }
+                  },
+                  "max_items": 1
+                },
+                "private_access": {
+                  "nesting_mode": "list",
+                  "block": {
+                    "attributes": {
+                      "prometheus": {
+                        "type": "string",
+                        "description": "Allow clients to connect to prometheus with a DNS name that always resolves to the service's private IP addresses. Only available in certain network locations",
+                        "optional": true
+                      }
+                    }
+                  },
+                  "max_items": 1
+                },
+                "public_access": {
+                  "nesting_mode": "list",
+                  "block": {
+                    "attributes": {
+                      "kafka": {
+                        "type": "string",
+                        "description": "Allow clients to connect to kafka from the public internet for service nodes that are in a project VPC or another type of private network",
+                        "optional": true
+                      },
+                      "kafka_connect": {
+                        "type": "string",
+                        "description": "Allow clients to connect to kafka_connect from the public internet for service nodes that are in a project VPC or another type of private network",
+                        "optional": true
+                      },
+                      "kafka_rest": {
+                        "type": "string",
+                        "description": "Allow clients to connect to kafka_rest from the public internet for service nodes that are in a project VPC or another type of private network",
+                        "optional": true
+                      },
+                      "prometheus": {
+                        "type": "string",
+                        "description": "Allow clients to connect to prometheus from the public internet for service nodes that are in a project VPC or another type of private network",
+                        "optional": true
+                      },
+                      "schema_registry": {
+                        "type": "string",
+                        "description": "Allow clients to connect to schema_registry from the public internet for service nodes that are in a project VPC or another type of private network",
+                        "optional": true
+                      }
+                    }
+                  },
+                  "max_items": 1
+                }
+              }
+            },
+            "max_items": 1
+          },
+          "mysql": {
+            "nesting_mode": "list",
+            "block": {},
+            "max_items": 1
+          },
+          "mysql_user_config": {
+            "nesting_mode": "list",
+            "block": {
+              "attributes": {
+                "admin_password": {
+                  "type": "string",
+                  "description": "Custom password for admin user. Defaults to random string. This must be set only when a new service is being created.",
+                  "optional": true,
+                  "sensitive": true
+                },
+                "admin_username": {
+                  "type": "string",
+                  "description": "Custom username for admin user. This must be set only when a new service is being created.",
+                  "optional": true
+                },
+                "backup_hour": {
+                  "type": "number",
+                  "description": "The hour of day (in UTC) when backup for the service is started. New backup is only started if previous backup has already completed.",
+                  "optional": true
+                },
+                "backup_minute": {
+                  "type": "number",
+                  "description": "The minute of an hour when backup for the service is started. New backup is only started if previous backup has already completed.",
+                  "optional": true
+                },
+                "ip_filter": {
+                  "type": [
+                    "list",
+                    "string"
+                  ],
+                  "description": "IP filter",
+                  "optional": true
+                },
+                "mysql_version": {
+                  "type": "string",
+                  "description": "MySQL major version",
+                  "optional": true
+                },
+                "recovery_target_time": {
+                  "type": "string",
+                  "description": "Recovery target time when forking a service. This has effect only when a new service is being created.",
+                  "optional": true
+                },
+                "service_to_fork_from": {
+                  "type": "string",
+                  "description": "Name of another service to fork from. This has effect only when a new service is being created.",
+                  "optional": true
+                }
+              },
+              "block_types": {
+                "mysql": {
+                  "nesting_mode": "list",
+                  "block": {
+                    "attributes": {
+                      "connect_timeout": {
+                        "type": "number",
+                        "description": "connect_timeout",
+                        "optional": true
+                      },
+                      "default_time_zone": {
+                        "type": "string",
+                        "description": "default_time_zone",
+                        "optional": true
+                      },
+                      "group_concat_max_len": {
+                        "type": "number",
+                        "description": "group_concat_max_len",
+                        "optional": true
+                      },
+                      "information_schema_stats_expiry": {
+                        "type": "number",
+                        "description": "information_schema_stats_expiry",
+                        "optional": true
+                      },
+                      "innodb_ft_min_token_size": {
+                        "type": "number",
+                        "description": "innodb_ft_min_token_size",
+                        "optional": true
+                      },
+                      "innodb_ft_server_stopword_table": {
+                        "type": "string",
+                        "description": "innodb_ft_server_stopword_table",
+                        "optional": true
+                      },
+                      "innodb_lock_wait_timeout": {
+                        "type": "number",
+                        "description": "innodb_lock_wait_timeout",
+                        "optional": true
+                      },
+                      "innodb_log_buffer_size": {
+                        "type": "number",
+                        "description": "innodb_log_buffer_size",
+                        "optional": true
+                      },
+                      "innodb_online_alter_log_max_size": {
+                        "type": "number",
+                        "description": "innodb_online_alter_log_max_size",
+                        "optional": true
+                      },
+                      "innodb_rollback_on_timeout": {
+                        "type": "string",
+                        "description": "innodb_rollback_on_timeout",
+                        "optional": true
+                      },
+                      "interactive_timeout": {
+                        "type": "number",
+                        "description": "interactive_timeout",
+                        "optional": true
+                      },
+                      "max_allowed_packet": {
+                        "type": "number",
+                        "description": "max_allowed_packet",
+                        "optional": true
+                      },
+                      "max_heap_table_size": {
+                        "type": "number",
+                        "description": "max_heap_table_size",
+                        "optional": true
+                      },
+                      "net_read_timeout": {
+                        "type": "number",
+                        "description": "net_read_timeout",
+                        "optional": true
+                      },
+                      "net_write_timeout": {
+                        "type": "number",
+                        "description": "net_write_timeout",
+                        "optional": true
+                      },
+                      "sort_buffer_size": {
+                        "type": "number",
+                        "description": "sort_buffer_size",
+                        "optional": true
+                      },
+                      "sql_mode": {
+                        "type": "string",
+                        "description": "sql_mode",
+                        "optional": true
+                      },
+                      "sql_require_primary_key": {
+                        "type": "string",
+                        "description": "sql_require_primary_key",
+                        "optional": true
+                      },
+                      "tmp_table_size": {
+                        "type": "number",
+                        "description": "tmp_table_size",
+                        "optional": true
+                      },
+                      "wait_timeout": {
+                        "type": "number",
+                        "description": "wait_timeout",
+                        "optional": true
+                      }
+                    }
+                  },
+                  "max_items": 1
+                },
+                "private_access": {
+                  "nesting_mode": "list",
+                  "block": {
+                    "attributes": {
+                      "mysql": {
+                        "type": "string",
+                        "description": "Allow clients to connect to mysql with a DNS name that always resolves to the service's private IP addresses. Only available in certain network locations",
+                        "optional": true
+                      },
+                      "prometheus": {
+                        "type": "string",
+                        "description": "Allow clients to connect to prometheus with a DNS name that always resolves to the service's private IP addresses. Only available in certain network locations",
+                        "optional": true
+                      }
+                    }
+                  },
+                  "max_items": 1
+                },
+                "public_access": {
+                  "nesting_mode": "list",
+                  "block": {
+                    "attributes": {
+                      "mysql": {
+                        "type": "string",
+                        "description": "Allow clients to connect to mysql from the public internet for service nodes that are in a project VPC or another type of private network",
+                        "optional": true
+                      },
+                      "prometheus": {
+                        "type": "string",
+                        "description": "Allow clients to connect to prometheus from the public internet for service nodes that are in a project VPC or another type of private network",
+                        "optional": true
+                      }
+                    }
+                  },
+                  "max_items": 1
+                }
+              }
+            },
+            "max_items": 1
+          },
+          "pg": {
+            "nesting_mode": "list",
+            "block": {
+              "attributes": {
+                "dbname": {
+                  "type": "string",
+                  "description": "Primary PostgreSQL database name",
+                  "computed": true
+                },
+                "host": {
+                  "type": "string",
+                  "description": "PostgreSQL master node host IP or name",
+                  "computed": true
+                },
+                "password": {
+                  "type": "string",
+                  "description": "PostgreSQL admin user password",
+                  "computed": true,
+                  "sensitive": true
+                },
+                "port": {
+                  "type": "number",
+                  "description": "PostgreSQL port",
+                  "computed": true
+                },
+                "replica_uri": {
+                  "type": "string",
+                  "description": "PostgreSQL replica URI for services with a replica",
+                  "computed": true,
+                  "sensitive": true
+                },
+                "sslmode": {
+                  "type": "string",
+                  "description": "PostgreSQL sslmode setting (currently always \"require\")",
+                  "computed": true
+                },
+                "uri": {
+                  "type": "string",
+                  "description": "PostgreSQL master connection URI",
+                  "optional": true,
+                  "computed": true,
+                  "sensitive": true
+                },
+                "user": {
+                  "type": "string",
+                  "description": "PostgreSQL admin user name",
+                  "computed": true
+                }
+              }
+            },
+            "max_items": 1
+          },
+          "pg_user_config": {
+            "nesting_mode": "list",
+            "block": {
+              "attributes": {
+                "admin_password": {
+                  "type": "string",
+                  "description": "Custom password for admin user. Defaults to random string. This must be set only when a new service is being created.",
+                  "optional": true,
+                  "sensitive": true
+                },
+                "admin_username": {
+                  "type": "string",
+                  "description": "Custom username for admin user. This must be set only when a new service is being created.",
+                  "optional": true
+                },
+                "backup_hour": {
+                  "type": "number",
+                  "description": "The hour of day (in UTC) when backup for the service is started. New backup is only started if previous backup has already completed.",
+                  "optional": true
+                },
+                "backup_minute": {
+                  "type": "number",
+                  "description": "The minute of an hour when backup for the service is started. New backup is only started if previous backup has already completed.",
+                  "optional": true
+                },
+                "ip_filter": {
+                  "type": [
+                    "list",
+                    "string"
+                  ],
+                  "description": "IP filter",
+                  "optional": true
+                },
+                "pg_read_replica": {
+                  "type": "string",
+                  "description": "Should the service which is being forked be a read replica",
+                  "optional": true
+                },
+                "pg_service_to_fork_from": {
+                  "type": "string",
+                  "description": "Name of the PG Service from which to fork (deprecated, use service_to_fork_from). This has effect only when a new service is being created.",
+                  "optional": true
+                },
+                "pg_version": {
+                  "type": "string",
+                  "description": "PostgreSQL major version",
+                  "optional": true
+                },
+                "recovery_target_time": {
+                  "type": "string",
+                  "description": "Recovery target time when forking a service. This has effect only when a new service is being created.",
+                  "optional": true
+                },
+                "service_to_fork_from": {
+                  "type": "string",
+                  "description": "Name of another service to fork from. This has effect only when a new service is being created.",
+                  "optional": true
+                },
+                "synchronous_replication": {
+                  "type": "string",
+                  "description": "Synchronous replication type. Note that the service plan also needs to support synchronous replication.",
+                  "optional": true
+                },
+                "variant": {
+                  "type": "string",
+                  "description": "Variant of the PostgreSQL service, may affect the features that are exposed by default",
+                  "optional": true
+                }
+              },
+              "block_types": {
+                "pg": {
+                  "nesting_mode": "list",
+                  "block": {
+                    "attributes": {
+                      "autovacuum_analyze_scale_factor": {
+                        "type": "number",
+                        "description": "autovacuum_analyze_scale_factor",
+                        "optional": true
+                      },
+                      "autovacuum_analyze_threshold": {
+                        "type": "number",
+                        "description": "autovacuum_analyze_threshold",
+                        "optional": true
+                      },
+                      "autovacuum_freeze_max_age": {
+                        "type": "number",
+                        "description": "autovacuum_freeze_max_age",
+                        "optional": true
+                      },
+                      "autovacuum_max_workers": {
+                        "type": "number",
+                        "description": "autovacuum_max_workers",
+                        "optional": true
+                      },
+                      "autovacuum_naptime": {
+                        "type": "number",
+                        "description": "autovacuum_naptime",
+                        "optional": true
+                      },
+                      "autovacuum_vacuum_cost_delay": {
+                        "type": "number",
+                        "description": "autovacuum_vacuum_cost_delay",
+                        "optional": true
+                      },
+                      "autovacuum_vacuum_cost_limit": {
+                        "type": "number",
+                        "description": "autovacuum_vacuum_cost_limit",
+                        "optional": true
+                      },
+                      "autovacuum_vacuum_scale_factor": {
+                        "type": "number",
+                        "description": "autovacuum_vacuum_scale_factor",
+                        "optional": true
+                      },
+                      "autovacuum_vacuum_threshold": {
+                        "type": "number",
+                        "description": "autovacuum_vacuum_threshold",
+                        "optional": true
+                      },
+                      "deadlock_timeout": {
+                        "type": "number",
+                        "description": "deadlock_timeout",
+                        "optional": true
+                      },
+                      "idle_in_transaction_session_timeout": {
+                        "type": "number",
+                        "description": "idle_in_transaction_session_timeout",
+                        "optional": true
+                      },
+                      "jit": {
+                        "type": "string",
+                        "description": "jit",
+                        "optional": true
+                      },
+                      "log_autovacuum_min_duration": {
+                        "type": "number",
+                        "description": "log_autovacuum_min_duration",
+                        "optional": true
+                      },
+                      "log_error_verbosity": {
+                        "type": "string",
+                        "description": "log_error_verbosity",
+                        "optional": true
+                      },
+                      "log_min_duration_statement": {
+                        "type": "number",
+                        "description": "log_min_duration_statement",
+                        "optional": true
+                      },
+                      "max_locks_per_transaction": {
+                        "type": "number",
+                        "description": "max_locks_per_transaction",
+                        "optional": true
+                      },
+                      "max_parallel_workers": {
+                        "type": "number",
+                        "description": "max_parallel_workers",
+                        "optional": true
+                      },
+                      "max_parallel_workers_per_gather": {
+                        "type": "number",
+                        "description": "max_parallel_workers_per_gather",
+                        "optional": true
+                      },
+                      "max_pred_locks_per_transaction": {
+                        "type": "number",
+                        "description": "max_pred_locks_per_transaction",
+                        "optional": true
+                      },
+                      "max_prepared_transactions": {
+                        "type": "number",
+                        "description": "max_prepared_transactions",
+                        "optional": true
+                      },
+                      "max_stack_depth": {
+                        "type": "number",
+                        "description": "max_stack_depth",
+                        "optional": true
+                      },
+                      "max_standby_archive_delay": {
+                        "type": "number",
+                        "description": "max_standby_archive_delay",
+                        "optional": true
+                      },
+                      "max_standby_streaming_delay": {
+                        "type": "number",
+                        "description": "max_standby_streaming_delay",
+                        "optional": true
+                      },
+                      "max_worker_processes": {
+                        "type": "number",
+                        "description": "max_worker_processes",
+                        "optional": true
+                      },
+                      "pg_stat_statements__dot__track": {
+                        "type": "string",
+                        "description": "pg_stat_statements.track",
+                        "optional": true
+                      },
+                      "temp_file_limit": {
+                        "type": "number",
+                        "description": "temp_file_limit",
+                        "optional": true
+                      },
+                      "timezone": {
+                        "type": "string",
+                        "description": "timezone",
+                        "optional": true
+                      },
+                      "track_activity_query_size": {
+                        "type": "number",
+                        "description": "track_activity_query_size",
+                        "optional": true
+                      },
+                      "track_commit_timestamp": {
+                        "type": "string",
+                        "description": "track_commit_timestamp",
+                        "optional": true
+                      },
+                      "track_functions": {
+                        "type": "string",
+                        "description": "track_functions",
+                        "optional": true
+                      },
+                      "wal_sender_timeout": {
+                        "type": "number",
+                        "description": "wal_sender_timeout",
+                        "optional": true
+                      },
+                      "wal_writer_delay": {
+                        "type": "number",
+                        "description": "wal_writer_delay",
+                        "optional": true
+                      }
+                    }
+                  },
+                  "max_items": 1
+                },
+                "pgbouncer": {
+                  "nesting_mode": "list",
+                  "block": {
+                    "attributes": {
+                      "ignore_startup_parameters": {
+                        "type": [
+                          "list",
+                          "string"
+                        ],
+                        "description": "List of parameters to ignore when given in startup packet",
+                        "optional": true
+                      },
+                      "server_reset_query_always": {
+                        "type": "bool",
+                        "description": "Run server_reset_query (DISCARD ALL) in all pooling modes",
+                        "optional": true
+                      }
+                    }
+                  },
+                  "max_items": 1
+                },
+                "pglookout": {
+                  "nesting_mode": "list",
+                  "block": {
+                    "attributes": {
+                      "max_failover_replication_time_lag": {
+                        "type": "number",
+                        "description": "max_failover_replication_time_lag",
+                        "optional": true
+                      }
+                    }
+                  },
+                  "max_items": 1
+                },
+                "private_access": {
+                  "nesting_mode": "list",
+                  "block": {
+                    "attributes": {
+                      "pg": {
+                        "type": "string",
+                        "description": "Allow clients to connect to pg with a DNS name that always resolves to the service's private IP addresses. Only available in certain network locations",
+                        "optional": true
+                      },
+                      "pgbouncer": {
+                        "type": "string",
+                        "description": "Allow clients to connect to pgbouncer with a DNS name that always resolves to the service's private IP addresses. Only available in certain network locations",
+                        "optional": true
+                      },
+                      "prometheus": {
+                        "type": "string",
+                        "description": "Allow clients to connect to prometheus with a DNS name that always resolves to the service's private IP addresses. Only available in certain network locations",
+                        "optional": true
+                      }
+                    }
+                  },
+                  "max_items": 1
+                },
+                "public_access": {
+                  "nesting_mode": "list",
+                  "block": {
+                    "attributes": {
+                      "pg": {
+                        "type": "string",
+                        "description": "Allow clients to connect to pg from the public internet for service nodes that are in a project VPC or another type of private network",
+                        "optional": true
+                      },
+                      "pgbouncer": {
+                        "type": "string",
+                        "description": "Allow clients to connect to pgbouncer from the public internet for service nodes that are in a project VPC or another type of private network",
+                        "optional": true
+                      },
+                      "prometheus": {
+                        "type": "string",
+                        "description": "Allow clients to connect to prometheus from the public internet for service nodes that are in a project VPC or another type of private network",
+                        "optional": true
+                      }
+                    }
+                  },
+                  "max_items": 1
+                },
+                "timescaledb": {
+                  "nesting_mode": "list",
+                  "block": {
+                    "attributes": {
+                      "max_background_workers": {
+                        "type": "number",
+                        "description": "timescaledb.max_background_workers",
+                        "optional": true
+                      }
+                    }
+                  },
+                  "max_items": 1
+                }
+              }
+            },
+            "max_items": 1
+          },
+          "redis": {
+            "nesting_mode": "list",
+            "block": {},
+            "max_items": 1
+          },
+          "redis_user_config": {
+            "nesting_mode": "list",
+            "block": {
+              "attributes": {
+                "ip_filter": {
+                  "type": [
+                    "list",
+                    "string"
+                  ],
+                  "description": "IP filter",
+                  "optional": true
+                },
+                "redis_lfu_decay_time": {
+                  "type": "number",
+                  "description": "LFU maxmemory-policy counter decay time in minutes",
+                  "optional": true
+                },
+                "redis_lfu_log_factor": {
+                  "type": "number",
+                  "description": "Counter logarithm factor for volatile-lfu and allkeys-lfu maxmemory-policies",
+                  "optional": true
+                },
+                "redis_maxmemory_policy": {
+                  "type": "string",
+                  "description": "Redis maxmemory-policy",
+                  "optional": true
+                },
+                "redis_notify_keyspace_events": {
+                  "type": "string",
+                  "description": "Set notify-keyspace-events option",
+                  "optional": true
+                },
+                "redis_ssl": {
+                  "type": "bool",
+                  "description": "Require SSL to access Redis",
+                  "optional": true
+                },
+                "redis_timeout": {
+                  "type": "number",
+                  "description": "Redis idle connection timeout",
+                  "optional": true
+                }
+              },
+              "block_types": {
+                "migration": {
+                  "nesting_mode": "list",
+                  "block": {
+                    "attributes": {
+                      "host": {
+                        "type": "string",
+                        "description": "Hostname or IP address of the server where to migrate data from",
+                        "optional": true
+                      },
+                      "password": {
+                        "type": "string",
+                        "description": "Password for authentication with the server where to migrate data from",
+                        "optional": true,
+                        "sensitive": true
+                      },
+                      "port": {
+                        "type": "number",
+                        "description": "Port number of the server where to migrate data from",
+                        "optional": true
+                      },
+                      "ssl": {
+                        "type": "bool",
+                        "description": "The server where to migrate data from is secured with SSL",
+                        "optional": true
+                      },
+                      "username": {
+                        "type": "string",
+                        "description": "User name for authentication with the server where to migrate data from",
+                        "optional": true
+                      }
+                    }
+                  },
+                  "max_items": 1
+                },
+                "private_access": {
+                  "nesting_mode": "list",
+                  "block": {
+                    "attributes": {
+                      "prometheus": {
+                        "type": "string",
+                        "description": "Allow clients to connect to prometheus with a DNS name that always resolves to the service's private IP addresses. Only available in certain network locations",
+                        "optional": true
+                      },
+                      "redis": {
+                        "type": "string",
+                        "description": "Allow clients to connect to redis with a DNS name that always resolves to the service's private IP addresses. Only available in certain network locations",
+                        "optional": true
+                      }
+                    }
+                  },
+                  "max_items": 1
+                },
+                "public_access": {
+                  "nesting_mode": "list",
+                  "block": {
+                    "attributes": {
+                      "prometheus": {
+                        "type": "string",
+                        "description": "Allow clients to connect to prometheus from the public internet for service nodes that are in a project VPC or another type of private network",
+                        "optional": true
+                      },
+                      "redis": {
+                        "type": "string",
+                        "description": "Allow clients to connect to redis from the public internet for service nodes that are in a project VPC or another type of private network",
+                        "optional": true
+                      }
+                    }
+                  },
+                  "max_items": 1
+                }
+              }
+            },
+            "max_items": 1
+          },
+          "service_integrations": {
+            "nesting_mode": "list",
+            "block": {
+              "attributes": {
+                "integration_type": {
+                  "type": "string",
+                  "description": "Type of the service integration. The only supported value at the moment is 'read_replica'",
+                  "required": true
+                },
+                "source_service_name": {
+                  "type": "string",
+                  "description": "Name of the source service",
+                  "required": true
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "aiven_service_integration": {
+      "version": 0,
+      "block": {
+        "attributes": {
+          "destination_endpoint_id": {
+            "type": "string",
+            "description": "Destination endpoint for the integration (if any)",
+            "optional": true
+          },
+          "destination_service_name": {
+            "type": "string",
+            "description": "Destination service for the integration (if any)",
+            "optional": true
+          },
+          "id": {
+            "type": "string",
+            "optional": true,
+            "computed": true
+          },
+          "integration_type": {
+            "type": "string",
+            "description": "Type of the service integration",
+            "required": true
+          },
+          "project": {
+            "type": "string",
+            "description": "Project the integration belongs to",
+            "required": true
+          },
+          "source_endpoint_id": {
+            "type": "string",
+            "description": "Source endpoint for the integration (if any)",
+            "optional": true
+          },
+          "source_service_name": {
+            "type": "string",
+            "description": "Source service for the integration (if any)",
+            "optional": true
+          }
+        },
+        "block_types": {
+          "kafka_mirrormaker_user_config": {
+            "nesting_mode": "list",
+            "block": {
+              "attributes": {
+                "cluster_alias": {
+                  "type": "string",
+                  "description": "Kafka cluster alias",
+                  "optional": true
+                }
+              }
+            },
+            "max_items": 1
+          },
+          "logs_user_config": {
+            "nesting_mode": "list",
+            "block": {
+              "attributes": {
+                "elasticsearch_index_days_max": {
+                  "type": "number",
+                  "description": "Elasticsearch index retention limit",
+                  "optional": true
+                },
+                "elasticsearch_index_prefix": {
+                  "type": "string",
+                  "description": "Elasticsearch index prefix",
+                  "optional": true
+                }
+              }
+            },
+            "max_items": 1
+          },
+          "mirrormaker_user_config": {
+            "nesting_mode": "list",
+            "block": {
+              "attributes": {
+                "mirrormaker_whitelist": {
+                  "type": "string",
+                  "description": "Mirrormaker topic whitelist",
+                  "optional": true
+                }
+              }
+            },
+            "max_items": 1
+          }
+        }
+      }
+    },
+    "aiven_service_integration_endpoint": {
+      "version": 0,
+      "block": {
+        "attributes": {
+          "endpoint_config": {
+            "type": [
+              "map",
+              "string"
+            ],
+            "description": "Integration endpoint specific backend configuration",
+            "computed": true
+          },
+          "endpoint_name": {
+            "type": "string",
+            "description": "Name of the service integration endpoint",
+            "required": true
+          },
+          "endpoint_type": {
+            "type": "string",
+            "description": "Type of the service integration endpoint",
+            "required": true
+          },
+          "id": {
+            "type": "string",
+            "optional": true,
+            "computed": true
+          },
+          "project": {
+            "type": "string",
+            "description": "Project the service integration endpoint belongs to",
+            "required": true
+          }
+        },
+        "block_types": {
+          "datadog_user_config": {
+            "nesting_mode": "list",
+            "block": {
+              "attributes": {
+                "datadog_api_key": {
+                  "type": "string",
+                  "description": "Datadog API key",
+                  "optional": true,
+                  "sensitive": true
+                },
+                "disable_consumer_stats": {
+                  "type": "string",
+                  "description": "Disable consumer group metrics",
+                  "optional": true
+                },
+                "max_partition_contexts": {
+                  "type": "number",
+                  "description": "Maximum number of partition contexts to send",
+                  "optional": true
+                },
+                "site": {
+                  "type": "string",
+                  "description": "Datadog intake site. Defaults to datadoghq.com",
+                  "optional": true
+                }
+              }
+            },
+            "max_items": 1
+          },
+          "external_elasticsearch_logs_user_config": {
+            "nesting_mode": "list",
+            "block": {
+              "attributes": {
+                "ca": {
+                  "type": "string",
+                  "description": "PEM encoded CA certificate",
+                  "optional": true
+                },
+                "index_days_max": {
+                  "type": "number",
+                  "description": "Maximum number of days of logs to keep",
+                  "optional": true
+                },
+                "index_prefix": {
+                  "type": "string",
+                  "description": "Elasticsearch index prefix",
+                  "optional": true
+                },
+                "timeout": {
+                  "type": "number",
+                  "description": "Elasticsearch request timeout limit",
+                  "optional": true
+                },
+                "url": {
+                  "type": "string",
+                  "description": "Elasticsearch connection URL",
+                  "optional": true
+                }
+              }
+            },
+            "max_items": 1
+          },
+          "prometheus_user_config": {
+            "nesting_mode": "list",
+            "block": {
+              "attributes": {
+                "basic_auth_password": {
+                  "type": "string",
+                  "description": "Prometheus basic authentication password",
+                  "optional": true,
+                  "sensitive": true
+                },
+                "basic_auth_username": {
+                  "type": "string",
+                  "description": "Prometheus basic authentication username",
+                  "optional": true
+                }
+              }
+            },
+            "max_items": 1
+          },
+          "rsyslog_user_config": {
+            "nesting_mode": "list",
+            "block": {
+              "attributes": {
+                "ca": {
+                  "type": "string",
+                  "description": "PEM encoded CA certificate",
+                  "optional": true
+                },
+                "cert": {
+                  "type": "string",
+                  "description": "PEM encoded client certificate",
+                  "optional": true
+                },
+                "format": {
+                  "type": "string",
+                  "description": "message format",
+                  "optional": true
+                },
+                "key": {
+                  "type": "string",
+                  "description": "PEM encoded client key",
+                  "optional": true
+                },
+                "logline": {
+                  "type": "string",
+                  "description": "custom syslog message format",
+                  "optional": true
+                },
+                "port": {
+                  "type": "number",
+                  "description": "rsyslog server port",
+                  "optional": true
+                },
+                "sd": {
+                  "type": "string",
+                  "description": "Structured data block for log message",
+                  "optional": true
+                },
+                "server": {
+                  "type": "string",
+                  "description": "rsyslog server IP address or hostname",
+                  "optional": true
+                },
+                "tls": {
+                  "type": "bool",
+                  "description": "Require TLS",
+                  "optional": true
+                }
+              }
+            },
+            "max_items": 1
+          }
+        }
+      }
+    },
+    "aiven_service_user": {
+      "version": 0,
+      "block": {
+        "attributes": {
+          "access_cert": {
+            "type": "string",
+            "description": "Access certificate for the user if applicable for the service in question",
+            "computed": true,
+            "sensitive": true
+          },
+          "access_key": {
+            "type": "string",
+            "description": "Access certificate key for the user if applicable for the service in question",
+            "computed": true,
+            "sensitive": true
+          },
+          "id": {
+            "type": "string",
+            "optional": true,
+            "computed": true
+          },
+          "password": {
+            "type": "string",
+            "description": "Password of the user",
+            "computed": true,
+            "sensitive": true
+          },
+          "project": {
+            "type": "string",
+            "description": "Project to link the user to",
+            "required": true
+          },
+          "service_name": {
+            "type": "string",
+            "description": "Service to link the user to",
+            "required": true
+          },
+          "type": {
+            "type": "string",
+            "description": "Type of the user account",
+            "computed": true
+          },
+          "username": {
+            "type": "string",
+            "description": "Name of the user account",
+            "required": true
+          }
+        }
+      }
+    },
+    "aiven_vpc_peering_connection": {
+      "version": 0,
+      "block": {
+        "attributes": {
+          "id": {
+            "type": "string",
+            "optional": true,
+            "computed": true
+          },
+          "peer_cloud_account": {
+            "type": "string",
+            "description": "AWS account ID or GCP project ID of the peered VPC",
+            "required": true
+          },
+          "peer_region": {
+            "type": "string",
+            "description": "AWS region of the peered VPC (if not in the same region as Aiven VPC)",
+            "optional": true
+          },
+          "peer_vpc": {
+            "type": "string",
+            "description": "AWS VPC ID or GCP VPC network name of the peered VPC",
+            "required": true
+          },
+          "peering_connection_id": {
+            "type": "string",
+            "description": "Cloud provider identifier for the peering connection if available",
+            "computed": true
+          },
+          "state": {
+            "type": "string",
+            "description": "State of the peering connection",
+            "computed": true
+          },
+          "state_info": {
+            "type": [
+              "map",
+              "string"
+            ],
+            "description": "State-specific help or error information",
+            "computed": true
+          },
+          "vpc_id": {
+            "type": "string",
+            "description": "The VPC the peering connection belongs to",
+            "required": true
+          }
+        },
+        "block_types": {
+          "client_timeout": {
+            "nesting_mode": "set",
+            "block": {
+              "attributes": {
+                "create": {
+                  "type": "string",
+                  "description": "create timeout",
+                  "optional": true
+                }
+              }
+            },
+            "max_items": 1
+          }
+        }
+      }
+    }
+  },
+  "data_source_schemas": {
+    "aiven_account": {
+      "version": 0,
+      "block": {
+        "attributes": {
+          "account_id": {
+            "type": "string",
+            "description": "Account id",
+            "optional": true,
+            "computed": true
+          },
+          "create_time": {
+            "type": "string",
+            "description": "Time of creation",
+            "optional": true,
+            "computed": true
+          },
+          "id": {
+            "type": "string",
+            "optional": true,
+            "computed": true
+          },
+          "name": {
+            "type": "string",
+            "description": "Account name",
+            "required": true
+          },
+          "owner_team_id": {
+            "type": "string",
+            "description": "Owner team id",
+            "optional": true,
+            "computed": true
+          },
+          "tenant_id": {
+            "type": "string",
+            "description": "Tenant id",
+            "optional": true,
+            "computed": true
+          },
+          "update_time": {
+            "type": "string",
+            "description": "Time of last update",
+            "optional": true,
+            "computed": true
+          }
+        }
+      }
+    },
+    "aiven_account_team": {
+      "version": 0,
+      "block": {
+        "attributes": {
+          "account_id": {
+            "type": "string",
+            "description": "Account id",
+            "required": true
+          },
+          "create_time": {
+            "type": "string",
+            "description": "Time of creation",
+            "optional": true,
+            "computed": true
+          },
+          "id": {
+            "type": "string",
+            "optional": true,
+            "computed": true
+          },
+          "name": {
+            "type": "string",
+            "description": "Account team name",
+            "required": true
+          },
+          "team_id": {
+            "type": "string",
+            "description": "Account team id",
+            "optional": true,
+            "computed": true
+          },
+          "update_time": {
+            "type": "string",
+            "description": "Time of last update",
+            "optional": true,
+            "computed": true
+          }
+        }
+      }
+    },
+    "aiven_account_team_member": {
+      "version": 0,
+      "block": {
+        "attributes": {
+          "accepted": {
+            "type": "bool",
+            "description": "Team member invitation status",
+            "optional": true,
+            "computed": true
+          },
+          "account_id": {
+            "type": "string",
+            "description": "Account id",
+            "required": true
+          },
+          "create_time": {
+            "type": "string",
+            "description": "Time of creation",
+            "optional": true,
+            "computed": true
+          },
+          "id": {
+            "type": "string",
+            "optional": true,
+            "computed": true
+          },
+          "invited_by_user_email": {
+            "type": "string",
+            "description": "Team invited by user email",
+            "optional": true,
+            "computed": true
+          },
+          "team_id": {
+            "type": "string",
+            "description": "Account team id",
+            "required": true
+          },
+          "user_email": {
+            "type": "string",
+            "description": "Team invite user email",
+            "required": true
+          }
+        }
+      }
+    },
+    "aiven_account_team_project": {
+      "version": 0,
+      "block": {
+        "attributes": {
+          "account_id": {
+            "type": "string",
+            "description": "Account id",
+            "required": true
+          },
+          "id": {
+            "type": "string",
+            "optional": true,
+            "computed": true
+          },
+          "project_name": {
+            "type": "string",
+            "description": "Account team project name",
+            "required": true
+          },
+          "team_id": {
+            "type": "string",
+            "description": "Account team id",
+            "required": true
+          },
+          "team_type": {
+            "type": "string",
+            "description": "Account team project type, can one of the following values: admin, developer, operator and read_only",
+            "optional": true
+          }
+        }
+      }
+    },
+    "aiven_connection_pool": {
+      "version": 0,
+      "block": {
+        "attributes": {
+          "connection_uri": {
+            "type": "string",
+            "description": "URI for connecting to the pool",
+            "optional": true,
+            "computed": true,
+            "sensitive": true
+          },
+          "database_name": {
+            "type": "string",
+            "description": "Name of the database the pool connects to",
+            "optional": true
+          },
+          "id": {
+            "type": "string",
+            "optional": true,
+            "computed": true
+          },
+          "pool_mode": {
+            "type": "string",
+            "description": "Mode the pool operates in (session, transaction, statement)",
+            "optional": true
+          },
+          "pool_name": {
+            "type": "string",
+            "description": "Name of the pool",
+            "required": true
+          },
+          "pool_size": {
+            "type": "number",
+            "description": "Number of connections the pool may create towards the backend server",
+            "optional": true
+          },
+          "project": {
+            "type": "string",
+            "description": "Project to link the connection pool to",
+            "required": true
+          },
+          "service_name": {
+            "type": "string",
+            "description": "Service to link the connection pool to",
+            "required": true
+          },
+          "username": {
+            "type": "string",
+            "description": "Name of the service user used to connect to the database",
+            "optional": true
+          }
+        }
+      }
+    },
+    "aiven_database": {
+      "version": 0,
+      "block": {
+        "attributes": {
+          "database_name": {
+            "type": "string",
+            "description": "Service database name",
+            "required": true
+          },
+          "id": {
+            "type": "string",
+            "optional": true,
+            "computed": true
+          },
+          "lc_collate": {
+            "type": "string",
+            "description": "Default string sort order (LC_COLLATE) of the database. Default value: en_US.UTF-8",
+            "optional": true
+          },
+          "lc_ctype": {
+            "type": "string",
+            "description": "Default character classification (LC_CTYPE) of the database. Default value: en_US.UTF-8",
+            "optional": true
+          },
+          "project": {
+            "type": "string",
+            "description": "Project to link the database to",
+            "required": true
+          },
+          "service_name": {
+            "type": "string",
+            "description": "Service to link the database to",
+            "required": true
+          },
+          "termination_protection": {
+            "type": "bool",
+            "description": "It is a Terraform client-side deletion protections, which prevents the database\n\t\t\tfrom being deleted by Terraform. It is recommended to enable this for any production\n\t\t\tdatabases containing critical data.",
+            "optional": true
+          }
+        }
+      }
+    },
+    "aiven_elasticsearch_acl": {
+      "version": 0,
+      "block": {
+        "attributes": {
+          "enabled": {
+            "type": "bool",
+            "description": "Enable Elasticsearch ACLs. When disabled authenticated service users have unrestricted access",
+            "optional": true
+          },
+          "extended_acl": {
+            "type": "bool",
+            "description": "Index rules can be applied in a limited fashion to the _mget, _msearch and _bulk APIs (and only those) by enabling the ExtendedAcl option for the service. When it is enabled, users can use these APIs as long as all operations only target indexes they have been granted access to",
+            "optional": true
+          },
+          "id": {
+            "type": "string",
+            "optional": true,
+            "computed": true
+          },
+          "project": {
+            "type": "string",
+            "description": "Project to link the Elasticsearch ACLs to",
+            "required": true
+          },
+          "service_name": {
+            "type": "string",
+            "description": "Service to link the Elasticsearch ACLs to",
+            "required": true
+          }
+        },
+        "block_types": {
+          "acl": {
+            "nesting_mode": "set",
+            "block": {
+              "attributes": {
+                "username": {
+                  "type": "string",
+                  "description": "Username for the ACL entry",
+                  "required": true
+                }
+              },
+              "block_types": {
+                "rule": {
+                  "nesting_mode": "set",
+                  "block": {
+                    "attributes": {
+                      "index": {
+                        "type": "string",
+                        "description": "Elasticsearch index pattern",
+                        "required": true
+                      },
+                      "permission": {
+                        "type": "string",
+                        "description": "Elasticsearch permission",
+                        "required": true
+                      }
+                    }
+                  },
+                  "min_items": 1
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "aiven_kafka_acl": {
+      "version": 0,
+      "block": {
+        "attributes": {
+          "id": {
+            "type": "string",
+            "optional": true,
+            "computed": true
+          },
+          "permission": {
+            "type": "string",
+            "description": "Kafka permission to grant (admin, read, readwrite, write)",
+            "optional": true
+          },
+          "project": {
+            "type": "string",
+            "description": "Project to link the Kafka ACL to",
+            "required": true
+          },
+          "service_name": {
+            "type": "string",
+            "description": "Service to link the Kafka ACL to",
+            "required": true
+          },
+          "topic": {
+            "type": "string",
+            "description": "Topic name pattern for the ACL entry",
+            "required": true
+          },
+          "username": {
+            "type": "string",
+            "description": "Username pattern for the ACL entry",
+            "required": true
+          }
+        }
+      }
+    },
+    "aiven_kafka_connector": {
+      "version": 0,
+      "block": {
+        "attributes": {
+          "config": {
+            "type": [
+              "map",
+              "string"
+            ],
+            "description": "Kafka Connector configuration parameters",
+            "optional": true
+          },
+          "connector_name": {
+            "type": "string",
+            "description": "Kafka connector name",
+            "required": true
+          },
+          "id": {
+            "type": "string",
+            "optional": true,
+            "computed": true
+          },
+          "plugin_author": {
+            "type": "string",
+            "description": "Kafka connector author",
+            "optional": true,
+            "computed": true
+          },
+          "plugin_class": {
+            "type": "string",
+            "description": "Kafka connector Java class",
+            "optional": true,
+            "computed": true
+          },
+          "plugin_doc_url": {
+            "type": "string",
+            "description": "Kafka connector documentation URL",
+            "optional": true,
+            "computed": true
+          },
+          "plugin_title": {
+            "type": "string",
+            "description": "Kafka connector title",
+            "optional": true,
+            "computed": true
+          },
+          "plugin_type": {
+            "type": "string",
+            "description": "Kafka connector type",
+            "optional": true,
+            "computed": true
+          },
+          "plugin_version": {
+            "type": "string",
+            "description": "Kafka connector version",
+            "optional": true,
+            "computed": true
+          },
+          "project": {
+            "type": "string",
+            "description": "Project to link the kafka connector to",
+            "required": true
+          },
+          "service_name": {
+            "type": "string",
+            "description": "Service to link the kafka connector to",
+            "required": true
+          }
+        },
+        "block_types": {
+          "task": {
+            "nesting_mode": "set",
+            "block": {
+              "attributes": {
+                "connector": {
+                  "type": "string",
+                  "description": "Related connector name",
+                  "computed": true
+                },
+                "task": {
+                  "type": "number",
+                  "description": "Task id / number",
+                  "computed": true
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "aiven_kafka_schema": {
+      "version": 0,
+      "block": {
+        "attributes": {
+          "id": {
+            "type": "string",
+            "optional": true,
+            "computed": true
+          },
+          "project": {
+            "type": "string",
+            "description": "Project to link the Kafka Schema to",
+            "required": true
+          },
+          "schema": {
+            "type": "string",
+            "description": "Kafka Schema configuration should be a valid Avro Schema JSON format",
+            "optional": true
+          },
+          "service_name": {
+            "type": "string",
+            "description": "Service to link the Kafka Schema to",
+            "required": true
+          },
+          "subject_name": {
+            "type": "string",
+            "description": "Kafka Schema Subject name",
+            "required": true
+          },
+          "version": {
+            "type": "number",
+            "description": "Kafka Schema configuration version",
+            "optional": true,
+            "computed": true
+          }
+        }
+      }
+    },
+    "aiven_kafka_schema_configuration": {
+      "version": 0,
+      "block": {
+        "attributes": {
+          "id": {
+            "type": "string",
+            "optional": true,
+            "computed": true
+          },
+          "project": {
+            "type": "string",
+            "description": "Project to link the Kafka Schema to",
+            "required": true
+          },
+          "schema": {
+            "type": "string",
+            "description": "Kafka Schema configuration should be a valid Avro Schema JSON format",
+            "optional": true
+          },
+          "service_name": {
+            "type": "string",
+            "description": "Service to link the Kafka Schema to",
+            "required": true
+          },
+          "subject_name": {
+            "type": "string",
+            "description": "Kafka Schema Subject name",
+            "optional": true
+          },
+          "version": {
+            "type": "number",
+            "description": "Kafka Schema configuration version",
+            "optional": true,
+            "computed": true
+          }
+        }
+      }
+    },
+    "aiven_kafka_topic": {
+      "version": 0,
+      "block": {
+        "attributes": {
+          "cleanup_policy": {
+            "type": "string",
+            "description": "Topic cleanup policy. Allowed values: delete, compact",
+            "optional": true
+          },
+          "id": {
+            "type": "string",
+            "optional": true,
+            "computed": true
+          },
+          "minimum_in_sync_replicas": {
+            "type": "number",
+            "description": "Minimum required nodes in-sync replicas (ISR) to produce to a partition",
+            "optional": true
+          },
+          "partitions": {
+            "type": "number",
+            "description": "Number of partitions to create in the topic",
+            "optional": true
+          },
+          "project": {
+            "type": "string",
+            "description": "Project to link the kafka topic to",
+            "required": true
+          },
+          "replication": {
+            "type": "number",
+            "description": "Replication factor for the topic",
+            "optional": true
+          },
+          "retention_bytes": {
+            "type": "number",
+            "description": "Retention bytes",
+            "optional": true
+          },
+          "retention_hours": {
+            "type": "number",
+            "description": "Retention period (hours)",
+            "optional": true
+          },
+          "service_name": {
+            "type": "string",
+            "description": "Service to link the kafka topic to",
+            "required": true
+          },
+          "termination_protection": {
+            "type": "bool",
+            "description": "It is a Terraform client-side deletion protection, which prevents a Kafka \n\t\t\ttopic from being deleted. It is recommended to enable this for any production Kafka \n\t\t\ttopic containing critical data.",
+            "optional": true
+          },
+          "topic_name": {
+            "type": "string",
+            "description": "Topic name",
+            "required": true
+          }
+        },
+        "block_types": {
+          "client_timeout": {
+            "nesting_mode": "set",
+            "block": {
+              "attributes": {
+                "create": {
+                  "type": "string",
+                  "description": "create timeout",
+                  "optional": true
+                },
+                "read": {
+                  "type": "string",
+                  "description": "read timeout",
+                  "optional": true
+                }
+              }
+            },
+            "max_items": 1
+          }
+        }
+      }
+    },
+    "aiven_project": {
+      "version": 0,
+      "block": {
+        "attributes": {
+          "account_id": {
+            "type": "string",
+            "description": "Account ID",
+            "optional": true
+          },
+          "billing_address": {
+            "type": "string",
+            "description": "Billing name and address of the project",
+            "optional": true
+          },
+          "billing_emails": {
+            "type": [
+              "set",
+              "string"
+            ],
+            "description": "Billing contact emails of the project",
+            "optional": true
+          },
+          "ca_cert": {
+            "type": "string",
+            "description": "Project root CA. This is used by some services like Kafka to sign service certificate",
+            "optional": true,
+            "computed": true
+          },
+          "card_id": {
+            "type": "string",
+            "description": "Credit card ID",
+            "optional": true
+          },
+          "copy_from_project": {
+            "type": "string",
+            "description": "Copy properties from another project. Only has effect when a new project is created.",
+            "optional": true
+          },
+          "country_code": {
+            "type": "string",
+            "description": "Billing country code of the project",
+            "optional": true
+          },
+          "id": {
+            "type": "string",
+            "optional": true,
+            "computed": true
+          },
+          "project": {
+            "type": "string",
+            "description": "Project name",
+            "required": true
+          },
+          "technical_emails": {
+            "type": [
+              "set",
+              "string"
+            ],
+            "description": "Technical contact emails of the project",
+            "optional": true
+          }
+        }
+      }
+    },
+    "aiven_project_user": {
+      "version": 0,
+      "block": {
+        "attributes": {
+          "accepted": {
+            "type": "bool",
+            "description": "Whether the user has accepted project membership or not",
+            "optional": true,
+            "computed": true
+          },
+          "email": {
+            "type": "string",
+            "description": "Email address of the user",
+            "required": true
+          },
+          "id": {
+            "type": "string",
+            "optional": true,
+            "computed": true
+          },
+          "member_type": {
+            "type": "string",
+            "description": "Project membership type. One of: admin, developer, operator",
+            "optional": true
+          },
+          "project": {
+            "type": "string",
+            "description": "The project the user belongs to",
+            "required": true
+          }
+        }
+      }
+    },
+    "aiven_project_vpc": {
+      "version": 0,
+      "block": {
+        "attributes": {
+          "cloud_name": {
+            "type": "string",
+            "description": "Cloud the VPC is in",
+            "required": true
+          },
+          "id": {
+            "type": "string",
+            "optional": true,
+            "computed": true
+          },
+          "network_cidr": {
+            "type": "string",
+            "description": "Network address range used by the VPC like 192.168.0.0/24",
+            "optional": true
+          },
+          "project": {
+            "type": "string",
+            "description": "The project the VPC belongs to",
+            "required": true
+          },
+          "state": {
+            "type": "string",
+            "description": "State of the VPC (APPROVED, ACTIVE, DELETING, DELETED)",
+            "optional": true,
+            "computed": true
+          }
+        },
+        "block_types": {
+          "client_timeout": {
+            "nesting_mode": "set",
+            "block": {
+              "attributes": {
+                "create": {
+                  "type": "string",
+                  "description": "create timeout",
+                  "optional": true
+                },
+                "delete": {
+                  "type": "string",
+                  "description": "delete timeout",
+                  "optional": true
+                }
+              }
+            },
+            "max_items": 1
+          }
+        }
+      }
+    },
+    "aiven_service": {
+      "version": 0,
+      "block": {
+        "attributes": {
+          "cloud_name": {
+            "type": "string",
+            "description": "Cloud the service runs in",
+            "optional": true
+          },
+          "id": {
+            "type": "string",
+            "optional": true,
+            "computed": true
+          },
+          "maintenance_window_dow": {
+            "type": "string",
+            "description": "Day of week when maintenance operations should be performed. One monday, tuesday, wednesday, etc.",
+            "optional": true
+          },
+          "maintenance_window_time": {
+            "type": "string",
+            "description": "Time of day when maintenance operations should be performed. UTC time in HH:mm:ss format.",
+            "optional": true
+          },
+          "plan": {
+            "type": "string",
+            "description": "Subscription plan",
+            "optional": true
+          },
+          "project": {
+            "type": "string",
+            "description": "Target project",
+            "required": true
+          },
+          "project_vpc_id": {
+            "type": "string",
+            "description": "Identifier of the VPC the service should be in, if any",
+            "optional": true
+          },
+          "service_host": {
+            "type": "string",
+            "description": "Service hostname",
+            "optional": true,
+            "computed": true
+          },
+          "service_name": {
+            "type": "string",
+            "description": "Service name",
+            "required": true
+          },
+          "service_password": {
+            "type": "string",
+            "description": "Password used for connecting to the service, if applicable",
+            "optional": true,
+            "computed": true,
+            "sensitive": true
+          },
+          "service_port": {
+            "type": "number",
+            "description": "Service port",
+            "optional": true,
+            "computed": true
+          },
+          "service_type": {
+            "type": "string",
+            "description": "Service type code",
+            "optional": true
+          },
+          "service_uri": {
+            "type": "string",
+            "description": "URI for connecting to the service. Service specific info is under \"kafka\", \"pg\", etc.",
+            "optional": true,
+            "computed": true,
+            "sensitive": true
+          },
+          "service_username": {
+            "type": "string",
+            "description": "Username used for connecting to the service, if applicable",
+            "optional": true,
+            "computed": true
+          },
+          "state": {
+            "type": "string",
+            "description": "Service state",
+            "optional": true,
+            "computed": true
+          },
+          "termination_protection": {
+            "type": "bool",
+            "description": "Prevent service from being deleted. It is recommended to have this enabled for all services.",
+            "optional": true
+          }
+        },
+        "block_types": {
+          "cassandra": {
+            "nesting_mode": "list",
+            "block": {},
+            "max_items": 1
+          },
+          "cassandra_user_config": {
+            "nesting_mode": "list",
+            "block": {
+              "attributes": {
+                "ip_filter": {
+                  "type": [
+                    "list",
+                    "string"
+                  ],
+                  "description": "IP filter",
+                  "optional": true
+                },
+                "migrate_sstableloader": {
+                  "type": "string",
+                  "description": "Migration mode for the sstableloader utility",
+                  "optional": true
+                },
+                "service_to_fork_from": {
+                  "type": "string",
+                  "description": "Name of another service to fork from. This has effect only when a new service is being created.",
+                  "optional": true
+                }
+              },
+              "block_types": {
+                "private_access": {
+                  "nesting_mode": "list",
+                  "block": {
+                    "attributes": {
+                      "prometheus": {
+                        "type": "string",
+                        "description": "Allow clients to connect to prometheus with a DNS name that always resolves to the service's private IP addresses. Only available in certain network locations",
+                        "optional": true
+                      }
+                    }
+                  },
+                  "max_items": 1
+                },
+                "public_access": {
+                  "nesting_mode": "list",
+                  "block": {
+                    "attributes": {
+                      "prometheus": {
+                        "type": "string",
+                        "description": "Allow clients to connect to prometheus from the public internet for service nodes that are in a project VPC or another type of private network",
+                        "optional": true
+                      }
+                    }
+                  },
+                  "max_items": 1
+                }
+              }
+            },
+            "max_items": 1
+          },
+          "client_timeout": {
+            "nesting_mode": "set",
+            "block": {
+              "attributes": {
+                "create": {
+                  "type": "string",
+                  "description": "create timeout",
+                  "optional": true
+                },
+                "update": {
+                  "type": "string",
+                  "description": "update timeout",
+                  "optional": true
+                }
+              }
+            },
+            "max_items": 1
+          },
+          "components": {
+            "nesting_mode": "list",
+            "block": {
+              "attributes": {
+                "component": {
+                  "type": "string",
+                  "description": "Service component name",
+                  "computed": true
+                },
+                "host": {
+                  "type": "string",
+                  "description": "DNS name for connecting to the service component",
+                  "computed": true
+                },
+                "kafka_authentication_method": {
+                  "type": "string",
+                  "description": "Kafka authentication method. This is a value specific to the 'kafka' service component",
+                  "optional": true,
+                  "computed": true
+                },
+                "port": {
+                  "type": "number",
+                  "description": "Port number for connecting to the service component",
+                  "computed": true
+                },
+                "route": {
+                  "type": "string",
+                  "description": "Network access route",
+                  "computed": true
+                },
+                "ssl": {
+                  "type": "bool",
+                  "description": "Whether the endpoint is encrypted or accepts plaintext. By default endpoints are always encrypted and this property is only included for service components they may disable encryption",
+                  "computed": true
+                },
+                "usage": {
+                  "type": "string",
+                  "description": "DNS usage name",
+                  "computed": true
+                }
+              }
+            }
+          },
+          "elasticsearch": {
+            "nesting_mode": "list",
+            "block": {
+              "attributes": {
+                "kibana_uri": {
+                  "type": "string",
+                  "description": "URI for Kibana frontend",
+                  "computed": true,
+                  "sensitive": true
+                }
+              }
+            },
+            "max_items": 1
+          },
+          "elasticsearch_user_config": {
+            "nesting_mode": "list",
+            "block": {
+              "attributes": {
+                "custom_domain": {
+                  "type": "string",
+                  "description": "Custom domain",
+                  "optional": true
+                },
+                "disable_replication_factor_adjustment": {
+                  "type": "string",
+                  "description": "Disable replication factor adjustment",
+                  "optional": true
+                },
+                "elasticsearch_version": {
+                  "type": "string",
+                  "description": "Elasticsearch major version",
+                  "optional": true
+                },
+                "ip_filter": {
+                  "type": [
+                    "list",
+                    "string"
+                  ],
+                  "description": "IP filter",
+                  "optional": true
+                },
+                "max_index_count": {
+                  "type": "number",
+                  "description": "Maximum index count",
+                  "optional": true
+                },
+                "recovery_basebackup_name": {
+                  "type": "string",
+                  "description": "Name of the basebackup to restore in forked service",
+                  "optional": true
+                },
+                "service_to_fork_from": {
+                  "type": "string",
+                  "description": "Name of another service to fork from. This has effect only when a new service is being created.",
+                  "optional": true
+                }
+              },
+              "block_types": {
+                "elasticsearch": {
+                  "nesting_mode": "list",
+                  "block": {
+                    "attributes": {
+                      "action_auto_create_index_enabled": {
+                        "type": "string",
+                        "description": "action.auto_create_index",
+                        "optional": true
+                      },
+                      "action_destructive_requires_name": {
+                        "type": "string",
+                        "description": "Require explicit index names when deleting",
+                        "optional": true
+                      },
+                      "http_max_content_length": {
+                        "type": "number",
+                        "description": "http.max_content_length",
+                        "optional": true
+                      },
+                      "http_max_header_size": {
+                        "type": "number",
+                        "description": "http.max_header_size",
+                        "optional": true
+                      },
+                      "http_max_initial_line_length": {
+                        "type": "number",
+                        "description": "http.max_initial_line_length",
+                        "optional": true
+                      },
+                      "indices_fielddata_cache_size": {
+                        "type": "number",
+                        "description": "indices.fielddata.cache.size",
+                        "optional": true
+                      },
+                      "indices_memory_index_buffer_size": {
+                        "type": "number",
+                        "description": "indices.memory.index_buffer_size",
+                        "optional": true
+                      },
+                      "indices_queries_cache_size": {
+                        "type": "number",
+                        "description": "indices.queries.cache.size",
+                        "optional": true
+                      },
+                      "indices_query_bool_max_clause_count": {
+                        "type": "number",
+                        "description": "indices.query.bool.max_clause_count",
+                        "optional": true
+                      },
+                      "reindex_remote_whitelist": {
+                        "type": [
+                          "list",
+                          "string"
+                        ],
+                        "description": "reindex_remote_whitelist",
+                        "optional": true
+                      },
+                      "thread_pool_analyze_queue_size": {
+                        "type": "number",
+                        "description": "analyze thread pool queue size",
+                        "optional": true
+                      },
+                      "thread_pool_analyze_size": {
+                        "type": "number",
+                        "description": "analyze thread pool size",
+                        "optional": true
+                      },
+                      "thread_pool_force_merge_size": {
+                        "type": "number",
+                        "description": "force_merge thread pool size",
+                        "optional": true
+                      },
+                      "thread_pool_get_queue_size": {
+                        "type": "number",
+                        "description": "get thread pool queue size",
+                        "optional": true
+                      },
+                      "thread_pool_get_size": {
+                        "type": "number",
+                        "description": "get thread pool size",
+                        "optional": true
+                      },
+                      "thread_pool_index_queue_size": {
+                        "type": "number",
+                        "description": "index thread pool queue size",
+                        "optional": true
+                      },
+                      "thread_pool_index_size": {
+                        "type": "number",
+                        "description": "index thread pool size",
+                        "optional": true
+                      },
+                      "thread_pool_search_queue_size": {
+                        "type": "number",
+                        "description": "search thread pool queue size",
+                        "optional": true
+                      },
+                      "thread_pool_search_size": {
+                        "type": "number",
+                        "description": "search thread pool size",
+                        "optional": true
+                      },
+                      "thread_pool_search_throttled_queue_size": {
+                        "type": "number",
+                        "description": "search_throttled thread pool queue size",
+                        "optional": true
+                      },
+                      "thread_pool_search_throttled_size": {
+                        "type": "number",
+                        "description": "search_throttled thread pool size",
+                        "optional": true
+                      },
+                      "thread_pool_write_queue_size": {
+                        "type": "number",
+                        "description": "write thread pool queue size",
+                        "optional": true
+                      },
+                      "thread_pool_write_size": {
+                        "type": "number",
+                        "description": "write thread pool size",
+                        "optional": true
+                      }
+                    }
+                  },
+                  "max_items": 1
+                },
+                "index_patterns": {
+                  "nesting_mode": "list",
+                  "block": {
+                    "attributes": {
+                      "max_index_count": {
+                        "type": "number",
+                        "description": "Maximum number of indexes to keep",
+                        "optional": true
+                      },
+                      "pattern": {
+                        "type": "string",
+                        "description": "fnmatch pattern",
+                        "optional": true
+                      }
+                    }
+                  },
+                  "max_items": 512
+                },
+                "kibana": {
+                  "nesting_mode": "list",
+                  "block": {
+                    "attributes": {
+                      "elasticsearch_request_timeout": {
+                        "type": "number",
+                        "description": "Timeout in milliseconds for requests made by Kibana towards Elasticsearch",
+                        "optional": true
+                      },
+                      "enabled": {
+                        "type": "bool",
+                        "description": "Enable or disable Kibana",
+                        "optional": true
+                      },
+                      "max_old_space_size": {
+                        "type": "number",
+                        "description": "max_old_space_size",
+                        "optional": true
+                      }
+                    }
+                  },
+                  "max_items": 1
+                },
+                "private_access": {
+                  "nesting_mode": "list",
+                  "block": {
+                    "attributes": {
+                      "elasticsearch": {
+                        "type": "string",
+                        "description": "Allow clients to connect to elasticsearch with a DNS name that always resolves to the service's private IP addresses. Only available in certain network locations",
+                        "optional": true
+                      },
+                      "kibana": {
+                        "type": "string",
+                        "description": "Allow clients to connect to kibana with a DNS name that always resolves to the service's private IP addresses. Only available in certain network locations",
+                        "optional": true
+                      },
+                      "prometheus": {
+                        "type": "string",
+                        "description": "Allow clients to connect to prometheus with a DNS name that always resolves to the service's private IP addresses. Only available in certain network locations",
+                        "optional": true
+                      }
+                    }
+                  },
+                  "max_items": 1
+                },
+                "public_access": {
+                  "nesting_mode": "list",
+                  "block": {
+                    "attributes": {
+                      "elasticsearch": {
+                        "type": "string",
+                        "description": "Allow clients to connect to elasticsearch from the public internet for service nodes that are in a project VPC or another type of private network",
+                        "optional": true
+                      },
+                      "kibana": {
+                        "type": "string",
+                        "description": "Allow clients to connect to kibana from the public internet for service nodes that are in a project VPC or another type of private network",
+                        "optional": true
+                      },
+                      "prometheus": {
+                        "type": "string",
+                        "description": "Allow clients to connect to prometheus from the public internet for service nodes that are in a project VPC or another type of private network",
+                        "optional": true
+                      }
+                    }
+                  },
+                  "max_items": 1
+                }
+              }
+            },
+            "max_items": 1
+          },
+          "grafana": {
+            "nesting_mode": "list",
+            "block": {},
+            "max_items": 1
+          },
+          "grafana_user_config": {
+            "nesting_mode": "list",
+            "block": {
+              "attributes": {
+                "alerting_enabled": {
+                  "type": "string",
+                  "description": "Enable or disable Grafana alerting functionality",
+                  "optional": true
+                },
+                "alerting_error_or_timeout": {
+                  "type": "string",
+                  "description": "Default error or timeout setting for new alerting rules",
+                  "optional": true
+                },
+                "alerting_nodata_or_nullvalues": {
+                  "type": "string",
+                  "description": "Default value for 'no data or null values' for new alerting rules",
+                  "optional": true
+                },
+                "allow_embedding": {
+                  "type": "string",
+                  "description": "Allow embedding Grafana dashboards with iframe/frame/object/embed tags. Disabled by default to limit impact of clickjacking",
+                  "optional": true
+                },
+                "auth_basic_enabled": {
+                  "type": "string",
+                  "description": "Enable or disable basic authentication form, used by Grafana built-in login",
+                  "optional": true
+                },
+                "cookie_samesite": {
+                  "type": "string",
+                  "description": "Cookie SameSite attribute: 'strict' prevents sending cookie for cross-site requests, effectively disabling direct linking from other sites to Grafana. 'lax' is the default value.",
+                  "optional": true
+                },
+                "custom_domain": {
+                  "type": "string",
+                  "description": "Custom domain",
+                  "optional": true
+                },
+                "dashboards_versions_to_keep": {
+                  "type": "number",
+                  "description": "Dashboard versions to keep per dashboard",
+                  "optional": true
+                },
+                "dataproxy_send_user_header": {
+                  "type": "string",
+                  "description": "Send 'X-Grafana-User' header to data source",
+                  "optional": true
+                },
+                "dataproxy_timeout": {
+                  "type": "number",
+                  "description": "Timeout for data proxy requests in seconds",
+                  "optional": true
+                },
+                "disable_gravatar": {
+                  "type": "string",
+                  "description": "Set to true to disable gravatar. Defaults to false (gravatar is enabled)",
+                  "optional": true
+                },
+                "editors_can_admin": {
+                  "type": "string",
+                  "description": "Editors can manage folders, teams and dashboards created by them",
+                  "optional": true
+                },
+                "google_analytics_ua_id": {
+                  "type": "string",
+                  "description": "Google Analytics Universal Analytics ID for tracking Grafana usage",
+                  "optional": true
+                },
+                "ip_filter": {
+                  "type": [
+                    "list",
+                    "string"
+                  ],
+                  "description": "IP filter",
+                  "optional": true
+                },
+                "metrics_enabled": {
+                  "type": "string",
+                  "description": "Enable Grafana /metrics endpoint",
+                  "optional": true
+                },
+                "user_auto_assign_org": {
+                  "type": "string",
+                  "description": "Auto-assign new users on signup to main organization. Defaults to false",
+                  "optional": true
+                },
+                "user_auto_assign_org_role": {
+                  "type": "string",
+                  "description": "Set role for new signups. Defaults to Viewer",
+                  "optional": true
+                },
+                "viewers_can_edit": {
+                  "type": "string",
+                  "description": "Users with view-only permission can edit but not save dashboards",
+                  "optional": true
+                }
+              },
+              "block_types": {
+                "auth_generic_oauth": {
+                  "nesting_mode": "list",
+                  "block": {
+                    "attributes": {
+                      "allow_sign_up": {
+                        "type": "string",
+                        "description": "Automatically sign-up users on successful sign-in",
+                        "optional": true
+                      },
+                      "allowed_domains": {
+                        "type": [
+                          "list",
+                          "string"
+                        ],
+                        "description": "Allowed domains",
+                        "optional": true
+                      },
+                      "allowed_organizations": {
+                        "type": [
+                          "list",
+                          "string"
+                        ],
+                        "description": "Require user to be member of one of the listed organizations",
+                        "optional": true
+                      },
+                      "api_url": {
+                        "type": "string",
+                        "description": "API URL",
+                        "optional": true
+                      },
+                      "auth_url": {
+                        "type": "string",
+                        "description": "Authorization URL",
+                        "optional": true
+                      },
+                      "client_id": {
+                        "type": "string",
+                        "description": "Client ID from provider",
+                        "optional": true
+                      },
+                      "client_secret": {
+                        "type": "string",
+                        "description": "Client secret from provider",
+                        "optional": true
+                      },
+                      "name": {
+                        "type": "string",
+                        "description": "Name of the OAuth integration",
+                        "optional": true
+                      },
+                      "scopes": {
+                        "type": [
+                          "list",
+                          "string"
+                        ],
+                        "description": "OAuth scopes",
+                        "optional": true
+                      },
+                      "token_url": {
+                        "type": "string",
+                        "description": "Token URL",
+                        "optional": true
+                      }
+                    }
+                  },
+                  "max_items": 1
+                },
+                "auth_github": {
+                  "nesting_mode": "list",
+                  "block": {
+                    "attributes": {
+                      "allow_sign_up": {
+                        "type": "string",
+                        "description": "Automatically sign-up users on successful sign-in",
+                        "optional": true
+                      },
+                      "allowed_organizations": {
+                        "type": [
+                          "list",
+                          "string"
+                        ],
+                        "description": "Require users to belong to one of given organizations",
+                        "optional": true
+                      },
+                      "client_id": {
+                        "type": "string",
+                        "description": "Client ID from provider",
+                        "optional": true
+                      },
+                      "client_secret": {
+                        "type": "string",
+                        "description": "Client secret from provider",
+                        "optional": true
+                      },
+                      "team_ids": {
+                        "type": [
+                          "list",
+                          "number"
+                        ],
+                        "description": "Require users to belong to one of given team IDs",
+                        "optional": true
+                      }
+                    }
+                  },
+                  "max_items": 1
+                },
+                "auth_gitlab": {
+                  "nesting_mode": "list",
+                  "block": {
+                    "attributes": {
+                      "allow_sign_up": {
+                        "type": "string",
+                        "description": "Automatically sign-up users on successful sign-in",
+                        "optional": true
+                      },
+                      "allowed_groups": {
+                        "type": [
+                          "list",
+                          "string"
+                        ],
+                        "description": "Require users to belong to one of given groups",
+                        "optional": true
+                      },
+                      "api_url": {
+                        "type": "string",
+                        "description": "API URL. This only needs to be set when using self hosted GitLab",
+                        "optional": true
+                      },
+                      "auth_url": {
+                        "type": "string",
+                        "description": "Authorization URL. This only needs to be set when using self hosted GitLab",
+                        "optional": true
+                      },
+                      "client_id": {
+                        "type": "string",
+                        "description": "Client ID from provider",
+                        "optional": true
+                      },
+                      "client_secret": {
+                        "type": "string",
+                        "description": "Client secret from provider",
+                        "optional": true
+                      },
+                      "token_url": {
+                        "type": "string",
+                        "description": "Token URL. This only needs to be set when using self hosted GitLab",
+                        "optional": true
+                      }
+                    }
+                  },
+                  "max_items": 1
+                },
+                "auth_google": {
+                  "nesting_mode": "list",
+                  "block": {
+                    "attributes": {
+                      "allow_sign_up": {
+                        "type": "string",
+                        "description": "Automatically sign-up users on successful sign-in",
+                        "optional": true
+                      },
+                      "allowed_domains": {
+                        "type": [
+                          "list",
+                          "string"
+                        ],
+                        "description": "Domains allowed to sign-in to this Grafana",
+                        "optional": true
+                      },
+                      "client_id": {
+                        "type": "string",
+                        "description": "Client ID from provider",
+                        "optional": true
+                      },
+                      "client_secret": {
+                        "type": "string",
+                        "description": "Client secret from provider",
+                        "optional": true
+                      }
+                    }
+                  },
+                  "max_items": 1
+                },
+                "external_image_storage": {
+                  "nesting_mode": "list",
+                  "block": {
+                    "attributes": {
+                      "access_key": {
+                        "type": "string",
+                        "description": "S3 access key. Requires permissions to the S3 bucket for the s3:PutObject and s3:PutObjectAcl actions",
+                        "optional": true
+                      },
+                      "bucket_url": {
+                        "type": "string",
+                        "description": "Bucket URL for S3",
+                        "optional": true
+                      },
+                      "provider": {
+                        "type": "string",
+                        "description": "Provider type",
+                        "optional": true
+                      },
+                      "secret_key": {
+                        "type": "string",
+                        "description": "S3 secret key",
+                        "optional": true
+                      }
+                    }
+                  },
+                  "max_items": 1
+                },
+                "private_access": {
+                  "nesting_mode": "list",
+                  "block": {
+                    "attributes": {
+                      "grafana": {
+                        "type": "string",
+                        "description": "Allow clients to connect to grafana with a DNS name that always resolves to the service's private IP addresses. Only available in certain network locations",
+                        "optional": true
+                      }
+                    }
+                  },
+                  "max_items": 1
+                },
+                "public_access": {
+                  "nesting_mode": "list",
+                  "block": {
+                    "attributes": {
+                      "grafana": {
+                        "type": "string",
+                        "description": "Allow clients to connect to grafana from the public internet for service nodes that are in a project VPC or another type of private network",
+                        "optional": true
+                      }
+                    }
+                  },
+                  "max_items": 1
+                },
+                "smtp_server": {
+                  "nesting_mode": "list",
+                  "block": {
+                    "attributes": {
+                      "from_address": {
+                        "type": "string",
+                        "description": "Address used for sending emails",
+                        "optional": true
+                      },
+                      "from_name": {
+                        "type": "string",
+                        "description": "Name used in outgoing emails, defaults to Grafana",
+                        "optional": true
+                      },
+                      "host": {
+                        "type": "string",
+                        "description": "Server hostname or IP",
+                        "optional": true
+                      },
+                      "password": {
+                        "type": "string",
+                        "description": "Password for SMTP authentication",
+                        "optional": true,
+                        "sensitive": true
+                      },
+                      "port": {
+                        "type": "number",
+                        "description": "SMTP server port",
+                        "optional": true
+                      },
+                      "skip_verify": {
+                        "type": "string",
+                        "description": "Skip verifying server certificate. Defaults to false",
+                        "optional": true
+                      },
+                      "username": {
+                        "type": "string",
+                        "description": "Username for SMTP authentication",
+                        "optional": true
+                      }
+                    }
+                  },
+                  "max_items": 1
+                }
+              }
+            },
+            "max_items": 1
+          },
+          "influxdb": {
+            "nesting_mode": "list",
+            "block": {
+              "attributes": {
+                "database_name": {
+                  "type": "string",
+                  "description": "Name of the default InfluxDB database",
+                  "computed": true
+                }
+              }
+            },
+            "max_items": 1
+          },
+          "influxdb_user_config": {
+            "nesting_mode": "list",
+            "block": {
+              "attributes": {
+                "custom_domain": {
+                  "type": "string",
+                  "description": "Custom domain",
+                  "optional": true
+                },
+                "ip_filter": {
+                  "type": [
+                    "list",
+                    "string"
+                  ],
+                  "description": "IP filter",
+                  "optional": true
+                },
+                "service_to_fork_from": {
+                  "type": "string",
+                  "description": "Name of another service to fork from. This has effect only when a new service is being created.",
+                  "optional": true
+                }
+              },
+              "block_types": {
+                "private_access": {
+                  "nesting_mode": "list",
+                  "block": {
+                    "attributes": {
+                      "influxdb": {
+                        "type": "string",
+                        "description": "Allow clients to connect to influxdb with a DNS name that always resolves to the service's private IP addresses. Only available in certain network locations",
+                        "optional": true
+                      }
+                    }
+                  },
+                  "max_items": 1
+                },
+                "public_access": {
+                  "nesting_mode": "list",
+                  "block": {
+                    "attributes": {
+                      "influxdb": {
+                        "type": "string",
+                        "description": "Allow clients to connect to influxdb from the public internet for service nodes that are in a project VPC or another type of private network",
+                        "optional": true
+                      }
+                    }
+                  },
+                  "max_items": 1
+                }
+              }
+            },
+            "max_items": 1
+          },
+          "kafka": {
+            "nesting_mode": "list",
+            "block": {
+              "attributes": {
+                "access_cert": {
+                  "type": "string",
+                  "description": "The Kafka client certificate",
+                  "optional": true,
+                  "computed": true,
+                  "sensitive": true
+                },
+                "access_key": {
+                  "type": "string",
+                  "description": "The Kafka client certificate key",
+                  "optional": true,
+                  "computed": true,
+                  "sensitive": true
+                },
+                "connect_uri": {
+                  "type": "string",
+                  "description": "The Kafka Connect URI, if any",
+                  "optional": true,
+                  "computed": true,
+                  "sensitive": true
+                },
+                "rest_uri": {
+                  "type": "string",
+                  "description": "The Kafka REST URI, if any",
+                  "optional": true,
+                  "computed": true,
+                  "sensitive": true
+                },
+                "schema_registry_uri": {
+                  "type": "string",
+                  "description": "The Schema Registry URI, if any",
+                  "optional": true,
+                  "computed": true,
+                  "sensitive": true
+                }
+              }
+            },
+            "max_items": 1
+          },
+          "kafka_connect": {
+            "nesting_mode": "list",
+            "block": {},
+            "max_items": 1
+          },
+          "kafka_connect_user_config": {
+            "nesting_mode": "list",
+            "block": {
+              "attributes": {
+                "ip_filter": {
+                  "type": [
+                    "list",
+                    "string"
+                  ],
+                  "description": "IP filter",
+                  "optional": true
+                }
+              },
+              "block_types": {
+                "kafka_connect": {
+                  "nesting_mode": "list",
+                  "block": {
+                    "attributes": {
+                      "consumer_isolation_level": {
+                        "type": "string",
+                        "description": "Consumer isolation level",
+                        "optional": true
+                      },
+                      "consumer_max_poll_records": {
+                        "type": "number",
+                        "description": "The maximum number of records returned by a single poll",
+                        "optional": true
+                      },
+                      "offset_flush_interval_ms": {
+                        "type": "number",
+                        "description": "The interval at which to try committing offsets for tasks",
+                        "optional": true
+                      }
+                    }
+                  },
+                  "max_items": 1
+                },
+                "private_access": {
+                  "nesting_mode": "list",
+                  "block": {
+                    "attributes": {
+                      "kafka_connect": {
+                        "type": "string",
+                        "description": "Allow clients to connect to kafka_connect with a DNS name that always resolves to the service's private IP addresses. Only available in certain network locations",
+                        "optional": true
+                      },
+                      "prometheus": {
+                        "type": "string",
+                        "description": "Allow clients to connect to prometheus with a DNS name that always resolves to the service's private IP addresses. Only available in certain network locations",
+                        "optional": true
+                      }
+                    }
+                  },
+                  "max_items": 1
+                },
+                "public_access": {
+                  "nesting_mode": "list",
+                  "block": {
+                    "attributes": {
+                      "kafka_connect": {
+                        "type": "string",
+                        "description": "Allow clients to connect to kafka_connect from the public internet for service nodes that are in a project VPC or another type of private network",
+                        "optional": true
+                      },
+                      "prometheus": {
+                        "type": "string",
+                        "description": "Allow clients to connect to prometheus from the public internet for service nodes that are in a project VPC or another type of private network",
+                        "optional": true
+                      }
+                    }
+                  },
+                  "max_items": 1
+                }
+              }
+            },
+            "max_items": 1
+          },
+          "kafka_mirrormaker": {
+            "nesting_mode": "list",
+            "block": {},
+            "max_items": 1
+          },
+          "kafka_mirrormaker_user_config": {
+            "nesting_mode": "list",
+            "block": {
+              "attributes": {
+                "ip_filter": {
+                  "type": [
+                    "list",
+                    "string"
+                  ],
+                  "description": "IP filter",
+                  "optional": true
+                }
+              },
+              "block_types": {
+                "kafka_mirrormaker": {
+                  "nesting_mode": "list",
+                  "block": {
+                    "attributes": {
+                      "refresh_groups_enabled": {
+                        "type": "string",
+                        "description": "Refresh consumer groups",
+                        "optional": true
+                      },
+                      "refresh_groups_interval_seconds": {
+                        "type": "number",
+                        "description": "Frequency of group refresh",
+                        "optional": true
+                      },
+                      "refresh_topics_enabled": {
+                        "type": "string",
+                        "description": "Refresh topics and partitions",
+                        "optional": true
+                      },
+                      "refresh_topics_interval_seconds": {
+                        "type": "number",
+                        "description": "Frequency of topic and partitions refresh",
+                        "optional": true
+                      }
+                    }
+                  },
+                  "max_items": 1
+                }
+              }
+            },
+            "max_items": 1
+          },
+          "kafka_user_config": {
+            "nesting_mode": "list",
+            "block": {
+              "attributes": {
+                "custom_domain": {
+                  "type": "string",
+                  "description": "Custom domain",
+                  "optional": true
+                },
+                "ip_filter": {
+                  "type": [
+                    "list",
+                    "string"
+                  ],
+                  "description": "IP filter",
+                  "optional": true
+                },
+                "kafka_connect": {
+                  "type": "bool",
+                  "description": "Enable Kafka Connect service",
+                  "optional": true
+                },
+                "kafka_rest": {
+                  "type": "bool",
+                  "description": "Enable Kafka-REST service",
+                  "optional": true
+                },
+                "kafka_version": {
+                  "type": "string",
+                  "description": "Kafka major version",
+                  "optional": true
+                },
+                "schema_registry": {
+                  "type": "bool",
+                  "description": "Enable Schema-Registry service",
+                  "optional": true
+                }
+              },
+              "block_types": {
+                "kafka": {
+                  "nesting_mode": "list",
+                  "block": {
+                    "attributes": {
+                      "auto_create_topics_enable": {
+                        "type": "string",
+                        "description": "auto.create.topics.enable",
+                        "optional": true
+                      },
+                      "compression_type": {
+                        "type": "string",
+                        "description": "compression.type",
+                        "optional": true
+                      },
+                      "connections_max_idle_ms": {
+                        "type": "number",
+                        "description": "connections.max.idle.ms",
+                        "optional": true
+                      },
+                      "default_replication_factor": {
+                        "type": "number",
+                        "description": "default.replication.factor",
+                        "optional": true
+                      },
+                      "group_max_session_timeout_ms": {
+                        "type": "number",
+                        "description": "group.max.session.timeout.ms",
+                        "optional": true
+                      },
+                      "group_min_session_timeout_ms": {
+                        "type": "number",
+                        "description": "group.min.session.timeout.ms",
+                        "optional": true
+                      },
+                      "log_cleaner_max_compaction_lag_ms": {
+                        "type": "number",
+                        "description": "log.cleaner.max.compaction.lag.ms",
+                        "optional": true
+                      },
+                      "log_cleaner_min_cleanable_ratio": {
+                        "type": "number",
+                        "description": "log.cleaner.min.cleanable.ratio",
+                        "optional": true
+                      },
+                      "log_cleaner_min_compaction_lag_ms": {
+                        "type": "number",
+                        "description": "log.cleaner.min.compaction.lag.ms",
+                        "optional": true
+                      },
+                      "log_cleanup_policy": {
+                        "type": "string",
+                        "description": "log.cleanup.policy",
+                        "optional": true
+                      },
+                      "log_message_timestamp_difference_max_ms": {
+                        "type": "number",
+                        "description": "log.message.timestamp.difference.max.ms",
+                        "optional": true
+                      },
+                      "log_message_timestamp_type": {
+                        "type": "string",
+                        "description": "log.message.timestamp.type",
+                        "optional": true
+                      },
+                      "log_retention_bytes": {
+                        "type": "number",
+                        "description": "log.retention.bytes",
+                        "optional": true
+                      },
+                      "log_retention_hours": {
+                        "type": "number",
+                        "description": "log.retention.hours",
+                        "optional": true
+                      },
+                      "log_segment_bytes": {
+                        "type": "number",
+                        "description": "log.segment.bytes",
+                        "optional": true
+                      },
+                      "max_connections_per_ip": {
+                        "type": "number",
+                        "description": "max.connections.per.ip",
+                        "optional": true
+                      },
+                      "message_max_bytes": {
+                        "type": "number",
+                        "description": "message.max.bytes",
+                        "optional": true
+                      },
+                      "num_partitions": {
+                        "type": "number",
+                        "description": "num.partitions",
+                        "optional": true
+                      },
+                      "offsets_retention_minutes": {
+                        "type": "number",
+                        "description": "offsets.retention.minutes",
+                        "optional": true
+                      },
+                      "producer_purgatory_purge_interval_requests": {
+                        "type": "number",
+                        "description": "producer.purgatory.purge.interval.requests",
+                        "optional": true
+                      },
+                      "replica_fetch_max_bytes": {
+                        "type": "number",
+                        "description": "replica.fetch.max.bytes",
+                        "optional": true
+                      },
+                      "replica_fetch_response_max_bytes": {
+                        "type": "number",
+                        "description": "replica.fetch.response.max.bytes",
+                        "optional": true
+                      },
+                      "socket_request_max_bytes": {
+                        "type": "number",
+                        "description": "socket.request.max.bytes",
+                        "optional": true
+                      }
+                    }
+                  },
+                  "max_items": 1
+                },
+                "kafka_authentication_methods": {
+                  "nesting_mode": "list",
+                  "block": {
+                    "attributes": {
+                      "certificate": {
+                        "type": "bool",
+                        "description": "Enable certificate/SSL authentication",
+                        "optional": true
+                      },
+                      "sasl": {
+                        "type": "bool",
+                        "description": "Enable SASL authentication",
+                        "optional": true
+                      }
+                    }
+                  },
+                  "max_items": 1
+                },
+                "kafka_connect_config": {
+                  "nesting_mode": "list",
+                  "block": {
+                    "attributes": {
+                      "consumer_isolation_level": {
+                        "type": "string",
+                        "description": "Consumer isolation level",
+                        "optional": true
+                      },
+                      "consumer_max_poll_records": {
+                        "type": "number",
+                        "description": "The maximum number of records returned by a single poll",
+                        "optional": true
+                      },
+                      "offset_flush_interval_ms": {
+                        "type": "number",
+                        "description": "The interval at which to try committing offsets for tasks",
+                        "optional": true
+                      }
+                    }
+                  },
+                  "max_items": 1
+                },
+                "kafka_rest_config": {
+                  "nesting_mode": "list",
+                  "block": {
+                    "attributes": {
+                      "consumer_enable_auto_commit": {
+                        "type": "bool",
+                        "description": "consumer.enable.auto.commit",
+                        "optional": true
+                      },
+                      "consumer_request_max_bytes": {
+                        "type": "number",
+                        "description": "consumer.request.max.bytes",
+                        "optional": true
+                      },
+                      "consumer_request_timeout_ms": {
+                        "type": "number",
+                        "description": "consumer.request.timeout.ms",
+                        "optional": true
+                      },
+                      "producer_acks": {
+                        "type": "string",
+                        "description": "producer.acks",
+                        "optional": true
+                      },
+                      "producer_linger_ms": {
+                        "type": "number",
+                        "description": "producer.linger.ms",
+                        "optional": true
+                      },
+                      "simpleconsumer_pool_size_max": {
+                        "type": "number",
+                        "description": "simpleconsumer.pool.size.max",
+                        "optional": true
+                      }
+                    }
+                  },
+                  "max_items": 1
+                },
+                "private_access": {
+                  "nesting_mode": "list",
+                  "block": {
+                    "attributes": {
+                      "prometheus": {
+                        "type": "string",
+                        "description": "Allow clients to connect to prometheus with a DNS name that always resolves to the service's private IP addresses. Only available in certain network locations",
+                        "optional": true
+                      }
+                    }
+                  },
+                  "max_items": 1
+                },
+                "public_access": {
+                  "nesting_mode": "list",
+                  "block": {
+                    "attributes": {
+                      "kafka": {
+                        "type": "string",
+                        "description": "Allow clients to connect to kafka from the public internet for service nodes that are in a project VPC or another type of private network",
+                        "optional": true
+                      },
+                      "kafka_connect": {
+                        "type": "string",
+                        "description": "Allow clients to connect to kafka_connect from the public internet for service nodes that are in a project VPC or another type of private network",
+                        "optional": true
+                      },
+                      "kafka_rest": {
+                        "type": "string",
+                        "description": "Allow clients to connect to kafka_rest from the public internet for service nodes that are in a project VPC or another type of private network",
+                        "optional": true
+                      },
+                      "prometheus": {
+                        "type": "string",
+                        "description": "Allow clients to connect to prometheus from the public internet for service nodes that are in a project VPC or another type of private network",
+                        "optional": true
+                      },
+                      "schema_registry": {
+                        "type": "string",
+                        "description": "Allow clients to connect to schema_registry from the public internet for service nodes that are in a project VPC or another type of private network",
+                        "optional": true
+                      }
+                    }
+                  },
+                  "max_items": 1
+                }
+              }
+            },
+            "max_items": 1
+          },
+          "mysql": {
+            "nesting_mode": "list",
+            "block": {},
+            "max_items": 1
+          },
+          "mysql_user_config": {
+            "nesting_mode": "list",
+            "block": {
+              "attributes": {
+                "admin_password": {
+                  "type": "string",
+                  "description": "Custom password for admin user. Defaults to random string. This must be set only when a new service is being created.",
+                  "optional": true,
+                  "sensitive": true
+                },
+                "admin_username": {
+                  "type": "string",
+                  "description": "Custom username for admin user. This must be set only when a new service is being created.",
+                  "optional": true
+                },
+                "backup_hour": {
+                  "type": "number",
+                  "description": "The hour of day (in UTC) when backup for the service is started. New backup is only started if previous backup has already completed.",
+                  "optional": true
+                },
+                "backup_minute": {
+                  "type": "number",
+                  "description": "The minute of an hour when backup for the service is started. New backup is only started if previous backup has already completed.",
+                  "optional": true
+                },
+                "ip_filter": {
+                  "type": [
+                    "list",
+                    "string"
+                  ],
+                  "description": "IP filter",
+                  "optional": true
+                },
+                "mysql_version": {
+                  "type": "string",
+                  "description": "MySQL major version",
+                  "optional": true
+                },
+                "recovery_target_time": {
+                  "type": "string",
+                  "description": "Recovery target time when forking a service. This has effect only when a new service is being created.",
+                  "optional": true
+                },
+                "service_to_fork_from": {
+                  "type": "string",
+                  "description": "Name of another service to fork from. This has effect only when a new service is being created.",
+                  "optional": true
+                }
+              },
+              "block_types": {
+                "mysql": {
+                  "nesting_mode": "list",
+                  "block": {
+                    "attributes": {
+                      "connect_timeout": {
+                        "type": "number",
+                        "description": "connect_timeout",
+                        "optional": true
+                      },
+                      "default_time_zone": {
+                        "type": "string",
+                        "description": "default_time_zone",
+                        "optional": true
+                      },
+                      "group_concat_max_len": {
+                        "type": "number",
+                        "description": "group_concat_max_len",
+                        "optional": true
+                      },
+                      "information_schema_stats_expiry": {
+                        "type": "number",
+                        "description": "information_schema_stats_expiry",
+                        "optional": true
+                      },
+                      "innodb_ft_min_token_size": {
+                        "type": "number",
+                        "description": "innodb_ft_min_token_size",
+                        "optional": true
+                      },
+                      "innodb_ft_server_stopword_table": {
+                        "type": "string",
+                        "description": "innodb_ft_server_stopword_table",
+                        "optional": true
+                      },
+                      "innodb_lock_wait_timeout": {
+                        "type": "number",
+                        "description": "innodb_lock_wait_timeout",
+                        "optional": true
+                      },
+                      "innodb_log_buffer_size": {
+                        "type": "number",
+                        "description": "innodb_log_buffer_size",
+                        "optional": true
+                      },
+                      "innodb_online_alter_log_max_size": {
+                        "type": "number",
+                        "description": "innodb_online_alter_log_max_size",
+                        "optional": true
+                      },
+                      "innodb_rollback_on_timeout": {
+                        "type": "string",
+                        "description": "innodb_rollback_on_timeout",
+                        "optional": true
+                      },
+                      "interactive_timeout": {
+                        "type": "number",
+                        "description": "interactive_timeout",
+                        "optional": true
+                      },
+                      "max_allowed_packet": {
+                        "type": "number",
+                        "description": "max_allowed_packet",
+                        "optional": true
+                      },
+                      "max_heap_table_size": {
+                        "type": "number",
+                        "description": "max_heap_table_size",
+                        "optional": true
+                      },
+                      "net_read_timeout": {
+                        "type": "number",
+                        "description": "net_read_timeout",
+                        "optional": true
+                      },
+                      "net_write_timeout": {
+                        "type": "number",
+                        "description": "net_write_timeout",
+                        "optional": true
+                      },
+                      "sort_buffer_size": {
+                        "type": "number",
+                        "description": "sort_buffer_size",
+                        "optional": true
+                      },
+                      "sql_mode": {
+                        "type": "string",
+                        "description": "sql_mode",
+                        "optional": true
+                      },
+                      "sql_require_primary_key": {
+                        "type": "string",
+                        "description": "sql_require_primary_key",
+                        "optional": true
+                      },
+                      "tmp_table_size": {
+                        "type": "number",
+                        "description": "tmp_table_size",
+                        "optional": true
+                      },
+                      "wait_timeout": {
+                        "type": "number",
+                        "description": "wait_timeout",
+                        "optional": true
+                      }
+                    }
+                  },
+                  "max_items": 1
+                },
+                "private_access": {
+                  "nesting_mode": "list",
+                  "block": {
+                    "attributes": {
+                      "mysql": {
+                        "type": "string",
+                        "description": "Allow clients to connect to mysql with a DNS name that always resolves to the service's private IP addresses. Only available in certain network locations",
+                        "optional": true
+                      },
+                      "prometheus": {
+                        "type": "string",
+                        "description": "Allow clients to connect to prometheus with a DNS name that always resolves to the service's private IP addresses. Only available in certain network locations",
+                        "optional": true
+                      }
+                    }
+                  },
+                  "max_items": 1
+                },
+                "public_access": {
+                  "nesting_mode": "list",
+                  "block": {
+                    "attributes": {
+                      "mysql": {
+                        "type": "string",
+                        "description": "Allow clients to connect to mysql from the public internet for service nodes that are in a project VPC or another type of private network",
+                        "optional": true
+                      },
+                      "prometheus": {
+                        "type": "string",
+                        "description": "Allow clients to connect to prometheus from the public internet for service nodes that are in a project VPC or another type of private network",
+                        "optional": true
+                      }
+                    }
+                  },
+                  "max_items": 1
+                }
+              }
+            },
+            "max_items": 1
+          },
+          "pg": {
+            "nesting_mode": "list",
+            "block": {
+              "attributes": {
+                "dbname": {
+                  "type": "string",
+                  "description": "Primary PostgreSQL database name",
+                  "computed": true
+                },
+                "host": {
+                  "type": "string",
+                  "description": "PostgreSQL master node host IP or name",
+                  "computed": true
+                },
+                "password": {
+                  "type": "string",
+                  "description": "PostgreSQL admin user password",
+                  "computed": true,
+                  "sensitive": true
+                },
+                "port": {
+                  "type": "number",
+                  "description": "PostgreSQL port",
+                  "computed": true
+                },
+                "replica_uri": {
+                  "type": "string",
+                  "description": "PostgreSQL replica URI for services with a replica",
+                  "computed": true,
+                  "sensitive": true
+                },
+                "sslmode": {
+                  "type": "string",
+                  "description": "PostgreSQL sslmode setting (currently always \"require\")",
+                  "computed": true
+                },
+                "uri": {
+                  "type": "string",
+                  "description": "PostgreSQL master connection URI",
+                  "optional": true,
+                  "computed": true,
+                  "sensitive": true
+                },
+                "user": {
+                  "type": "string",
+                  "description": "PostgreSQL admin user name",
+                  "computed": true
+                }
+              }
+            },
+            "max_items": 1
+          },
+          "pg_user_config": {
+            "nesting_mode": "list",
+            "block": {
+              "attributes": {
+                "admin_password": {
+                  "type": "string",
+                  "description": "Custom password for admin user. Defaults to random string. This must be set only when a new service is being created.",
+                  "optional": true,
+                  "sensitive": true
+                },
+                "admin_username": {
+                  "type": "string",
+                  "description": "Custom username for admin user. This must be set only when a new service is being created.",
+                  "optional": true
+                },
+                "backup_hour": {
+                  "type": "number",
+                  "description": "The hour of day (in UTC) when backup for the service is started. New backup is only started if previous backup has already completed.",
+                  "optional": true
+                },
+                "backup_minute": {
+                  "type": "number",
+                  "description": "The minute of an hour when backup for the service is started. New backup is only started if previous backup has already completed.",
+                  "optional": true
+                },
+                "ip_filter": {
+                  "type": [
+                    "list",
+                    "string"
+                  ],
+                  "description": "IP filter",
+                  "optional": true
+                },
+                "pg_read_replica": {
+                  "type": "string",
+                  "description": "Should the service which is being forked be a read replica",
+                  "optional": true
+                },
+                "pg_service_to_fork_from": {
+                  "type": "string",
+                  "description": "Name of the PG Service from which to fork (deprecated, use service_to_fork_from). This has effect only when a new service is being created.",
+                  "optional": true
+                },
+                "pg_version": {
+                  "type": "string",
+                  "description": "PostgreSQL major version",
+                  "optional": true
+                },
+                "recovery_target_time": {
+                  "type": "string",
+                  "description": "Recovery target time when forking a service. This has effect only when a new service is being created.",
+                  "optional": true
+                },
+                "service_to_fork_from": {
+                  "type": "string",
+                  "description": "Name of another service to fork from. This has effect only when a new service is being created.",
+                  "optional": true
+                },
+                "synchronous_replication": {
+                  "type": "string",
+                  "description": "Synchronous replication type. Note that the service plan also needs to support synchronous replication.",
+                  "optional": true
+                },
+                "variant": {
+                  "type": "string",
+                  "description": "Variant of the PostgreSQL service, may affect the features that are exposed by default",
+                  "optional": true
+                }
+              },
+              "block_types": {
+                "pg": {
+                  "nesting_mode": "list",
+                  "block": {
+                    "attributes": {
+                      "autovacuum_analyze_scale_factor": {
+                        "type": "number",
+                        "description": "autovacuum_analyze_scale_factor",
+                        "optional": true
+                      },
+                      "autovacuum_analyze_threshold": {
+                        "type": "number",
+                        "description": "autovacuum_analyze_threshold",
+                        "optional": true
+                      },
+                      "autovacuum_freeze_max_age": {
+                        "type": "number",
+                        "description": "autovacuum_freeze_max_age",
+                        "optional": true
+                      },
+                      "autovacuum_max_workers": {
+                        "type": "number",
+                        "description": "autovacuum_max_workers",
+                        "optional": true
+                      },
+                      "autovacuum_naptime": {
+                        "type": "number",
+                        "description": "autovacuum_naptime",
+                        "optional": true
+                      },
+                      "autovacuum_vacuum_cost_delay": {
+                        "type": "number",
+                        "description": "autovacuum_vacuum_cost_delay",
+                        "optional": true
+                      },
+                      "autovacuum_vacuum_cost_limit": {
+                        "type": "number",
+                        "description": "autovacuum_vacuum_cost_limit",
+                        "optional": true
+                      },
+                      "autovacuum_vacuum_scale_factor": {
+                        "type": "number",
+                        "description": "autovacuum_vacuum_scale_factor",
+                        "optional": true
+                      },
+                      "autovacuum_vacuum_threshold": {
+                        "type": "number",
+                        "description": "autovacuum_vacuum_threshold",
+                        "optional": true
+                      },
+                      "deadlock_timeout": {
+                        "type": "number",
+                        "description": "deadlock_timeout",
+                        "optional": true
+                      },
+                      "idle_in_transaction_session_timeout": {
+                        "type": "number",
+                        "description": "idle_in_transaction_session_timeout",
+                        "optional": true
+                      },
+                      "jit": {
+                        "type": "string",
+                        "description": "jit",
+                        "optional": true
+                      },
+                      "log_autovacuum_min_duration": {
+                        "type": "number",
+                        "description": "log_autovacuum_min_duration",
+                        "optional": true
+                      },
+                      "log_error_verbosity": {
+                        "type": "string",
+                        "description": "log_error_verbosity",
+                        "optional": true
+                      },
+                      "log_min_duration_statement": {
+                        "type": "number",
+                        "description": "log_min_duration_statement",
+                        "optional": true
+                      },
+                      "max_locks_per_transaction": {
+                        "type": "number",
+                        "description": "max_locks_per_transaction",
+                        "optional": true
+                      },
+                      "max_parallel_workers": {
+                        "type": "number",
+                        "description": "max_parallel_workers",
+                        "optional": true
+                      },
+                      "max_parallel_workers_per_gather": {
+                        "type": "number",
+                        "description": "max_parallel_workers_per_gather",
+                        "optional": true
+                      },
+                      "max_pred_locks_per_transaction": {
+                        "type": "number",
+                        "description": "max_pred_locks_per_transaction",
+                        "optional": true
+                      },
+                      "max_prepared_transactions": {
+                        "type": "number",
+                        "description": "max_prepared_transactions",
+                        "optional": true
+                      },
+                      "max_stack_depth": {
+                        "type": "number",
+                        "description": "max_stack_depth",
+                        "optional": true
+                      },
+                      "max_standby_archive_delay": {
+                        "type": "number",
+                        "description": "max_standby_archive_delay",
+                        "optional": true
+                      },
+                      "max_standby_streaming_delay": {
+                        "type": "number",
+                        "description": "max_standby_streaming_delay",
+                        "optional": true
+                      },
+                      "max_worker_processes": {
+                        "type": "number",
+                        "description": "max_worker_processes",
+                        "optional": true
+                      },
+                      "pg_stat_statements__dot__track": {
+                        "type": "string",
+                        "description": "pg_stat_statements.track",
+                        "optional": true
+                      },
+                      "temp_file_limit": {
+                        "type": "number",
+                        "description": "temp_file_limit",
+                        "optional": true
+                      },
+                      "timezone": {
+                        "type": "string",
+                        "description": "timezone",
+                        "optional": true
+                      },
+                      "track_activity_query_size": {
+                        "type": "number",
+                        "description": "track_activity_query_size",
+                        "optional": true
+                      },
+                      "track_commit_timestamp": {
+                        "type": "string",
+                        "description": "track_commit_timestamp",
+                        "optional": true
+                      },
+                      "track_functions": {
+                        "type": "string",
+                        "description": "track_functions",
+                        "optional": true
+                      },
+                      "wal_sender_timeout": {
+                        "type": "number",
+                        "description": "wal_sender_timeout",
+                        "optional": true
+                      },
+                      "wal_writer_delay": {
+                        "type": "number",
+                        "description": "wal_writer_delay",
+                        "optional": true
+                      }
+                    }
+                  },
+                  "max_items": 1
+                },
+                "pgbouncer": {
+                  "nesting_mode": "list",
+                  "block": {
+                    "attributes": {
+                      "ignore_startup_parameters": {
+                        "type": [
+                          "list",
+                          "string"
+                        ],
+                        "description": "List of parameters to ignore when given in startup packet",
+                        "optional": true
+                      },
+                      "server_reset_query_always": {
+                        "type": "bool",
+                        "description": "Run server_reset_query (DISCARD ALL) in all pooling modes",
+                        "optional": true
+                      }
+                    }
+                  },
+                  "max_items": 1
+                },
+                "pglookout": {
+                  "nesting_mode": "list",
+                  "block": {
+                    "attributes": {
+                      "max_failover_replication_time_lag": {
+                        "type": "number",
+                        "description": "max_failover_replication_time_lag",
+                        "optional": true
+                      }
+                    }
+                  },
+                  "max_items": 1
+                },
+                "private_access": {
+                  "nesting_mode": "list",
+                  "block": {
+                    "attributes": {
+                      "pg": {
+                        "type": "string",
+                        "description": "Allow clients to connect to pg with a DNS name that always resolves to the service's private IP addresses. Only available in certain network locations",
+                        "optional": true
+                      },
+                      "pgbouncer": {
+                        "type": "string",
+                        "description": "Allow clients to connect to pgbouncer with a DNS name that always resolves to the service's private IP addresses. Only available in certain network locations",
+                        "optional": true
+                      },
+                      "prometheus": {
+                        "type": "string",
+                        "description": "Allow clients to connect to prometheus with a DNS name that always resolves to the service's private IP addresses. Only available in certain network locations",
+                        "optional": true
+                      }
+                    }
+                  },
+                  "max_items": 1
+                },
+                "public_access": {
+                  "nesting_mode": "list",
+                  "block": {
+                    "attributes": {
+                      "pg": {
+                        "type": "string",
+                        "description": "Allow clients to connect to pg from the public internet for service nodes that are in a project VPC or another type of private network",
+                        "optional": true
+                      },
+                      "pgbouncer": {
+                        "type": "string",
+                        "description": "Allow clients to connect to pgbouncer from the public internet for service nodes that are in a project VPC or another type of private network",
+                        "optional": true
+                      },
+                      "prometheus": {
+                        "type": "string",
+                        "description": "Allow clients to connect to prometheus from the public internet for service nodes that are in a project VPC or another type of private network",
+                        "optional": true
+                      }
+                    }
+                  },
+                  "max_items": 1
+                },
+                "timescaledb": {
+                  "nesting_mode": "list",
+                  "block": {
+                    "attributes": {
+                      "max_background_workers": {
+                        "type": "number",
+                        "description": "timescaledb.max_background_workers",
+                        "optional": true
+                      }
+                    }
+                  },
+                  "max_items": 1
+                }
+              }
+            },
+            "max_items": 1
+          },
+          "redis": {
+            "nesting_mode": "list",
+            "block": {},
+            "max_items": 1
+          },
+          "redis_user_config": {
+            "nesting_mode": "list",
+            "block": {
+              "attributes": {
+                "ip_filter": {
+                  "type": [
+                    "list",
+                    "string"
+                  ],
+                  "description": "IP filter",
+                  "optional": true
+                },
+                "redis_lfu_decay_time": {
+                  "type": "number",
+                  "description": "LFU maxmemory-policy counter decay time in minutes",
+                  "optional": true
+                },
+                "redis_lfu_log_factor": {
+                  "type": "number",
+                  "description": "Counter logarithm factor for volatile-lfu and allkeys-lfu maxmemory-policies",
+                  "optional": true
+                },
+                "redis_maxmemory_policy": {
+                  "type": "string",
+                  "description": "Redis maxmemory-policy",
+                  "optional": true
+                },
+                "redis_notify_keyspace_events": {
+                  "type": "string",
+                  "description": "Set notify-keyspace-events option",
+                  "optional": true
+                },
+                "redis_ssl": {
+                  "type": "bool",
+                  "description": "Require SSL to access Redis",
+                  "optional": true
+                },
+                "redis_timeout": {
+                  "type": "number",
+                  "description": "Redis idle connection timeout",
+                  "optional": true
+                }
+              },
+              "block_types": {
+                "migration": {
+                  "nesting_mode": "list",
+                  "block": {
+                    "attributes": {
+                      "host": {
+                        "type": "string",
+                        "description": "Hostname or IP address of the server where to migrate data from",
+                        "optional": true
+                      },
+                      "password": {
+                        "type": "string",
+                        "description": "Password for authentication with the server where to migrate data from",
+                        "optional": true,
+                        "sensitive": true
+                      },
+                      "port": {
+                        "type": "number",
+                        "description": "Port number of the server where to migrate data from",
+                        "optional": true
+                      },
+                      "ssl": {
+                        "type": "bool",
+                        "description": "The server where to migrate data from is secured with SSL",
+                        "optional": true
+                      },
+                      "username": {
+                        "type": "string",
+                        "description": "User name for authentication with the server where to migrate data from",
+                        "optional": true
+                      }
+                    }
+                  },
+                  "max_items": 1
+                },
+                "private_access": {
+                  "nesting_mode": "list",
+                  "block": {
+                    "attributes": {
+                      "prometheus": {
+                        "type": "string",
+                        "description": "Allow clients to connect to prometheus with a DNS name that always resolves to the service's private IP addresses. Only available in certain network locations",
+                        "optional": true
+                      },
+                      "redis": {
+                        "type": "string",
+                        "description": "Allow clients to connect to redis with a DNS name that always resolves to the service's private IP addresses. Only available in certain network locations",
+                        "optional": true
+                      }
+                    }
+                  },
+                  "max_items": 1
+                },
+                "public_access": {
+                  "nesting_mode": "list",
+                  "block": {
+                    "attributes": {
+                      "prometheus": {
+                        "type": "string",
+                        "description": "Allow clients to connect to prometheus from the public internet for service nodes that are in a project VPC or another type of private network",
+                        "optional": true
+                      },
+                      "redis": {
+                        "type": "string",
+                        "description": "Allow clients to connect to redis from the public internet for service nodes that are in a project VPC or another type of private network",
+                        "optional": true
+                      }
+                    }
+                  },
+                  "max_items": 1
+                }
+              }
+            },
+            "max_items": 1
+          },
+          "service_integrations": {
+            "nesting_mode": "list",
+            "block": {
+              "attributes": {
+                "integration_type": {
+                  "type": "string",
+                  "description": "Type of the service integration. The only supported value at the moment is 'read_replica'",
+                  "required": true
+                },
+                "source_service_name": {
+                  "type": "string",
+                  "description": "Name of the source service",
+                  "required": true
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "aiven_service_integration_endpoint": {
+      "version": 0,
+      "block": {
+        "attributes": {
+          "endpoint_config": {
+            "type": [
+              "map",
+              "string"
+            ],
+            "description": "Integration endpoint specific backend configuration",
+            "optional": true,
+            "computed": true
+          },
+          "endpoint_name": {
+            "type": "string",
+            "description": "Name of the service integration endpoint",
+            "required": true
+          },
+          "endpoint_type": {
+            "type": "string",
+            "description": "Type of the service integration endpoint",
+            "optional": true
+          },
+          "id": {
+            "type": "string",
+            "optional": true,
+            "computed": true
+          },
+          "project": {
+            "type": "string",
+            "description": "Project the service integration endpoint belongs to",
+            "required": true
+          }
+        },
+        "block_types": {
+          "datadog_user_config": {
+            "nesting_mode": "list",
+            "block": {
+              "attributes": {
+                "datadog_api_key": {
+                  "type": "string",
+                  "description": "Datadog API key",
+                  "optional": true,
+                  "sensitive": true
+                },
+                "disable_consumer_stats": {
+                  "type": "string",
+                  "description": "Disable consumer group metrics",
+                  "optional": true
+                },
+                "max_partition_contexts": {
+                  "type": "number",
+                  "description": "Maximum number of partition contexts to send",
+                  "optional": true
+                },
+                "site": {
+                  "type": "string",
+                  "description": "Datadog intake site. Defaults to datadoghq.com",
+                  "optional": true
+                }
+              }
+            },
+            "max_items": 1
+          },
+          "external_elasticsearch_logs_user_config": {
+            "nesting_mode": "list",
+            "block": {
+              "attributes": {
+                "ca": {
+                  "type": "string",
+                  "description": "PEM encoded CA certificate",
+                  "optional": true
+                },
+                "index_days_max": {
+                  "type": "number",
+                  "description": "Maximum number of days of logs to keep",
+                  "optional": true
+                },
+                "index_prefix": {
+                  "type": "string",
+                  "description": "Elasticsearch index prefix",
+                  "optional": true
+                },
+                "timeout": {
+                  "type": "number",
+                  "description": "Elasticsearch request timeout limit",
+                  "optional": true
+                },
+                "url": {
+                  "type": "string",
+                  "description": "Elasticsearch connection URL",
+                  "optional": true
+                }
+              }
+            },
+            "max_items": 1
+          },
+          "prometheus_user_config": {
+            "nesting_mode": "list",
+            "block": {
+              "attributes": {
+                "basic_auth_password": {
+                  "type": "string",
+                  "description": "Prometheus basic authentication password",
+                  "optional": true,
+                  "sensitive": true
+                },
+                "basic_auth_username": {
+                  "type": "string",
+                  "description": "Prometheus basic authentication username",
+                  "optional": true
+                }
+              }
+            },
+            "max_items": 1
+          },
+          "rsyslog_user_config": {
+            "nesting_mode": "list",
+            "block": {
+              "attributes": {
+                "ca": {
+                  "type": "string",
+                  "description": "PEM encoded CA certificate",
+                  "optional": true
+                },
+                "cert": {
+                  "type": "string",
+                  "description": "PEM encoded client certificate",
+                  "optional": true
+                },
+                "format": {
+                  "type": "string",
+                  "description": "message format",
+                  "optional": true
+                },
+                "key": {
+                  "type": "string",
+                  "description": "PEM encoded client key",
+                  "optional": true
+                },
+                "logline": {
+                  "type": "string",
+                  "description": "custom syslog message format",
+                  "optional": true
+                },
+                "port": {
+                  "type": "number",
+                  "description": "rsyslog server port",
+                  "optional": true
+                },
+                "sd": {
+                  "type": "string",
+                  "description": "Structured data block for log message",
+                  "optional": true
+                },
+                "server": {
+                  "type": "string",
+                  "description": "rsyslog server IP address or hostname",
+                  "optional": true
+                },
+                "tls": {
+                  "type": "bool",
+                  "description": "Require TLS",
+                  "optional": true
+                }
+              }
+            },
+            "max_items": 1
+          }
+        }
+      }
+    },
+    "aiven_service_user": {
+      "version": 0,
+      "block": {
+        "attributes": {
+          "access_cert": {
+            "type": "string",
+            "description": "Access certificate for the user if applicable for the service in question",
+            "optional": true,
+            "computed": true,
+            "sensitive": true
+          },
+          "access_key": {
+            "type": "string",
+            "description": "Access certificate key for the user if applicable for the service in question",
+            "optional": true,
+            "computed": true,
+            "sensitive": true
+          },
+          "id": {
+            "type": "string",
+            "optional": true,
+            "computed": true
+          },
+          "password": {
+            "type": "string",
+            "description": "Password of the user",
+            "optional": true,
+            "computed": true,
+            "sensitive": true
+          },
+          "project": {
+            "type": "string",
+            "description": "Project to link the user to",
+            "required": true
+          },
+          "service_name": {
+            "type": "string",
+            "description": "Service to link the user to",
+            "required": true
+          },
+          "type": {
+            "type": "string",
+            "description": "Type of the user account",
+            "optional": true,
+            "computed": true
+          },
+          "username": {
+            "type": "string",
+            "description": "Name of the user account",
+            "required": true
+          }
+        }
+      }
+    },
+    "aiven_vpc_peering_connection": {
+      "version": 0,
+      "block": {
+        "attributes": {
+          "id": {
+            "type": "string",
+            "optional": true,
+            "computed": true
+          },
+          "peer_cloud_account": {
+            "type": "string",
+            "description": "AWS account ID or GCP project ID of the peered VPC",
+            "required": true
+          },
+          "peer_region": {
+            "type": "string",
+            "description": "AWS region of the peered VPC (if not in the same region as Aiven VPC)",
+            "optional": true
+          },
+          "peer_vpc": {
+            "type": "string",
+            "description": "AWS VPC ID or GCP VPC network name of the peered VPC",
+            "required": true
+          },
+          "peering_connection_id": {
+            "type": "string",
+            "description": "Cloud provider identifier for the peering connection if available",
+            "optional": true,
+            "computed": true
+          },
+          "state": {
+            "type": "string",
+            "description": "State of the peering connection",
+            "optional": true,
+            "computed": true
+          },
+          "state_info": {
+            "type": [
+              "map",
+              "string"
+            ],
+            "description": "State-specific help or error information",
+            "optional": true,
+            "computed": true
+          },
+          "vpc_id": {
+            "type": "string",
+            "description": "The VPC the peering connection belongs to",
+            "required": true
+          }
+        },
+        "block_types": {
+          "client_timeout": {
+            "nesting_mode": "set",
+            "block": {
+              "attributes": {
+                "create": {
+                  "type": "string",
+                  "description": "create timeout",
+                  "optional": true
+                }
+              }
+            },
+            "max_items": 1
+          }
+        }
+      }
+    }
+  }
+}

--- a/scripts/template_all.md
+++ b/scripts/template_all.md
@@ -1,0 +1,6 @@
+---
+page_title: "Provider: Aiven"
+sidebar_current: "docs-aiven-index"
+description: |-
+  The Aiven Terraform Provider is a way to access all of your Aiven services within Terraform. Use this provider to set up and teardown services and test out configurations. Any issues, please email support@aiven.io
+---

--- a/scripts/template_ds.md
+++ b/scripts/template_ds.md
@@ -1,0 +1,6 @@
+---
+page_title: "Provider: Aiven Datasources"
+sidebar_current: "docs-aiven-datasources-index"
+description: |-
+  The Aiven Terraform Provider is a way to access all of your Aiven services within Terraform. Use this provider to set up and teardown services and test out configurations. Any issues, please email support@aiven.io
+---

--- a/scripts/template_re.md
+++ b/scripts/template_re.md
@@ -1,0 +1,6 @@
+---
+page_title: "Provider: Aiven Resources"
+sidebar_current: "docs-aiven-resources-index"
+description: |-
+  The Aiven Terraform Provider is a way to access all of your Aiven services within Terraform. Use this provider to set up and teardown services and test out configurations. Any issues, please email support@aiven.io
+---


### PR DESCRIPTION
Generating schema for provider from `terraform providers schema -json` (not in build task)
Add `docs` directory following format outlined in: https://www.terraform.io/docs/registry/providers/docs.html

- docs/
    - datasources/
    - resources/
    - guides/

Add scripts directory to generate documentation for `index.md` based on
schema. Others will need to be written manually.
Github Pages config added and using `Just the Docs` theme with search enabled.

Once merged, Github Pages needs to be enabled for `master docs/ folder`

Structure exists but docs are **WIP**