### PR TITLE
add TF native timeouts support

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,7 +258,7 @@ resource "aiven_service" "myservice" {
         pg_version = "10"
     }
     
-    client_timeout {
+    timeouts {
         create = "20m"
         update = "15m"
     }
@@ -307,7 +307,9 @@ deletions. This does not shield against deleting databases or topics but for ser
 with backups much of the content can at least be restored from backup in case accidental
 deletion is done.
 
-`client_timeout` a custom client timeouts.
+`client_timeout` a deprecated custom client timeouts please use `timeouts` instead.
+
+`timeouts` a custom client timeouts.
 
 `x_user_config` defines service specific additional configuration options. These
 options can be found from the [JSON schema description](aiven/templates/service_user_config_schema.json).
@@ -473,7 +475,7 @@ resource "aiven_kafka_topic" "mytesttopic" {
     cleanup_policy = "delete"
     termination_protection = true
 
-    client_timeout {
+    timeouts {
         create = "1m"
         read = "5m"
     }
@@ -498,7 +500,9 @@ created.
 
 Aiven ID format when importing existing resource: `<project_name>/<service_name>/<topic_name>`
 
-`client_timeout` a custom client timeouts.
+`client_timeout` a deprecated custom client timeouts please use `timeouts` instead.
+
+`timeouts` a custom client timeouts.
 
 ### Resource Kafka ACL
 
@@ -791,7 +795,7 @@ resource "aiven_project_vpc" "myvpc" {
     cloud_name = "google-europe-west1"
     network_cidr = "192.168.0.1/24"
 
-    client_timeout {
+    timeouts {
         create = "5m"
     }
 }
@@ -821,7 +825,7 @@ resource "aiven_vpc_peering_connection" "mypeeringconnection" {
     peer_vpc = "<PEER_VPC_ID/NAME>"
     peer_region = "<PEER_REGION>"
 
-    client_timeout {
+    timeouts {
         create = "10m"
     }
 }
@@ -836,7 +840,9 @@ peered with.
 
 `peer_region` defines the region of the remote VPC if it is not in the same region as Aiven VPC.
 
-`client_timeout` a custom client timeouts.
+`client_timeout` a deprecated custom client timeouts please use `timeouts` instead.
+
+`timeouts` a custom client timeouts.
 
 `state` is the state of the peering connection. This property is computed by Aiven 
 therefore cannot be set, only read. Where state can be one of: `APPROVED`, 

--- a/aiven/provider_test.go
+++ b/aiven/provider_test.go
@@ -110,7 +110,6 @@ func Test_generateClientTimeoutsSchema(t *testing.T) {
 							Type:         schema.TypeString,
 							Description:  "create timeout",
 							Optional:     true,
-							Default:      "1m0s",
 							ValidateFunc: validateDurationString,
 						},
 					},
@@ -125,7 +124,6 @@ func Test_generateClientTimeoutsSchema(t *testing.T) {
 			assert.Equal(t, tt.want.MaxItems, got.MaxItems)
 			assert.Equal(t, tt.want.Description, got.Description)
 			assert.Equal(t, tt.want.Optional, got.Optional)
-			assert.Equal(t, tt.want.ForceNew, got.ForceNew)
 
 			for name, s := range got.Elem.(*schema.Resource).Schema {
 				want := tt.want.Elem.(*schema.Resource).Schema[name]
@@ -133,7 +131,6 @@ func Test_generateClientTimeoutsSchema(t *testing.T) {
 				assert.Equal(t, want.Type, s.Type)
 				assert.Equal(t, want.Description, s.Description)
 				assert.Equal(t, want.Optional, s.Optional)
-				assert.Equal(t, want.Default, s.Default)
 			}
 		})
 	}
@@ -164,12 +161,12 @@ func Test_getTimeoutHelper(t *testing.T) {
 				name:            "create",
 				defaultDuration: 1 * time.Minute,
 			},
-			want: 1 * time.Minute,
+			want: 0,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := getTimeoutHelper(tt.args.d, tt.args.name, tt.args.defaultDuration)
+			got, err := getTimeoutHelper(tt.args.d, tt.args.name)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("getTimeoutHelper() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/aiven/resource_kafka_topic.go
+++ b/aiven/resource_kafka_topic.go
@@ -88,6 +88,10 @@ func resourceKafkaTopic() *schema.Resource {
 		Importer: &schema.ResourceImporter{
 			State: resourceKafkaTopicState,
 		},
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(1 * time.Minute),
+			Read:   schema.DefaultTimeout(4 * time.Minute),
+		},
 
 		Schema: aivenKafkaTopicSchema,
 	}
@@ -118,9 +122,12 @@ func resourceKafkaTopicCreate(d *schema.ResourceData, m interface{}) error {
 	}
 
 	// Get creation timeout
-	timeout, err := getTimeoutHelper(d, "create", 1*time.Minute)
+	timeout, err := getTimeoutHelper(d, "create")
 	if err != nil {
 		return err
+	}
+	if timeout == 0 {
+		timeout = d.Timeout(schema.TimeoutCreate)
 	}
 
 	_, err = w.Conf(timeout).WaitForState()
@@ -185,9 +192,12 @@ func getTopic(d *schema.ResourceData, m interface{}) (aiven.KafkaTopic, error) {
 	}
 
 	// Get availability timeout
-	timeout, err := getTimeoutHelper(d, "read", 4*time.Minute)
+	timeout, err := getTimeoutHelper(d, "read")
 	if err != nil {
 		return aiven.KafkaTopic{}, err
+	}
+	if timeout == 0 {
+		timeout = d.Timeout(schema.TimeoutRead)
 	}
 
 	topic, err := w.Conf(timeout).WaitForState()

--- a/aiven/resource_kafka_topic_test.go
+++ b/aiven/resource_kafka_topic_test.go
@@ -223,7 +223,7 @@ func testAccKafkaTopicCustomTimeoutsResource(name string) string {
 			maintenance_window_dow = "monday"
 			maintenance_window_time = "10:00:00"
 
-			client_timeout {
+			timeouts {
 				create = "25m"
 				update = "20m"
 			}
@@ -240,7 +240,7 @@ func testAccKafkaTopicCustomTimeoutsResource(name string) string {
 			partitions = 3
 			replication = 2
 
-			client_timeout {
+			timeouts {
 				create = "5m"
 				read = "5m"
 			}

--- a/aiven/resource_project_vpc.go
+++ b/aiven/resource_project_vpc.go
@@ -50,6 +50,10 @@ func resourceProjectVPC() *schema.Resource {
 		Importer: &schema.ResourceImporter{
 			State: resourceProjectVPCState,
 		},
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(4 * time.Minute),
+			Delete: schema.DefaultTimeout(4 * time.Minute),
+		},
 
 		Schema: aivenProjectVPCSchema,
 	}
@@ -71,9 +75,12 @@ func resourceProjectVPCCreate(d *schema.ResourceData, m interface{}) error {
 	}
 
 	// Get creation timeout
-	timeout, err := getTimeoutHelper(d, "create", 4*time.Minute)
+	timeout, err := getTimeoutHelper(d, "create")
 	if err != nil {
 		return err
+	}
+	if timeout == 0 {
+		timeout = d.Timeout(schema.TimeoutCreate)
 	}
 
 	// Make sure the VPC is active before returning it because service creation, moving
@@ -112,9 +119,12 @@ func resourceProjectVPCDelete(d *schema.ResourceData, m interface{}) error {
 	projectName, vpcID := splitResourceID2(d.Id())
 
 	// Get deletion timeout
-	timeout, err := getTimeoutHelper(d, "delete", 4*time.Minute)
+	timeout, err := getTimeoutHelper(d, "delete")
 	if err != nil {
 		return err
+	}
+	if timeout == 0 {
+		timeout = d.Timeout(schema.TimeoutDelete)
 	}
 
 	waiter := ProjectVPCDeleteWaiter{

--- a/aiven/resource_project_vpc_test.go
+++ b/aiven/resource_project_vpc_test.go
@@ -73,7 +73,7 @@ func testAccProjectVPCCustomTimeoutResource(name string) string {
 			cloud_name = "google-europe-west1"
 			network_cidr = "192.168.0.0/24"
 
-			client_timeout {
+			timeouts {
 				create = "10m"
 				delete = "5m"
 			}

--- a/aiven/resource_service_pg_test.go
+++ b/aiven/resource_service_pg_test.go
@@ -150,7 +150,7 @@ func testAccPGServiceCustomTimeoutsResource(name string) string {
 			maintenance_window_dow = "monday"
 			maintenance_window_time = "10:00:00"
 			
-			client_timeout {
+			timeouts {
 				create = "25m"
 				update = "30m"
 			}

--- a/aiven/resource_vpc_peering_connection.go
+++ b/aiven/resource_vpc_peering_connection.go
@@ -69,6 +69,9 @@ func resourceVPCPeeringConnection() *schema.Resource {
 		Importer: &schema.ResourceImporter{
 			State: resourceVPCPeeringConnectionState,
 		},
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(2 * time.Minute),
+		},
 
 		Schema: aivenVPCPeeringConnectionSchema,
 	}
@@ -102,9 +105,12 @@ func resourceVPCPeeringConnectionCreate(d *schema.ResourceData, m interface{}) e
 	}
 
 	// Get creation timeout
-	timeout, err := getTimeoutHelper(d, "create", 2*time.Minute)
+	timeout, err := getTimeoutHelper(d, "create")
 	if err != nil {
 		return err
+	}
+	if timeout == 0 {
+		timeout = d.Timeout(schema.TimeoutCreate)
 	}
 
 	// Wait until the peering connection has actually been built

--- a/aiven/resource_vpc_peering_connection_test.go
+++ b/aiven/resource_vpc_peering_connection_test.go
@@ -72,7 +72,7 @@ func testAccVPCPeeringConnectionCustomTimeoutResource(name string) string {
 			peer_vpc = "google-project1"
 			peer_region = "google-europe-west1"
 			
-			client_timeout {
+			timeouts {
 				create = "5m"
 			}
 		}


### PR DESCRIPTION
`client_timeout `is marked as deprecated and instead, and users welcome to use native Terraform `timeouts` functionality