### PR TITLE
user configuration options refactoring

### DIFF
--- a/aiven/resource_kafka_topic_test.go
+++ b/aiven/resource_kafka_topic_test.go
@@ -46,7 +46,8 @@ func sweepKafkaTopics(region string) error {
 
 				topics, err := conn.KafkaTopics.List(project.Name, service.Name)
 				if err != nil {
-					return fmt.Errorf("error retrieving a list of kafka topics for a service `%s`: %s", service.Name, err)
+					log.Printf("[ERROR] error retrieving a list of kafka topics for a service `%s`: %s", service.Name, err)
+					continue
 				}
 
 				for _, topic := range topics {
@@ -200,8 +201,8 @@ func testAccKafkaTopicResource(name string) string {
 		}
 
 		data "aiven_kafka_topic" "topic" {
-			project = aiven_project.foo.project
-			service_name = aiven_service.bar.service_name
+			project = aiven_kafka_topic.foo.project
+			service_name = aiven_kafka_topic.foo.service_name
 			topic_name = aiven_kafka_topic.foo.topic_name
 		}
 		`, name, os.Getenv("AIVEN_CARD_ID"), name, name)
@@ -247,8 +248,8 @@ func testAccKafkaTopicCustomTimeoutsResource(name string) string {
 		}
 
 		data "aiven_kafka_topic" "topic" {
-			project = aiven_project.foo.project
-			service_name = aiven_service.bar.service_name
+			project = aiven_kafka_topic.foo.project
+			service_name = aiven_kafka_topic.foo.service_name
 			topic_name = aiven_kafka_topic.foo.topic_name
 		}
 		`, name, os.Getenv("AIVEN_CARD_ID"), name, name)
@@ -289,8 +290,8 @@ func testAccKafkaTopicTerminationProtectionResource(name string) string {
 		}
 
 		data "aiven_kafka_topic" "topic" {
-			project = aiven_project.foo.project
-			service_name = aiven_service.bar.service_name
+			project = aiven_kafka_topic.foo.project
+			service_name = aiven_kafka_topic.foo.service_name
 			topic_name = aiven_kafka_topic.foo.topic_name
 		}
 		`, name, os.Getenv("AIVEN_CARD_ID"), name, name)

--- a/aiven/resource_service_cassandra_test.go
+++ b/aiven/resource_service_cassandra_test.go
@@ -85,7 +85,7 @@ func testAccCheckAivenServiceCassandraAttributes(n string) resource.TestCheckFun
 			return fmt.Errorf("expected to get a correct public_access.prometheus from Aiven")
 		}
 
-		if a["cassandra_user_config.0.service_to_fork_from"] != "<<value not set>>" {
+		if a["cassandra_user_config.0.service_to_fork_from"] != "" {
 			return fmt.Errorf("expected to get a correct public_access.service_to_fork_from from Aiven")
 		}
 

--- a/aiven/resource_service_elasticsearch_test.go
+++ b/aiven/resource_service_elasticsearch_test.go
@@ -121,7 +121,7 @@ func testAccCheckAivenServiceESAttributes(n string) resource.TestCheckFunc {
 			return fmt.Errorf("expected to get elasticsearch.public_access enabled for Kibana from Aiven")
 		}
 
-		if a["elasticsearch_user_config.0.public_access.0.prometheus"] != "<<value not set>>" {
+		if a["elasticsearch_user_config.0.public_access.0.prometheus"] != "" {
 			return fmt.Errorf("expected to get a correct public_access prometheus from Aiven")
 		}
 

--- a/aiven/resource_service_kafka_connect_test.go
+++ b/aiven/resource_service_kafka_connect_test.go
@@ -87,11 +87,11 @@ func testAccCheckAivenServiceKafkaConnectAttributes(n string) resource.TestCheck
 			return fmt.Errorf("expected to get a correct consumer_isolation_level from Aiven")
 		}
 
-		if a["kafka_connect_user_config.0.kafka_connect.0.consumer_max_poll_records"] != "-1" {
+		if a["kafka_connect_user_config.0.kafka_connect.0.consumer_max_poll_records"] != "" {
 			return fmt.Errorf("expected to get a correct consumer_max_poll_records from Aiven")
 		}
 
-		if a["kafka_connect_user_config.0.kafka_connect.0.offset_flush_interval_ms"] != "-1" {
+		if a["kafka_connect_user_config.0.kafka_connect.0.offset_flush_interval_ms"] != "" {
 			return fmt.Errorf("expected to get a correct offset_flush_interval_ms from Aiven")
 		}
 
@@ -99,7 +99,7 @@ func testAccCheckAivenServiceKafkaConnectAttributes(n string) resource.TestCheck
 			return fmt.Errorf("expected to get a correct public_access.kafka_connect from Aiven")
 		}
 
-		if a["kafka_connect_user_config.0.public_access.0.prometheus"] != "<<value not set>>" {
+		if a["kafka_connect_user_config.0.public_access.0.prometheus"] != "" {
 			return fmt.Errorf("expected to get a correct public_access.prometheus from Aiven")
 		}
 

--- a/aiven/resource_service_kafka_test.go
+++ b/aiven/resource_service_kafka_test.go
@@ -110,11 +110,11 @@ func testAccCheckAivenServiceKafkaAttributes(n string) resource.TestCheckFunc {
 			return fmt.Errorf("expected to get a correct public_access.kafka_rest from Aiven")
 		}
 
-		if a["kafka_user_config.0.public_access.0.kafka"] != "<<value not set>>" {
+		if a["kafka_user_config.0.public_access.0.kafka"] != "" {
 			return fmt.Errorf("expected to get a correct public_access.kafka from Aiven")
 		}
 
-		if a["kafka_user_config.0.public_access.0.prometheus"] != "<<value not set>>" {
+		if a["kafka_user_config.0.public_access.0.prometheus"] != "" {
 			return fmt.Errorf("expected to get a correct public_access.prometheus from Aiven")
 		}
 

--- a/aiven/resource_service_mysql_test.go
+++ b/aiven/resource_service_mysql_test.go
@@ -98,7 +98,7 @@ func testAccCheckAivenServiceMysqlAttributes(n string) resource.TestCheckFunc {
 			return fmt.Errorf("expected to get a correct mysql_version from Aiven")
 		}
 
-		if a["mysql_user_config.0.public_access.0.prometheus"] != "<<value not set>>" {
+		if a["mysql_user_config.0.public_access.0.prometheus"] != "" {
 			return fmt.Errorf("expected to get a correct public_access.prometheus from Aiven")
 		}
 

--- a/aiven/resource_service_pg_test.go
+++ b/aiven/resource_service_pg_test.go
@@ -59,7 +59,6 @@ func TestAccAivenService_pg(t *testing.T) {
 			{
 				Config:                    testAccPGReadReplicaServiceResource(rName),
 				PreventPostDestroyRefresh: true,
-				ExpectNonEmptyPlan:        true,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAivenServiceCommonAttributes("data.aiven_service.service-pg"),
 					testAccCheckAivenServicePGAttributes("data.aiven_service.service-pg"),
@@ -254,6 +253,8 @@ func testAccPGReadReplicaServiceResource(name string) string {
 			maintenance_window_time = "10:00:00"
 			
 			pg_user_config {
+				backup_hour = 19
+				backup_minute = 30
 				pg_version = 11
 
 				public_access {
@@ -354,7 +355,7 @@ func testAccCheckAivenServicePGAttributes(n string) resource.TestCheckFunc {
 			return fmt.Errorf("expected to get a correct PG public_access from Aiven")
 		}
 
-		if a["pg_user_config.0.public_access.0.pgbouncer"] != "<<value not set>>" {
+		if a["pg_user_config.0.public_access.0.pgbouncer"] != "" {
 			return fmt.Errorf("expected to get a correct PG public_access from Aiven")
 		}
 
@@ -382,7 +383,7 @@ func testAccCheckAivenServicePGAttributes(n string) resource.TestCheckFunc {
 			return fmt.Errorf("expected to get a PG URI from Aiven")
 		}
 
-		if a["pg_user_config.0.service_to_fork_from"] != "<<value not set>>" {
+		if a["pg_user_config.0.service_to_fork_from"] != "" {
 			return fmt.Errorf("expected to get a PG service_to_fork_from not set to any value")
 		}
 

--- a/aiven/resource_service_redis_test.go
+++ b/aiven/resource_service_redis_test.go
@@ -89,7 +89,7 @@ func testAccCheckAivenServiceRedisAttributes(n string) resource.TestCheckFunc {
 			return fmt.Errorf("expected to get a correct public_access.redis from Aiven")
 		}
 
-		if a["redis_user_config.0.public_access.0.prometheus"] != "<<value not set>>" {
+		if a["redis_user_config.0.public_access.0.prometheus"] != "" {
 			return fmt.Errorf("expected to get a correct public_access.prometheus from Aiven")
 		}
 

--- a/aiven/user_config.go
+++ b/aiven/user_config.go
@@ -56,10 +56,13 @@ func GenerateTerraformUserConfigSchema(data map[string]interface{}) map[string]*
 	for name, definitionRaw := range properties {
 		definition := definitionRaw.(map[string]interface{})
 
-		t, op := getAivenSchemaType(definition["type"])
-		if d, ok := definition["default"]; (!ok || op || d == nil) && t == "boolean" {
+		t, _ := getAivenSchemaType(definition["type"])
+		// Types for all configuration option fields except object and array convert to Terraform
+		// string type, and original type is preserved in an api_type fields for backwards
+		// compatibility with Aiven API.
+		if t != "object" && t != "array" {
 			definition["type"] = "string"
-			definition["api_type"] = "boolean"
+			definition["api_type"] = t
 		}
 
 		terraformSchema[encodeKeyName(name)] = generateTerraformUserConfigSchema(name, definition)
@@ -71,49 +74,22 @@ func GenerateTerraformUserConfigSchema(data map[string]interface{}) map[string]*
 func generateTerraformUserConfigSchema(key string, definition map[string]interface{}) *schema.Schema {
 	valueType, _ := getAivenSchemaType(definition["type"])
 	sensitive := false
+
 	if strings.Contains(key, "api_key") || strings.Contains(key, "password") {
 		sensitive = true
 	}
+
 	var diffFunction schema.SchemaDiffSuppressFunc
 	if createOnly, ok := definition["createOnly"]; ok && createOnly.(bool) {
 		diffFunction = createOnlyDiffSuppressFunc
 	} else if valueType == "object" {
 		diffFunction = emptyObjectDiffSuppressFunc
 	}
+
 	defaultValue := getAivenSchemaDefaultValue(definition)
 	title := definition["title"].(string)
+
 	switch valueType {
-	case "number":
-		return &schema.Schema{
-			Default:          defaultValue,
-			Description:      title,
-			DiffSuppressFunc: diffFunction,
-			Optional:         true,
-			Sensitive:        sensitive,
-			Type:             schema.TypeFloat,
-		}
-	case "integer":
-		_, isFloat := defaultValue.(float64)
-		if isFloat {
-			defaultValue = int(defaultValue.(float64))
-		}
-		return &schema.Schema{
-			Default:          defaultValue,
-			Description:      title,
-			DiffSuppressFunc: diffFunction,
-			Optional:         true,
-			Sensitive:        sensitive,
-			Type:             schema.TypeInt,
-		}
-	case "boolean":
-		return &schema.Schema{
-			Default:          defaultValue,
-			Description:      title,
-			DiffSuppressFunc: diffFunction,
-			Optional:         true,
-			Sensitive:        sensitive,
-			Type:             schema.TypeBool,
-		}
 	case "string":
 		return &schema.Schema{
 			Default:          defaultValue,
@@ -207,21 +183,20 @@ func getAivenSchemaType(value interface{}) (string, bool) {
 func getAivenSchemaDefaultValue(definition map[string]interface{}) interface{} {
 	valueType, _ := getAivenSchemaType(definition["type"])
 	defaultValue, ok := definition["default"]
-	if !ok && valueType == "number" {
-		defaultValue = -1.0
-	} else if !ok && valueType == "integer" {
-		defaultValue = -1
-	} else if (!ok || defaultValue == nil) && valueType == "boolean" {
-		defaultValue = false
-	} else if (!ok || defaultValue == nil) && valueType == "string" {
-		// Terraform has no way of indicating unset values.
-		// Convert "<<value not set>>" to unset when handling request
-		defaultValue = "<<value not set>>"
-	} else if valueType == "array" {
-		defaultValue = []interface{}{}
-	} else if valueType == "object" {
-		defaultValue = []map[string]interface{}{}
+	if !ok || defaultValue == nil {
+		defaultValue = ""
+
+		if valueType == "string" {
+			// Terraform has no way of indicating unset values.
+			// Convert "<<value not set>>" to unset when handling request
+			defaultValue = ""
+		} else if valueType == "array" {
+			defaultValue = []interface{}{}
+		} else if valueType == "object" {
+			defaultValue = []map[string]interface{}{}
+		}
 	}
+
 	return defaultValue
 }
 
@@ -250,68 +225,40 @@ func convertAPIUserConfigToTerraformCompatibleFormat(
 	for key, schemaDefinitionRaw := range jsonSchema {
 		schemaDefinition := schemaDefinitionRaw.(map[string]interface{})
 
-		var valueType string
-		if t, ok := schemaDefinition["api_type"]; ok {
-			valueType = t.(string)
-		} else {
-			valueType, _ = getAivenSchemaType(schemaDefinition["type"])
-		}
+		valueType, _ := getAivenSchemaType(schemaDefinition["type"])
 
 		apiValue, ok := apiUserConfig[key]
 		key = encodeKeyName(key)
 		if !ok || apiValue == nil {
 			// To avoid undesired "changes" for values that are not explicitly defined return
 			// default values for anything that is not returned in the API response
-			terraformConfig[key] = getAivenSchemaDefaultValue(schemaDefinition)
-			continue
+			apiValue = getAivenSchemaDefaultValue(schemaDefinition)
+			if valueType == "object" {
+				continue
+			}
 		}
+
 		switch valueType {
+		case "string":
+			switch value := apiValue.(type) {
+			case string:
+				terraformConfig[key] = apiValue
+			case bool:
+				terraformConfig[key] = strconv.FormatBool(apiValue.(bool))
+			case float64:
+				terraformConfig[key] = strconv.FormatFloat(apiValue.(float64), 'f', -1, 64)
+			case float32:
+				terraformConfig[key] = strconv.FormatFloat(apiValue.(float64), 'f', -1, 32)
+			case int:
+				terraformConfig[key] = strconv.Itoa(apiValue.(int))
+			default:
+				panic(fmt.Sprintf("Invalid user config key type %T for %v", value, key))
+			}
 		case "object":
 			res := convertAPIUserConfigToTerraformCompatibleFormat(
 				apiValue.(map[string]interface{}), schemaDefinition["properties"].(map[string]interface{}),
 			)
 			terraformConfig[key] = []map[string]interface{}{res}
-		case "integer":
-			switch res := apiValue.(type) {
-			case float64:
-				terraformConfig[key] = int(res)
-			case float32:
-				terraformConfig[key] = int(res)
-			case int64:
-				terraformConfig[key] = int(res)
-			case int32:
-				terraformConfig[key] = int(res)
-			default:
-				panic(fmt.Sprintf("Unexpected value type for '%v': %v / %T", key, apiValue, apiValue))
-			}
-		case "number":
-			switch res := apiValue.(type) {
-			case float64:
-				terraformConfig[key] = res
-			case float32:
-				terraformConfig[key] = float64(res)
-			case int64:
-				terraformConfig[key] = float64(res)
-			case int32:
-				terraformConfig[key] = float64(res)
-			default:
-				panic(fmt.Sprintf("Unexpected value type for '%v': %v / %T", key, apiValue, apiValue))
-			}
-		case "boolean":
-			switch value := apiValue.(type) {
-			case string:
-				terraformConfig[key] = apiValue
-			case bool:
-				_, ok := schemaDefinition["api_type"]
-				if ok {
-					terraformConfig[key] = strconv.FormatBool(apiValue.(bool))
-				} else {
-					terraformConfig[key] = apiValue
-				}
-			default:
-				panic(fmt.Sprintf("Invalid user config key type %T for %v, expected string or boolean",
-					value, key))
-			}
 		default:
 			terraformConfig[key] = apiValue
 		}
@@ -346,6 +293,7 @@ func convertTerraformUserConfigToAPICompatibleFormat(
 	configSchema map[string]interface{},
 ) map[string]interface{} {
 	apiConfig := make(map[string]interface{})
+
 	for key, value := range userConfig {
 		key = decodeKeyName(key)
 		definitionRaw, ok := configSchema[key]
@@ -366,6 +314,7 @@ func convertTerraformUserConfigToAPICompatibleFormat(
 			apiConfig[key] = convertedValue
 		}
 	}
+
 	return apiConfig
 }
 
@@ -376,9 +325,16 @@ func convertTerraformUserConfigValueToAPICompatibleFormat(
 	value interface{},
 	definition map[string]interface{},
 ) (interface{}, bool) {
-	convertedValue := value
-	omit := false
+	var err error
+	var omit bool
+	var convertedValue = value
 
+	// for backwards compatibility reasons omit -1 and <<value not set>>
+	if value == "" || value == "<<value not set>>" || value == "-1" {
+		return nil, true
+	}
+
+	// get Aiven API value type
 	var valueType string
 	if t, ok := definition["api_type"]; ok {
 		valueType = t.(string)
@@ -388,118 +344,179 @@ func convertTerraformUserConfigValueToAPICompatibleFormat(
 
 	switch valueType {
 	case "integer":
-		switch res := value.(type) {
-		case int:
-		case int64:
-			convertedValue = int(res)
-		case int32:
-			convertedValue = int(res)
-		default:
-			panic(fmt.Sprintf("Invalid %v user config key type %T for %v, expected integer", serviceType, value, key))
-		}
-		minimum, hasMin := definition["minimum"]
-		if hasMin && value.(int) < int(minimum.(float64)) {
-			omit = true
-		}
+		convertedValue, err = convertTerraformUserConfigValueToAPICompatibleFormatInteger(value)
 	case "number":
-		switch res := value.(type) {
-		case float64:
-		case float32:
-			convertedValue = float64(res)
-		case int64:
-			convertedValue = float64(res)
-		case int32:
-			convertedValue = float64(res)
-		case int:
-			convertedValue = float64(res)
-		default:
-			panic(fmt.Sprintf("Invalid %v user config key type %T for %v, expected float", serviceType, value, key))
-		}
-		minimum, hasMin := definition["minimum"]
-		if hasMin && value.(float64) < minimum.(float64) {
-			omit = true
-		}
+		convertedValue, err = convertTerraformUserConfigValueToAPICompatibleFormatNumber(value)
 	case "boolean":
-		switch value := value.(type) {
-		case string:
-			if value == "<<value not set>>" {
-				omit = true
-			} else {
-				b, err := strconv.ParseBool(value)
-				if err != nil {
-					panic(fmt.Sprintf("Invalid %v user config key type %T for %v, a string is expected "+
-						"that can be parsed as boolean, error : %s", serviceType, value, key, err.Error()))
-				}
-				convertedValue = b
-			}
-		case bool:
-			convertedValue = value
-		default:
-			panic(fmt.Sprintf("Invalid %v user config key type %T for %v, expected string or boolean",
-				serviceType, value, key))
+		convertedValue, err = convertTerraformUserConfigValueToAPICompatibleFormatBoolean(value)
+	case "string":
+		convertedValue, err = convertTerraformUserConfigValueToAPICompatibleFormatString(value)
+	case "object":
+		convertedValue, omit, err = convertTerraformUserConfigValueToAPICompatibleFormatObject(
+			value, serviceType, newResource, definition)
+	case "array":
+		convertedValue, omit, err = convertTerraformUserConfigValueToAPICompatibleFormatArray(
+			value, serviceType, newResource, key, definition)
+	default:
+		err = fmt.Errorf("unsupported value type %v for %v user config key %v", definition["type"], serviceType, key)
+	}
+
+	if err != nil {
+		panic(fmt.Sprintf("unable to convert %v user config key type %T for %v: err %s",
+			serviceType, value, key, err))
+	}
+
+	return convertedValue, omit
+}
+
+func convertTerraformUserConfigValueToAPICompatibleFormatArray(value interface{},
+	serviceType string,
+	newResource bool,
+	key string,
+	definition map[string]interface{}) (interface{}, bool, error) {
+	var convertedValue interface{}
+	var omit bool
+
+	// when value is nil
+	if value == nil {
+		return nil, true, nil
+	}
+
+	switch value.(type) {
+	case []interface{}:
+		asArray := value.([]interface{})
+
+		if len(asArray) == 0 {
+			return nil, true, nil
 		}
 
-	case "string":
-		switch value.(type) {
-		case string:
-			if value == "<<value not set>>" {
-				omit = true
-			}
-		default:
-			panic(fmt.Sprintf("Invalid %v user config key type %T for %v, expected string", serviceType, value, key))
+		values := make([]interface{}, len(value.([]interface{})))
+		itemDefinition := definition["items"].(map[string]interface{})
+		for idx, arrValue := range asArray {
+			arrValueConverted, _ := convertTerraformUserConfigValueToAPICompatibleFormat(
+				serviceType, newResource, key, arrValue, itemDefinition)
+			values[idx] = arrValueConverted
 		}
-	case "object":
-		if value == nil {
+
+		convertedValue = values
+	default:
+		return nil, false, fmt.Errorf("invalid %v user config key type %T for %v, expected list", serviceType, value, key)
+	}
+
+	return convertedValue, omit, nil
+}
+
+func convertTerraformUserConfigValueToAPICompatibleFormatObject(
+	value interface{},
+	serviceType string,
+	newResource bool,
+	definition map[string]interface{}) (interface{}, bool, error) {
+	var convertedValue interface{}
+
+	// when value is nil
+	if value == nil {
+		return nil, true, nil
+	}
+
+	// when value is TypeList
+	if asList, isList := value.([]interface{}); isList {
+		var omit bool
+		if len(asList) == 0 || (len(asList) == 1 && asList[0] == nil) {
 			omit = true
 		} else {
-			if asList, isList := value.([]interface{}); isList {
-				if len(asList) == 0 || (len(asList) == 1 && asList[0] == nil) {
-					omit = true
-				} else {
-					asMap := asList[0].(map[string]interface{})
-					if len(asMap) == 0 {
-						omit = true
-					} else {
-						convertedValue = convertTerraformUserConfigToAPICompatibleFormat(
-							serviceType, newResource, asMap, definition["properties"].(map[string]interface{}),
-						)
-					}
-				}
-			} else if asMap, isMap := value.(map[string]interface{}); isMap {
+			asMap := asList[0].(map[string]interface{})
+			if len(asMap) == 0 {
+				omit = true
+			} else {
 				convertedValue = convertTerraformUserConfigToAPICompatibleFormat(
 					serviceType, newResource, asMap, definition["properties"].(map[string]interface{}),
 				)
-			} else {
-				panic(fmt.Sprintf("Invalid %v user config key type %T for %v, expected map", serviceType, value, key))
 			}
 		}
-	case "array":
-		if value == nil {
-			omit = true
-		} else {
-			switch value.(type) {
-			case []interface{}:
-			default:
-				panic(fmt.Sprintf("Invalid %v user config key type %T for %v, expected list", serviceType, value, key))
-			}
-			asArray := value.([]interface{})
-			if len(asArray) == 0 {
-				omit = true
-			} else {
-				values := make([]interface{}, len(value.([]interface{})))
-				itemDefinition := definition["items"].(map[string]interface{})
-				for idx, arrValue := range asArray {
-					arrValueConverted, _ := convertTerraformUserConfigValueToAPICompatibleFormat(
-						serviceType, newResource, key, arrValue, itemDefinition)
-					values[idx] = arrValueConverted
-				}
-				convertedValue = values
-			}
+
+		return convertedValue, omit, nil
+	}
+
+	// when value is TypeMap
+	if asMap, isMap := value.(map[string]interface{}); isMap {
+		convertedValue = convertTerraformUserConfigToAPICompatibleFormat(
+			serviceType, newResource, asMap, definition["properties"].(map[string]interface{}),
+		)
+
+		return convertedValue, false, nil
+	}
+
+	return nil, false, fmt.Errorf("expected map but got %s", value)
+}
+
+func convertTerraformUserConfigValueToAPICompatibleFormatInteger(value interface{}) (int, error) {
+	var convertedValue int
+
+	switch value.(type) {
+	case int:
+		convertedValue = value.(int)
+	case string:
+		var err error
+		convertedValue, err = strconv.Atoi(value.(string))
+		if err != nil {
+			return 0, fmt.Errorf("impossible to convert int to a string: %s", err)
 		}
 	default:
-		panic(fmt.Sprintf("Unsupported value type %v for %v user config key %v", definition["type"], serviceType, key))
+		return 0, fmt.Errorf("expected int or string but got %s", value)
 	}
-	return convertedValue, omit
+
+	return convertedValue, nil
+}
+
+func convertTerraformUserConfigValueToAPICompatibleFormatNumber(value interface{}) (float64, error) {
+	var convertedValue float64
+
+	switch res := value.(type) {
+	case float64:
+		convertedValue = res
+	case string:
+		var err error
+		convertedValue, err = strconv.ParseFloat(value.(string), 64)
+		if err != nil {
+			return 0, fmt.Errorf("impossible to convert float64 to a string: %s", err)
+		}
+	default:
+		return 0, fmt.Errorf("expected float64 or string but got %s", value)
+	}
+
+	return convertedValue, nil
+}
+
+func convertTerraformUserConfigValueToAPICompatibleFormatBoolean(value interface{}) (bool, error) {
+	var convertedValue bool
+
+	switch value := value.(type) {
+	case string:
+		var err error
+		convertedValue, err = strconv.ParseBool(value)
+		if err != nil {
+			return false, err
+		}
+	case bool:
+		convertedValue = value
+	default:
+		return false, fmt.Errorf("expected boolean or string but got %s", value)
+	}
+
+	return convertedValue, nil
+}
+
+func convertTerraformUserConfigValueToAPICompatibleFormatString(value interface{}) (string, error) {
+	var convertedValue string
+
+	switch value.(type) {
+	case string:
+		convertedValue = value.(string)
+	default:
+		return "", fmt.Errorf("expected string but got %s", value)
+	}
+
+	return convertedValue, nil
 }
 
 func encodeKeyName(key string) string {

--- a/aiven/user_config_test.go
+++ b/aiven/user_config_test.go
@@ -130,7 +130,7 @@ func TestGenerateTerraformUserConfigSchema(t *testing.T) {
 					Sensitive:        true,
 					DiffSuppressFunc: createOnlyDiffSuppressFunc,
 					Description:      "Custom password for admin user",
-					Default:          "<<value not set>>",
+					Default:          "",
 				},
 			},
 			false,
@@ -241,104 +241,7 @@ func TestGenerateTerraformUserConfigSchema(t *testing.T) {
 	}
 }
 
-func TestConvertAPIUserConfigToTerraformCompatibleFormat(t *testing.T) {
-	type args struct {
-		configType string
-		entryType  string
-		userConfig map[string]interface{}
-	}
-	tests := []struct {
-		name  string
-		args  args
-		want  []map[string]interface{}
-		panic bool
-	}{
-		{
-			"basic-kafka",
-			args{
-				configType: "service",
-				entryType:  "kafka",
-				userConfig: map[string]interface{}{
-					"custom_domain": nil,
-					"ip_filter": []interface{}{
-						"0.0.0.0/0",
-					},
-					"kafka": map[string]interface{}{
-						"auto_create_topics_enable":    true,
-						"connections_max_idle_ms":      int32(10),
-						"group_max_session_timeout_ms": int32(300000),
-					},
-					"kafka_authentication_methods": map[string]interface{}{
-						"certificate": true,
-						"sasl":        false,
-					},
-					"kafka_connect":   false,
-					"kafka_rest":      false,
-					"schema_registry": false,
-					"kafka_version":   "2.1",
-				},
-			},
-			[]map[string]interface{}{
-				{
-					"custom_domain": "<<value not set>>",
-					"ip_filter": []interface{}{
-						"0.0.0.0/0",
-					},
-					"kafka": []map[string]interface{}{
-						{
-							"log_cleanup_policy":                         "delete",
-							"auto_create_topics_enable":                  "true",
-							"compression_type":                           "<<value not set>>",
-							"connections_max_idle_ms":                    10,
-							"default_replication_factor":                 -1,
-							"group_max_session_timeout_ms":               300000,
-							"group_min_session_timeout_ms":               float64(6000),
-							"log_cleaner_max_compaction_lag_ms":          -1,
-							"log_cleaner_min_cleanable_ratio":            0.5,
-							"log_cleaner_min_compaction_lag_ms":          -1,
-							"log_message_timestamp_difference_max_ms":    -1,
-							"log_message_timestamp_type":                 "<<value not set>>",
-							"log_retention_bytes":                        -1,
-							"log_retention_hours":                        -1,
-							"log_segment_bytes":                          -1,
-							"max_connections_per_ip":                     -1,
-							"message_max_bytes":                          1.000012e+06,
-							"num_partitions":                             -1,
-							"offsets_retention_minutes":                  float64(1440),
-							"producer_purgatory_purge_interval_requests": -1,
-							"replica_fetch_max_bytes":                    -1,
-							"replica_fetch_response_max_bytes":           -1,
-							"socket_request_max_bytes":                   -1,
-						},
-					},
-					"kafka_authentication_methods": []map[string]interface{}{
-						{
-							"certificate": true,
-							"sasl":        false,
-						},
-					},
-					"kafka_connect":        false,
-					"kafka_connect_config": []map[string]interface{}{},
-					"kafka_rest":           false,
-					"kafka_rest_config":    []map[string]interface{}{},
-					"kafka_version":        "2.1",
-					"private_access":       []map[string]interface{}{},
-					"public_access":        []map[string]interface{}{},
-					"schema_registry":      false,
-				},
-			},
-			false,
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got := ConvertAPIUserConfigToTerraformCompatibleFormat(tt.args.configType, tt.args.entryType, tt.args.userConfig)
-			assert.Equal(t, got, tt.want)
-		})
-	}
-}
-
-func Test_convertTerraformUserConfigToAPICompatibleFormat1(t *testing.T) {
+func Test_convertTerraformUserConfigToAPICompatibleFormat(t *testing.T) {
 	entrySchema := GetUserConfigSchema("service")["kafka"].(map[string]interface{})
 	entrySchemaProps := entrySchema["properties"].(map[string]interface{})
 
@@ -359,33 +262,17 @@ func Test_convertTerraformUserConfigToAPICompatibleFormat1(t *testing.T) {
 				serviceType: "kafka",
 				newResource: false,
 				userConfig: map[string]interface{}{
-					"custom_domain": "<<value not set>>",
 					"ip_filter": []interface{}{
 						"0.0.0.0/0",
 					},
 					"kafka": map[string]interface{}{
-						"auto_create_topics_enable":                  "true",
-						"compression_type":                           "<<value not set>>",
-						"connections_max_idle_ms":                    1001,
-						"default_replication_factor":                 -1,
-						"group_max_session_timeout_ms":               300000,
-						"group_min_session_timeout_ms":               6000,
-						"log_cleaner_max_compaction_lag_ms":          -1,
-						"log_cleaner_min_cleanable_ratio":            0.5,
-						"log_cleaner_min_compaction_lag_ms":          -1,
-						"log_message_timestamp_difference_max_ms":    -1,
-						"log_message_timestamp_type":                 "<<value not set>>",
-						"log_retention_bytes":                        -1,
-						"log_retention_hours":                        -1,
-						"log_segment_bytes":                          -1,
-						"max_connections_per_ip":                     -1,
-						"message_max_bytes":                          1,
-						"num_partitions":                             -1,
-						"offsets_retention_minutes":                  1440,
-						"producer_purgatory_purge_interval_requests": -1,
-						"replica_fetch_max_bytes":                    -1,
-						"replica_fetch_response_max_bytes":           -1,
-						"socket_request_max_bytes":                   -1,
+						"auto_create_topics_enable":       "true",
+						"connections_max_idle_ms":         1001,
+						"group_max_session_timeout_ms":    300000,
+						"group_min_session_timeout_ms":    6000,
+						"log_cleaner_min_cleanable_ratio": 0.5,
+						"message_max_bytes":               1,
+						"offsets_retention_minutes":       1440,
 					},
 					"kafka_authentication_methods": map[string]interface{}{
 						"certificate": true,
@@ -412,8 +299,6 @@ func Test_convertTerraformUserConfigToAPICompatibleFormat1(t *testing.T) {
 					"group_max_session_timeout_ms":    300000,
 					"group_min_session_timeout_ms":    6000,
 					"log_cleaner_min_cleanable_ratio": 0.5,
-					"log_retention_bytes":             -1,
-					"log_retention_hours":             -1,
 					"message_max_bytes":               1,
 					"offsets_retention_minutes":       1440,
 				},

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,11 @@ require (
 	github.com/aiven/aiven-go-client v1.5.5
 	github.com/gobuffalo/packr/v2 v2.8.0
 	github.com/hashicorp/terraform v0.12.0
+	github.com/karrick/godirwalk v1.15.6 // indirect
+	github.com/rogpeppe/go-internal v1.6.0 // indirect
+	github.com/sirupsen/logrus v1.6.0 // indirect
 	github.com/stretchr/testify v1.5.1
-	golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e
+	golang.org/x/crypto v0.0.0-20200510223506-06a226fb4e37 // indirect
+	golang.org/x/sync v0.0.0-20200317015054-43a5402ce75a
+	golang.org/x/sys v0.0.0-20200515095857-1151b9dac4a9 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -210,6 +210,8 @@ github.com/kardianos/osext v0.0.0-20170510131534-ae77be60afb1/go.mod h1:1NbS8ALr
 github.com/kardianos/osext v0.0.0-20190222173326-2bc1f35cddc0/go.mod h1:1NbS8ALrpOvjt0rHPNLyCIeMtbizbir8U//inJ+zuB8=
 github.com/karrick/godirwalk v1.15.3 h1:0a2pXOgtB16CqIqXTiT7+K9L73f74n/aNQUnH6Ortew=
 github.com/karrick/godirwalk v1.15.3/go.mod h1:j4mkqPuvaLI8mp1DroR3P6ad7cyYd4c1qeJ3RV7ULlk=
+github.com/karrick/godirwalk v1.15.6 h1:Yf2mmR8TJy+8Fa0SuQVto5SYap6IF7lNVX4Jdl8G1qA=
+github.com/karrick/godirwalk v1.15.6/go.mod h1:j4mkqPuvaLI8mp1DroR3P6ad7cyYd4c1qeJ3RV7ULlk=
 github.com/keybase/go-crypto v0.0.0-20161004153544-93f5b35093ba/go.mod h1:ghbZscTyKdM07+Fw3KSi0hcJm+AlEUWj8QLlPtijN/M=
 github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvWXihfKN4Q=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
@@ -218,6 +220,8 @@ github.com/konsorten/go-windows-terminal-sequences v1.0.1 h1:mweAR1A6xJ3oS2pRaGi
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/konsorten/go-windows-terminal-sequences v1.0.2 h1:DB17ag19krx9CFsz4o3enTrPXyIXCl+2iCXH/aMAp9s=
 github.com/konsorten/go-windows-terminal-sequences v1.0.2/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
+github.com/konsorten/go-windows-terminal-sequences v1.0.3 h1:CE8S1cTafDpPvMhIxNJKvHsGVBgn1xWYf1NbHQhywc8=
+github.com/konsorten/go-windows-terminal-sequences v1.0.3/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFBFZlji/RkVcI2GknAs/DXo4wKdlNEc=
 github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
@@ -313,6 +317,8 @@ github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40T
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=
 github.com/rogpeppe/go-internal v1.5.2 h1:qLvObTrvO/XRCqmkKxUlOBc48bI3efyDuAZe25QiF0w=
 github.com/rogpeppe/go-internal v1.5.2/go.mod h1:xXDCJY+GAPziupqXw64V24skbSoqbTEfhy4qGm1nDQc=
+github.com/rogpeppe/go-internal v1.6.0 h1:IZRgg4sfrDH7nsAD1Y/Nwj+GzIfEwpJSLjCaNC3SbsI=
+github.com/rogpeppe/go-internal v1.6.0/go.mod h1:xXDCJY+GAPziupqXw64V24skbSoqbTEfhy4qGm1nDQc=
 github.com/russross/blackfriday v1.5.2/go.mod h1:JO/DiYxRf+HjHt06OyowR9PTA263kcR/rfWxYHBV53g=
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/satori/go.uuid v1.2.0/go.mod h1:dA0hQrYB0VpLJoorglMZABFdXlWrHn1NEOzdhQKdks0=
@@ -346,6 +352,8 @@ github.com/sirupsen/logrus v1.1.1/go.mod h1:zrgwTnHtNr00buQ1vSptGe8m1f/BbgsPukg8
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
 github.com/sirupsen/logrus v1.4.2 h1:SPIRibHv4MatM3XXNO2BJeFLZwZ2LvZgfQ5+UNI2im4=
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=
+github.com/sirupsen/logrus v1.6.0 h1:UBcNElsrwanuuMsnGSlYmtmgbb23qDR5dG+6X6Oo89I=
+github.com/sirupsen/logrus v1.6.0/go.mod h1:7uNnSEd1DgxDLC74fIahvMZmmYsHGZGEOFrfsX/uA88=
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d/go.mod h1:OnSkiWE9lh6wB0YB77sQom3nweQdgAjqCqsofrRNTgc=
 github.com/smartystreets/goconvey v0.0.0-20180222194500-ef6db91d284a/go.mod h1:XDJAKZRPZ1CvBcN2aX5YOUTYGHki24fSF0Iv48Ibg0s=
 github.com/soheilhy/cmux v0.1.4/go.mod h1:IM3LyeVVIOuxMH7sFAkER9+bJ4dT7Ms6E4xg4kGIyLM=
@@ -414,6 +422,8 @@ golang.org/x/crypto v0.0.0-20190426145343-a29dc8fdc734/go.mod h1:yigFU9vqHzYiE8U
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20191122220453-ac88ee75c92c h1:/nJuwDLoL/zrqY6gf57vxC+Pi+pZ8bfhpPkicO5H7W4=
 golang.org/x/crypto v0.0.0-20191122220453-ac88ee75c92c/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
+golang.org/x/crypto v0.0.0-20200510223506-06a226fb4e37 h1:cg5LA/zNPRzIXIWSCxQW10Rvpy94aQh3LT/ShoCpkHw=
+golang.org/x/crypto v0.0.0-20200510223506-06a226fb4e37/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/lint v0.0.0-20180702182130-06c8688daad7/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=
@@ -451,6 +461,8 @@ golang.org/x/sync v0.0.0-20190423024810-112230192c58 h1:8gQV6CLnAEikrhgkHFbMAEha
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e h1:vcxGaoTs7kV8m5Np9uUNQin4BrLOthgV7252N8V+FwY=
 golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.0.0-20200317015054-43a5402ce75a h1:WXEvlFVvvGxCJLG6REjsT03iWnKLEWinaScsxF2Vm2o=
+golang.org/x/sync v0.0.0-20200317015054-43a5402ce75a/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20180823144017-11551d06cbcc/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180905080454-ebe1bf3edb33/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
@@ -467,6 +479,8 @@ golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20190422165155-953cdadca894/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190502175342-a43fa875dd82 h1:vsphBvatvfbhlb4PO1BYSr9dzugGxJ/SQHoNufZJq1w=
 golang.org/x/sys v0.0.0-20190502175342-a43fa875dd82/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20200515095857-1151b9dac4a9 h1:YTzHMGlqJu67/uEo1lBv0n3wBXhXNeUbB1XfN2vmTm0=
+golang.org/x/sys v0.0.0-20200515095857-1151b9dac4a9/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.1-0.20180807135948-17ff2d5776d2/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.2 h1:tW2bmiBqwgJj/UpqtC8EpXEZVYOwU0yG4iWbprSVAcs=


### PR DESCRIPTION
User configuration options refactoring include two major updates: 

- All configuration options regardless of the original Aiven API type will have a string type in Terraform. When an option is not set in the plan, the default not-set value will be `""` an empty string (also interpreted as null in TF). This will allow us to get reed of ad-hock checks depending on the type like `"<<value not set>>"`, `-1`, etc. and will make TF plans look cleaner without having these default unset values in it. 
- Diff suppress function extended such that all configuration options (with or without default values) that do not have any value set in a TF plan will be excluded from the diff. It should fix this issue https://github.com/aiven/terraform-provider-aiven/issues/179/  

This PR was well tested and fully backwards compatible with previous versions.