### PR TITLE
make acc tests use one project

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ test:
 	CGO_ENABLED=0 go test -v --cover ./...
 
 testacc:
-	TF_ACC=1 CGO_ENABLED=0 go test -v -count 1 -parallel 15 --cover ./... $(TESTARGS) -timeout 120m
+	TF_ACC=1 CGO_ENABLED=0 go test -v -count 1 -parallel 20 --cover ./... $(TESTARGS) -timeout 120m
 
 sweep:
 	@echo "WARNING: This will destroy infrastructure. Use only in development accounts."

--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ test:
 	CGO_ENABLED=0 go test -v --cover ./...
 
 testacc:
-	TF_ACC=1 CGO_ENABLED=0 go test -v -count 1 -parallel 20 --cover ./... $(TESTARGS) -timeout 120m
+	TF_ACC=1 CGO_ENABLED=0 go test -v -count 1 -parallel 15 --cover ./... $(TESTARGS) -timeout 120m
 
 sweep:
 	@echo "WARNING: This will destroy infrastructure. Use only in development accounts."

--- a/aiven/provider_test.go
+++ b/aiven/provider_test.go
@@ -4,6 +4,7 @@ import (
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/terraform/terraform"
 	"github.com/stretchr/testify/assert"
+	"log"
 	"os"
 	"reflect"
 	"testing"
@@ -38,8 +39,10 @@ func testAccPreCheck(t *testing.T) {
 		t.Fatal("AIVEN_TOKEN must be set for acceptance tests")
 	}
 
-	if v := os.Getenv("AIVEN_CARD_ID"); v == "" {
-		t.Fatal("AIVEN_CARD_ID must be set for acceptance tests")
+	// Provider a project name with enough credits to run acceptance
+	// tests or project name with the assigned payment card.
+	if v := os.Getenv("AIVEN_PROJECT_NAME"); v == "" {
+		log.Print("[WARNING] AIVEN_PROJECT_NAME must be set for some acceptance tests")
 	}
 }
 

--- a/aiven/resource_connection_pool_test.go
+++ b/aiven/resource_connection_pool_test.go
@@ -7,7 +7,6 @@ import (
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
 	"os"
-	"strings"
 	"testing"
 )
 
@@ -32,7 +31,7 @@ func sweepConnectionPools(region string) error {
 	}
 
 	for _, project := range projects {
-		if strings.Contains(project.Name, "test-acc-") {
+		if project.Name == os.Getenv("AIVEN_PROJECT_NAME") {
 			services, err := conn.Services.List(project.Name)
 			if err != nil {
 				return fmt.Errorf("error retrieving a list of services for a project `%s`: %s", project.Name, err)
@@ -62,12 +61,10 @@ func sweepConnectionPools(region string) error {
 }
 
 func TestAccAivenConnectionPool_basic(t *testing.T) {
-	t.Parallel()
-
 	resourceName := "aiven_connection_pool.foo"
 	rName := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAivenConnectionPoolResourceDestroy,
@@ -76,7 +73,7 @@ func TestAccAivenConnectionPool_basic(t *testing.T) {
 				Config: testAccConnectionPoolResource(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAivenConnectionPoolAttributes("data.aiven_connection_pool.pool"),
-					resource.TestCheckResourceAttr(resourceName, "project", fmt.Sprintf("test-acc-pr-%s", rName)),
+					resource.TestCheckResourceAttr(resourceName, "project", os.Getenv("AIVEN_PROJECT_NAME")),
 					resource.TestCheckResourceAttr(resourceName, "service_name", fmt.Sprintf("test-acc-sr-%s", rName)),
 					resource.TestCheckResourceAttr(resourceName, "database_name", fmt.Sprintf("test-acc-db-%s", rName)),
 					resource.TestCheckResourceAttr(resourceName, "username", fmt.Sprintf("user-%s", rName)),
@@ -91,13 +88,12 @@ func TestAccAivenConnectionPool_basic(t *testing.T) {
 
 func testAccConnectionPoolResource(name string) string {
 	return fmt.Sprintf(`
-		resource "aiven_project" "foo" {
-			project = "test-acc-pr-%s"
-			card_id="%s"	
+		data "aiven_project" "foo" {
+			project = "%s"
 		}
 
 		resource "aiven_service" "bar" {
-			project = aiven_project.foo.project
+			project = data.aiven_project.foo.project
 			cloud_name = "google-europe-west1"
 			plan = "startup-4"
 			service_name = "test-acc-sr-%s"
@@ -112,7 +108,7 @@ func testAccConnectionPoolResource(name string) string {
 		
 		resource "aiven_service_user" "foo" {
 			service_name = aiven_service.bar.service_name
-			project = aiven_project.foo.project
+			project = data.aiven_project.foo.project
 			username = "user-%s"
 		}
 
@@ -124,7 +120,7 @@ func testAccConnectionPoolResource(name string) string {
 
 		resource "aiven_connection_pool" "foo" {
 			service_name = aiven_service.bar.service_name
-			project = aiven_project.foo.project
+			project = data.aiven_project.foo.project
 			database_name = aiven_database.foo.database_name
 			username = aiven_service_user.foo.username
 			pool_name = "test-acc-pool-%s"
@@ -137,7 +133,7 @@ func testAccConnectionPoolResource(name string) string {
 			service_name = aiven_connection_pool.foo.service_name
 			pool_name = aiven_connection_pool.foo.pool_name
 		}
-		`, name, os.Getenv("AIVEN_CARD_ID"), name, name, name, name)
+		`, os.Getenv("AIVEN_PROJECT_NAME"), name, name, name, name)
 }
 
 func testAccCheckAivenConnectionPoolAttributes(n string) resource.TestCheckFunc {

--- a/aiven/resource_kafka_acl_test.go
+++ b/aiven/resource_kafka_acl_test.go
@@ -52,7 +52,7 @@ func TestAccAivenKafkaACL_basic(t *testing.T) {
 				Config: testAccKafkaACLResource(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAivenKafkaACLAttributes("data.aiven_kafka_acl.acl"),
-					resource.TestCheckResourceAttr(resourceName, "project", fmt.Sprintf("test-acc-pr-%s", rName)),
+					resource.TestCheckResourceAttr(resourceName, "project", os.Getenv("AIVEN_PROJECT_NAME")),
 					resource.TestCheckResourceAttr(resourceName, "service_name", fmt.Sprintf("test-acc-sr-%s", rName)),
 					resource.TestCheckResourceAttr(resourceName, "topic", fmt.Sprintf("test-acc-topic-%s", rName)),
 					resource.TestCheckResourceAttr(resourceName, "username", fmt.Sprintf("user-%s", rName)),
@@ -156,13 +156,12 @@ func testAccKafkaACLWrongUsernameResource(_ string) string {
 
 func testAccKafkaACLResource(name string) string {
 	return fmt.Sprintf(`
-		resource "aiven_project" "foo" {
-			project = "test-acc-pr-%s"
-			card_id="%s"	
+		data "aiven_project" "foo" {
+			project = "%s"
 		}
 
 		resource "aiven_service" "bar" {
-			project = aiven_project.foo.project
+			project = data.aiven_project.foo.project
 			cloud_name = "google-europe-west1"
 			plan = "business-4"
 			service_name = "test-acc-sr-%s"
@@ -180,7 +179,7 @@ func testAccKafkaACLResource(name string) string {
 		}
 		
 		resource "aiven_kafka_topic" "foo" {
-			project = aiven_project.foo.project
+			project = data.aiven_project.foo.project
 			service_name = aiven_service.bar.service_name
 			topic_name = "test-acc-topic-%s"
 			partitions = 3
@@ -188,7 +187,7 @@ func testAccKafkaACLResource(name string) string {
 		}
 
 		resource "aiven_kafka_acl" "foo" {
-			project = aiven_project.foo.project
+			project = data.aiven_project.foo.project
 			service_name = aiven_service.bar.service_name
 			topic = aiven_kafka_topic.foo.topic_name
 			username = "user-%s"
@@ -202,7 +201,7 @@ func testAccKafkaACLResource(name string) string {
 			username = aiven_kafka_acl.foo.username
 			permission = aiven_kafka_acl.foo.permission
 		}
-		`, name, os.Getenv("AIVEN_CARD_ID"), name, name, name)
+		`, os.Getenv("AIVEN_PROJECT_NAME"), name, name, name)
 }
 
 func testAccCheckAivenKafkaACLResourceDestroy(s *terraform.State) error {

--- a/aiven/resource_kafka_connector_test.go
+++ b/aiven/resource_kafka_connector_test.go
@@ -7,7 +7,6 @@ import (
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
 	"os"
-	"strings"
 	"testing"
 )
 
@@ -32,7 +31,7 @@ func sweepKafkaConnectos(region string) error {
 	}
 
 	for _, project := range projects {
-		if strings.Contains(project.Name, "test-acc-") {
+		if project.Name == os.Getenv("AIVEN_PROJECT_NAME") {
 			services, err := conn.Services.List(project.Name)
 			if err != nil {
 				return fmt.Errorf("error retrieving a list of services for a project `%s`: %s", project.Name, err)
@@ -66,12 +65,10 @@ func sweepKafkaConnectos(region string) error {
 }
 
 func TestAccAivenKafkaConnector_basic(t *testing.T) {
-	t.Parallel()
-
 	resourceName := "aiven_kafka_connector.foo"
 	rName := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAivenKafkaConnectorResourceDestroy,
@@ -80,7 +77,7 @@ func TestAccAivenKafkaConnector_basic(t *testing.T) {
 				Config: testAccKafkaConnectorResource(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAivenKafkaConnectorAttributes("data.aiven_kafka_connector.connector"),
-					resource.TestCheckResourceAttr(resourceName, "project", fmt.Sprintf("test-acc-pr-%s", rName)),
+					resource.TestCheckResourceAttr(resourceName, "project", os.Getenv("AIVEN_PROJECT_NAME")),
 					resource.TestCheckResourceAttr(resourceName, "service_name", fmt.Sprintf("test-acc-sr-%s", rName)),
 					resource.TestCheckResourceAttr(resourceName, "connector_name", fmt.Sprintf("test-acc-con-%s", rName)),
 				),
@@ -139,13 +136,12 @@ func testAccCheckAivenKafkaConnectorResourceDestroy(s *terraform.State) error {
 
 func testAccKafkaConnectorResource(name string) string {
 	return fmt.Sprintf(`
-		resource "aiven_project" "foo" {
-			project = "test-acc-pr-%s"
-			card_id="%s"	
+		data "aiven_project" "foo" {
+			project = "%s"
 		}
 
 		resource "aiven_service" "bar" {
-			project = aiven_project.foo.project
+			project = data.aiven_project.foo.project
 			cloud_name = "google-europe-west1"
 			plan = "business-4"
 			service_name = "test-acc-sr-%s"
@@ -165,7 +161,7 @@ func testAccKafkaConnectorResource(name string) string {
 		}
 		
 		resource "aiven_kafka_topic" "foo" {
-			project = aiven_project.foo.project
+			project = data.aiven_project.foo.project
 			service_name = aiven_service.bar.service_name
 			topic_name = "test-acc-topic-%s"
 			partitions = 3
@@ -173,7 +169,7 @@ func testAccKafkaConnectorResource(name string) string {
 		}
 		
 		resource "aiven_service" "dest" {
-			project = aiven_project.foo.project
+			project = data.aiven_project.foo.project
 			cloud_name = "google-europe-west1"
 			plan = "startup-4"
 			service_name = "test-acc-sr2-%s"
@@ -187,7 +183,7 @@ func testAccKafkaConnectorResource(name string) string {
 		}
 
 		resource "aiven_kafka_connector" "foo" {
-			project = aiven_project.foo.project
+			project = data.aiven_project.foo.project
 			service_name = aiven_service.bar.service_name
 			connector_name = "test-acc-con-%s"
 			
@@ -205,7 +201,7 @@ func testAccKafkaConnectorResource(name string) string {
 			service_name = aiven_kafka_connector.foo.service_name
 			connector_name = aiven_kafka_connector.foo.connector_name
 		}
-		`, name, os.Getenv("AIVEN_CARD_ID"), name, name, name, name, name)
+		`, os.Getenv("AIVEN_PROJECT_NAME"), name, name, name, name, name)
 }
 
 func testAccCheckAivenKafkaConnectorAttributes(n string) resource.TestCheckFunc {

--- a/aiven/resource_kafka_schema_configuration_test.go
+++ b/aiven/resource_kafka_schema_configuration_test.go
@@ -10,12 +10,10 @@ import (
 )
 
 func TestAccAivenKafkaSchemaConfiguration_basic(t *testing.T) {
-	t.Parallel()
-
 	resourceName := "aiven_kafka_schema_configuration.foo"
 	rName := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                  func() { testAccPreCheck(t) },
 		Providers:                 testAccProviders,
 		PreventPostDestroyRefresh: true,
@@ -24,7 +22,7 @@ func TestAccAivenKafkaSchemaConfiguration_basic(t *testing.T) {
 			{
 				Config: testAccKafkaSchemaConfigurationResource(rName),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(resourceName, "project", fmt.Sprintf("test-acc-pr-%s", rName)),
+					resource.TestCheckResourceAttr(resourceName, "project", os.Getenv("AIVEN_PROJECT_NAME")),
 					resource.TestCheckResourceAttr(resourceName, "service_name", fmt.Sprintf("test-acc-sr-%s", rName)),
 					resource.TestCheckResourceAttr(resourceName, "compatibility_level", "BACKWARD"),
 				),
@@ -40,13 +38,12 @@ func testAccCheckAivenKafkaSchemaConfigurationResourceDestroy(_ *terraform.State
 
 func testAccKafkaSchemaConfigurationResource(name string) string {
 	return fmt.Sprintf(`
-		resource "aiven_project" "foo" {
-			project = "test-acc-pr-%s"
-			card_id="%s"	
+		data "aiven_project" "foo" {
+			project = "%s"
 		}
 
 		resource "aiven_service" "bar" {
-			project = aiven_project.foo.project
+			project = data.aiven_project.foo.project
 			cloud_name = "google-europe-west1"
 			plan = "business-4"
 			service_name = "test-acc-sr-%s"
@@ -65,9 +62,9 @@ func testAccKafkaSchemaConfigurationResource(name string) string {
 		}
 		
 		resource "aiven_kafka_schema_configuration" "foo" {
-			project = aiven_project.foo.project
+			project = data.aiven_project.foo.project
 			service_name = aiven_service.bar.service_name
 			compatibility_level = "BACKWARD"
 		}
-		`, name, os.Getenv("AIVEN_CARD_ID"), name)
+		`, os.Getenv("AIVEN_PROJECT_NAME"), name)
 }

--- a/aiven/resource_kafka_schema_test.go
+++ b/aiven/resource_kafka_schema_test.go
@@ -7,7 +7,6 @@ import (
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
 	"os"
-	"strings"
 	"testing"
 )
 
@@ -32,7 +31,7 @@ func sweepKafkaSchemas(region string) error {
 	}
 
 	for _, project := range projects {
-		if strings.Contains(project.Name, "test-acc-") {
+		if project.Name == os.Getenv("AIVEN_PROJECT_NAME") {
 			services, err := conn.Services.List(project.Name)
 			if err != nil {
 				return fmt.Errorf("error retrieving a list of services for a project `%s`: %s", project.Name, err)
@@ -66,12 +65,10 @@ func sweepKafkaSchemas(region string) error {
 }
 
 func TestAccAivenKafkaSchema_basic(t *testing.T) {
-	t.Parallel()
-
 	resourceName := "aiven_kafka_schema.foo"
 	rName := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAivenKafkaSchemaResourceDestroy,
@@ -80,7 +77,7 @@ func TestAccAivenKafkaSchema_basic(t *testing.T) {
 				Config: testAccKafkaSchemaResource(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAivenKafkaSchemaAttributes("data.aiven_kafka_schema.schema"),
-					resource.TestCheckResourceAttr(resourceName, "project", fmt.Sprintf("test-acc-pr-%s", rName)),
+					resource.TestCheckResourceAttr(resourceName, "project", os.Getenv("AIVEN_PROJECT_NAME")),
 					resource.TestCheckResourceAttr(resourceName, "service_name", fmt.Sprintf("test-acc-sr-%s", rName)),
 					resource.TestCheckResourceAttr(resourceName, "subject_name", fmt.Sprintf("kafka-schema-%s", rName)),
 				),
@@ -139,13 +136,12 @@ func testAccCheckAivenKafkaSchemaResourceDestroy(s *terraform.State) error {
 
 func testAccKafkaSchemaResource(name string) string {
 	return fmt.Sprintf(`
-		resource "aiven_project" "foo" {
-			project = "test-acc-pr-%s"
-			card_id="%s"	
+		data "aiven_project" "foo" {
+			project = "%s"
 		}
 
 		resource "aiven_service" "bar" {
-			project = aiven_project.foo.project
+			project = data.aiven_project.foo.project
 			cloud_name = "google-europe-west1"
 			plan = "business-4"
 			service_name = "test-acc-sr-%s"
@@ -165,13 +161,13 @@ func testAccKafkaSchemaResource(name string) string {
 		}
 		
 		resource "aiven_kafka_schema_configuration" "foo" {
-			project = aiven_project.foo.project
+			project = data.aiven_project.foo.project
 			service_name = aiven_service.bar.service_name
 			compatibility_level = "BACKWARD"
 		}
 
 		resource "aiven_kafka_schema" "foo" {
-			project = aiven_project.foo.project
+			project = data.aiven_project.foo.project
 			service_name = aiven_service.bar.service_name
 			subject_name = "kafka-schema-%s"
 			
@@ -197,7 +193,7 @@ func testAccKafkaSchemaResource(name string) string {
 			service_name = aiven_kafka_schema.foo.service_name
 			subject_name = aiven_kafka_schema.foo.subject_name
 		}
-		`, name, os.Getenv("AIVEN_CARD_ID"), name, name)
+		`, os.Getenv("AIVEN_PROJECT_NAME"), name, name)
 }
 
 func testAccCheckAivenKafkaSchemaAttributes(n string) resource.TestCheckFunc {

--- a/aiven/resource_kafka_topic_test.go
+++ b/aiven/resource_kafka_topic_test.go
@@ -8,7 +8,6 @@ import (
 	"github.com/hashicorp/terraform/terraform"
 	"log"
 	"os"
-	"strings"
 	"testing"
 )
 
@@ -33,7 +32,7 @@ func sweepKafkaTopics(region string) error {
 	}
 
 	for _, project := range projects {
-		if strings.Contains(project.Name, "test-acc-") {
+		if project.Name == os.Getenv("AIVEN_PROJECT_NAME") {
 			services, err := conn.Services.List(project.Name)
 			if err != nil {
 				return fmt.Errorf("error retrieving a list of services for a project `%s`: %s", project.Name, err)
@@ -77,7 +76,7 @@ func TestAccAivenKafkaTopic_basic(t *testing.T) {
 				Config: testAccKafkaTopicResource(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAivenKafkaTopicAttributes("data.aiven_kafka_topic.topic"),
-					resource.TestCheckResourceAttr(resourceName, "project", fmt.Sprintf("test-acc-pr-%s", rName)),
+					resource.TestCheckResourceAttr(resourceName, "project", os.Getenv("AIVEN_PROJECT_NAME")),
 					resource.TestCheckResourceAttr(resourceName, "service_name", fmt.Sprintf("test-acc-sr-%s", rName)),
 					resource.TestCheckResourceAttr(resourceName, "topic_name", fmt.Sprintf("test-acc-topic-%s", rName)),
 					resource.TestCheckResourceAttr(resourceName, "partitions", "3"),
@@ -90,7 +89,7 @@ func TestAccAivenKafkaTopic_basic(t *testing.T) {
 				Config: testAccKafkaTopicCustomTimeoutsResource(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAivenKafkaTopicAttributes("data.aiven_kafka_topic.topic"),
-					resource.TestCheckResourceAttr(resourceName, "project", fmt.Sprintf("test-acc-pr-%s", rName)),
+					resource.TestCheckResourceAttr(resourceName, "project", os.Getenv("AIVEN_PROJECT_NAME")),
 					resource.TestCheckResourceAttr(resourceName, "service_name", fmt.Sprintf("test-acc-sr-%s", rName)),
 					resource.TestCheckResourceAttr(resourceName, "topic_name", fmt.Sprintf("test-acc-topic-%s", rName)),
 					resource.TestCheckResourceAttr(resourceName, "partitions", "3"),
@@ -105,7 +104,7 @@ func TestAccAivenKafkaTopic_basic(t *testing.T) {
 				ExpectNonEmptyPlan:        true,
 				PlanOnly:                  true,
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(resourceName, "project", fmt.Sprintf("test-acc-pr-%s", rName)),
+					resource.TestCheckResourceAttr(resourceName, "project", os.Getenv("AIVEN_PROJECT_NAME")),
 					resource.TestCheckResourceAttr(resourceName, "service_name", fmt.Sprintf("test-acc-sr-%s", rName)),
 					resource.TestCheckResourceAttr(resourceName, "topic_name", fmt.Sprintf("test-acc-topic-%s", rName)),
 					resource.TestCheckResourceAttr(resourceName, "partitions", "3"),
@@ -118,15 +117,10 @@ func TestAccAivenKafkaTopic_basic(t *testing.T) {
 }
 
 func TestAccAivenKafkaTopic_100topics(t *testing.T) {
-	if os.Getenv("AIVEN_ACC_LONG") == "" {
-		t.Skip("Acceptance tests skipped unless env AIVEN_ACC_LONG set")
-	}
-	t.Parallel()
-
 	resourceName := "aiven_kafka_topic.foo"
 	rName := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAivenKafkaTopicResourceDestroy,
@@ -135,7 +129,7 @@ func TestAccAivenKafkaTopic_100topics(t *testing.T) {
 				Config: testAccKafka101TopicResource(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAivenKafkaTopicAttributes("data.aiven_kafka_topic.topic"),
-					resource.TestCheckResourceAttr(resourceName, "project", fmt.Sprintf("test-acc-pr-%s", rName)),
+					resource.TestCheckResourceAttr(resourceName, "project", os.Getenv("AIVEN_PROJECT_NAME")),
 					resource.TestCheckResourceAttr(resourceName, "service_name", fmt.Sprintf("test-acc-sr-%s", rName)),
 					resource.TestCheckResourceAttr(resourceName, "topic_name", fmt.Sprintf("test-acc-topic-%s", rName)),
 					resource.TestCheckResourceAttr(resourceName, "partitions", "3"),
@@ -153,7 +147,7 @@ func testAccKafka101TopicResource(name string) string {
 	for i := 1; i < 100; i++ {
 		s += fmt.Sprintf(`
 			resource "aiven_kafka_topic" "foo%s" {
-				project = aiven_project.foo.project
+				project = data.aiven_project.foo.project
 				service_name = aiven_service.bar.service_name
 				topic_name = "test-acc-topic-%s"
 				partitions = 3
@@ -169,13 +163,12 @@ func testAccKafka101TopicResource(name string) string {
 
 func testAccKafkaTopicResource(name string) string {
 	return fmt.Sprintf(`
-		resource "aiven_project" "foo" {
-			project = "test-acc-pr-%s"
-			card_id="%s"	
+		data "aiven_project" "foo" {
+			project = "%s"
 		}
 
 		resource "aiven_service" "bar" {
-			project = aiven_project.foo.project
+			project = data.aiven_project.foo.project
 			cloud_name = "google-europe-west1"
 			plan = "business-4"
 			service_name = "test-acc-sr-%s"
@@ -193,7 +186,7 @@ func testAccKafkaTopicResource(name string) string {
 		}
 		
 		resource "aiven_kafka_topic" "foo" {
-			project = aiven_project.foo.project
+			project = data.aiven_project.foo.project
 			service_name = aiven_service.bar.service_name
 			topic_name = "test-acc-topic-%s"
 			partitions = 3
@@ -205,18 +198,17 @@ func testAccKafkaTopicResource(name string) string {
 			service_name = aiven_kafka_topic.foo.service_name
 			topic_name = aiven_kafka_topic.foo.topic_name
 		}
-		`, name, os.Getenv("AIVEN_CARD_ID"), name, name)
+		`, os.Getenv("AIVEN_PROJECT_NAME"), name, name)
 }
 
 func testAccKafkaTopicCustomTimeoutsResource(name string) string {
 	return fmt.Sprintf(`
-		resource "aiven_project" "foo" {
-			project = "test-acc-pr-%s"
-			card_id="%s"	
+		data "aiven_project" "foo" {
+			project = "%s"
 		}
 
 		resource "aiven_service" "bar" {
-			project = aiven_project.foo.project
+			project = data.aiven_project.foo.project
 			cloud_name = "google-europe-west1"
 			plan = "business-4"
 			service_name = "test-acc-sr-%s"
@@ -235,7 +227,7 @@ func testAccKafkaTopicCustomTimeoutsResource(name string) string {
 		}
 		
 		resource "aiven_kafka_topic" "foo" {
-			project = aiven_project.foo.project
+			project = data.aiven_project.foo.project
 			service_name = aiven_service.bar.service_name
 			topic_name = "test-acc-topic-%s"
 			partitions = 3
@@ -252,18 +244,17 @@ func testAccKafkaTopicCustomTimeoutsResource(name string) string {
 			service_name = aiven_kafka_topic.foo.service_name
 			topic_name = aiven_kafka_topic.foo.topic_name
 		}
-		`, name, os.Getenv("AIVEN_CARD_ID"), name, name)
+		`, os.Getenv("AIVEN_PROJECT_NAME"), name, name)
 }
 
 func testAccKafkaTopicTerminationProtectionResource(name string) string {
 	return fmt.Sprintf(`
-		resource "aiven_project" "foo" {
-			project = "test-acc-pr-%s"
-			card_id="%s"	
+		data "aiven_project" "foo" {
+			project = "%s"
 		}
 
 		resource "aiven_service" "bar" {
-			project = aiven_project.foo.project
+			project = data.aiven_project.foo.project
 			cloud_name = "google-europe-west1"
 			plan = "business-4"
 			service_name = "test-acc-sr-%s"
@@ -281,7 +272,7 @@ func testAccKafkaTopicTerminationProtectionResource(name string) string {
 		}
 		
 		resource "aiven_kafka_topic" "foo" {
-			project = aiven_project.foo.project
+			project = data.aiven_project.foo.project
 			service_name = aiven_service.bar.service_name
 			topic_name = "test-acc-topic-%s"
 			partitions = 3
@@ -294,7 +285,7 @@ func testAccKafkaTopicTerminationProtectionResource(name string) string {
 			service_name = aiven_kafka_topic.foo.service_name
 			topic_name = aiven_kafka_topic.foo.topic_name
 		}
-		`, name, os.Getenv("AIVEN_CARD_ID"), name, name)
+		`, os.Getenv("AIVEN_PROJECT_NAME"), name, name)
 }
 
 func testAccCheckAivenKafkaTopicAttributes(n string) resource.TestCheckFunc {

--- a/aiven/resource_project_test.go
+++ b/aiven/resource_project_test.go
@@ -79,12 +79,10 @@ func TestAccAivenProject_basic(t *testing.T) {
 }
 
 func TestAccAivenProject_accounts(t *testing.T) {
-	t.Parallel()
-
 	resourceName := "aiven_project.foo"
 	rName := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAivenProjectResourceDestroy,

--- a/aiven/resource_project_user_test.go
+++ b/aiven/resource_project_user_test.go
@@ -10,12 +10,10 @@ import (
 )
 
 func TestAccAivenProjectUser_basic(t *testing.T) {
-	t.Parallel()
-
 	resourceName := "aiven_project_user.bar"
 	rName := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAivenProjectUserResourceDestroy,

--- a/aiven/resource_service_elasticsearch_test.go
+++ b/aiven/resource_service_elasticsearch_test.go
@@ -12,12 +12,10 @@ import (
 
 // Elasticsearch service tests
 func TestAccAivenService_es(t *testing.T) {
-	t.Parallel()
-
 	resourceName := "aiven_service.bar-es"
 	rName := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAivenServiceResourceDestroy,
@@ -29,7 +27,7 @@ func TestAccAivenService_es(t *testing.T) {
 					testAccCheckAivenServiceESAttributes("data.aiven_service.service-es"),
 					resource.TestCheckResourceAttr(resourceName, "service_name", fmt.Sprintf("test-acc-sr-%s", rName)),
 					resource.TestCheckResourceAttr(resourceName, "state", "RUNNING"),
-					resource.TestCheckResourceAttr(resourceName, "project", fmt.Sprintf("test-acc-pr-es-%s", rName)),
+					resource.TestCheckResourceAttr(resourceName, "project", os.Getenv("AIVEN_PROJECT_NAME")),
 					resource.TestCheckResourceAttr(resourceName, "service_type", "elasticsearch"),
 					resource.TestCheckResourceAttr(resourceName, "cloud_name", "google-europe-west1"),
 					resource.TestCheckResourceAttr(resourceName, "maintenance_window_dow", "monday"),
@@ -44,13 +42,12 @@ func TestAccAivenService_es(t *testing.T) {
 
 func testAccElasticsearchServiceResource(name string) string {
 	return fmt.Sprintf(`
-		resource "aiven_project" "foo-es" {
-			project = "test-acc-pr-es-%s"
-			card_id="%s"	
+		data "aiven_project" "foo-es" {
+			project = "%s"
 		}
 		
 		resource "aiven_service" "bar-es" {
-			project = aiven_project.foo-es.project
+			project = data.aiven_project.foo-es.project
 			cloud_name = "google-europe-west1"
 			plan = "startup-4"
 			service_name = "test-acc-sr-%s"
@@ -85,9 +82,9 @@ func testAccElasticsearchServiceResource(name string) string {
 		
 		data "aiven_service" "service-es" {
 			service_name = aiven_service.bar-es.service_name
-			project = aiven_project.foo-es.project
+			project = aiven_service.bar-es.project
 		}
-		`, name, os.Getenv("AIVEN_CARD_ID"), name)
+		`, os.Getenv("AIVEN_PROJECT_NAME"), name)
 }
 
 func testAccCheckAivenServiceESAttributes(n string) resource.TestCheckFunc {

--- a/aiven/resource_service_grafana_test.go
+++ b/aiven/resource_service_grafana_test.go
@@ -26,7 +26,7 @@ func TestAccAivenService_grafana(t *testing.T) {
 					testAccCheckAivenServiceGrafanaAttributes("data.aiven_service.service"),
 					resource.TestCheckResourceAttr(resourceName, "service_name", fmt.Sprintf("test-acc-sr-%s", rName)),
 					resource.TestCheckResourceAttr(resourceName, "state", "RUNNING"),
-					resource.TestCheckResourceAttr(resourceName, "project", fmt.Sprintf("test-acc-pr-%s", rName)),
+					resource.TestCheckResourceAttr(resourceName, "project", os.Getenv("AIVEN_PROJECT_NAME")),
 					resource.TestCheckResourceAttr(resourceName, "service_type", "grafana"),
 					resource.TestCheckResourceAttr(resourceName, "cloud_name", "google-europe-west1"),
 					resource.TestCheckResourceAttr(resourceName, "maintenance_window_dow", "monday"),
@@ -42,7 +42,7 @@ func TestAccAivenService_grafana(t *testing.T) {
 					testAccCheckAivenServiceGrafanaAttributes("data.aiven_service.service"),
 					resource.TestCheckResourceAttr(resourceName, "service_name", fmt.Sprintf("test-acc-sr-%s", rName)),
 					resource.TestCheckResourceAttr(resourceName, "state", "RUNNING"),
-					resource.TestCheckResourceAttr(resourceName, "project", fmt.Sprintf("test-acc-pr-%s", rName)),
+					resource.TestCheckResourceAttr(resourceName, "project", os.Getenv("AIVEN_PROJECT_NAME")),
 					resource.TestCheckResourceAttr(resourceName, "service_type", "grafana"),
 					resource.TestCheckResourceAttr(resourceName, "cloud_name", "google-europe-west1"),
 					resource.TestCheckResourceAttr(resourceName, "maintenance_window_dow", "monday"),
@@ -57,13 +57,12 @@ func TestAccAivenService_grafana(t *testing.T) {
 
 func testAccGrafanaServiceResource(name string) string {
 	return fmt.Sprintf(`
-		resource "aiven_project" "foo" {
-			project = "test-acc-pr-%s"
-			card_id="%s"	
+		data "aiven_project" "foo" {
+			project = "%s"
 		}
 		
 		resource "aiven_service" "bar" {
-			project = aiven_project.foo.project
+			project = data.aiven_project.foo.project
 			cloud_name = "google-europe-west1"
 			plan = "startup-1"
 			service_name = "test-acc-sr-%s"
@@ -82,20 +81,19 @@ func testAccGrafanaServiceResource(name string) string {
 		
 		data "aiven_service" "service" {
 			service_name = aiven_service.bar.service_name
-			project = aiven_project.foo.project
+			project = aiven_service.bar.project
 		}
-		`, name, os.Getenv("AIVEN_CARD_ID"), name)
+		`, os.Getenv("AIVEN_PROJECT_NAME"), name)
 }
 
 func testAccGrafanaServiceCustomIpFiltersResource(name string) string {
 	return fmt.Sprintf(`
-		resource "aiven_project" "foo" {
-			project = "test-acc-pr-%s"
-			card_id="%s"	
+		data "aiven_project" "foo" {
+			project = "%s"
 		}
 		
 		resource "aiven_service" "bar" {
-			project = aiven_project.foo.project
+			project = data.aiven_project.foo.project
 			cloud_name = "google-europe-west1"
 			plan = "startup-1"
 			service_name = "test-acc-sr-%s"
@@ -115,9 +113,9 @@ func testAccGrafanaServiceCustomIpFiltersResource(name string) string {
 		
 		data "aiven_service" "service" {
 			service_name = aiven_service.bar.service_name
-			project = aiven_project.foo.project
+			project = aiven_service.bar.project
 		}
-		`, name, os.Getenv("AIVEN_CARD_ID"), name)
+		`, os.Getenv("AIVEN_PROJECT_NAME"), name)
 }
 
 func testAccCheckAivenServiceGrafanaAttributes(n string) resource.TestCheckFunc {

--- a/aiven/resource_service_influxdb_test.go
+++ b/aiven/resource_service_influxdb_test.go
@@ -11,11 +11,10 @@ import (
 
 // InfluxDB service tests
 func TestAccAivenService_influxdb(t *testing.T) {
-	t.Parallel()
 	resourceName := "aiven_service.bar"
 	rName := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAivenServiceResourceDestroy,
@@ -27,7 +26,7 @@ func TestAccAivenService_influxdb(t *testing.T) {
 					testAccCheckAivenServiceInfluxdbAttributes("data.aiven_service.service"),
 					resource.TestCheckResourceAttr(resourceName, "service_name", fmt.Sprintf("test-acc-sr-%s", rName)),
 					resource.TestCheckResourceAttr(resourceName, "state", "RUNNING"),
-					resource.TestCheckResourceAttr(resourceName, "project", fmt.Sprintf("test-acc-pr-%s", rName)),
+					resource.TestCheckResourceAttr(resourceName, "project", os.Getenv("AIVEN_PROJECT_NAME")),
 					resource.TestCheckResourceAttr(resourceName, "service_type", "influxdb"),
 					resource.TestCheckResourceAttr(resourceName, "cloud_name", "google-europe-west1"),
 					resource.TestCheckResourceAttr(resourceName, "maintenance_window_dow", "monday"),
@@ -42,13 +41,12 @@ func TestAccAivenService_influxdb(t *testing.T) {
 
 func testAccInfluxdbServiceResource(name string) string {
 	return fmt.Sprintf(`
-		resource "aiven_project" "foo" {
-			project = "test-acc-pr-%s"
-			card_id="%s"	
+		data "aiven_project" "foo" {
+			project = "%s"
 		}
 		
 		resource "aiven_service" "bar" {
-			project = aiven_project.foo.project
+			project = data.aiven_project.foo.project
 			cloud_name = "google-europe-west1"
 			plan = "startup-4"
 			service_name = "test-acc-sr-%s"
@@ -65,9 +63,9 @@ func testAccInfluxdbServiceResource(name string) string {
 		
 		data "aiven_service" "service" {
 			service_name = aiven_service.bar.service_name
-			project = aiven_project.foo.project
+			project = aiven_service.bar.project
 		}
-		`, name, os.Getenv("AIVEN_CARD_ID"), name)
+		`, os.Getenv("AIVEN_PROJECT_NAME"), name)
 }
 
 func testAccCheckAivenServiceInfluxdbAttributes(n string) resource.TestCheckFunc {

--- a/aiven/resource_service_integration_endpoint_test.go
+++ b/aiven/resource_service_integration_endpoint_test.go
@@ -23,7 +23,7 @@ func TestAccAivenServiceIntegrationEndpoint_basic(t *testing.T) {
 				Config: testAccServiceIntegrationEndpointResource(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAivenServiceEndpointIntegrationAttributes("data.aiven_service_integration_endpoint.endpoint"),
-					resource.TestCheckResourceAttr(resourceName, "project", fmt.Sprintf("test-acc-pr-%s", rName)),
+					resource.TestCheckResourceAttr(resourceName, "project", os.Getenv("AIVEN_PROJECT_NAME")),
 					resource.TestCheckResourceAttr(resourceName, "endpoint_name", fmt.Sprintf("test-acc-ie-%s", rName)),
 					resource.TestCheckResourceAttr(resourceName, "endpoint_type", "external_elasticsearch_logs"),
 				),
@@ -34,13 +34,12 @@ func TestAccAivenServiceIntegrationEndpoint_basic(t *testing.T) {
 
 func testAccServiceIntegrationEndpointResource(name string) string {
 	return fmt.Sprintf(`
-		resource "aiven_project" "foo" {
-			project = "test-acc-pr-%s"
-			card_id="%s"	
+		data "aiven_project" "foo" {
+			project = "%s"
 		}
 		
 		resource "aiven_service" "bar-pg" {
-			project = aiven_project.foo.project
+			project = data.aiven_project.foo.project
 			cloud_name = "google-europe-west1"
 			plan = "startup-4"
 			service_name = "test-acc-sr-pg-%s"
@@ -63,7 +62,7 @@ func testAccServiceIntegrationEndpointResource(name string) string {
 		}
 		
 		resource "aiven_service_integration_endpoint" "bar" {
-			project = aiven_project.foo.project
+			project = data.aiven_project.foo.project
 			endpoint_name = "test-acc-ie-%s"
 			endpoint_type = "external_elasticsearch_logs"
 
@@ -76,7 +75,7 @@ func testAccServiceIntegrationEndpointResource(name string) string {
 		}
 
 		resource "aiven_service_integration" "bar" {
-			project = aiven_project.foo.project
+			project = data.aiven_project.foo.project
 			integration_type = "external_elasticsearch_logs"
 			source_service_name = aiven_service.bar-pg.service_name
 			destination_endpoint_id = aiven_service_integration_endpoint.bar.id
@@ -86,7 +85,7 @@ func testAccServiceIntegrationEndpointResource(name string) string {
 			project = aiven_service_integration_endpoint.bar.project
 			endpoint_name = aiven_service_integration_endpoint.bar.endpoint_name
 		}
-		`, name, os.Getenv("AIVEN_CARD_ID"), name, name, name)
+		`, os.Getenv("AIVEN_PROJECT_NAME"), name, name, name)
 }
 
 func testAccCheckAivenServiceIntegraitonEndpointResourceDestroy(s *terraform.State) error {

--- a/aiven/resource_service_integration_test.go
+++ b/aiven/resource_service_integration_test.go
@@ -17,7 +17,7 @@ func TestAccAivenServiceIntegration_basic(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckAivenServiceIntegraitonResourceDestroy,
+		CheckDestroy: testAccCheckAivenServiceIntegrationResourceDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccServiceIntegrationResource(rName),
@@ -277,7 +277,7 @@ func testAccServiceIntegrationMirrorMakerResource(name string) string {
 		`, os.Getenv("AIVEN_PROJECT_NAME"), name, name, name, name, name)
 }
 
-func testAccCheckAivenServiceIntegraitonResourceDestroy(s *terraform.State) error {
+func testAccCheckAivenServiceIntegrationResourceDestroy(s *terraform.State) error {
 	c := testAccProvider.Meta().(*aiven.Client)
 
 	// loop through the resources in state, verifying each aiven_service_integration is destroyed

--- a/aiven/resource_service_integration_test.go
+++ b/aiven/resource_service_integration_test.go
@@ -24,7 +24,7 @@ func TestAccAivenServiceIntegration_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAivenServiceIntegrationAttributes("data.aiven_service_integration.int"),
 					resource.TestCheckResourceAttr(resourceName, "integration_type", "metrics"),
-					resource.TestCheckResourceAttr(resourceName, "project", fmt.Sprintf("test-acc-pr-%s", rName)),
+					resource.TestCheckResourceAttr(resourceName, "project", os.Getenv("AIVEN_PROJECT_NAME")),
 					resource.TestCheckResourceAttr(resourceName, "source_service_name", fmt.Sprintf("test-acc-sr-pg-%s", rName)),
 					resource.TestCheckResourceAttr(resourceName, "destination_service_name", fmt.Sprintf("test-acc-sr-influxdb-%s", rName)),
 				),
@@ -34,7 +34,7 @@ func TestAccAivenServiceIntegration_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAivenServiceIntegrationAttributes("data.aiven_service_integration.int"),
 					resource.TestCheckResourceAttr(resourceName, "integration_type", "kafka_connect"),
-					resource.TestCheckResourceAttr(resourceName, "project", fmt.Sprintf("test-acc-pr-%s", rName)),
+					resource.TestCheckResourceAttr(resourceName, "project", os.Getenv("AIVEN_PROJECT_NAME")),
 					resource.TestCheckResourceAttr(resourceName, "source_service_name", fmt.Sprintf("test-acc-sr-kafka-%s", rName)),
 					resource.TestCheckResourceAttr(resourceName, "destination_service_name", fmt.Sprintf("test-acc-sr-kafka-con-%s", rName)),
 				),
@@ -43,7 +43,7 @@ func TestAccAivenServiceIntegration_basic(t *testing.T) {
 				Config: testAccServiceIntegrationMirrorMakerResource(rName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "integration_type", "kafka_mirrormaker"),
-					resource.TestCheckResourceAttr(resourceName, "project", fmt.Sprintf("test-acc-pr-%s", rName)),
+					resource.TestCheckResourceAttr(resourceName, "project", os.Getenv("AIVEN_PROJECT_NAME")),
 					resource.TestCheckResourceAttr(resourceName, "source_service_name", fmt.Sprintf("test-acc-sr-source-%s", rName)),
 					resource.TestCheckResourceAttr(resourceName, "destination_service_name", fmt.Sprintf("test-acc-sr-mm-%s", rName)),
 				),
@@ -54,13 +54,12 @@ func TestAccAivenServiceIntegration_basic(t *testing.T) {
 
 func testAccServiceIntegrationResource(name string) string {
 	return fmt.Sprintf(`
-		resource "aiven_project" "foo" {
-			project = "test-acc-pr-%s"
-			card_id="%s"	
+		data "aiven_project" "foo" {
+			project = "%s"
 		}
 		
 		resource "aiven_service" "bar-pg" {
-			project = aiven_project.foo.project
+			project = data.aiven_project.foo.project
 			cloud_name = "google-europe-west1"
 			plan = "startup-4"
 			service_name = "test-acc-sr-pg-%s"
@@ -83,7 +82,7 @@ func testAccServiceIntegrationResource(name string) string {
 		}
 
 		resource "aiven_service" "bar-influxdb" {
-				project = aiven_project.foo.project
+			project = data.aiven_project.foo.project
 			cloud_name = "google-europe-west1"
 			plan = "startup-4"
 			service_name = "test-acc-sr-influxdb-%s"
@@ -99,7 +98,7 @@ func testAccServiceIntegrationResource(name string) string {
 		}
 
 		resource "aiven_service_integration" "bar" {
-			project = aiven_project.foo.project
+			project = data.aiven_project.foo.project
 			integration_type = "metrics"
 			source_service_name = aiven_service.bar-pg.service_name
 			destination_service_name = aiven_service.bar-influxdb.service_name
@@ -111,18 +110,17 @@ func testAccServiceIntegrationResource(name string) string {
 			source_service_name = aiven_service_integration.bar.source_service_name
 			destination_service_name = aiven_service_integration.bar.destination_service_name
 		}
-		`, name, os.Getenv("AIVEN_CARD_ID"), name, name)
+		`, os.Getenv("AIVEN_PROJECT_NAME"), name, name)
 }
 
 func testAccServiceIntegrationKafkaConnectResource(name string) string {
 	return fmt.Sprintf(`
-		resource "aiven_project" "foo" {
-			project = "test-acc-pr-%s"
-			card_id="%s"	
+		data "aiven_project" "foo" {
+			project = "%s"
 		}
 		
 		resource "aiven_service" "kafka1" {
-			project = aiven_project.foo.project
+			project = data.aiven_project.foo.project
 			cloud_name = "google-europe-west1"
 			plan = "business-4"
 			service_name =  "test-acc-sr-kafka-%s"
@@ -136,7 +134,7 @@ func testAccServiceIntegrationKafkaConnectResource(name string) string {
 		}
 		
 		resource "aiven_service" "kafka_connect1" {
-			project = aiven_project.foo.project
+			project = data.aiven_project.foo.project
 			cloud_name = "google-europe-west1"
 			plan = "startup-4"
 			service_name = "test-acc-sr-kafka-con-%s"
@@ -156,7 +154,7 @@ func testAccServiceIntegrationKafkaConnectResource(name string) string {
 		}
 
 		resource "aiven_service_integration" "bar" {
-			project = aiven_project.foo.project
+			project = data.aiven_project.foo.project
 			integration_type = "kafka_connect"
 			source_service_name = aiven_service.kafka1.service_name
 			destination_service_name = aiven_service.kafka_connect1.service_name
@@ -176,18 +174,17 @@ func testAccServiceIntegrationKafkaConnectResource(name string) string {
 			source_service_name = aiven_service_integration.bar.source_service_name
 			destination_service_name = aiven_service_integration.bar.destination_service_name
 		}
-		`, name, os.Getenv("AIVEN_CARD_ID"), name, name)
+		`, os.Getenv("AIVEN_PROJECT_NAME"), name, name)
 }
 
 func testAccServiceIntegrationMirrorMakerResource(name string) string {
 	return fmt.Sprintf(`
-		resource "aiven_project" "foo" {
-			project = "test-acc-pr-%s"
-			card_id="%s"	
+		data "aiven_project" "foo" {
+			project = "%s"
 		}
 		
 		resource "aiven_service" "source" {
-			project = aiven_project.foo.project
+			project = data.aiven_project.foo.project
 			cloud_name = "google-europe-west1"
 			plan = "business-4"
 			service_name = "test-acc-sr-source-%s"
@@ -205,7 +202,7 @@ func testAccServiceIntegrationMirrorMakerResource(name string) string {
 		}
 		
 		resource "aiven_kafka_topic" "source" {
-			project = aiven_project.foo.project
+			project = data.aiven_project.foo.project
 			service_name = aiven_service.source.service_name
 			topic_name = "test-acc-topic-a-%s"
 			partitions = 3
@@ -213,7 +210,7 @@ func testAccServiceIntegrationMirrorMakerResource(name string) string {
 		}
 
 		resource "aiven_service" "target" {
-			project = aiven_project.foo.project
+			project = data.aiven_project.foo.project
 			cloud_name = "google-europe-west1"
 			plan = "business-4"
 			service_name = "test-acc-sr-target-%s"
@@ -231,7 +228,7 @@ func testAccServiceIntegrationMirrorMakerResource(name string) string {
 		}
 		
 		resource "aiven_kafka_topic" "target" {
-			project = aiven_project.foo.project
+			project = data.aiven_project.foo.project
 			service_name = aiven_service.target.service_name
 			topic_name = "test-acc-topic-b-%s"
 			partitions = 3
@@ -239,7 +236,7 @@ func testAccServiceIntegrationMirrorMakerResource(name string) string {
 		}
 
 		resource "aiven_service" "mm" {
-			project = aiven_project.foo.project
+			project = data.aiven_project.foo.project
 			cloud_name = "google-europe-west1"
 			plan = "startup-4"
 			service_name = "test-acc-sr-mm-%s"
@@ -257,7 +254,7 @@ func testAccServiceIntegrationMirrorMakerResource(name string) string {
 		}
 
 		resource "aiven_service_integration" "bar" {
-			project = aiven_project.foo.project
+			project = data.aiven_project.foo.project
 			integration_type = "kafka_mirrormaker"
 			source_service_name = aiven_service.source.service_name
 			destination_service_name = aiven_service.mm.service_name
@@ -268,7 +265,7 @@ func testAccServiceIntegrationMirrorMakerResource(name string) string {
 		}
 
 		resource "aiven_service_integration" "i2" {
-			project = aiven_project.foo.project
+			project = data.aiven_project.foo.project
 			integration_type = "kafka_mirrormaker"
 			source_service_name = aiven_service.target.service_name
 			destination_service_name = aiven_service.mm.service_name
@@ -277,7 +274,7 @@ func testAccServiceIntegrationMirrorMakerResource(name string) string {
 				cluster_alias = "target"
 			}
 		}
-		`, name, os.Getenv("AIVEN_CARD_ID"), name, name, name, name, name)
+		`, os.Getenv("AIVEN_PROJECT_NAME"), name, name, name, name, name)
 }
 
 func testAccCheckAivenServiceIntegraitonResourceDestroy(s *terraform.State) error {

--- a/aiven/resource_service_kafka_connect_test.go
+++ b/aiven/resource_service_kafka_connect_test.go
@@ -11,11 +11,10 @@ import (
 
 // Kafka Connect service tests
 func TestAccAivenService_kafkaconnect(t *testing.T) {
-	t.Parallel()
 	resourceName := "aiven_service.bar"
 	rName := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAivenServiceResourceDestroy,
@@ -27,7 +26,7 @@ func TestAccAivenService_kafkaconnect(t *testing.T) {
 					testAccCheckAivenServiceKafkaConnectAttributes("data.aiven_service.service"),
 					resource.TestCheckResourceAttr(resourceName, "service_name", fmt.Sprintf("test-acc-sr-%s", rName)),
 					resource.TestCheckResourceAttr(resourceName, "state", "RUNNING"),
-					resource.TestCheckResourceAttr(resourceName, "project", fmt.Sprintf("test-acc-pr-%s", rName)),
+					resource.TestCheckResourceAttr(resourceName, "project", os.Getenv("AIVEN_PROJECT_NAME")),
 					resource.TestCheckResourceAttr(resourceName, "service_type", "kafka_connect"),
 					resource.TestCheckResourceAttr(resourceName, "cloud_name", "google-europe-west1"),
 					resource.TestCheckResourceAttr(resourceName, "maintenance_window_dow", "monday"),
@@ -42,13 +41,12 @@ func TestAccAivenService_kafkaconnect(t *testing.T) {
 
 func testAccKafkaConnectServiceResource(name string) string {
 	return fmt.Sprintf(`
-		resource "aiven_project" "foo" {
-			project = "test-acc-pr-%s"
-			card_id="%s"	
+		data "aiven_project" "foo" {
+			project = "%s"
 		}
 		
 		resource "aiven_service" "bar" {
-			project = aiven_project.foo.project
+			project = data.aiven_project.foo.project
 			cloud_name = "google-europe-west1"
 			plan = "startup-4"
 			service_name = "test-acc-sr-%s"
@@ -69,9 +67,9 @@ func testAccKafkaConnectServiceResource(name string) string {
 		
 		data "aiven_service" "service" {
 			service_name = aiven_service.bar.service_name
-			project = aiven_project.foo.project
+			project = aiven_service.bar.project
 		}
-		`, name, os.Getenv("AIVEN_CARD_ID"), name)
+		`, os.Getenv("AIVEN_PROJECT_NAME"), name)
 }
 
 func testAccCheckAivenServiceKafkaConnectAttributes(n string) resource.TestCheckFunc {

--- a/aiven/resource_service_kafka_test.go
+++ b/aiven/resource_service_kafka_test.go
@@ -11,11 +11,10 @@ import (
 
 // Kafka service tests
 func TestAccAivenService_kafka(t *testing.T) {
-	t.Parallel()
 	resourceName := "aiven_service.bar"
 	rName := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAivenServiceResourceDestroy,
@@ -27,7 +26,7 @@ func TestAccAivenService_kafka(t *testing.T) {
 					testAccCheckAivenServiceKafkaAttributes("data.aiven_service.service"),
 					resource.TestCheckResourceAttr(resourceName, "service_name", fmt.Sprintf("test-acc-sr-%s", rName)),
 					resource.TestCheckResourceAttr(resourceName, "state", "RUNNING"),
-					resource.TestCheckResourceAttr(resourceName, "project", fmt.Sprintf("test-acc-pr-%s", rName)),
+					resource.TestCheckResourceAttr(resourceName, "project", os.Getenv("AIVEN_PROJECT_NAME")),
 					resource.TestCheckResourceAttr(resourceName, "service_type", "kafka"),
 					resource.TestCheckResourceAttr(resourceName, "cloud_name", "google-europe-west1"),
 					resource.TestCheckResourceAttr(resourceName, "maintenance_window_dow", "monday"),
@@ -42,13 +41,12 @@ func TestAccAivenService_kafka(t *testing.T) {
 
 func testAccKafkaServiceResource(name string) string {
 	return fmt.Sprintf(`
-		resource "aiven_project" "foo" {
-			project = "test-acc-pr-%s"
-			card_id="%s"	
+		data "aiven_project" "foo" {
+			project = "%s"
 		}
 		
 		resource "aiven_service" "bar" {
-			project = aiven_project.foo.project
+			project = data.aiven_project.foo.project
 			cloud_name = "google-europe-west1"
 			plan = "business-4"
 			service_name = "test-acc-sr-%s"
@@ -76,9 +74,9 @@ func testAccKafkaServiceResource(name string) string {
 		
 		data "aiven_service" "service" {
 			service_name = aiven_service.bar.service_name
-			project = aiven_project.foo.project
+			project = aiven_service.bar.project
 		}
-		`, name, os.Getenv("AIVEN_CARD_ID"), name)
+		`, os.Getenv("AIVEN_PROJECT_NAME"), name)
 }
 
 func testAccCheckAivenServiceKafkaAttributes(n string) resource.TestCheckFunc {

--- a/aiven/resource_service_mirrormaker_test.go
+++ b/aiven/resource_service_mirrormaker_test.go
@@ -11,11 +11,10 @@ import (
 
 // MySQL service tests
 func TestAccAivenService_mirrormaker(t *testing.T) {
-	t.Parallel()
 	resourceName := "aiven_service.bar"
 	rName := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAivenServiceResourceDestroy,
@@ -26,7 +25,7 @@ func TestAccAivenService_mirrormaker(t *testing.T) {
 					testAccCheckAivenServiceMirrorMakerAttributes("data.aiven_service.service"),
 					resource.TestCheckResourceAttr(resourceName, "service_name", fmt.Sprintf("test-acc-sr-%s", rName)),
 					resource.TestCheckResourceAttr(resourceName, "state", "RUNNING"),
-					resource.TestCheckResourceAttr(resourceName, "project", fmt.Sprintf("test-acc-pr-%s", rName)),
+					resource.TestCheckResourceAttr(resourceName, "project", os.Getenv("AIVEN_PROJECT_NAME")),
 					resource.TestCheckResourceAttr(resourceName, "service_type", "kafka_mirrormaker"),
 					resource.TestCheckResourceAttr(resourceName, "cloud_name", "google-europe-west1"),
 					resource.TestCheckResourceAttr(resourceName, "state", "RUNNING"),
@@ -39,13 +38,12 @@ func TestAccAivenService_mirrormaker(t *testing.T) {
 
 func testAccMirrorMakerServiceResource(name string) string {
 	return fmt.Sprintf(`
-		resource "aiven_project" "foo" {
-			project = "test-acc-pr-%s"
-			card_id="%s"	
+		data "aiven_project" "foo" {
+			project = "%s"
 		}
 		
 		resource "aiven_service" "bar" {
-			project = aiven_project.foo.project
+			project = data.aiven_project.foo.project
 			cloud_name = "google-europe-west1"
 			plan = "startup-4"
 			service_name = "test-acc-sr-%s"
@@ -64,9 +62,9 @@ func testAccMirrorMakerServiceResource(name string) string {
 
 		data "aiven_service" "service" {
 			service_name = aiven_service.bar.service_name
-			project = aiven_project.foo.project
+			project = aiven_service.bar.project
 		}
-		`, name, os.Getenv("AIVEN_CARD_ID"), name)
+		`, os.Getenv("AIVEN_PROJECT_NAME"), name)
 }
 
 func testAccCheckAivenServiceMirrorMakerAttributes(n string) resource.TestCheckFunc {

--- a/aiven/resource_service_mysql_test.go
+++ b/aiven/resource_service_mysql_test.go
@@ -11,11 +11,10 @@ import (
 
 // MySQL service tests
 func TestAccAivenService_mysql(t *testing.T) {
-	t.Parallel()
 	resourceName := "aiven_service.bar"
 	rName := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAivenServiceResourceDestroy,
@@ -27,7 +26,7 @@ func TestAccAivenService_mysql(t *testing.T) {
 					testAccCheckAivenServiceMysqlAttributes("data.aiven_service.service"),
 					resource.TestCheckResourceAttr(resourceName, "service_name", fmt.Sprintf("test-acc-sr-%s", rName)),
 					resource.TestCheckResourceAttr(resourceName, "state", "RUNNING"),
-					resource.TestCheckResourceAttr(resourceName, "project", fmt.Sprintf("test-acc-pr-%s", rName)),
+					resource.TestCheckResourceAttr(resourceName, "project", os.Getenv("AIVEN_PROJECT_NAME")),
 					resource.TestCheckResourceAttr(resourceName, "service_type", "mysql"),
 					resource.TestCheckResourceAttr(resourceName, "cloud_name", "google-europe-west1"),
 					resource.TestCheckResourceAttr(resourceName, "maintenance_window_dow", "monday"),
@@ -42,13 +41,12 @@ func TestAccAivenService_mysql(t *testing.T) {
 
 func testAccMysqlServiceResource(name string) string {
 	return fmt.Sprintf(`
-		resource "aiven_project" "foo" {
-			project = "test-acc-pr-%s"
-			card_id="%s"	
+		data "aiven_project" "foo" {
+			project = "%s"
 		}
 		
 		resource "aiven_service" "bar" {
-			project = aiven_project.foo.project
+			project = data.aiven_project.foo.project
 			cloud_name = "google-europe-west1"
 			plan = "business-4"
 			service_name = "test-acc-sr-%s"
@@ -72,9 +70,9 @@ func testAccMysqlServiceResource(name string) string {
 		
 		data "aiven_service" "service" {
 			service_name = aiven_service.bar.service_name
-			project = aiven_project.foo.project
+			project = aiven_service.bar.project
 		}
-		`, name, os.Getenv("AIVEN_CARD_ID"), name)
+		`, os.Getenv("AIVEN_PROJECT_NAME"), name)
 }
 
 func testAccCheckAivenServiceMysqlAttributes(n string) resource.TestCheckFunc {

--- a/aiven/resource_service_pg_test.go
+++ b/aiven/resource_service_pg_test.go
@@ -29,7 +29,7 @@ func TestAccAivenService_pg(t *testing.T) {
 					testAccCheckAivenServicePGAttributes("data.aiven_service.service-pg"),
 					resource.TestCheckResourceAttr(resourceName, "service_name", fmt.Sprintf("test-acc-sr-%s", rName)),
 					resource.TestCheckResourceAttr(resourceName, "state", "RUNNING"),
-					resource.TestCheckResourceAttr(resourceName, "project", fmt.Sprintf("test-acc-pr-pg-%s", rName)),
+					resource.TestCheckResourceAttr(resourceName, "project", os.Getenv("AIVEN_PROJECT_NAME")),
 					resource.TestCheckResourceAttr(resourceName, "service_type", "pg"),
 					resource.TestCheckResourceAttr(resourceName, "cloud_name", "google-europe-west1"),
 					resource.TestCheckResourceAttr(resourceName, "maintenance_window_dow", "monday"),
@@ -46,7 +46,7 @@ func TestAccAivenService_pg(t *testing.T) {
 					testAccCheckAivenServicePGAttributes("data.aiven_service.service-pg"),
 					resource.TestCheckResourceAttr(resourceName, "service_name", fmt.Sprintf("test-acc-sr-%s", rName)),
 					resource.TestCheckResourceAttr(resourceName, "state", "RUNNING"),
-					resource.TestCheckResourceAttr(resourceName, "project", fmt.Sprintf("test-acc-pr-pg-%s", rName)),
+					resource.TestCheckResourceAttr(resourceName, "project", os.Getenv("AIVEN_PROJECT_NAME")),
 					resource.TestCheckResourceAttr(resourceName, "service_type", "pg"),
 					resource.TestCheckResourceAttr(resourceName, "cloud_name", "google-europe-west1"),
 					resource.TestCheckResourceAttr(resourceName, "maintenance_window_dow", "monday"),
@@ -64,7 +64,7 @@ func TestAccAivenService_pg(t *testing.T) {
 					testAccCheckAivenServicePGAttributes("data.aiven_service.service-pg"),
 					resource.TestCheckResourceAttr(resourceName, "service_name", fmt.Sprintf("test-acc-sr-%s", rName)),
 					resource.TestCheckResourceAttr(resourceName, "state", "RUNNING"),
-					resource.TestCheckResourceAttr(resourceName, "project", fmt.Sprintf("test-acc-pr-pg-%s", rName)),
+					resource.TestCheckResourceAttr(resourceName, "project", os.Getenv("AIVEN_PROJECT_NAME")),
 					resource.TestCheckResourceAttr(resourceName, "service_type", "pg"),
 					resource.TestCheckResourceAttr(resourceName, "cloud_name", "google-europe-west1"),
 					resource.TestCheckResourceAttr(resourceName, "maintenance_window_dow", "monday"),
@@ -82,7 +82,7 @@ func TestAccAivenService_pg(t *testing.T) {
 					testAccCheckAivenServicePGAttributes("data.aiven_service.service-pg"),
 					resource.TestCheckResourceAttr(resourceName, "service_name", fmt.Sprintf("test-acc-sr-%s", rName)),
 					resource.TestCheckResourceAttr(resourceName, "state", "RUNNING"),
-					resource.TestCheckResourceAttr(resourceName, "project", fmt.Sprintf("test-acc-pr-pg-%s", rName)),
+					resource.TestCheckResourceAttr(resourceName, "project", os.Getenv("AIVEN_PROJECT_NAME")),
 					resource.TestCheckResourceAttr(resourceName, "service_type", "pg"),
 					resource.TestCheckResourceAttr(resourceName, "cloud_name", "google-europe-west1"),
 					resource.TestCheckResourceAttr(resourceName, "maintenance_window_dow", "monday"),
@@ -98,13 +98,12 @@ func TestAccAivenService_pg(t *testing.T) {
 
 func testAccPGServiceResource(name string) string {
 	return fmt.Sprintf(`
-		resource "aiven_project" "foo-pg" {
-			project = "test-acc-pr-pg-%s"
-			card_id="%s"	
+		data "aiven_project" "foo-pg" {
+			project = "%s"
 		}
 		
 		resource "aiven_service" "bar-pg" {
-			project = aiven_project.foo-pg.project
+			project = data.aiven_project.foo-pg.project
 			cloud_name = "google-europe-west1"
 			plan = "startup-4"
 			service_name = "test-acc-sr-%s"
@@ -128,20 +127,19 @@ func testAccPGServiceResource(name string) string {
 		
 		data "aiven_service" "service-pg" {
 			service_name = aiven_service.bar-pg.service_name
-			project = aiven_project.foo-pg.project
+			project = aiven_service.bar-pg.project
 		}
-		`, name, os.Getenv("AIVEN_CARD_ID"), name)
+		`, os.Getenv("AIVEN_PROJECT_NAME"), name)
 }
 
 func testAccPGServiceCustomTimeoutsResource(name string) string {
 	return fmt.Sprintf(`
-		resource "aiven_project" "foo-pg" {
-			project = "test-acc-pr-pg-%s"
-			card_id="%s"	
+		data "aiven_project" "foo-pg" {
+			project = "%s"
 		}
 		
 		resource "aiven_service" "bar-pg" {
-			project = aiven_project.foo-pg.project
+			project = data.aiven_project.foo-pg.project
 			cloud_name = "google-europe-west1"
 			plan = "startup-4"
 			service_name = "test-acc-sr-%s"
@@ -170,20 +168,19 @@ func testAccPGServiceCustomTimeoutsResource(name string) string {
 		
 		data "aiven_service" "service-pg" {
 			service_name = aiven_service.bar-pg.service_name
-			project = aiven_project.foo-pg.project
+			project = aiven_service.bar-pg.project
 		}
-		`, name, os.Getenv("AIVEN_CARD_ID"), name)
+		`, os.Getenv("AIVEN_PROJECT_NAME"), name)
 }
 
 func testAccPGTerminationProtectionServiceResource(name string) string {
 	return fmt.Sprintf(`
-		resource "aiven_project" "foo-pg" {
-			project = "test-acc-pr-pg-%s"
-			card_id="%s"	
+		data "aiven_project" "foo-pg" {
+			project = "%s"
 		}
 		
 		resource "aiven_service" "bar-pg" {
-			project = aiven_project.foo-pg.project
+			project = data.aiven_project.foo-pg.project
 			cloud_name = "google-europe-west1"
 			plan = "startup-4"
 			service_name = "test-acc-sr-%s"
@@ -208,20 +205,19 @@ func testAccPGTerminationProtectionServiceResource(name string) string {
 		
 		data "aiven_service" "service-pg" {
 			service_name = aiven_service.bar-pg.service_name
-			project = aiven_project.foo-pg.project
+			project = aiven_service.bar-pg.project
 		}
-		`, name, os.Getenv("AIVEN_CARD_ID"), name)
+		`, os.Getenv("AIVEN_PROJECT_NAME"), name)
 }
 
 func testAccPGReadReplicaServiceResource(name string) string {
 	return fmt.Sprintf(`
-		resource "aiven_project" "foo-pg" {
-			project = "test-acc-pr-pg-%s"
-			card_id="%s"	
+		data "aiven_project" "foo-pg" {
+			project = "%s"
 		}
 		
 		resource "aiven_service" "bar-pg" {
-			project = aiven_project.foo-pg.project
+			project = data.aiven_project.foo-pg.project
 			cloud_name = "google-europe-west1"
 			plan = "startup-4"
 			service_name = "test-acc-sr-%s"
@@ -244,7 +240,7 @@ func testAccPGReadReplicaServiceResource(name string) string {
 		}
 
 		resource "aiven_service" "bar-replica" {
-			project = aiven_project.foo-pg.project
+			project = data.aiven_project.foo-pg.project
 			cloud_name = "google-europe-west1"
 			plan = "startup-4"
 			service_name = "test-acc-sr-repica-%s"
@@ -277,9 +273,9 @@ func testAccPGReadReplicaServiceResource(name string) string {
 		
 		data "aiven_service" "service-pg" {
 			service_name = aiven_service.bar-pg.service_name
-			project = aiven_project.foo-pg.project
+			project = aiven_service.bar-pg.project
 		}
-		`, name, os.Getenv("AIVEN_CARD_ID"), name, name)
+		`, os.Getenv("AIVEN_PROJECT_NAME"), name, name)
 }
 
 func testAccCheckAivenServiceTerminationProtection(n string) resource.TestCheckFunc {

--- a/aiven/resource_service_redis_test.go
+++ b/aiven/resource_service_redis_test.go
@@ -11,11 +11,10 @@ import (
 
 // Redis service tests
 func TestAccAivenService_redis(t *testing.T) {
-	t.Parallel()
 	resourceName := "aiven_service.bar"
 	rName := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAivenServiceResourceDestroy,
@@ -27,7 +26,7 @@ func TestAccAivenService_redis(t *testing.T) {
 					testAccCheckAivenServiceRedisAttributes("data.aiven_service.service"),
 					resource.TestCheckResourceAttr(resourceName, "service_name", fmt.Sprintf("test-acc-sr-%s", rName)),
 					resource.TestCheckResourceAttr(resourceName, "state", "RUNNING"),
-					resource.TestCheckResourceAttr(resourceName, "project", fmt.Sprintf("test-acc-pr-%s", rName)),
+					resource.TestCheckResourceAttr(resourceName, "project", os.Getenv("AIVEN_PROJECT_NAME")),
 					resource.TestCheckResourceAttr(resourceName, "service_type", "redis"),
 					resource.TestCheckResourceAttr(resourceName, "cloud_name", "google-europe-west1"),
 					resource.TestCheckResourceAttr(resourceName, "maintenance_window_dow", "monday"),
@@ -42,13 +41,12 @@ func TestAccAivenService_redis(t *testing.T) {
 
 func testAccRedisServiceResource(name string) string {
 	return fmt.Sprintf(`
-		resource "aiven_project" "foo" {
-			project = "test-acc-pr-%s"
-			card_id="%s"	
+		data "aiven_project" "foo" {
+			project = "%s"
 		}
 		
 		resource "aiven_service" "bar" {
-			project = aiven_project.foo.project
+			project = data.aiven_project.foo.project
 			cloud_name = "google-europe-west1"
 			plan = "business-4"
 			service_name = "test-acc-sr-%s"
@@ -67,9 +65,9 @@ func testAccRedisServiceResource(name string) string {
 		
 		data "aiven_service" "service" {
 			service_name = aiven_service.bar.service_name
-			project = aiven_project.foo.project
+			project = aiven_service.bar.project
 		}
-		`, name, os.Getenv("AIVEN_CARD_ID"), name)
+		`, os.Getenv("AIVEN_PROJECT_NAME"), name)
 }
 
 func testAccCheckAivenServiceRedisAttributes(n string) resource.TestCheckFunc {

--- a/aiven/resource_service_test.go
+++ b/aiven/resource_service_test.go
@@ -5,8 +5,8 @@ import (
 	"github.com/aiven/aiven-go-client"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
+	"os"
 	"reflect"
-	"strings"
 	"testing"
 )
 
@@ -38,7 +38,7 @@ func sweepServices(region string) error {
 	}
 
 	for _, project := range projects {
-		if strings.Contains(project.Name, "test-acc-") {
+		if project.Name == os.Getenv("AIVEN_PROJECT_NAME") {
 			services, err := conn.Services.List(project.Name)
 			if err != nil {
 				return fmt.Errorf("error retrieving a list of services for a project `%s`: %s", project.Name, err)


### PR DESCRIPTION
Change acceptance tests to use one pre-existing project instead of creating a new project each time during execution, with exceptions for the projects that are not using services.