### PR TITLE
Kafka ACL regex update to allow wildcard as suffix

### DIFF
--- a/aiven/resource_kafka_acl.go
+++ b/aiven/resource_kafka_acl.go
@@ -47,7 +47,7 @@ var aivenKafkaACLSchema = map[string]*schema.Schema{
 		Required:    true,
 		Description: "Username pattern for the ACL entry",
 		ForceNew:    true,
-		ValidateFunc: validation.StringMatch(regexp.MustCompile("^([*]{1}$|[a-zA-Z0-9_-]*)$"),
+		ValidateFunc: validation.StringMatch(regexp.MustCompile("^([*]{1}$|[a-zA-Z0-9-_*?]*)$"),
 			"username should be alphanumeric"),
 	},
 }

--- a/aiven/resource_kafka_acl_test.go
+++ b/aiven/resource_kafka_acl_test.go
@@ -142,6 +142,18 @@ func testAccKafkaACLWildcardResource(_ string) string {
 		`
 }
 
+func testAccKafkaACLPrefixWildcardResource(_ string) string {
+	return `
+		resource "aiven_kafka_acl" "foo" {
+			project = "test-acc-pr-1"
+			service_name = "test-acc-sr-1"
+			topic = "test-acc-topic-1"
+			username = "group-user-*"
+			permission = "admin"
+		}
+		`
+}
+
 func testAccKafkaACLWrongUsernameResource(_ string) string {
 	return `
 		resource "aiven_kafka_acl" "foo" {


### PR DESCRIPTION
Username ACL allows:
* Literal - "user1"
* Prefixed - "group-user-"
* Wildcard - "*"

Suffixed ("*-user-group") is not supported. Regex username check has been updated to
reflect this.