### PR TITLE
split service resource to multiple separate resources

### DIFF
--- a/aiven/datasource_cassandra.go
+++ b/aiven/datasource_cassandra.go
@@ -1,0 +1,12 @@
+package aiven
+
+import (
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func datasourceCassandra() *schema.Resource {
+	return &schema.Resource{
+		Read:   datasourceServiceRead,
+		Schema: resourceSchemaAsDatasourceSchema(cassandraSchema(), "project", "service_name"),
+	}
+}

--- a/aiven/datasource_cassandra.go
+++ b/aiven/datasource_cassandra.go
@@ -1,7 +1,7 @@
 package aiven
 
 import (
-	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 )
 
 func datasourceCassandra() *schema.Resource {

--- a/aiven/datasource_elasticsearch.go
+++ b/aiven/datasource_elasticsearch.go
@@ -1,7 +1,7 @@
 package aiven
 
 import (
-	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 )
 
 func datasourceElasticsearch() *schema.Resource {

--- a/aiven/datasource_elasticsearch.go
+++ b/aiven/datasource_elasticsearch.go
@@ -1,0 +1,12 @@
+package aiven
+
+import (
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func datasourceElasticsearch() *schema.Resource {
+	return &schema.Resource{
+		Read:   datasourceServiceRead,
+		Schema: resourceSchemaAsDatasourceSchema(elasticsearchSchema(), "project", "service_name"),
+	}
+}

--- a/aiven/datasource_grafana.go
+++ b/aiven/datasource_grafana.go
@@ -1,0 +1,12 @@
+package aiven
+
+import (
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func datasourceGrafana() *schema.Resource {
+	return &schema.Resource{
+		Read:   datasourceServiceRead,
+		Schema: resourceSchemaAsDatasourceSchema(grafanaSchema(), "project", "service_name"),
+	}
+}

--- a/aiven/datasource_grafana.go
+++ b/aiven/datasource_grafana.go
@@ -1,7 +1,7 @@
 package aiven
 
 import (
-	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 )
 
 func datasourceGrafana() *schema.Resource {

--- a/aiven/datasource_influxdb.go
+++ b/aiven/datasource_influxdb.go
@@ -1,0 +1,12 @@
+package aiven
+
+import (
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func datasourceInfluxDB() *schema.Resource {
+	return &schema.Resource{
+		Read:   datasourceServiceRead,
+		Schema: resourceSchemaAsDatasourceSchema(influxDBSchema(), "project", "service_name"),
+	}
+}

--- a/aiven/datasource_influxdb.go
+++ b/aiven/datasource_influxdb.go
@@ -1,7 +1,7 @@
 package aiven
 
 import (
-	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 )
 
 func datasourceInfluxDB() *schema.Resource {

--- a/aiven/datasource_kafka.go
+++ b/aiven/datasource_kafka.go
@@ -1,7 +1,7 @@
 package aiven
 
 import (
-	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 )
 
 func datasourceKafka() *schema.Resource {

--- a/aiven/datasource_kafka.go
+++ b/aiven/datasource_kafka.go
@@ -7,6 +7,6 @@ import (
 func datasourceKafka() *schema.Resource {
 	return &schema.Resource{
 		Read:   datasourceServiceRead,
-		Schema: resourceSchemaAsDatasourceSchema(aivenKafkaSchema, "project", "service_name"),
+		Schema: resourceSchemaAsDatasourceSchema(aivenKafkaSchema(), "project", "service_name"),
 	}
 }

--- a/aiven/datasource_kafka.go
+++ b/aiven/datasource_kafka.go
@@ -1,0 +1,12 @@
+package aiven
+
+import (
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func datasourceKafka() *schema.Resource {
+	return &schema.Resource{
+		Read:   datasourceServiceRead,
+		Schema: resourceSchemaAsDatasourceSchema(aivenKafkaSchema, "project", "service_name"),
+	}
+}

--- a/aiven/datasource_kafka_connect.go
+++ b/aiven/datasource_kafka_connect.go
@@ -7,6 +7,6 @@ import (
 func datasourceKafkaConnect() *schema.Resource {
 	return &schema.Resource{
 		Read:   datasourceServiceRead,
-		Schema: resourceSchemaAsDatasourceSchema(aivenKafkaConnectSchema, "project", "service_name"),
+		Schema: resourceSchemaAsDatasourceSchema(aivenKafkaConnectSchema(), "project", "service_name"),
 	}
 }

--- a/aiven/datasource_kafka_connect.go
+++ b/aiven/datasource_kafka_connect.go
@@ -1,7 +1,7 @@
 package aiven
 
 import (
-	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 )
 
 func datasourceKafkaConnect() *schema.Resource {

--- a/aiven/datasource_kafka_connect.go
+++ b/aiven/datasource_kafka_connect.go
@@ -1,0 +1,12 @@
+package aiven
+
+import (
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func datasourceKafkaConnect() *schema.Resource {
+	return &schema.Resource{
+		Read:   datasourceServiceRead,
+		Schema: resourceSchemaAsDatasourceSchema(aivenKafkaConnectSchema, "project", "service_name"),
+	}
+}

--- a/aiven/datasource_kafka_mirrormaker.go
+++ b/aiven/datasource_kafka_mirrormaker.go
@@ -1,7 +1,7 @@
 package aiven
 
 import (
-	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 )
 
 func datasourceKafkaMirrormaker() *schema.Resource {

--- a/aiven/datasource_kafka_mirrormaker.go
+++ b/aiven/datasource_kafka_mirrormaker.go
@@ -1,0 +1,12 @@
+package aiven
+
+import (
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func datasourceKafkaMirrormaker() *schema.Resource {
+	return &schema.Resource{
+		Read:   datasourceServiceRead,
+		Schema: resourceSchemaAsDatasourceSchema(aivenKafkaMirrormakerSchema(), "project", "service_name"),
+	}
+}

--- a/aiven/datasource_mysql.go
+++ b/aiven/datasource_mysql.go
@@ -1,0 +1,12 @@
+package aiven
+
+import (
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func datasourceMySQL() *schema.Resource {
+	return &schema.Resource{
+		Read:   datasourceServiceRead,
+		Schema: resourceSchemaAsDatasourceSchema(aivenMySQLSchema(), "project", "service_name"),
+	}
+}

--- a/aiven/datasource_pg.go
+++ b/aiven/datasource_pg.go
@@ -1,0 +1,12 @@
+package aiven
+
+import (
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func datasourcePG() *schema.Resource {
+	return &schema.Resource{
+		Read:   datasourceServiceRead,
+		Schema: resourceSchemaAsDatasourceSchema(aivenPGSchema(), "project", "service_name"),
+	}
+}

--- a/aiven/datasource_pg.go
+++ b/aiven/datasource_pg.go
@@ -1,7 +1,7 @@
 package aiven
 
 import (
-	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 )
 
 func datasourcePG() *schema.Resource {

--- a/aiven/datasource_redis.go
+++ b/aiven/datasource_redis.go
@@ -4,9 +4,9 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 )
 
-func datasourceMySQL() *schema.Resource {
+func datasourceRedis() *schema.Resource {
 	return &schema.Resource{
 		Read:   datasourceServiceRead,
-		Schema: resourceSchemaAsDatasourceSchema(aivenMySQLSchema(), "project", "service_name"),
+		Schema: resourceSchemaAsDatasourceSchema(redisSchema(), "project", "service_name"),
 	}
 }

--- a/aiven/provider.go
+++ b/aiven/provider.go
@@ -55,6 +55,7 @@ func Provider() terraform.ResourceProvider {
 			"aiven_kafka_connect":                datasourceKafkaConnect(),
 			"aiven_kafka_mirrormaker":            datasourceKafkaMirrormaker(),
 			"aiven_pg":                           datasourcePG(),
+			"aiven_mysql":                        datasourceMySQL(),
 		},
 
 		ResourcesMap: map[string]*schema.Resource{
@@ -84,6 +85,7 @@ func Provider() terraform.ResourceProvider {
 			"aiven_kafka_connect":                resourceKafkaConnect(),
 			"aiven_kafka_mirrormaker":            resourceKafkaMirrormaker(),
 			"aiven_pg":                           resourcePG(),
+			"aiven_mysql":                        resourceMySQL(),
 		},
 
 		ConfigureFunc: func(d *schema.ResourceData) (interface{}, error) {

--- a/aiven/provider.go
+++ b/aiven/provider.go
@@ -54,7 +54,7 @@ func Provider() terraform.ResourceProvider {
 			"aiven_kafka":                        datasourceKafka(),
 			"aiven_kafka_connect":                datasourceKafkaConnect(),
 			"aiven_kafka_mirrormaker":            datasourceKafkaMirrormaker(),
-			"aiven_kafka_pg":                     datasourcePG(),
+			"aiven_pg":                           datasourcePG(),
 		},
 
 		ResourcesMap: map[string]*schema.Resource{
@@ -83,7 +83,7 @@ func Provider() terraform.ResourceProvider {
 			"aiven_kafka":                        resourceKafka(),
 			"aiven_kafka_connect":                resourceKafkaConnect(),
 			"aiven_kafka_mirrormaker":            resourceKafkaMirrormaker(),
-			"aiven_kafka_pg":                     resourcePG(),
+			"aiven_pg":                           resourcePG(),
 		},
 
 		ConfigureFunc: func(d *schema.ResourceData) (interface{}, error) {

--- a/aiven/provider.go
+++ b/aiven/provider.go
@@ -51,6 +51,10 @@ func Provider() terraform.ResourceProvider {
 			"aiven_account_team_member":          datasourceAccountTeamMember(),
 			"aiven_mirrormaker_replication_flow": datasourceMirrorMakerReplicationFlowTopic(),
 			"aiven_account_authentication":       datasourceAccountAuthentication(),
+			"aiven_kafka":                        datasourceKafka(),
+			"aiven_kafka_connect":                datasourceKafkaConnect(),
+			"aiven_kafka_mirrormaker":            datasourceKafkaMirrormaker(),
+			"aiven_kafka_pg":                     datasourcePG(),
 		},
 
 		ResourcesMap: map[string]*schema.Resource{
@@ -76,6 +80,10 @@ func Provider() terraform.ResourceProvider {
 			"aiven_account_team_member":          resourceAccountTeamMember(),
 			"aiven_mirrormaker_replication_flow": resourceMirrorMakerReplicationFlow(),
 			"aiven_account_authentication":       resourceAccountAuthentication(),
+			"aiven_kafka":                        resourceKafka(),
+			"aiven_kafka_connect":                resourceKafkaConnect(),
+			"aiven_kafka_mirrormaker":            resourceKafkaMirrormaker(),
+			"aiven_kafka_pg":                     resourcePG(),
 		},
 
 		ConfigureFunc: func(d *schema.ResourceData) (interface{}, error) {

--- a/aiven/provider.go
+++ b/aiven/provider.go
@@ -59,6 +59,7 @@ func Provider() terraform.ResourceProvider {
 			"aiven_cassandra":                    datasourceCassandra(),
 			"aiven_elasticsearch":                datasourceElasticsearch(),
 			"aiven_grafana":                      datasourceGrafana(),
+			"aiven_influxdb":                     datasourceInfluxDB(),
 		},
 
 		ResourcesMap: map[string]*schema.Resource{
@@ -92,6 +93,7 @@ func Provider() terraform.ResourceProvider {
 			"aiven_cassandra":                    resourceCassandra(),
 			"aiven_elasticsearch":                resourceElasticsearch(),
 			"aiven_grafana":                      resourceGrafana(),
+			"aiven_influxdb":                     resourceInfluxDB(),
 		},
 
 		ConfigureFunc: func(d *schema.ResourceData) (interface{}, error) {

--- a/aiven/provider.go
+++ b/aiven/provider.go
@@ -60,6 +60,7 @@ func Provider() terraform.ResourceProvider {
 			"aiven_elasticsearch":                datasourceElasticsearch(),
 			"aiven_grafana":                      datasourceGrafana(),
 			"aiven_influxdb":                     datasourceInfluxDB(),
+			"aiven_redis":                        datasourceRedis(),
 		},
 
 		ResourcesMap: map[string]*schema.Resource{
@@ -94,6 +95,7 @@ func Provider() terraform.ResourceProvider {
 			"aiven_elasticsearch":                resourceElasticsearch(),
 			"aiven_grafana":                      resourceGrafana(),
 			"aiven_influxdb":                     resourceInfluxDB(),
+			"aiven_redis":                        resourceRedis(),
 		},
 
 		ConfigureFunc: func(d *schema.ResourceData) (interface{}, error) {

--- a/aiven/provider.go
+++ b/aiven/provider.go
@@ -57,6 +57,7 @@ func Provider() terraform.ResourceProvider {
 			"aiven_pg":                           datasourcePG(),
 			"aiven_mysql":                        datasourceMySQL(),
 			"aiven_cassandra":                    datasourceCassandra(),
+			"aiven_elasticsearch":                datasourceElasticsearch(),
 		},
 
 		ResourcesMap: map[string]*schema.Resource{
@@ -88,6 +89,7 @@ func Provider() terraform.ResourceProvider {
 			"aiven_pg":                           resourcePG(),
 			"aiven_mysql":                        resourceMySQL(),
 			"aiven_cassandra":                    resourceCassandra(),
+			"aiven_elasticsearch":                resourceElasticsearch(),
 		},
 
 		ConfigureFunc: func(d *schema.ResourceData) (interface{}, error) {

--- a/aiven/provider.go
+++ b/aiven/provider.go
@@ -58,6 +58,7 @@ func Provider() terraform.ResourceProvider {
 			"aiven_mysql":                        datasourceMySQL(),
 			"aiven_cassandra":                    datasourceCassandra(),
 			"aiven_elasticsearch":                datasourceElasticsearch(),
+			"aiven_grafana":                      datasourceGrafana(),
 		},
 
 		ResourcesMap: map[string]*schema.Resource{
@@ -90,6 +91,7 @@ func Provider() terraform.ResourceProvider {
 			"aiven_mysql":                        resourceMySQL(),
 			"aiven_cassandra":                    resourceCassandra(),
 			"aiven_elasticsearch":                resourceElasticsearch(),
+			"aiven_grafana":                      resourceGrafana(),
 		},
 
 		ConfigureFunc: func(d *schema.ResourceData) (interface{}, error) {

--- a/aiven/provider.go
+++ b/aiven/provider.go
@@ -56,6 +56,7 @@ func Provider() terraform.ResourceProvider {
 			"aiven_kafka_mirrormaker":            datasourceKafkaMirrormaker(),
 			"aiven_pg":                           datasourcePG(),
 			"aiven_mysql":                        datasourceMySQL(),
+			"aiven_cassandra":                    datasourceCassandra(),
 		},
 
 		ResourcesMap: map[string]*schema.Resource{
@@ -86,6 +87,7 @@ func Provider() terraform.ResourceProvider {
 			"aiven_kafka_mirrormaker":            resourceKafkaMirrormaker(),
 			"aiven_pg":                           resourcePG(),
 			"aiven_mysql":                        resourceMySQL(),
+			"aiven_cassandra":                    resourceCassandra(),
 		},
 
 		ConfigureFunc: func(d *schema.ResourceData) (interface{}, error) {

--- a/aiven/resource_cassandra.go
+++ b/aiven/resource_cassandra.go
@@ -2,7 +2,7 @@ package aiven
 
 import (
 	"github.com/aiven/terraform-provider-aiven/aiven/templates"
-	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"time"
 )
 

--- a/aiven/resource_cassandra.go
+++ b/aiven/resource_cassandra.go
@@ -1,0 +1,53 @@
+package aiven
+
+import (
+	"github.com/aiven/terraform-provider-aiven/aiven/templates"
+	"github.com/hashicorp/terraform/helper/schema"
+	"time"
+)
+
+func cassandraSchema() map[string]*schema.Schema {
+	s := serviceCommonSchema()
+	s[ServiceTypeCassandra] = &schema.Schema{
+		Type:        schema.TypeList,
+		MaxItems:    1,
+		Computed:    true,
+		Description: "Cassandra server provided values",
+		Optional:    true,
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{},
+		},
+	}
+	s[ServiceTypeCassandra+"_user_config"] = &schema.Schema{
+		Type:             schema.TypeList,
+		MaxItems:         1,
+		Optional:         true,
+		Description:      "Cassandra user configurable settings",
+		DiffSuppressFunc: emptyObjectDiffSuppressFunc,
+		Elem: &schema.Resource{
+			Schema: GenerateTerraformUserConfigSchema(
+				templates.GetUserConfigSchema("service")[ServiceTypeCassandra].(map[string]interface{})),
+		},
+	}
+
+	return s
+}
+
+func resourceCassandra() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceServiceCreateWrapper(ServiceTypeCassandra),
+		Read:   resourceServiceRead,
+		Update: resourceServiceUpdate,
+		Delete: resourceServiceDelete,
+		Exists: resourceServiceExists,
+		Importer: &schema.ResourceImporter{
+			State: resourceServiceState,
+		},
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(20 * time.Minute),
+			Update: schema.DefaultTimeout(20 * time.Minute),
+		},
+
+		Schema: cassandraSchema(),
+	}
+}

--- a/aiven/resource_cassandra_test.go
+++ b/aiven/resource_cassandra_test.go
@@ -2,8 +2,8 @@ package aiven
 
 import (
 	"fmt"
-	"github.com/hashicorp/terraform/helper/acctest"
-	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"os"
 	"testing"
 )

--- a/aiven/resource_cassandra_test.go
+++ b/aiven/resource_cassandra_test.go
@@ -1,0 +1,69 @@
+package aiven
+
+import (
+	"fmt"
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+	"os"
+	"testing"
+)
+
+func TestAccAiven_cassandra(t *testing.T) {
+	resourceName := "aiven_cassandra.bar"
+	rName := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAivenServiceResourceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCassandraResource(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAivenServiceCommonAttributes("data.aiven_cassandra.service"),
+					testAccCheckAivenServiceCassandraAttributes("data.aiven_cassandra.service"),
+					resource.TestCheckResourceAttr(resourceName, "service_name", fmt.Sprintf("test-acc-sr-%s", rName)),
+					resource.TestCheckResourceAttr(resourceName, "state", "RUNNING"),
+					resource.TestCheckResourceAttr(resourceName, "project", fmt.Sprintf("test-acc-pr-%s", rName)),
+					resource.TestCheckResourceAttr(resourceName, "service_type", "cassandra"),
+					resource.TestCheckResourceAttr(resourceName, "cloud_name", "google-europe-west1"),
+					resource.TestCheckResourceAttr(resourceName, "maintenance_window_dow", "monday"),
+					resource.TestCheckResourceAttr(resourceName, "maintenance_window_time", "10:00:00"),
+					resource.TestCheckResourceAttr(resourceName, "state", "RUNNING"),
+					resource.TestCheckResourceAttr(resourceName, "termination_protection", "false"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCassandraResource(name string) string {
+	return fmt.Sprintf(`
+		resource "aiven_project" "foo" {
+			project = "test-acc-pr-%s"
+			card_id="%s"	
+		}
+		
+		resource "aiven_cassandra" "bar" {
+			project = aiven_project.foo.project
+			cloud_name = "google-europe-west1"
+			plan = "startup-4"
+			service_name = "test-acc-sr-%s"
+			maintenance_window_dow = "monday"
+			maintenance_window_time = "10:00:00"
+			
+			cassandra_user_config {
+				migrate_sstableloader = true		
+	
+				public_access {
+					prometheus = true
+				}
+			}
+		}
+		
+		data "aiven_cassandra" "service" {
+			service_name = aiven_cassandra.bar.service_name
+			project = aiven_project.foo.project
+		}
+		`, name, os.Getenv("AIVEN_CARD_ID"), name)
+}

--- a/aiven/resource_elasticsearch.go
+++ b/aiven/resource_elasticsearch.go
@@ -2,7 +2,7 @@ package aiven
 
 import (
 	"github.com/aiven/terraform-provider-aiven/aiven/templates"
-	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"time"
 )
 

--- a/aiven/resource_elasticsearch.go
+++ b/aiven/resource_elasticsearch.go
@@ -1,0 +1,60 @@
+package aiven
+
+import (
+	"github.com/aiven/terraform-provider-aiven/aiven/templates"
+	"github.com/hashicorp/terraform/helper/schema"
+	"time"
+)
+
+func elasticsearchSchema() map[string]*schema.Schema {
+	s := serviceCommonSchema()
+	s[ServiceTypeElasticsearch] = &schema.Schema{
+		Type:        schema.TypeList,
+		MaxItems:    1,
+		Computed:    true,
+		Description: "Elasticsearch server provided values",
+		Optional:    true,
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				"kibana_uri": {
+					Type:        schema.TypeString,
+					Computed:    true,
+					Description: "URI for Kibana frontend",
+					Sensitive:   true,
+				},
+			},
+		},
+	}
+	s[ServiceTypeElasticsearch+"_user_config"] = &schema.Schema{
+		Type:             schema.TypeList,
+		MaxItems:         1,
+		Optional:         true,
+		Description:      "Elasticsearch user configurable settings",
+		DiffSuppressFunc: emptyObjectDiffSuppressFunc,
+		Elem: &schema.Resource{
+			Schema: GenerateTerraformUserConfigSchema(
+				templates.GetUserConfigSchema("service")[ServiceTypeElasticsearch].(map[string]interface{})),
+		},
+	}
+
+	return s
+}
+
+func resourceElasticsearch() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceServiceCreateWrapper(ServiceTypeElasticsearch),
+		Read:   resourceServiceRead,
+		Update: resourceServiceUpdate,
+		Delete: resourceServiceDelete,
+		Exists: resourceServiceExists,
+		Importer: &schema.ResourceImporter{
+			State: resourceServiceState,
+		},
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(20 * time.Minute),
+			Update: schema.DefaultTimeout(20 * time.Minute),
+		},
+
+		Schema: elasticsearchSchema(),
+	}
+}

--- a/aiven/resource_elasticsearch_test.go
+++ b/aiven/resource_elasticsearch_test.go
@@ -1,0 +1,75 @@
+package aiven
+
+import (
+	"fmt"
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+	"os"
+	"testing"
+)
+
+func TestAccAiven_elasticsearch(t *testing.T) {
+	resourceName := "aiven_elasticsearch.bar-es"
+	rName := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAivenServiceResourceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccElasticsearchResource(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAivenServiceCommonAttributes("data.aiven_elasticsearch.service-es"),
+					testAccCheckAivenServiceESAttributes("data.aiven_elasticsearch.service-es"),
+					resource.TestCheckResourceAttr(resourceName, "service_name", fmt.Sprintf("test-acc-sr-%s", rName)),
+					resource.TestCheckResourceAttr(resourceName, "state", "RUNNING"),
+					resource.TestCheckResourceAttr(resourceName, "project", fmt.Sprintf("test-acc-pr-es-%s", rName)),
+					resource.TestCheckResourceAttr(resourceName, "service_type", "elasticsearch"),
+					resource.TestCheckResourceAttr(resourceName, "cloud_name", "google-europe-west1"),
+					resource.TestCheckResourceAttr(resourceName, "maintenance_window_dow", "monday"),
+					resource.TestCheckResourceAttr(resourceName, "maintenance_window_time", "10:00:00"),
+					resource.TestCheckResourceAttr(resourceName, "state", "RUNNING"),
+					resource.TestCheckResourceAttr(resourceName, "termination_protection", "false"),
+				),
+			},
+		},
+	})
+}
+
+func testAccElasticsearchResource(name string) string {
+	return fmt.Sprintf(`
+		resource "aiven_project" "foo-es" {
+			project = "test-acc-pr-es-%s"
+			card_id="%s"	
+		}
+		
+		resource "aiven_elasticsearch" "bar-es" {
+			project = aiven_project.foo-es.project
+			cloud_name = "google-europe-west1"
+			plan = "startup-4"
+			service_name = "test-acc-sr-%s"
+			maintenance_window_dow = "monday"
+			maintenance_window_time = "10:00:00"
+			
+			elasticsearch_user_config {
+				elasticsearch_version = 7
+
+				kibana {
+					enabled = true
+					elasticsearch_request_timeout = 30000
+				}
+
+				public_access {
+					elasticsearch = true
+					kibana = true
+				}
+			}
+		}
+		
+		data "aiven_elasticsearch" "service-es" {
+			service_name = aiven_elasticsearch.bar-es.service_name
+			project = aiven_project.foo-es.project
+		}
+		`, name, os.Getenv("AIVEN_CARD_ID"), name)
+}

--- a/aiven/resource_elasticsearch_test.go
+++ b/aiven/resource_elasticsearch_test.go
@@ -2,8 +2,8 @@ package aiven
 
 import (
 	"fmt"
-	"github.com/hashicorp/terraform/helper/acctest"
-	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"os"
 	"testing"
 )

--- a/aiven/resource_grafana.go
+++ b/aiven/resource_grafana.go
@@ -2,7 +2,7 @@ package aiven
 
 import (
 	"github.com/aiven/terraform-provider-aiven/aiven/templates"
-	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"time"
 )
 

--- a/aiven/resource_grafana.go
+++ b/aiven/resource_grafana.go
@@ -1,0 +1,53 @@
+package aiven
+
+import (
+	"github.com/aiven/terraform-provider-aiven/aiven/templates"
+	"github.com/hashicorp/terraform/helper/schema"
+	"time"
+)
+
+func grafanaSchema() map[string]*schema.Schema {
+	s := serviceCommonSchema()
+	s[ServiceTypeGrafana] = &schema.Schema{
+		Type:        schema.TypeList,
+		MaxItems:    1,
+		Computed:    true,
+		Description: "Grafana server provided values",
+		Optional:    true,
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{},
+		},
+	}
+	s[ServiceTypeGrafana+"_user_config"] = &schema.Schema{
+		Type:             schema.TypeList,
+		MaxItems:         1,
+		Optional:         true,
+		Description:      "Grafana user configurable settings",
+		DiffSuppressFunc: emptyObjectDiffSuppressFunc,
+		Elem: &schema.Resource{
+			Schema: GenerateTerraformUserConfigSchema(
+				templates.GetUserConfigSchema("service")[ServiceTypeGrafana].(map[string]interface{})),
+		},
+	}
+
+	return s
+}
+
+func resourceGrafana() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceServiceCreateWrapper(ServiceTypeGrafana),
+		Read:   resourceServiceRead,
+		Update: resourceServiceUpdate,
+		Delete: resourceServiceDelete,
+		Exists: resourceServiceExists,
+		Importer: &schema.ResourceImporter{
+			State: resourceServiceState,
+		},
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(20 * time.Minute),
+			Update: schema.DefaultTimeout(20 * time.Minute),
+		},
+
+		Schema: grafanaSchema(),
+	}
+}

--- a/aiven/resource_grafana_test.go
+++ b/aiven/resource_grafana_test.go
@@ -1,0 +1,69 @@
+package aiven
+
+import (
+	"fmt"
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+	"os"
+	"testing"
+)
+
+func TestAccAiven_grafana(t *testing.T) {
+	resourceName := "aiven_grafana.bar"
+	rName := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAivenServiceResourceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccGrafanaResource(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAivenServiceCommonAttributes("data.aiven_grafana.service"),
+					testAccCheckAivenServiceGrafanaAttributes("data.aiven_grafana.service"),
+					resource.TestCheckResourceAttr(resourceName, "service_name", fmt.Sprintf("test-acc-sr-%s", rName)),
+					resource.TestCheckResourceAttr(resourceName, "state", "RUNNING"),
+					resource.TestCheckResourceAttr(resourceName, "project", fmt.Sprintf("test-acc-pr-%s", rName)),
+					resource.TestCheckResourceAttr(resourceName, "service_type", "grafana"),
+					resource.TestCheckResourceAttr(resourceName, "cloud_name", "google-europe-west1"),
+					resource.TestCheckResourceAttr(resourceName, "maintenance_window_dow", "monday"),
+					resource.TestCheckResourceAttr(resourceName, "maintenance_window_time", "10:00:00"),
+					resource.TestCheckResourceAttr(resourceName, "state", "RUNNING"),
+					resource.TestCheckResourceAttr(resourceName, "termination_protection", "false"),
+				),
+			},
+		},
+	})
+}
+
+func testAccGrafanaResource(name string) string {
+	return fmt.Sprintf(`
+		resource "aiven_project" "foo" {
+			project = "test-acc-pr-%s"
+			card_id="%s"	
+		}
+		
+		resource "aiven_grafana" "bar" {
+			project = aiven_project.foo.project
+			cloud_name = "google-europe-west1"
+			plan = "startup-1"
+			service_name = "test-acc-sr-%s"
+			maintenance_window_dow = "monday"
+			maintenance_window_time = "10:00:00"
+			
+			grafana_user_config {
+				alerting_enabled = true
+				
+				public_access {
+					grafana = true
+				}
+			}
+		}
+		
+		data "aiven_grafana" "service" {
+			service_name = aiven_grafana.bar.service_name
+			project = aiven_project.foo.project
+		}
+		`, name, os.Getenv("AIVEN_CARD_ID"), name)
+}

--- a/aiven/resource_grafana_test.go
+++ b/aiven/resource_grafana_test.go
@@ -2,8 +2,8 @@ package aiven
 
 import (
 	"fmt"
-	"github.com/hashicorp/terraform/helper/acctest"
-	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"os"
 	"testing"
 )

--- a/aiven/resource_influxdb.go
+++ b/aiven/resource_influxdb.go
@@ -1,0 +1,59 @@
+package aiven
+
+import (
+	"github.com/aiven/terraform-provider-aiven/aiven/templates"
+	"github.com/hashicorp/terraform/helper/schema"
+	"time"
+)
+
+func influxDBSchema() map[string]*schema.Schema {
+	s := serviceCommonSchema()
+	s[ServiceTypeInfluxDB] = &schema.Schema{
+		Type:        schema.TypeList,
+		MaxItems:    1,
+		Computed:    true,
+		Description: "InfluxDB server provided values",
+		Optional:    true,
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				"database_name": {
+					Type:        schema.TypeString,
+					Computed:    true,
+					Description: "Name of the default InfluxDB database",
+				},
+			},
+		},
+	}
+	s[ServiceTypeInfluxDB+"_user_config"] = &schema.Schema{
+		Type:             schema.TypeList,
+		MaxItems:         1,
+		Optional:         true,
+		Description:      "InfluxDB user configurable settings",
+		DiffSuppressFunc: emptyObjectDiffSuppressFunc,
+		Elem: &schema.Resource{
+			Schema: GenerateTerraformUserConfigSchema(
+				templates.GetUserConfigSchema("service")[ServiceTypeInfluxDB].(map[string]interface{})),
+		},
+	}
+
+	return s
+}
+
+func resourceInfluxDB() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceServiceCreateWrapper(ServiceTypeInfluxDB),
+		Read:   resourceServiceRead,
+		Update: resourceServiceUpdate,
+		Delete: resourceServiceDelete,
+		Exists: resourceServiceExists,
+		Importer: &schema.ResourceImporter{
+			State: resourceServiceState,
+		},
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(20 * time.Minute),
+			Update: schema.DefaultTimeout(20 * time.Minute),
+		},
+
+		Schema: influxDBSchema(),
+	}
+}

--- a/aiven/resource_influxdb.go
+++ b/aiven/resource_influxdb.go
@@ -2,7 +2,7 @@ package aiven
 
 import (
 	"github.com/aiven/terraform-provider-aiven/aiven/templates"
-	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"time"
 )
 

--- a/aiven/resource_influxdb_test.go
+++ b/aiven/resource_influxdb_test.go
@@ -1,0 +1,67 @@
+package aiven
+
+import (
+	"fmt"
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+	"os"
+	"testing"
+)
+
+func TestAccAiven_influxdb(t *testing.T) {
+	resourceName := "aiven_influxdb.bar"
+	rName := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAivenServiceResourceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccInfluxDBResource(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAivenServiceCommonAttributes("data.aiven_influxdb.service"),
+					testAccCheckAivenServiceInfluxdbAttributes("data.aiven_influxdb.service"),
+					resource.TestCheckResourceAttr(resourceName, "service_name", fmt.Sprintf("test-acc-sr-%s", rName)),
+					resource.TestCheckResourceAttr(resourceName, "state", "RUNNING"),
+					resource.TestCheckResourceAttr(resourceName, "project", fmt.Sprintf("test-acc-pr-%s", rName)),
+					resource.TestCheckResourceAttr(resourceName, "service_type", "influxdb"),
+					resource.TestCheckResourceAttr(resourceName, "cloud_name", "google-europe-west1"),
+					resource.TestCheckResourceAttr(resourceName, "maintenance_window_dow", "monday"),
+					resource.TestCheckResourceAttr(resourceName, "maintenance_window_time", "10:00:00"),
+					resource.TestCheckResourceAttr(resourceName, "state", "RUNNING"),
+					resource.TestCheckResourceAttr(resourceName, "termination_protection", "false"),
+				),
+			},
+		},
+	})
+}
+
+func testAccInfluxDBResource(name string) string {
+	return fmt.Sprintf(`
+		resource "aiven_project" "foo" {
+			project = "test-acc-pr-%s"
+			card_id="%s"	
+		}
+		
+		resource "aiven_influxdb" "bar" {
+			project = aiven_project.foo.project
+			cloud_name = "google-europe-west1"
+			plan = "startup-4"
+			service_name = "test-acc-sr-%s"
+			maintenance_window_dow = "monday"
+			maintenance_window_time = "10:00:00"
+			
+			influxdb_user_config {
+				public_access {
+					influxdb = true
+				}
+			}
+		}
+		
+		data "aiven_influxdb" "service" {
+			service_name = aiven_influxdb.bar.service_name
+			project = aiven_influxdb.bar.project
+		}
+		`, name, os.Getenv("AIVEN_CARD_ID"), name)
+}

--- a/aiven/resource_influxdb_test.go
+++ b/aiven/resource_influxdb_test.go
@@ -2,8 +2,8 @@ package aiven
 
 import (
 	"fmt"
-	"github.com/hashicorp/terraform/helper/acctest"
-	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"os"
 	"testing"
 )

--- a/aiven/resource_kafka.go
+++ b/aiven/resource_kafka.go
@@ -1,0 +1,248 @@
+package aiven
+
+import (
+	"github.com/hashicorp/terraform/helper/schema"
+	"time"
+)
+
+var aivenKafkaSchema = map[string]*schema.Schema{
+	"project": {
+		Type:        schema.TypeString,
+		Required:    true,
+		Description: "Target project",
+		ForceNew:    true,
+	},
+	"cloud_name": {
+		Type:        schema.TypeString,
+		Optional:    true,
+		Description: "Cloud the service runs in",
+	},
+	"plan": {
+		Type:        schema.TypeString,
+		Optional:    true,
+		Description: "Subscription plan",
+	},
+	"service_name": {
+		Type:        schema.TypeString,
+		Required:    true,
+		Description: "Service name",
+		ForceNew:    true,
+	},
+	"service_type": {
+		Type:        schema.TypeString,
+		Computed:    true,
+		Description: "Aiven internal service type code",
+	},
+	"project_vpc_id": {
+		Type:        schema.TypeString,
+		Optional:    true,
+		Description: "Identifier of the VPC the service should be in, if any",
+	},
+	"maintenance_window_dow": {
+		Type:        schema.TypeString,
+		Optional:    true,
+		Description: "Day of week when maintenance operations should be performed. One monday, tuesday, wednesday, etc.",
+		DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+			return new == ""
+		},
+	},
+	"maintenance_window_time": {
+		Type:        schema.TypeString,
+		Optional:    true,
+		Description: "Time of day when maintenance operations should be performed. UTC time in HH:mm:ss format.",
+		DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+			return new == ""
+		},
+	},
+	"termination_protection": {
+		Type:        schema.TypeBool,
+		Optional:    true,
+		Description: "Prevent service from being deleted. It is recommended to have this enabled for all services.",
+	},
+	"service_uri": {
+		Type:        schema.TypeString,
+		Computed:    true,
+		Description: "URI for connecting to the service. Service specific info is under \"kafka\", \"pg\", etc.",
+		Sensitive:   true,
+	},
+	"service_host": {
+		Type:        schema.TypeString,
+		Computed:    true,
+		Description: "Service hostname",
+	},
+	"service_port": {
+		Type:        schema.TypeInt,
+		Computed:    true,
+		Description: "Service port",
+	},
+	"service_password": {
+		Type:        schema.TypeString,
+		Computed:    true,
+		Description: "Password used for connecting to the service, if applicable",
+		Sensitive:   true,
+	},
+	"service_username": {
+		Type:        schema.TypeString,
+		Computed:    true,
+		Description: "Username used for connecting to the service, if applicable",
+	},
+	"state": {
+		Type:        schema.TypeString,
+		Computed:    true,
+		Description: "Service state",
+	},
+	"service_integrations": {
+		Type:             schema.TypeList,
+		Optional:         true,
+		Description:      "Service integrations to specify when creating a service. Not applied after initial service creation",
+		DiffSuppressFunc: createOnlyDiffSuppressFunc,
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				"source_service_name": {
+					Type:        schema.TypeString,
+					Required:    true,
+					Description: "Name of the source service",
+				},
+				"integration_type": {
+					Type:        schema.TypeString,
+					Required:    true,
+					Description: "Type of the service integration. The only supported value at the moment is 'read_replica'",
+				},
+			},
+		},
+	},
+	"components": {
+		Type:        schema.TypeList,
+		Computed:    true,
+		Description: "Service component information objects",
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				"component": {
+					Type:        schema.TypeString,
+					Computed:    true,
+					Description: "Service component name",
+				},
+				"host": {
+					Type:        schema.TypeString,
+					Computed:    true,
+					Description: "DNS name for connecting to the service component",
+				},
+				"kafka_authentication_method": {
+					Type:        schema.TypeString,
+					Computed:    true,
+					Optional:    true,
+					Description: "Kafka authentication method. This is a value specific to the 'kafka' service component",
+				},
+				"port": {
+					Type:        schema.TypeInt,
+					Computed:    true,
+					Description: "Port number for connecting to the service component",
+				},
+				"route": {
+					Type:        schema.TypeString,
+					Computed:    true,
+					Description: "Network access route",
+				},
+				"ssl": {
+					Type:     schema.TypeBool,
+					Computed: true,
+					Description: "Whether the endpoint is encrypted or accepts plaintext. By default endpoints are " +
+						"always encrypted and this property is only included for service components they may " +
+						"disable encryption",
+				},
+				"usage": {
+					Type:        schema.TypeString,
+					Computed:    true,
+					Description: "DNS usage name",
+				},
+			},
+		},
+	},
+	"kafka": {
+		Type:        schema.TypeList,
+		MaxItems:    1,
+		Computed:    true,
+		Description: "Kafka specific server provided values",
+		Optional:    true,
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				"access_cert": {
+					Type:        schema.TypeString,
+					Computed:    true,
+					Description: "The Kafka client certificate",
+					Optional:    true,
+					Sensitive:   true,
+				},
+				"access_key": {
+					Type:        schema.TypeString,
+					Computed:    true,
+					Description: "The Kafka client certificate key",
+					Optional:    true,
+					Sensitive:   true,
+				},
+				"connect_uri": {
+					Type:        schema.TypeString,
+					Computed:    true,
+					Description: "The Kafka Connect URI, if any",
+					Optional:    true,
+					Sensitive:   true,
+				},
+				"rest_uri": {
+					Type:        schema.TypeString,
+					Computed:    true,
+					Description: "The Kafka REST URI, if any",
+					Optional:    true,
+					Sensitive:   true,
+				},
+				"schema_registry_uri": {
+					Type:        schema.TypeString,
+					Computed:    true,
+					Description: "The Schema Registry URI, if any",
+					Optional:    true,
+					Sensitive:   true,
+				},
+			},
+		},
+	},
+	"kafka_user_config": {
+		Type:             schema.TypeList,
+		MaxItems:         1,
+		Optional:         true,
+		Description:      "Kafka specific user configurable settings",
+		DiffSuppressFunc: emptyObjectDiffSuppressFunc,
+		Elem: &schema.Resource{
+			Schema: GenerateTerraformUserConfigSchema(
+				GetUserConfigSchema("service")[ServiceTypeKafka].(map[string]interface{})),
+		},
+	},
+}
+
+func resourceKafka() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceKafkaCreate,
+		Read:   resourceServiceRead,
+		Update: resourceServiceUpdate,
+		Delete: resourceServiceDelete,
+		Exists: resourceServiceExists,
+		Importer: &schema.ResourceImporter{
+			State: resourceServiceState,
+		},
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(20 * time.Minute),
+			Update: schema.DefaultTimeout(20 * time.Minute),
+		},
+
+		Schema: aivenKafkaSchema,
+	}
+}
+
+func resourceKafkaCreate(d *schema.ResourceData, m interface{}) error {
+	if err := d.Set("service_type", ServiceTypeKafka); err != nil {
+		return err
+	}
+	if err := d.Set(ServiceTypeKafka, []map[string]interface{}{}); err != nil {
+		return err
+	}
+
+	return resourceServiceCreate(d, m)
+}

--- a/aiven/resource_kafka.go
+++ b/aiven/resource_kafka.go
@@ -2,7 +2,7 @@ package aiven
 
 import (
 	"github.com/aiven/terraform-provider-aiven/aiven/templates"
-	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"time"
 )
 

--- a/aiven/resource_kafka.go
+++ b/aiven/resource_kafka.go
@@ -1,6 +1,7 @@
 package aiven
 
 import (
+	"github.com/aiven/terraform-provider-aiven/aiven/templates"
 	"github.com/hashicorp/terraform/helper/schema"
 	"time"
 )
@@ -61,7 +62,7 @@ func aivenKafkaSchema() map[string]*schema.Schema {
 		DiffSuppressFunc: emptyObjectDiffSuppressFunc,
 		Elem: &schema.Resource{
 			Schema: GenerateTerraformUserConfigSchema(
-				GetUserConfigSchema("service")[ServiceTypeKafka].(map[string]interface{})),
+				templates.GetUserConfigSchema("service")[ServiceTypeKafka].(map[string]interface{})),
 		},
 	}
 

--- a/aiven/resource_kafka.go
+++ b/aiven/resource_kafka.go
@@ -5,164 +5,13 @@ import (
 	"time"
 )
 
-var aivenKafkaSchema = map[string]*schema.Schema{
-	"project": {
-		Type:        schema.TypeString,
-		Required:    true,
-		Description: "Target project",
-		ForceNew:    true,
-	},
-	"cloud_name": {
-		Type:        schema.TypeString,
-		Optional:    true,
-		Description: "Cloud the service runs in",
-	},
-	"plan": {
-		Type:        schema.TypeString,
-		Optional:    true,
-		Description: "Subscription plan",
-	},
-	"service_name": {
-		Type:        schema.TypeString,
-		Required:    true,
-		Description: "Service name",
-		ForceNew:    true,
-	},
-	"service_type": {
-		Type:        schema.TypeString,
-		Computed:    true,
-		Description: "Aiven internal service type code",
-	},
-	"project_vpc_id": {
-		Type:        schema.TypeString,
-		Optional:    true,
-		Description: "Identifier of the VPC the service should be in, if any",
-	},
-	"maintenance_window_dow": {
-		Type:        schema.TypeString,
-		Optional:    true,
-		Description: "Day of week when maintenance operations should be performed. One monday, tuesday, wednesday, etc.",
-		DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
-			return new == ""
-		},
-	},
-	"maintenance_window_time": {
-		Type:        schema.TypeString,
-		Optional:    true,
-		Description: "Time of day when maintenance operations should be performed. UTC time in HH:mm:ss format.",
-		DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
-			return new == ""
-		},
-	},
-	"termination_protection": {
-		Type:        schema.TypeBool,
-		Optional:    true,
-		Description: "Prevent service from being deleted. It is recommended to have this enabled for all services.",
-	},
-	"service_uri": {
-		Type:        schema.TypeString,
-		Computed:    true,
-		Description: "URI for connecting to the service. Service specific info is under \"kafka\", \"pg\", etc.",
-		Sensitive:   true,
-	},
-	"service_host": {
-		Type:        schema.TypeString,
-		Computed:    true,
-		Description: "Service hostname",
-	},
-	"service_port": {
-		Type:        schema.TypeInt,
-		Computed:    true,
-		Description: "Service port",
-	},
-	"service_password": {
-		Type:        schema.TypeString,
-		Computed:    true,
-		Description: "Password used for connecting to the service, if applicable",
-		Sensitive:   true,
-	},
-	"service_username": {
-		Type:        schema.TypeString,
-		Computed:    true,
-		Description: "Username used for connecting to the service, if applicable",
-	},
-	"state": {
-		Type:        schema.TypeString,
-		Computed:    true,
-		Description: "Service state",
-	},
-	"service_integrations": {
-		Type:             schema.TypeList,
-		Optional:         true,
-		Description:      "Service integrations to specify when creating a service. Not applied after initial service creation",
-		DiffSuppressFunc: createOnlyDiffSuppressFunc,
-		Elem: &schema.Resource{
-			Schema: map[string]*schema.Schema{
-				"source_service_name": {
-					Type:        schema.TypeString,
-					Required:    true,
-					Description: "Name of the source service",
-				},
-				"integration_type": {
-					Type:        schema.TypeString,
-					Required:    true,
-					Description: "Type of the service integration. The only supported value at the moment is 'read_replica'",
-				},
-			},
-		},
-	},
-	"components": {
-		Type:        schema.TypeList,
-		Computed:    true,
-		Description: "Service component information objects",
-		Elem: &schema.Resource{
-			Schema: map[string]*schema.Schema{
-				"component": {
-					Type:        schema.TypeString,
-					Computed:    true,
-					Description: "Service component name",
-				},
-				"host": {
-					Type:        schema.TypeString,
-					Computed:    true,
-					Description: "DNS name for connecting to the service component",
-				},
-				"kafka_authentication_method": {
-					Type:        schema.TypeString,
-					Computed:    true,
-					Optional:    true,
-					Description: "Kafka authentication method. This is a value specific to the 'kafka' service component",
-				},
-				"port": {
-					Type:        schema.TypeInt,
-					Computed:    true,
-					Description: "Port number for connecting to the service component",
-				},
-				"route": {
-					Type:        schema.TypeString,
-					Computed:    true,
-					Description: "Network access route",
-				},
-				"ssl": {
-					Type:     schema.TypeBool,
-					Computed: true,
-					Description: "Whether the endpoint is encrypted or accepts plaintext. By default endpoints are " +
-						"always encrypted and this property is only included for service components they may " +
-						"disable encryption",
-				},
-				"usage": {
-					Type:        schema.TypeString,
-					Computed:    true,
-					Description: "DNS usage name",
-				},
-			},
-		},
-	},
-	"kafka": {
+func aivenKafkaSchema() map[string]*schema.Schema {
+	aivenKafkaSchema := serviceCommonSchema()
+	aivenKafkaSchema[ServiceTypeKafka] = &schema.Schema{
 		Type:        schema.TypeList,
 		MaxItems:    1,
 		Computed:    true,
-		Description: "Kafka specific server provided values",
+		Description: "Kafka server provided values",
 		Optional:    true,
 		Elem: &schema.Resource{
 			Schema: map[string]*schema.Schema{
@@ -203,23 +52,25 @@ var aivenKafkaSchema = map[string]*schema.Schema{
 				},
 			},
 		},
-	},
-	"kafka_user_config": {
+	}
+	aivenKafkaSchema[ServiceTypeKafka+"_user_config"] = &schema.Schema{
 		Type:             schema.TypeList,
 		MaxItems:         1,
 		Optional:         true,
-		Description:      "Kafka specific user configurable settings",
+		Description:      "Kafka user configurable settings",
 		DiffSuppressFunc: emptyObjectDiffSuppressFunc,
 		Elem: &schema.Resource{
 			Schema: GenerateTerraformUserConfigSchema(
 				GetUserConfigSchema("service")[ServiceTypeKafka].(map[string]interface{})),
 		},
-	},
+	}
+
+	return aivenKafkaSchema
 }
 
 func resourceKafka() *schema.Resource {
 	return &schema.Resource{
-		Create: resourceKafkaCreate,
+		Create: resourceServiceCreateWrapper(ServiceTypeKafka),
 		Read:   resourceServiceRead,
 		Update: resourceServiceUpdate,
 		Delete: resourceServiceDelete,
@@ -232,17 +83,6 @@ func resourceKafka() *schema.Resource {
 			Update: schema.DefaultTimeout(20 * time.Minute),
 		},
 
-		Schema: aivenKafkaSchema,
+		Schema: aivenKafkaSchema(),
 	}
-}
-
-func resourceKafkaCreate(d *schema.ResourceData, m interface{}) error {
-	if err := d.Set("service_type", ServiceTypeKafka); err != nil {
-		return err
-	}
-	if err := d.Set(ServiceTypeKafka, []map[string]interface{}{}); err != nil {
-		return err
-	}
-
-	return resourceServiceCreate(d, m)
 }

--- a/aiven/resource_kafka_connect.go
+++ b/aiven/resource_kafka_connect.go
@@ -1,0 +1,212 @@
+package aiven
+
+import (
+	"github.com/hashicorp/terraform/helper/schema"
+	"time"
+)
+
+var aivenKafkaConnectSchema = map[string]*schema.Schema{
+	"project": {
+		Type:        schema.TypeString,
+		Required:    true,
+		Description: "Target project",
+		ForceNew:    true,
+	},
+	"cloud_name": {
+		Type:        schema.TypeString,
+		Optional:    true,
+		Description: "Cloud the service runs in",
+	},
+	"plan": {
+		Type:        schema.TypeString,
+		Optional:    true,
+		Description: "Subscription plan",
+	},
+	"service_name": {
+		Type:        schema.TypeString,
+		Required:    true,
+		Description: "Service name",
+		ForceNew:    true,
+	},
+	"service_type": {
+		Type:        schema.TypeString,
+		Computed:    true,
+		Description: "Aiven internal service type code",
+	},
+	"project_vpc_id": {
+		Type:        schema.TypeString,
+		Optional:    true,
+		Description: "Identifier of the VPC the service should be in, if any",
+	},
+	"maintenance_window_dow": {
+		Type:        schema.TypeString,
+		Optional:    true,
+		Description: "Day of week when maintenance operations should be performed. One monday, tuesday, wednesday, etc.",
+		DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+			return new == ""
+		},
+	},
+	"maintenance_window_time": {
+		Type:        schema.TypeString,
+		Optional:    true,
+		Description: "Time of day when maintenance operations should be performed. UTC time in HH:mm:ss format.",
+		DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+			return new == ""
+		},
+	},
+	"termination_protection": {
+		Type:        schema.TypeBool,
+		Optional:    true,
+		Description: "Prevent service from being deleted. It is recommended to have this enabled for all services.",
+	},
+	"service_uri": {
+		Type:        schema.TypeString,
+		Computed:    true,
+		Description: "URI for connecting to the service. Service specific info is under \"kafka\", \"pg\", etc.",
+		Sensitive:   true,
+	},
+	"service_host": {
+		Type:        schema.TypeString,
+		Computed:    true,
+		Description: "Service hostname",
+	},
+	"service_port": {
+		Type:        schema.TypeInt,
+		Computed:    true,
+		Description: "Service port",
+	},
+	"service_password": {
+		Type:        schema.TypeString,
+		Computed:    true,
+		Description: "Password used for connecting to the service, if applicable",
+		Sensitive:   true,
+	},
+	"service_username": {
+		Type:        schema.TypeString,
+		Computed:    true,
+		Description: "Username used for connecting to the service, if applicable",
+	},
+	"state": {
+		Type:        schema.TypeString,
+		Computed:    true,
+		Description: "Service state",
+	},
+	"service_integrations": {
+		Type:             schema.TypeList,
+		Optional:         true,
+		Description:      "Service integrations to specify when creating a service. Not applied after initial service creation",
+		DiffSuppressFunc: createOnlyDiffSuppressFunc,
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				"source_service_name": {
+					Type:        schema.TypeString,
+					Required:    true,
+					Description: "Name of the source service",
+				},
+				"integration_type": {
+					Type:        schema.TypeString,
+					Required:    true,
+					Description: "Type of the service integration. The only supported value at the moment is 'read_replica'",
+				},
+			},
+		},
+	},
+	"components": {
+		Type:        schema.TypeList,
+		Computed:    true,
+		Description: "Service component information objects",
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				"component": {
+					Type:        schema.TypeString,
+					Computed:    true,
+					Description: "Service component name",
+				},
+				"host": {
+					Type:        schema.TypeString,
+					Computed:    true,
+					Description: "DNS name for connecting to the service component",
+				},
+				"kafka_authentication_method": {
+					Type:        schema.TypeString,
+					Computed:    true,
+					Optional:    true,
+					Description: "Kafka authentication method. This is a value specific to the 'kafka' service component",
+				},
+				"port": {
+					Type:        schema.TypeInt,
+					Computed:    true,
+					Description: "Port number for connecting to the service component",
+				},
+				"route": {
+					Type:        schema.TypeString,
+					Computed:    true,
+					Description: "Network access route",
+				},
+				"ssl": {
+					Type:     schema.TypeBool,
+					Computed: true,
+					Description: "Whether the endpoint is encrypted or accepts plaintext. By default endpoints are " +
+						"always encrypted and this property is only included for service components they may " +
+						"disable encryption",
+				},
+				"usage": {
+					Type:        schema.TypeString,
+					Computed:    true,
+					Description: "DNS usage name",
+				},
+			},
+		},
+	},
+	"kafka_connect_user_config": {
+		Type:             schema.TypeList,
+		MaxItems:         1,
+		Optional:         true,
+		Description:      "Kafka specific user configurable settings",
+		DiffSuppressFunc: emptyObjectDiffSuppressFunc,
+		Elem: &schema.Resource{
+			Schema: GenerateTerraformUserConfigSchema(
+				GetUserConfigSchema("service")[ServiceTypeKafkaConnect].(map[string]interface{})),
+		},
+	},
+	"kafka_connect": {
+		Type:        schema.TypeList,
+		MaxItems:    1,
+		Computed:    true,
+		Description: "Kafka Connect specific server provided values",
+		Optional:    true,
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{},
+		},
+	},
+}
+
+func resourceKafkaConnect() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceKafkaConnectCreate,
+		Read:   resourceServiceRead,
+		Update: resourceServiceUpdate,
+		Delete: resourceServiceDelete,
+		Exists: resourceServiceExists,
+		Importer: &schema.ResourceImporter{
+			State: resourceServiceState,
+		},
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(20 * time.Minute),
+			Update: schema.DefaultTimeout(20 * time.Minute),
+		},
+
+		Schema: aivenKafkaConnectSchema,
+	}
+}
+
+func resourceKafkaConnectCreate(d *schema.ResourceData, m interface{}) error {
+	if err := d.Set("service_type", ServiceTypeKafkaConnect); err != nil {
+		return err
+	}
+	if err := d.Set("kafka_connect", []map[string]interface{}{}); err != nil {
+		return err
+	}
+
+	return resourceServiceCreate(d, m)
+}

--- a/aiven/resource_kafka_connect.go
+++ b/aiven/resource_kafka_connect.go
@@ -2,7 +2,7 @@ package aiven
 
 import (
 	"github.com/aiven/terraform-provider-aiven/aiven/templates"
-	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"time"
 )
 

--- a/aiven/resource_kafka_connect_test.go
+++ b/aiven/resource_kafka_connect_test.go
@@ -2,8 +2,8 @@ package aiven
 
 import (
 	"fmt"
-	"github.com/hashicorp/terraform/helper/acctest"
-	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"os"
 	"testing"
 )

--- a/aiven/resource_kafka_connect_test.go
+++ b/aiven/resource_kafka_connect_test.go
@@ -1,0 +1,106 @@
+package aiven
+
+import (
+	"fmt"
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+	"os"
+	"testing"
+)
+
+// Kafka Connect service tests
+func TestAccAiven_kafkaconnect(t *testing.T) {
+	resourceName := "aiven_kafka_connect.bar"
+	rName := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAivenServiceResourceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccKafkaConnectResource(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAivenKafkaConnectAttributes("data.aiven_kafka_connect.service"),
+					testAccCheckAivenServiceKafkaConnectAttributes("data.aiven_kafka_connect.service"),
+					resource.TestCheckResourceAttr(resourceName, "service_name", fmt.Sprintf("test-acc-sr-%s", rName)),
+					resource.TestCheckResourceAttr(resourceName, "state", "RUNNING"),
+					resource.TestCheckResourceAttr(resourceName, "project", fmt.Sprintf("test-acc-pr-%s", rName)),
+					resource.TestCheckResourceAttr(resourceName, "service_type", "kafka_connect"),
+					resource.TestCheckResourceAttr(resourceName, "cloud_name", "google-europe-west1"),
+					resource.TestCheckResourceAttr(resourceName, "maintenance_window_dow", "monday"),
+					resource.TestCheckResourceAttr(resourceName, "maintenance_window_time", "10:00:00"),
+					resource.TestCheckResourceAttr(resourceName, "state", "RUNNING"),
+					resource.TestCheckResourceAttr(resourceName, "termination_protection", "false"),
+				),
+			},
+		},
+	})
+}
+
+func testAccKafkaConnectResource(name string) string {
+	return fmt.Sprintf(`
+		resource "aiven_project" "foo" {
+			project = "test-acc-pr-%s"
+			card_id="%s"	
+		}
+		
+		resource "aiven_kafka_connect" "bar" {
+			project = aiven_project.foo.project
+			cloud_name = "google-europe-west1"
+			plan = "startup-4"
+			service_name = "test-acc-sr-%s"
+			maintenance_window_dow = "monday"
+			maintenance_window_time = "10:00:00"
+			
+			kafka_connect_user_config {
+				kafka_connect {
+					consumer_isolation_level = "read_committed"
+				}
+		
+				public_access {
+					kafka_connect = true
+				}
+			}
+		}
+		
+		data "aiven_kafka_connect" "service" {
+			service_name = aiven_kafka_connect.bar.service_name
+			project = aiven_kafka_connect.bar.project
+		}
+		`, name, os.Getenv("AIVEN_CARD_ID"), name)
+}
+
+func testAccCheckAivenKafkaConnectAttributes(n string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		r := s.RootModule().Resources[n]
+		a := r.Primary.Attributes
+
+		if a["service_type"] != "kafka_connect" {
+			return fmt.Errorf("expected to get a correct service type from Aiven, got :%s", a["service_type"])
+		}
+
+		if a["kafka_connect_user_config.0.kafka_connect.0.consumer_isolation_level"] != "read_committed" {
+			return fmt.Errorf("expected to get a correct consumer_isolation_level from Aiven")
+		}
+
+		if a["kafka_connect_user_config.0.kafka_connect.0.consumer_max_poll_records"] != "" {
+			return fmt.Errorf("expected to get a correct consumer_max_poll_records from Aiven")
+		}
+
+		if a["kafka_connect_user_config.0.kafka_connect.0.offset_flush_interval_ms"] != "" {
+			return fmt.Errorf("expected to get a correct offset_flush_interval_ms from Aiven")
+		}
+
+		if a["kafka_connect_user_config.0.public_access.0.kafka_connect"] != "true" {
+			return fmt.Errorf("expected to get a correct public_access.kafka_connect from Aiven")
+		}
+
+		if a["kafka_connect_user_config.0.public_access.0.prometheus"] != "" {
+			return fmt.Errorf("expected to get a correct public_access.prometheus from Aiven")
+		}
+
+		return nil
+	}
+}

--- a/aiven/resource_kafka_mirrormaker.go
+++ b/aiven/resource_kafka_mirrormaker.go
@@ -1,6 +1,7 @@
 package aiven
 
 import (
+	"github.com/aiven/terraform-provider-aiven/aiven/templates"
 	"github.com/hashicorp/terraform/helper/schema"
 	"time"
 )
@@ -25,7 +26,7 @@ func aivenKafkaMirrormakerSchema() map[string]*schema.Schema {
 		DiffSuppressFunc: emptyObjectDiffSuppressFunc,
 		Elem: &schema.Resource{
 			Schema: GenerateTerraformUserConfigSchema(
-				GetUserConfigSchema("service")[ServiceTypeKafkaMirrormaker].(map[string]interface{})),
+				templates.GetUserConfigSchema("service")[ServiceTypeKafkaMirrormaker].(map[string]interface{})),
 		},
 	}
 

--- a/aiven/resource_kafka_mirrormaker.go
+++ b/aiven/resource_kafka_mirrormaker.go
@@ -5,36 +5,36 @@ import (
 	"time"
 )
 
-func aivenKafkaConnectSchema() map[string]*schema.Schema {
-	kafkaConnectSchema := serviceCommonSchema()
-	kafkaConnectSchema[ServiceTypeKafkaConnect] = &schema.Schema{
+func aivenKafkaMirrormakerSchema() map[string]*schema.Schema {
+	kafkaMMSchema := serviceCommonSchema()
+	kafkaMMSchema[ServiceTypeKafkaMirrormaker] = &schema.Schema{
 		Type:        schema.TypeList,
 		MaxItems:    1,
 		Computed:    true,
-		Description: "Kafka Connect server provided values",
+		Description: "Kafka MirrorMaker 2 server provided values",
 		Optional:    true,
 		Elem: &schema.Resource{
 			Schema: map[string]*schema.Schema{},
 		},
 	}
-	kafkaConnectSchema[ServiceTypeKafkaConnect+"_user_config"] = &schema.Schema{
+	kafkaMMSchema[ServiceTypeKafkaMirrormaker+"_user_config"] = &schema.Schema{
 		Type:             schema.TypeList,
 		MaxItems:         1,
 		Optional:         true,
-		Description:      "Kafka Connect user configurable settings",
+		Description:      "Kafka MirrorMaker 2 specific user configurable settings",
 		DiffSuppressFunc: emptyObjectDiffSuppressFunc,
 		Elem: &schema.Resource{
 			Schema: GenerateTerraformUserConfigSchema(
-				GetUserConfigSchema("service")[ServiceTypeKafkaConnect].(map[string]interface{})),
+				GetUserConfigSchema("service")[ServiceTypeKafkaMirrormaker].(map[string]interface{})),
 		},
 	}
 
-	return kafkaConnectSchema
+	return kafkaMMSchema
 }
+func resourceKafkaMirrormaker() *schema.Resource {
 
-func resourceKafkaConnect() *schema.Resource {
 	return &schema.Resource{
-		Create: resourceServiceCreateWrapper(ServiceTypeKafkaConnect),
+		Create: resourceServiceCreateWrapper(ServiceTypeKafkaMirrormaker),
 		Read:   resourceServiceRead,
 		Update: resourceServiceUpdate,
 		Delete: resourceServiceDelete,
@@ -47,6 +47,6 @@ func resourceKafkaConnect() *schema.Resource {
 			Update: schema.DefaultTimeout(20 * time.Minute),
 		},
 
-		Schema: aivenKafkaConnectSchema(),
+		Schema: aivenKafkaMirrormakerSchema(),
 	}
 }

--- a/aiven/resource_kafka_mirrormaker_test.go
+++ b/aiven/resource_kafka_mirrormaker_test.go
@@ -2,8 +2,8 @@ package aiven
 
 import (
 	"fmt"
-	"github.com/hashicorp/terraform/helper/acctest"
-	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"os"
 	"testing"
 )

--- a/aiven/resource_kafka_mirrormaker_test.go
+++ b/aiven/resource_kafka_mirrormaker_test.go
@@ -8,9 +8,8 @@ import (
 	"testing"
 )
 
-// Kafka Connect service tests
-func TestAccAiven_kafkaconnect(t *testing.T) {
-	resourceName := "aiven_kafka_connect.bar"
+func TestAccAiven_kafka_mirrormaker(t *testing.T) {
+	resourceName := "aiven_kafka_mirrormaker.bar"
 	rName := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -19,17 +18,14 @@ func TestAccAiven_kafkaconnect(t *testing.T) {
 		CheckDestroy: testAccCheckAivenServiceResourceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccKafkaConnectResource(rName),
+				Config: testAccMirrorMakerResource(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAivenServiceKafkaConnectAttributes("data.aiven_kafka_connect.service"),
-					testAccCheckAivenServiceKafkaConnectAttributes("data.aiven_kafka_connect.service"),
+					testAccCheckAivenServiceMirrorMakerAttributes("data.aiven_kafka_mirrormaker.service"),
 					resource.TestCheckResourceAttr(resourceName, "service_name", fmt.Sprintf("test-acc-sr-%s", rName)),
 					resource.TestCheckResourceAttr(resourceName, "state", "RUNNING"),
 					resource.TestCheckResourceAttr(resourceName, "project", fmt.Sprintf("test-acc-pr-%s", rName)),
-					resource.TestCheckResourceAttr(resourceName, "service_type", "kafka_connect"),
+					resource.TestCheckResourceAttr(resourceName, "service_type", "kafka_mirrormaker"),
 					resource.TestCheckResourceAttr(resourceName, "cloud_name", "google-europe-west1"),
-					resource.TestCheckResourceAttr(resourceName, "maintenance_window_dow", "monday"),
-					resource.TestCheckResourceAttr(resourceName, "maintenance_window_time", "10:00:00"),
 					resource.TestCheckResourceAttr(resourceName, "state", "RUNNING"),
 					resource.TestCheckResourceAttr(resourceName, "termination_protection", "false"),
 				),
@@ -38,35 +34,33 @@ func TestAccAiven_kafkaconnect(t *testing.T) {
 	})
 }
 
-func testAccKafkaConnectResource(name string) string {
+func testAccMirrorMakerResource(name string) string {
 	return fmt.Sprintf(`
 		resource "aiven_project" "foo" {
 			project = "test-acc-pr-%s"
 			card_id="%s"	
 		}
 		
-		resource "aiven_kafka_connect" "bar" {
+		resource "aiven_kafka_mirrormaker" "bar" {
 			project = aiven_project.foo.project
 			cloud_name = "google-europe-west1"
 			plan = "startup-4"
 			service_name = "test-acc-sr-%s"
-			maintenance_window_dow = "monday"
-			maintenance_window_time = "10:00:00"
 			
-			kafka_connect_user_config {
-				kafka_connect {
-					consumer_isolation_level = "read_committed"
-				}
-		
-				public_access {
-					kafka_connect = true
+			kafka_mirrormaker_user_config {
+				ip_filter = ["0.0.0.0/0"]
+
+				kafka_mirrormaker {
+					refresh_groups_interval_seconds = 600
+					refresh_topics_enabled = true
+					refresh_topics_interval_seconds = 600
 				}
 			}
 		}
-		
-		data "aiven_kafka_connect" "service" {
-			service_name = aiven_kafka_connect.bar.service_name
-			project = aiven_kafka_connect.bar.project
+
+		data "aiven_kafka_mirrormaker" "service" {
+			service_name = aiven_kafka_mirrormaker.bar.service_name
+			project = aiven_kafka_mirrormaker.bar.project
 		}
 		`, name, os.Getenv("AIVEN_CARD_ID"), name)
 }

--- a/aiven/resource_kafka_test.go
+++ b/aiven/resource_kafka_test.go
@@ -1,0 +1,140 @@
+package aiven
+
+import (
+	"fmt"
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+	"os"
+	"testing"
+)
+
+func TestAccAiven_kafka(t *testing.T) {
+	resourceName := "aiven_kafka.bar"
+	rName := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAivenServiceResourceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccKafkaResource(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAivenServiceCommonAttributes("data.aiven_kafka.service"),
+					testAccCheckAivenKafkaAttributes("data.aiven_kafka.service"),
+					resource.TestCheckResourceAttr(resourceName, "service_name", fmt.Sprintf("test-acc-sr-%s", rName)),
+					resource.TestCheckResourceAttr(resourceName, "state", "RUNNING"),
+					resource.TestCheckResourceAttr(resourceName, "project", fmt.Sprintf("test-acc-pr-%s", rName)),
+					resource.TestCheckResourceAttr(resourceName, "service_type", "kafka"),
+					resource.TestCheckResourceAttr(resourceName, "cloud_name", "google-europe-west1"),
+					resource.TestCheckResourceAttr(resourceName, "maintenance_window_dow", "monday"),
+					resource.TestCheckResourceAttr(resourceName, "maintenance_window_time", "10:00:00"),
+					resource.TestCheckResourceAttr(resourceName, "state", "RUNNING"),
+					resource.TestCheckResourceAttr(resourceName, "termination_protection", "false"),
+				),
+			},
+		},
+	})
+}
+
+func testAccKafkaResource(name string) string {
+	return fmt.Sprintf(`
+		resource "aiven_project" "foo" {
+			project = "test-acc-pr-%s"
+			card_id="%s"	
+		}
+		
+		resource "aiven_kafka" "bar" {
+			project = aiven_project.foo.project
+			cloud_name = "google-europe-west1"
+			plan = "business-4"
+			service_name = "test-acc-sr-%s"
+			maintenance_window_dow = "monday"
+			maintenance_window_time = "10:00:00"
+
+			kafka_user_config {
+				kafka_rest = true
+				kafka_connect = true
+				schema_registry = true
+				kafka_version = "2.4"
+
+				kafka {
+					group_max_session_timeout_ms = 70000
+					log_retention_bytes = 1000000000
+				}
+
+				public_access {
+					kafka_rest = true
+					kafka_connect = true
+				}
+			}
+		}
+
+		data "aiven_kafka" "service" {
+			service_name = aiven_kafka.bar.service_name
+			project = aiven_kafka.bar.project
+		}
+		`, name, os.Getenv("AIVEN_CARD_ID"), name)
+}
+
+func testAccCheckAivenKafkaAttributes(n string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		r := s.RootModule().Resources[n]
+		a := r.Primary.Attributes
+
+		if a["service_type"] != "kafka" {
+			return fmt.Errorf("expected to get a correct service type from Aiven, got :%s", a["service_type"])
+		}
+
+		if a["kafka_user_config.0.kafka_connect"] != "true" {
+			return fmt.Errorf("expected to get a correct kafka_connect from Aiven")
+		}
+
+		if a["kafka_user_config.0.kafka_rest"] != "true" {
+			return fmt.Errorf("expected to get a correct kafka_rest from Aiven")
+		}
+
+		if a["kafka_user_config.0.kafka_version"] != "2.4" {
+			return fmt.Errorf("expected to get a correct kafka_version from Aiven")
+		}
+
+		if a["kafka_user_config.0.public_access.0.kafka_connect"] != "true" {
+			return fmt.Errorf("expected to get a correct public_access.kafka_connect from Aiven")
+		}
+
+		if a["kafka_user_config.0.public_access.0.kafka_rest"] != "true" {
+			return fmt.Errorf("expected to get a correct public_access.kafka_rest from Aiven")
+		}
+
+		if a["kafka_user_config.0.public_access.0.kafka"] != "" {
+			return fmt.Errorf("expected to get a correct public_access.kafka from Aiven")
+		}
+
+		if a["kafka_user_config.0.public_access.0.prometheus"] != "" {
+			return fmt.Errorf("expected to get a correct public_access.prometheus from Aiven")
+		}
+
+		if a["kafka.0.connect_uri"] == "" {
+			return fmt.Errorf("expected to get a connect_uri from Aiven")
+		}
+
+		if a["kafka.0.rest_uri"] == "" {
+			return fmt.Errorf("expected to get a rest_uri from Aiven")
+		}
+
+		if a["kafka.0.schema_registry_uri"] == "" {
+			return fmt.Errorf("expected to get a schema_registry_uri from Aiven")
+		}
+
+		if a["kafka.0.access_key"] == "" {
+			return fmt.Errorf("expected to get an access_key from Aiven")
+		}
+
+		if a["kafka.0.access_cert"] == "" {
+			return fmt.Errorf("expected to get an access_cert from Aiven")
+		}
+
+		return nil
+	}
+}

--- a/aiven/resource_kafka_test.go
+++ b/aiven/resource_kafka_test.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
-	"github.com/hashicorp/terraform/terraform"
 	"os"
 	"testing"
 )
@@ -22,7 +21,7 @@ func TestAccAiven_kafka(t *testing.T) {
 				Config: testAccKafkaResource(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAivenServiceCommonAttributes("data.aiven_kafka.service"),
-					testAccCheckAivenKafkaAttributes("data.aiven_kafka.service"),
+					testAccCheckAivenServiceKafkaAttributes("data.aiven_kafka.service"),
 					resource.TestCheckResourceAttr(resourceName, "service_name", fmt.Sprintf("test-acc-sr-%s", rName)),
 					resource.TestCheckResourceAttr(resourceName, "state", "RUNNING"),
 					resource.TestCheckResourceAttr(resourceName, "project", fmt.Sprintf("test-acc-pr-%s", rName)),
@@ -76,65 +75,4 @@ func testAccKafkaResource(name string) string {
 			project = aiven_kafka.bar.project
 		}
 		`, name, os.Getenv("AIVEN_CARD_ID"), name)
-}
-
-func testAccCheckAivenKafkaAttributes(n string) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		r := s.RootModule().Resources[n]
-		a := r.Primary.Attributes
-
-		if a["service_type"] != "kafka" {
-			return fmt.Errorf("expected to get a correct service type from Aiven, got :%s", a["service_type"])
-		}
-
-		if a["kafka_user_config.0.kafka_connect"] != "true" {
-			return fmt.Errorf("expected to get a correct kafka_connect from Aiven")
-		}
-
-		if a["kafka_user_config.0.kafka_rest"] != "true" {
-			return fmt.Errorf("expected to get a correct kafka_rest from Aiven")
-		}
-
-		if a["kafka_user_config.0.kafka_version"] != "2.4" {
-			return fmt.Errorf("expected to get a correct kafka_version from Aiven")
-		}
-
-		if a["kafka_user_config.0.public_access.0.kafka_connect"] != "true" {
-			return fmt.Errorf("expected to get a correct public_access.kafka_connect from Aiven")
-		}
-
-		if a["kafka_user_config.0.public_access.0.kafka_rest"] != "true" {
-			return fmt.Errorf("expected to get a correct public_access.kafka_rest from Aiven")
-		}
-
-		if a["kafka_user_config.0.public_access.0.kafka"] != "" {
-			return fmt.Errorf("expected to get a correct public_access.kafka from Aiven")
-		}
-
-		if a["kafka_user_config.0.public_access.0.prometheus"] != "" {
-			return fmt.Errorf("expected to get a correct public_access.prometheus from Aiven")
-		}
-
-		if a["kafka.0.connect_uri"] == "" {
-			return fmt.Errorf("expected to get a connect_uri from Aiven")
-		}
-
-		if a["kafka.0.rest_uri"] == "" {
-			return fmt.Errorf("expected to get a rest_uri from Aiven")
-		}
-
-		if a["kafka.0.schema_registry_uri"] == "" {
-			return fmt.Errorf("expected to get a schema_registry_uri from Aiven")
-		}
-
-		if a["kafka.0.access_key"] == "" {
-			return fmt.Errorf("expected to get an access_key from Aiven")
-		}
-
-		if a["kafka.0.access_cert"] == "" {
-			return fmt.Errorf("expected to get an access_cert from Aiven")
-		}
-
-		return nil
-	}
 }

--- a/aiven/resource_kafka_test.go
+++ b/aiven/resource_kafka_test.go
@@ -2,8 +2,8 @@ package aiven
 
 import (
 	"fmt"
-	"github.com/hashicorp/terraform/helper/acctest"
-	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"os"
 	"testing"
 )

--- a/aiven/resource_mirrormaker_replication_flow_test.go
+++ b/aiven/resource_mirrormaker_replication_flow_test.go
@@ -104,12 +104,11 @@ func testAccMirrorMakerReplicationFlowResource(name string) string {
 			replication = 2
 		}
 
-		resource "aiven_service" "target" {
+		resource "aiven_kafka" "target" {
 			project = aiven_project.foo.project
 			cloud_name = "google-europe-west1"
 			plan = "business-4"
 			service_name = "test-acc-sr-target-%s"
-			service_type = "kafka"
 			maintenance_window_dow = "monday"
 			maintenance_window_time = "10:00:00"
 			
@@ -124,7 +123,7 @@ func testAccMirrorMakerReplicationFlowResource(name string) string {
 		
 		resource "aiven_kafka_topic" "target" {
 			project = aiven_project.foo.project
-			service_name = aiven_service.target.service_name
+			service_name = aiven_kafka.target.service_name
 			topic_name = "test-acc-topic-b-%s"
 			partitions = 3
 			replication = 2
@@ -162,7 +161,7 @@ func testAccMirrorMakerReplicationFlowResource(name string) string {
 		resource "aiven_service_integration" "i2" {
 			project = aiven_project.foo.project
 			integration_type = "kafka_mirrormaker"
-			source_service_name = aiven_service.target.service_name
+			source_service_name = aiven_kafka.target.service_name
 			destination_service_name = aiven_service.mm.service_name
 	
 			kafka_mirrormaker_user_config {

--- a/aiven/resource_mysql.go
+++ b/aiven/resource_mysql.go
@@ -6,36 +6,35 @@ import (
 	"time"
 )
 
-func aivenKafkaConnectSchema() map[string]*schema.Schema {
-	kafkaConnectSchema := serviceCommonSchema()
-	kafkaConnectSchema[ServiceTypeKafkaConnect] = &schema.Schema{
+func aivenMySQLSchema() map[string]*schema.Schema {
+	schemaMySQL := serviceCommonSchema()
+	schemaMySQL[ServiceTypeMySQL] = &schema.Schema{
 		Type:        schema.TypeList,
 		MaxItems:    1,
 		Computed:    true,
-		Description: "Kafka Connect server provided values",
+		Description: "MySQL specific server provided values",
 		Optional:    true,
 		Elem: &schema.Resource{
 			Schema: map[string]*schema.Schema{},
 		},
 	}
-	kafkaConnectSchema[ServiceTypeKafkaConnect+"_user_config"] = &schema.Schema{
+	schemaMySQL[ServiceTypeMySQL+"_user_config"] = &schema.Schema{
 		Type:             schema.TypeList,
 		MaxItems:         1,
 		Optional:         true,
-		Description:      "Kafka Connect user configurable settings",
+		Description:      "MySQL specific user configurable settings",
 		DiffSuppressFunc: emptyObjectDiffSuppressFunc,
 		Elem: &schema.Resource{
 			Schema: GenerateTerraformUserConfigSchema(
-				templates.GetUserConfigSchema("service")[ServiceTypeKafkaConnect].(map[string]interface{})),
+				templates.GetUserConfigSchema("service")[ServiceTypeMySQL].(map[string]interface{})),
 		},
 	}
 
-	return kafkaConnectSchema
+	return schemaMySQL
 }
-
-func resourceKafkaConnect() *schema.Resource {
+func resourceMySQL() *schema.Resource {
 	return &schema.Resource{
-		Create: resourceServiceCreateWrapper(ServiceTypeKafkaConnect),
+		Create: resourceServiceCreateWrapper(ServiceTypeMySQL),
 		Read:   resourceServiceRead,
 		Update: resourceServiceUpdate,
 		Delete: resourceServiceDelete,
@@ -48,6 +47,6 @@ func resourceKafkaConnect() *schema.Resource {
 			Update: schema.DefaultTimeout(20 * time.Minute),
 		},
 
-		Schema: aivenKafkaConnectSchema(),
+		Schema: aivenMySQLSchema(),
 	}
 }

--- a/aiven/resource_mysql.go
+++ b/aiven/resource_mysql.go
@@ -2,7 +2,7 @@ package aiven
 
 import (
 	"github.com/aiven/terraform-provider-aiven/aiven/templates"
-	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"time"
 )
 

--- a/aiven/resource_mysql_test.go
+++ b/aiven/resource_mysql_test.go
@@ -1,0 +1,74 @@
+package aiven
+
+import (
+	"fmt"
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+	"os"
+	"testing"
+)
+
+func TestAccAiven_mysql(t *testing.T) {
+	resourceName := "aiven_mysql.bar"
+	rName := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAivenServiceResourceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMysqlResource(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAivenServiceCommonAttributes("data.aiven_mysql.service"),
+					testAccCheckAivenServiceMysqlAttributes("data.aiven_mysql.service"),
+					resource.TestCheckResourceAttr(resourceName, "service_name", fmt.Sprintf("test-acc-sr-%s", rName)),
+					resource.TestCheckResourceAttr(resourceName, "state", "RUNNING"),
+					resource.TestCheckResourceAttr(resourceName, "project", fmt.Sprintf("test-acc-pr-%s", rName)),
+					resource.TestCheckResourceAttr(resourceName, "service_type", "mysql"),
+					resource.TestCheckResourceAttr(resourceName, "cloud_name", "google-europe-west1"),
+					resource.TestCheckResourceAttr(resourceName, "maintenance_window_dow", "monday"),
+					resource.TestCheckResourceAttr(resourceName, "maintenance_window_time", "10:00:00"),
+					resource.TestCheckResourceAttr(resourceName, "state", "RUNNING"),
+					resource.TestCheckResourceAttr(resourceName, "termination_protection", "false"),
+				),
+			},
+		},
+	})
+}
+
+func testAccMysqlResource(name string) string {
+	return fmt.Sprintf(`
+		resource "aiven_project" "foo" {
+			project = "test-acc-pr-%s"
+			card_id="%s"	
+		}
+		
+		resource "aiven_mysql" "bar" {
+			project = aiven_project.foo.project
+			cloud_name = "google-europe-west1"
+			plan = "business-4"
+			service_name = "test-acc-sr-%s"
+			maintenance_window_dow = "monday"
+			maintenance_window_time = "10:00:00"
+			
+			mysql_user_config {
+				mysql_version = 8
+							
+				mysql {
+					sql_mode = "ANSI,ERROR_FOR_DIVISION_BY_ZERO,NO_ENGINE_SUBSTITUTION,NO_ZERO_DATE,NO_ZERO_IN_DATE"
+					sql_require_primary_key = true
+				}
+
+				public_access {
+					mysql = true
+				}
+			}
+		}
+		
+		data "aiven_mysql" "service" {
+			service_name = aiven_mysql.bar.service_name
+			project = aiven_mysql.bar.project
+		}
+		`, name, os.Getenv("AIVEN_CARD_ID"), name)
+}

--- a/aiven/resource_pg.go
+++ b/aiven/resource_pg.go
@@ -2,7 +2,7 @@ package aiven
 
 import (
 	"github.com/aiven/terraform-provider-aiven/aiven/templates"
-	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"time"
 )
 

--- a/aiven/resource_pg.go
+++ b/aiven/resource_pg.go
@@ -1,6 +1,7 @@
 package aiven
 
 import (
+	"github.com/aiven/terraform-provider-aiven/aiven/templates"
 	"github.com/hashicorp/terraform/helper/schema"
 	"time"
 )
@@ -70,7 +71,7 @@ func aivenPGSchema() map[string]*schema.Schema {
 		DiffSuppressFunc: emptyObjectDiffSuppressFunc,
 		Elem: &schema.Resource{
 			Schema: GenerateTerraformUserConfigSchema(
-				GetUserConfigSchema("service")[ServiceTypePG].(map[string]interface{})),
+				templates.GetUserConfigSchema("service")[ServiceTypePG].(map[string]interface{})),
 		},
 	}
 

--- a/aiven/resource_pg.go
+++ b/aiven/resource_pg.go
@@ -1,0 +1,97 @@
+package aiven
+
+import (
+	"github.com/hashicorp/terraform/helper/schema"
+	"time"
+)
+
+func aivenPGSchema() map[string]*schema.Schema {
+	schemaPG := serviceCommonSchema()
+	schemaPG[ServiceTypePG] = &schema.Schema{
+		Type:        schema.TypeList,
+		MaxItems:    1,
+		Computed:    true,
+		Description: "PostgreSQL specific server provided values",
+		Optional:    true,
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				"replica_uri": {
+					Type:        schema.TypeString,
+					Computed:    true,
+					Description: "PostgreSQL replica URI for services with a replica",
+					Sensitive:   true,
+				},
+				"uri": {
+					Type:        schema.TypeString,
+					Computed:    true,
+					Description: "PostgreSQL master connection URI",
+					Optional:    true,
+					Sensitive:   true,
+				},
+				"dbname": {
+					Type:        schema.TypeString,
+					Computed:    true,
+					Description: "Primary PostgreSQL database name",
+				},
+				"host": {
+					Type:        schema.TypeString,
+					Computed:    true,
+					Description: "PostgreSQL master node host IP or name",
+				},
+				"password": {
+					Type:        schema.TypeString,
+					Computed:    true,
+					Description: "PostgreSQL admin user password",
+					Sensitive:   true,
+				},
+				"port": {
+					Type:        schema.TypeInt,
+					Computed:    true,
+					Description: "PostgreSQL port",
+				},
+				"sslmode": {
+					Type:        schema.TypeString,
+					Computed:    true,
+					Description: "PostgreSQL sslmode setting (currently always \"require\")",
+				},
+				"user": {
+					Type:        schema.TypeString,
+					Computed:    true,
+					Description: "PostgreSQL admin user name",
+				},
+			},
+		},
+	}
+	schemaPG[ServiceTypePG+"_user_config"] = &schema.Schema{
+		Type:             schema.TypeList,
+		MaxItems:         1,
+		Optional:         true,
+		Description:      "PostgreSQL specific user configurable settings",
+		DiffSuppressFunc: emptyObjectDiffSuppressFunc,
+		Elem: &schema.Resource{
+			Schema: GenerateTerraformUserConfigSchema(
+				GetUserConfigSchema("service")[ServiceTypePG].(map[string]interface{})),
+		},
+	}
+
+	return schemaPG
+}
+
+func resourcePG() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceServiceCreateWrapper(ServiceTypePG),
+		Read:   resourceServiceRead,
+		Update: resourceServiceUpdate,
+		Delete: resourceServiceDelete,
+		Exists: resourceServiceExists,
+		Importer: &schema.ResourceImporter{
+			State: resourceServiceState,
+		},
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(20 * time.Minute),
+			Update: schema.DefaultTimeout(20 * time.Minute),
+		},
+
+		Schema: aivenPGSchema(),
+	}
+}

--- a/aiven/resource_pg_test.go
+++ b/aiven/resource_pg_test.go
@@ -2,8 +2,8 @@ package aiven
 
 import (
 	"fmt"
-	"github.com/hashicorp/terraform/helper/acctest"
-	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"os"
 	"testing"
 )

--- a/aiven/resource_pg_test.go
+++ b/aiven/resource_pg_test.go
@@ -1,0 +1,74 @@
+package aiven
+
+import (
+	"fmt"
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+	"os"
+	"testing"
+)
+
+func TestAccAiven_pg(t *testing.T) {
+	resourceName := "aiven_pg.bar"
+	rName := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAivenServiceResourceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccPGResource(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAivenServicePGAttributes("data.aiven_pg.service"),
+					testAccCheckAivenServicePGAttributes("data.aiven_pg.service"),
+					resource.TestCheckResourceAttr(resourceName, "service_name", fmt.Sprintf("test-acc-sr-%s", rName)),
+					resource.TestCheckResourceAttr(resourceName, "state", "RUNNING"),
+					resource.TestCheckResourceAttr(resourceName, "project", fmt.Sprintf("test-acc-pr-pg-%s", rName)),
+					resource.TestCheckResourceAttr(resourceName, "service_type", "pg"),
+					resource.TestCheckResourceAttr(resourceName, "cloud_name", "google-europe-west1"),
+					resource.TestCheckResourceAttr(resourceName, "maintenance_window_dow", "monday"),
+					resource.TestCheckResourceAttr(resourceName, "maintenance_window_time", "10:00:00"),
+					resource.TestCheckResourceAttr(resourceName, "state", "RUNNING"),
+					resource.TestCheckResourceAttr(resourceName, "termination_protection", "false"),
+				),
+			},
+		},
+	})
+}
+
+func testAccPGResource(name string) string {
+	return fmt.Sprintf(`
+		resource "aiven_project" "foo" {
+			project = "test-acc-pr-pg-%s"
+			card_id="%s"	
+		}
+		
+		resource "aiven_pg" "bar" {
+			project = aiven_project.foo.project
+			cloud_name = "google-europe-west1"
+			plan = "startup-4"
+			service_name = "test-acc-sr-%s"
+			maintenance_window_dow = "monday"
+			maintenance_window_time = "10:00:00"
+			
+			pg_user_config {
+				pg_version = 11
+
+				public_access {
+					pg = true
+					prometheus = false
+				}
+
+				pg {
+					idle_in_transaction_session_timeout = 900
+				}
+			}
+		}
+		
+		data "aiven_pg" "service" {
+			service_name = aiven_pg.bar.service_name
+			project = aiven_pg.bar.project
+		}
+		`, name, os.Getenv("AIVEN_CARD_ID"), name)
+}

--- a/aiven/resource_redis.go
+++ b/aiven/resource_redis.go
@@ -6,36 +6,36 @@ import (
 	"time"
 )
 
-func aivenKafkaMirrormakerSchema() map[string]*schema.Schema {
-	kafkaMMSchema := serviceCommonSchema()
-	kafkaMMSchema[ServiceTypeKafkaMirrormaker] = &schema.Schema{
+func redisSchema() map[string]*schema.Schema {
+	s := serviceCommonSchema()
+	s[ServiceTypeRedis] = &schema.Schema{
 		Type:        schema.TypeList,
 		MaxItems:    1,
 		Computed:    true,
-		Description: "Kafka MirrorMaker 2 server provided values",
+		Description: "Redis server provided values",
 		Optional:    true,
 		Elem: &schema.Resource{
 			Schema: map[string]*schema.Schema{},
 		},
 	}
-	kafkaMMSchema[ServiceTypeKafkaMirrormaker+"_user_config"] = &schema.Schema{
+	s[ServiceTypeRedis+"_user_config"] = &schema.Schema{
 		Type:             schema.TypeList,
 		MaxItems:         1,
 		Optional:         true,
-		Description:      "Kafka MirrorMaker 2 specific user configurable settings",
+		Description:      "Redis user configurable settings",
 		DiffSuppressFunc: emptyObjectDiffSuppressFunc,
 		Elem: &schema.Resource{
 			Schema: GenerateTerraformUserConfigSchema(
-				templates.GetUserConfigSchema("service")[ServiceTypeKafkaMirrormaker].(map[string]interface{})),
+				templates.GetUserConfigSchema("service")[ServiceTypeRedis].(map[string]interface{})),
 		},
 	}
 
-	return kafkaMMSchema
+	return s
 }
-func resourceKafkaMirrormaker() *schema.Resource {
 
+func resourceRedis() *schema.Resource {
 	return &schema.Resource{
-		Create: resourceServiceCreateWrapper(ServiceTypeKafkaMirrormaker),
+		Create: resourceServiceCreateWrapper(ServiceTypeRedis),
 		Read:   resourceServiceRead,
 		Update: resourceServiceUpdate,
 		Delete: resourceServiceDelete,
@@ -48,6 +48,6 @@ func resourceKafkaMirrormaker() *schema.Resource {
 			Update: schema.DefaultTimeout(20 * time.Minute),
 		},
 
-		Schema: aivenKafkaMirrormakerSchema(),
+		Schema: redisSchema(),
 	}
 }

--- a/aiven/resource_service.go
+++ b/aiven/resource_service.go
@@ -41,6 +41,163 @@ func availableServiceTypes() []string {
 	}
 }
 
+func serviceCommonSchema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"project": {
+			Type:        schema.TypeString,
+			Required:    true,
+			Description: "Target project",
+			ForceNew:    true,
+		},
+		"cloud_name": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Description: "Cloud the service runs in",
+		},
+		"plan": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Description: "Subscription plan",
+		},
+		"service_name": {
+			Type:        schema.TypeString,
+			Required:    true,
+			Description: "Service name",
+			ForceNew:    true,
+		},
+		"service_type": {
+			Type:        schema.TypeString,
+			Computed:    true,
+			Description: "Aiven internal service type code",
+		},
+		"project_vpc_id": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Description: "Identifier of the VPC the service should be in, if any",
+		},
+		"maintenance_window_dow": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Description: "Day of week when maintenance operations should be performed. One monday, tuesday, wednesday, etc.",
+			DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+				return new == ""
+			},
+		},
+		"maintenance_window_time": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Description: "Time of day when maintenance operations should be performed. UTC time in HH:mm:ss format.",
+			DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+				return new == ""
+			},
+		},
+		"termination_protection": {
+			Type:        schema.TypeBool,
+			Optional:    true,
+			Description: "Prevent service from being deleted. It is recommended to have this enabled for all services.",
+		},
+		"service_uri": {
+			Type:        schema.TypeString,
+			Computed:    true,
+			Description: "URI for connecting to the service. Service specific info is under \"kafka\", \"pg\", etc.",
+			Sensitive:   true,
+		},
+		"service_host": {
+			Type:        schema.TypeString,
+			Computed:    true,
+			Description: "Service hostname",
+		},
+		"service_port": {
+			Type:        schema.TypeInt,
+			Computed:    true,
+			Description: "Service port",
+		},
+		"service_password": {
+			Type:        schema.TypeString,
+			Computed:    true,
+			Description: "Password used for connecting to the service, if applicable",
+			Sensitive:   true,
+		},
+		"service_username": {
+			Type:        schema.TypeString,
+			Computed:    true,
+			Description: "Username used for connecting to the service, if applicable",
+		},
+		"state": {
+			Type:        schema.TypeString,
+			Computed:    true,
+			Description: "Service state",
+		},
+		"service_integrations": {
+			Type:             schema.TypeList,
+			Optional:         true,
+			Description:      "Service integrations to specify when creating a service. Not applied after initial service creation",
+			DiffSuppressFunc: createOnlyDiffSuppressFunc,
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"source_service_name": {
+						Type:        schema.TypeString,
+						Required:    true,
+						Description: "Name of the source service",
+					},
+					"integration_type": {
+						Type:        schema.TypeString,
+						Required:    true,
+						Description: "Type of the service integration. The only supported value at the moment is 'read_replica'",
+					},
+				},
+			},
+		},
+		"components": {
+			Type:        schema.TypeList,
+			Computed:    true,
+			Description: "Service component information objects",
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"component": {
+						Type:        schema.TypeString,
+						Computed:    true,
+						Description: "Service component name",
+					},
+					"host": {
+						Type:        schema.TypeString,
+						Computed:    true,
+						Description: "DNS name for connecting to the service component",
+					},
+					"kafka_authentication_method": {
+						Type:        schema.TypeString,
+						Computed:    true,
+						Optional:    true,
+						Description: "Kafka authentication method. This is a value specific to the 'kafka' service component",
+					},
+					"port": {
+						Type:        schema.TypeInt,
+						Computed:    true,
+						Description: "Port number for connecting to the service component",
+					},
+					"route": {
+						Type:        schema.TypeString,
+						Computed:    true,
+						Description: "Network access route",
+					},
+					"ssl": {
+						Type:     schema.TypeBool,
+						Computed: true,
+						Description: "Whether the endpoint is encrypted or accepts plaintext. By default endpoints are " +
+							"always encrypted and this property is only included for service components they may " +
+							"disable encryption",
+					},
+					"usage": {
+						Type:        schema.TypeString,
+						Computed:    true,
+						Description: "DNS usage name",
+					},
+				},
+			},
+		},
+	}
+}
+
 var aivenServiceSchema = map[string]*schema.Schema{
 	"project": {
 		Type:        schema.TypeString,
@@ -504,7 +661,7 @@ var aivenServiceSchema = map[string]*schema.Schema{
 
 func resourceService() *schema.Resource {
 	return &schema.Resource{
-		Create: resourceServiceCreateWrapper,
+		Create: resourceServiceCreateWrapper("service"),
 		Read:   resourceServiceRead,
 		Update: resourceServiceUpdate,
 		Delete: resourceServiceDelete,
@@ -521,42 +678,63 @@ func resourceService() *schema.Resource {
 	}
 }
 
-func resourceServiceCreateWrapper(d *schema.ResourceData, m interface{}) error {
-	// Need to set empty value for all services or all Terraform keeps on showing there's
-	// a change in the computed values that don't match actual service type
-	if err := d.Set(ServiceTypeCassandra, []map[string]interface{}{}); err != nil {
-		return err
-	}
-	if err := d.Set(ServiceTypeCassandra, []map[string]interface{}{}); err != nil {
-		return err
-	}
-	if err := d.Set(ServiceTypeGrafana, []map[string]interface{}{}); err != nil {
-		return err
-	}
-	if err := d.Set(ServiceTypeInfluxDB, []map[string]interface{}{}); err != nil {
-		return err
-	}
-	if err := d.Set(ServiceTypeKafka, []map[string]interface{}{}); err != nil {
-		return err
-	}
-	if err := d.Set(ServiceTypeKafkaConnect, []map[string]interface{}{}); err != nil {
-		return err
-	}
-	if err := d.Set(ServiceTypeKafkaMirrormaker, []map[string]interface{}{}); err != nil {
-		return err
-	}
-	if err := d.Set(ServiceTypeMySQL, []map[string]interface{}{}); err != nil {
-		return err
-	}
-	if err := d.Set(ServiceTypePG, []map[string]interface{}{}); err != nil {
-		return err
-	}
-	if err := d.Set(ServiceTypeRedis, []map[string]interface{}{}); err != nil {
-		return err
+func resourceServiceCreateWrapper(serviceType string) schema.CreateFunc {
+	if serviceType == "service" {
+		return func(d *schema.ResourceData, m interface{}) error {
+			// Need to set empty value for all services or all Terraform keeps on showing there's
+			// a change in the computed values that don't match actual service type
+			if err := d.Set(ServiceTypeCassandra, []map[string]interface{}{}); err != nil {
+				return err
+			}
+			if err := d.Set(ServiceTypeElasticsearch, []map[string]interface{}{}); err != nil {
+				return err
+			}
+			if err := d.Set(ServiceTypeGrafana, []map[string]interface{}{}); err != nil {
+				return err
+			}
+			if err := d.Set(ServiceTypeInfluxDB, []map[string]interface{}{}); err != nil {
+				return err
+			}
+			if err := d.Set(ServiceTypeKafka, []map[string]interface{}{}); err != nil {
+				return err
+			}
+			if err := d.Set(ServiceTypeKafkaConnect, []map[string]interface{}{}); err != nil {
+				return err
+			}
+			if err := d.Set(ServiceTypeKafkaMirrormaker, []map[string]interface{}{}); err != nil {
+				return err
+			}
+			if err := d.Set(ServiceTypeMySQL, []map[string]interface{}{}); err != nil {
+				return err
+			}
+			if err := d.Set(ServiceTypePG, []map[string]interface{}{}); err != nil {
+				return err
+			}
+			if err := d.Set(ServiceTypeRedis, []map[string]interface{}{}); err != nil {
+				return err
+			}
+
+			return resourceServiceCreate(d, m)
+		}
 	}
 
-	return resourceServiceCreate(d, m)
+	return func(d *schema.ResourceData, m interface{}) error {
+		if err := d.Set("service_type", serviceType); err != nil {
+			return err
+		}
+		if err := d.Set(serviceType, []map[string]interface{}{}); err != nil {
+			return err
+		}
+
+		return resourceServiceCreate(d, m)
+	}
+
 }
+
+//func resourceServiceCreateWrapper(d *schema.ResourceData, m interface{}) error {
+//
+//	return resourceServiceCreate(d, m)
+//}
 
 func resourceServiceCreate(d *schema.ResourceData, m interface{}) error {
 	client := m.(*aiven.Client)

--- a/aiven/resource_service.go
+++ b/aiven/resource_service.go
@@ -13,17 +13,33 @@ import (
 	"time"
 )
 
-var availableServiceTypes = []string{
-	"pg",
-	"kafka",
-	"cassandra",
-	"elasticsearch",
-	"grafana",
-	"influxdb",
-	"redis",
-	"kafka_connect",
-	"kafka_mirrormaker",
-	"mysql"}
+const (
+	ServiceTypePG               = "pg"
+	ServiceTypeCassandra        = "cassandra"
+	ServiceTypeElasticsearch    = "elasticsearch"
+	ServiceTypeGrafana          = "grafana"
+	ServiceTypeInfluxDB         = "influxdb"
+	ServiceTypeRedis            = "redis"
+	ServiceTypeMySQL            = "mysql"
+	ServiceTypeKafka            = "kafka"
+	ServiceTypeKafkaConnect     = "kafka_connect"
+	ServiceTypeKafkaMirrormaker = "kafka_mirrormaker"
+)
+
+func availableServiceTypes() []string {
+	return []string{
+		ServiceTypePG,
+		ServiceTypeCassandra,
+		ServiceTypeElasticsearch,
+		ServiceTypeGrafana,
+		ServiceTypeInfluxDB,
+		ServiceTypeRedis,
+		ServiceTypeMySQL,
+		ServiceTypeKafka,
+		ServiceTypeKafkaConnect,
+		ServiceTypeKafkaMirrormaker,
+	}
+}
 
 var aivenServiceSchema = map[string]*schema.Schema{
 	"project": {
@@ -53,7 +69,7 @@ var aivenServiceSchema = map[string]*schema.Schema{
 		Required:     true,
 		Description:  "Service type code",
 		ForceNew:     true,
-		ValidateFunc: validation.StringInSlice(availableServiceTypes, false),
+		ValidateFunc: validation.StringInSlice(availableServiceTypes(), false),
 	},
 	"project_vpc_id": {
 		Type:        schema.TypeString,
@@ -488,7 +504,7 @@ var aivenServiceSchema = map[string]*schema.Schema{
 
 func resourceService() *schema.Resource {
 	return &schema.Resource{
-		Create: resourceServiceCreate,
+		Create: resourceServiceCreateWrapper,
 		Read:   resourceServiceRead,
 		Update: resourceServiceUpdate,
 		Delete: resourceServiceDelete,
@@ -503,6 +519,43 @@ func resourceService() *schema.Resource {
 
 		Schema: aivenServiceSchema,
 	}
+}
+
+func resourceServiceCreateWrapper(d *schema.ResourceData, m interface{}) error {
+	// Need to set empty value for all services or all Terraform keeps on showing there's
+	// a change in the computed values that don't match actual service type
+	if err := d.Set(ServiceTypeCassandra, []map[string]interface{}{}); err != nil {
+		return err
+	}
+	if err := d.Set(ServiceTypeCassandra, []map[string]interface{}{}); err != nil {
+		return err
+	}
+	if err := d.Set(ServiceTypeGrafana, []map[string]interface{}{}); err != nil {
+		return err
+	}
+	if err := d.Set(ServiceTypeInfluxDB, []map[string]interface{}{}); err != nil {
+		return err
+	}
+	if err := d.Set(ServiceTypeKafka, []map[string]interface{}{}); err != nil {
+		return err
+	}
+	if err := d.Set(ServiceTypeKafkaConnect, []map[string]interface{}{}); err != nil {
+		return err
+	}
+	if err := d.Set(ServiceTypeKafkaMirrormaker, []map[string]interface{}{}); err != nil {
+		return err
+	}
+	if err := d.Set(ServiceTypeMySQL, []map[string]interface{}{}); err != nil {
+		return err
+	}
+	if err := d.Set(ServiceTypePG, []map[string]interface{}{}); err != nil {
+		return err
+	}
+	if err := d.Set(ServiceTypeRedis, []map[string]interface{}{}); err != nil {
+		return err
+	}
+
+	return resourceServiceCreate(d, m)
 }
 
 func resourceServiceCreate(d *schema.ResourceData, m interface{}) error {
@@ -779,39 +832,6 @@ func copyConnectionInfoFromAPIResponseToTerraform(
 	serviceType string,
 	connectionInfo aiven.ConnectionInfo,
 ) error {
-	// Need to set empty value for all services or all Terraform keeps on showing there's
-	// a change in the computed values that don't match actual service type
-	if err := d.Set("cassandra", []map[string]interface{}{}); err != nil {
-		return err
-	}
-	if err := d.Set("elasticsearch", []map[string]interface{}{}); err != nil {
-		return err
-	}
-	if err := d.Set("grafana", []map[string]interface{}{}); err != nil {
-		return err
-	}
-	if err := d.Set("influxdb", []map[string]interface{}{}); err != nil {
-		return err
-	}
-	if err := d.Set("kafka", []map[string]interface{}{}); err != nil {
-		return err
-	}
-	if err := d.Set("kafka_connect", []map[string]interface{}{}); err != nil {
-		return err
-	}
-	if err := d.Set("kafka_mirrormaker", []map[string]interface{}{}); err != nil {
-		return err
-	}
-	if err := d.Set("mysql", []map[string]interface{}{}); err != nil {
-		return err
-	}
-	if err := d.Set("pg", []map[string]interface{}{}); err != nil {
-		return err
-	}
-	if err := d.Set("redis", []map[string]interface{}{}); err != nil {
-		return err
-	}
-
 	props := make(map[string]interface{})
 
 	switch serviceType {

--- a/aiven/resource_service.go
+++ b/aiven/resource_service.go
@@ -371,7 +371,7 @@ var aivenServiceSchema = map[string]*schema.Schema{
 		DiffSuppressFunc: emptyObjectDiffSuppressFunc,
 		Elem: &schema.Resource{
 			Schema: GenerateTerraformUserConfigSchema(
-				templates.GetUserConfigSchema("service")["cassandra"].(map[string]interface{})),
+				templates.GetUserConfigSchema("service")[ServiceTypeCassandra].(map[string]interface{})),
 		},
 	},
 	"elasticsearch": {
@@ -399,7 +399,7 @@ var aivenServiceSchema = map[string]*schema.Schema{
 		DiffSuppressFunc: emptyObjectDiffSuppressFunc,
 		Elem: &schema.Resource{
 			Schema: GenerateTerraformUserConfigSchema(
-				templates.GetUserConfigSchema("service")["elasticsearch"].(map[string]interface{})),
+				templates.GetUserConfigSchema("service")[ServiceTypeElasticsearch].(map[string]interface{})),
 		},
 	},
 	"grafana": {
@@ -420,7 +420,7 @@ var aivenServiceSchema = map[string]*schema.Schema{
 		DiffSuppressFunc: emptyObjectDiffSuppressFunc,
 		Elem: &schema.Resource{
 			Schema: GenerateTerraformUserConfigSchema(
-				templates.GetUserConfigSchema("service")["grafana"].(map[string]interface{})),
+				templates.GetUserConfigSchema("service")[ServiceTypeGrafana].(map[string]interface{})),
 		},
 	},
 	"influxdb": {
@@ -447,7 +447,7 @@ var aivenServiceSchema = map[string]*schema.Schema{
 		DiffSuppressFunc: emptyObjectDiffSuppressFunc,
 		Elem: &schema.Resource{
 			Schema: GenerateTerraformUserConfigSchema(
-				templates.GetUserConfigSchema("service")["influxdb"].(map[string]interface{})),
+				templates.GetUserConfigSchema("service")[ServiceTypeInfluxDB].(map[string]interface{})),
 		},
 	},
 	"kafka": {
@@ -504,7 +504,7 @@ var aivenServiceSchema = map[string]*schema.Schema{
 		DiffSuppressFunc: emptyObjectDiffSuppressFunc,
 		Elem: &schema.Resource{
 			Schema: GenerateTerraformUserConfigSchema(
-				templates.GetUserConfigSchema("service")["kafka"].(map[string]interface{})),
+				templates.GetUserConfigSchema("service")[ServiceTypeKafka].(map[string]interface{})),
 		},
 	},
 	"kafka_connect": {
@@ -525,7 +525,7 @@ var aivenServiceSchema = map[string]*schema.Schema{
 		DiffSuppressFunc: emptyObjectDiffSuppressFunc,
 		Elem: &schema.Resource{
 			Schema: GenerateTerraformUserConfigSchema(
-				templates.GetUserConfigSchema("service")["kafka_connect"].(map[string]interface{})),
+				templates.GetUserConfigSchema("service")[ServiceTypeKafkaConnect].(map[string]interface{})),
 		},
 	},
 	"mysql": {
@@ -546,7 +546,7 @@ var aivenServiceSchema = map[string]*schema.Schema{
 		DiffSuppressFunc: emptyObjectDiffSuppressFunc,
 		Elem: &schema.Resource{
 			Schema: GenerateTerraformUserConfigSchema(
-				templates.GetUserConfigSchema("service")["mysql"].(map[string]interface{})),
+				templates.GetUserConfigSchema("service")[ServiceTypeMySQL].(map[string]interface{})),
 		},
 	},
 	"kafka_mirrormaker": {
@@ -567,7 +567,7 @@ var aivenServiceSchema = map[string]*schema.Schema{
 		DiffSuppressFunc: emptyObjectDiffSuppressFunc,
 		Elem: &schema.Resource{
 			Schema: GenerateTerraformUserConfigSchema(
-				templates.GetUserConfigSchema("service")["kafka_mirrormaker"].(map[string]interface{})),
+				templates.GetUserConfigSchema("service")[ServiceTypeKafkaMirrormaker].(map[string]interface{})),
 		},
 	},
 	"pg": {
@@ -633,7 +633,7 @@ var aivenServiceSchema = map[string]*schema.Schema{
 		DiffSuppressFunc: emptyObjectDiffSuppressFunc,
 		Elem: &schema.Resource{
 			Schema: GenerateTerraformUserConfigSchema(
-				templates.GetUserConfigSchema("service")["pg"].(map[string]interface{})),
+				templates.GetUserConfigSchema("service")[ServiceTypePG].(map[string]interface{})),
 		},
 	},
 	"redis": {
@@ -654,7 +654,7 @@ var aivenServiceSchema = map[string]*schema.Schema{
 		DiffSuppressFunc: emptyObjectDiffSuppressFunc,
 		Elem: &schema.Resource{
 			Schema: GenerateTerraformUserConfigSchema(
-				templates.GetUserConfigSchema("service")["redis"].(map[string]interface{})),
+				templates.GetUserConfigSchema("service")[ServiceTypeRedis].(map[string]interface{})),
 		},
 	},
 }

--- a/examples/cassandra_fork/service.tf
+++ b/examples/cassandra_fork/service.tf
@@ -1,20 +1,18 @@
 # Cassandra service
-resource "aiven_service" "cassandra-svc" {
+resource "aiven_casandra" "cassandra-svc" {
   project = aiven_project.project1.project
   cloud_name = "google-europe-west1"
   plan = "startup-4"
   service_name = "samplecassandra"
-  service_type = "cassandra"
 }
 # Forked service
-resource "aiven_service" "cassandra-fork" {
+resource "aiven_casandra" "cassandra-fork" {
   project = aiven_project.project1.project
   cloud_name = "google-europe-west1"
   plan = "startup-8"
   service_name = "forkedcassandra"
-  service_type = "cassandra"
   depends_on = ["aiven_service.cassandra-svc"]
   cassandra_user_config {
-    service_to_fork_from = aiven_service.cassandra-svc.service_name
+    service_to_fork_from = aiven_casandra.cassandra-svc.service_name
   }
 }

--- a/examples/elasticsearch/elasticsearch_acl.tf
+++ b/examples/elasticsearch/elasticsearch_acl.tf
@@ -1,7 +1,7 @@
 # Elasticsearch ACLs
 resource "aiven_elasticsearch_acl" "es-acls" {
   project = aiven_project.es-project.project
-  service_name = aiven_service.es.service_name
+  service_name = aiven_elasticsearch.es.service_name
   enabled = true
   extended_acl = false
   acl {

--- a/examples/elasticsearch/elasticsearch_service.tf
+++ b/examples/elasticsearch/elasticsearch_service.tf
@@ -1,10 +1,9 @@
 # Elasticsearch service
-resource "aiven_service" "es" {
+resource "aiven_elasticsearch" "es" {
   project = aiven_project.es-project.project
   cloud_name = "google-europe-west1"
   plan = "hobbyist"
   service_name = "es-service"
-  service_type = "elasticsearch"
   maintenance_window_dow = "monday"
   maintenance_window_time = "10:00:00"
 }
@@ -12,6 +11,6 @@ resource "aiven_service" "es" {
 # Elasticsearch user
 resource "aiven_service_user" "es-user" {
   project = aiven_project.es-project.project
-  service_name = aiven_service.es.service_name
+  service_name = aiven_elasticsearch.es.service_name
   username = "test-user1"
 }

--- a/examples/kafka_connect/services.tf
+++ b/examples/kafka_connect/services.tf
@@ -1,10 +1,9 @@
 # Kafka service
-resource "aiven_service" "kafka-service1" {
+resource "aiven_kafka" "kafka-service" {
   project = aiven_project.kafka-con-project1.project
   cloud_name = "google-europe-west1"
   plan = "business-4"
   service_name = "kafka-service1"
-  service_type = "kafka"
   maintenance_window_dow = "monday"
   maintenance_window_time = "10:00:00"
 
@@ -14,12 +13,11 @@ resource "aiven_service" "kafka-service1" {
 }
 
 # Kafka connect service
-resource "aiven_service" "kafka_connect1" {
+resource "aiven_kafka_connect" "kafka_connect" {
   project = aiven_project.kafka-con-project1.project
   cloud_name = "google-europe-west1"
   plan = "startup-4"
   service_name = "kafka-connect1"
-  service_type = "kafka_connect"
   maintenance_window_dow = "monday"
   maintenance_window_time = "10:00:00"
 
@@ -38,8 +36,8 @@ resource "aiven_service" "kafka_connect1" {
 resource "aiven_service_integration" "i1" {
   project = aiven_project.kafka-con-project1.project
   integration_type = "kafka_connect"
-  source_service_name = aiven_service.kafka-service1.service_name
-  destination_service_name = aiven_service.kafka_connect1.service_name
+  source_service_name = aiven_kafka.kafka-service.service_name
+  destination_service_name = aiven_kafka_connect.kafka_connect.service_name
 
   kafka_connect_user_config {
     kafka_connect {

--- a/examples/kafka_connectors/connector.tf
+++ b/examples/kafka_connectors/connector.tf
@@ -1,7 +1,7 @@
 # Kafka connector
 resource "aiven_kafka_connector" "kafka-es-con1" {
   project = aiven_project.kafka-con-project1.project
-  service_name = aiven_service.kafka-service1.service_name
+  service_name = aiven_kafka.kafka-service1.service_name
   connector_name = "kafka-es-con1"
 
   config = {
@@ -9,6 +9,6 @@ resource "aiven_kafka_connector" "kafka-es-con1" {
     "connector.class" : "io.aiven.connect.elasticsearch.ElasticsearchSinkConnector"
     "type.name" = "es-connector"
     "name" = "kafka-es-con1"
-    "connection.url" = aiven_service.es-service1.service_uri
+    "connection.url" = aiven_elasticsearch.es-service1.service_uri
   }
 }

--- a/examples/kafka_connectors/services.tf
+++ b/examples/kafka_connectors/services.tf
@@ -1,10 +1,9 @@
 # Kafka service
-resource "aiven_service" "kafka-service1" {
+resource "aiven_kafka" "kafka-service1" {
   project = aiven_project.kafka-con-project1.project
   cloud_name = "google-europe-west1"
   plan = "business-4"
   service_name = "kafka-service1"
-  service_type = "kafka"
   maintenance_window_dow = "monday"
   maintenance_window_time = "10:00:00"
 
@@ -22,19 +21,18 @@ resource "aiven_service" "kafka-service1" {
 # Kafka topic
 resource "aiven_kafka_topic" "kafka-topic1" {
   project = aiven_project.kafka-con-project1.project
-  service_name = aiven_service.kafka-service1.service_name
+  service_name = aiven_kafka.kafka-service1.service_name
   topic_name = "test-kafka-topic1"
   partitions = 3
   replication = 2
 }
 
 # Elasticsearch service
-resource "aiven_service" "es-service1" {
+resource "aiven_elasticsearch" "es-service1" {
   project = aiven_project.kafka-con-project1.project
   cloud_name = "google-europe-west1"
   plan = "hobbyist"
   service_name = "es-service1"
-  service_type = "elasticsearch"
   maintenance_window_dow = "monday"
   maintenance_window_time = "10:00:00"
 

--- a/examples/kafka_mirrormaker/kafka.tf
+++ b/examples/kafka_mirrormaker/kafka.tf
@@ -1,9 +1,8 @@
-resource "aiven_service" "source" {
+resource "aiven_kafka" "source" {
   project = aiven_project.kafka-mm-project1.project
   cloud_name = "google-europe-west1"
   plan = "business-4"
   service_name = "source"
-  service_type = "kafka"
   maintenance_window_dow = "monday"
   maintenance_window_time = "10:00:00"
 
@@ -18,18 +17,17 @@ resource "aiven_service" "source" {
 
 resource "aiven_kafka_topic" "source" {
   project = aiven_project.kafka-mm-project1.project
-  service_name = aiven_service.source.service_name
+  service_name = aiven_kafka.source.service_name
   topic_name = "topic-a"
   partitions = 3
   replication = 2
 }
 
-resource "aiven_service" "target" {
+resource "aiven_kafka" "target" {
   project = aiven_project.kafka-mm-project1.project
   cloud_name = "google-europe-west1"
   plan = "business-4"
   service_name = "target"
-  service_type = "kafka"
   maintenance_window_dow = "monday"
   maintenance_window_time = "10:00:00"
 
@@ -44,7 +42,7 @@ resource "aiven_service" "target" {
 
 resource "aiven_kafka_topic" "target" {
   project = aiven_project.kafka-mm-project1.project
-  service_name = aiven_service.target.service_name
+  service_name = aiven_kafka.target.service_name
   topic_name = "topic-b"
   partitions = 3
   replication = 2

--- a/examples/kafka_mirrormaker/mirrormaker.tf
+++ b/examples/kafka_mirrormaker/mirrormaker.tf
@@ -1,9 +1,8 @@
-resource "aiven_service" "mm" {
+resource "aiven_mirror_maker" "mm" {
   project = aiven_project.kafka-mm-project1.project
   cloud_name = "google-europe-west1"
   plan = "startup-4"
   service_name = "mm"
-  service_type = "kafka_mirrormaker"
 
   kafka_mirrormaker_user_config {
     ip_filter = [
@@ -21,8 +20,8 @@ resource "aiven_service" "mm" {
 resource "aiven_service_integration" "i1" {
   project = aiven_project.kafka-mm-project1.project
   integration_type = "kafka_mirrormaker"
-  source_service_name = aiven_service.source.service_name
-  destination_service_name = aiven_service.mm.service_name
+  source_service_name = aiven_kafka.source.service_name
+  destination_service_name = aiven_mirror_maker.mm.service_name
 
   kafka_mirrormaker_user_config {
     cluster_alias = "source"
@@ -32,8 +31,8 @@ resource "aiven_service_integration" "i1" {
 resource "aiven_service_integration" "i2" {
   project = aiven_project.kafka-mm-project1.project
   integration_type = "kafka_mirrormaker"
-  source_service_name = aiven_service.target.service_name
-  destination_service_name = aiven_service.mm.service_name
+  source_service_name = aiven_kafka.target.service_name
+  destination_service_name = aiven_mirror_maker.mm.service_name
 
   kafka_mirrormaker_user_config {
     cluster_alias = "target"
@@ -42,9 +41,9 @@ resource "aiven_service_integration" "i2" {
 
 resource "aiven_mirrormaker_replication_flow" "f1" {
   project = aiven_project.kafka-mm-project1.project
-  service_name = aiven_service.mm.service_name
-  source_cluster = aiven_service.source.service_name
-  target_cluster = aiven_service.target.service_name
+  service_name = aiven_mirror_maker.mm.service_name
+  source_cluster = aiven_kafka.source.service_name
+  target_cluster = aiven_kafka.target.service_name
   enable = true
 
   topics = [

--- a/examples/kafka_schemas/kafka_service.tf
+++ b/examples/kafka_schemas/kafka_service.tf
@@ -1,10 +1,9 @@
 # Kafka service
-resource "aiven_service" "kafka-service1" {
+resource "aiven_kafka" "kafka-service1" {
   project = aiven_project.kafka-schemas-project1.project
   cloud_name = "google-europe-west1"
   plan = "business-4"
   service_name = "kafka-service1"
-  service_type = "kafka"
   maintenance_window_dow = "monday"
   maintenance_window_time = "10:00:00"
 
@@ -23,7 +22,7 @@ resource "aiven_service" "kafka-service1" {
 # Kafka topic
 resource "aiven_kafka_topic" "kafka-topic1" {
   project = aiven_project.kafka-schemas-project1.project
-  service_name = aiven_service.kafka-service1.service_name
+  service_name = aiven_kafka.kafka-service1.service_name
   topic_name = "test-kafka-topic1"
   partitions = 3
   replication = 2

--- a/examples/service/service.tf
+++ b/examples/service/service.tf
@@ -1,10 +1,9 @@
 # Grafana service
-resource "aiven_service" "grafana-service1" {
+resource "aiven_grafana" "grafana-service1" {
   project = aiven_project.project1.project
   cloud_name = "google-europe-west1"
   plan = "startup-4"
   service_name = "samplegrafana"
-  service_type = "grafana"
   grafana_user_config {
     public_access {
       grafana = true
@@ -14,7 +13,7 @@ resource "aiven_service" "grafana-service1" {
 
 locals {
   # A list of components is sorted on API side in a way that the client should pick first entry based on the query
-  components_flat = {for component in aiven_service.grafana-service1.components :
+  components_flat = {for component in aiven_grafana.grafana-service1.components :
   "${component.component}_${component.route}" =>  "${component.host}:${component.port}" if component.usage == "primary"
   }
 }


### PR DESCRIPTION
Add the following resources: 
- `aiven_kafka`
- `aiven_kafka_connect` 
- `aiven_kafka_mirrormaker` 
- `aiven_pg`
- `aiven_mysql`
- `aiven_cassandra`
- `aiven_elasticsearch`
- `aiven_grafana`
- `aiven_influxdb`
- `aiven_redis`

GitHub friendly documentation will be added in a separate PR.