### PR TITLE
Allow wildcard for username in Kafka ACL

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -10,5 +10,4 @@ Description: The Aiven Terraform Provider is a way to access all of your Aiven s
 search_enabled: true
 exclude:
   - scripts/
-
 theme: jekyll-theme-minimal

--- a/aiven/resource_kafka_acl.go
+++ b/aiven/resource_kafka_acl.go
@@ -47,7 +47,7 @@ var aivenKafkaACLSchema = map[string]*schema.Schema{
 		Required:    true,
 		Description: "Username pattern for the ACL entry",
 		ForceNew:    true,
-		ValidateFunc: validation.StringMatch(regexp.MustCompile("^[a-zA-Z0-9_-]*$"),
+		ValidateFunc: validation.StringMatch(regexp.MustCompile("^([*]{1}$|[a-zA-Z0-9_-]*)$"),
 			"username should be alphanumeric"),
 	},
 }

--- a/aiven/resource_kafka_acl_test.go
+++ b/aiven/resource_kafka_acl_test.go
@@ -2,15 +2,16 @@ package aiven
 
 import (
 	"fmt"
+	"log"
+	"os"
+	"regexp"
+	"testing"
+
 	"github.com/aiven/aiven-go-client"
 	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/terraform/terraform"
-	"log"
-	"os"
-	"regexp"
-	"testing"
 )
 
 func TestAccAivenKafkaACL_basic(t *testing.T) {
@@ -41,6 +42,11 @@ func TestAccAivenKafkaACL_basic(t *testing.T) {
 				Config:      testAccKafkaACLWrongUsernameResource(rName),
 				PlanOnly:    true,
 				ExpectError: regexp.MustCompile("invalid value for username"),
+			},
+			{
+				Config:             testAccKafkaACLWildcardResource(rName),
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: true,
 			},
 			{
 				Config: testAccKafkaACLResource(rName),
@@ -123,6 +129,19 @@ func testAccKafkaACLWrongPermisionResource(_ string) string {
 		}
 		`
 }
+
+func testAccKafkaACLWildcardResource(_ string) string {
+	return `
+		resource "aiven_kafka_acl" "foo" {
+			project = "test-acc-pr-1"
+			service_name = "test-acc-sr-1"
+			topic = "test-acc-topic-1"
+			username = "*"
+			permission = "admin"
+		}
+		`
+}
+
 func testAccKafkaACLWrongUsernameResource(_ string) string {
 	return `
 		resource "aiven_kafka_acl" "foo" {


### PR DESCRIPTION
Default Kafka ACL is `*`. Alphanumeric check does not allow this to be removed before adding new ACLs. Regexp has been changed to allow either a single `*` or an alphanumeric string.