### PR TITLE
Kafka ACL regex modification

### DIFF
--- a/aiven/resource_kafka_acl.go
+++ b/aiven/resource_kafka_acl.go
@@ -3,10 +3,11 @@ package aiven
 
 import (
 	"fmt"
-	"github.com/aiven/terraform-provider-aiven/pkg/cache"
-	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
 	"regexp"
 	"strings"
+
+	"github.com/aiven/terraform-provider-aiven/pkg/cache"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
 
 	"github.com/aiven/aiven-go-client"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
@@ -47,7 +48,7 @@ var aivenKafkaACLSchema = map[string]*schema.Schema{
 		Required:    true,
 		Description: "Username pattern for the ACL entry",
 		ForceNew:    true,
-		ValidateFunc: validation.StringMatch(regexp.MustCompile("^([*]{1}$|[a-zA-Z0-9-_*?]*)$"),
+		ValidateFunc: validation.StringMatch(regexp.MustCompile(`^(\*$|[a-zA-Z0-9-_?][a-zA-Z0-9-_?*]+)$`),
 			"username should be alphanumeric"),
 	},
 }

--- a/aiven/resource_kafka_acl_test.go
+++ b/aiven/resource_kafka_acl_test.go
@@ -44,7 +44,12 @@ func TestAccAivenKafkaACL_basic(t *testing.T) {
 				ExpectError: regexp.MustCompile("invalid value for username"),
 			},
 			{
-				Config:             testAccKafkaACLWildcardResource(rName),
+				Config:      testAccKafkaACLInvalidCharsResource(rName),
+				PlanOnly:    true,
+				ExpectError: regexp.MustCompile("invalid value for username"),
+			},
+			{
+				Config:             testAccKafkaACLPrefixWildcardResource(rName),
 				PlanOnly:           true,
 				ExpectNonEmptyPlan: true,
 			},
@@ -155,6 +160,18 @@ func testAccKafkaACLPrefixWildcardResource(_ string) string {
 }
 
 func testAccKafkaACLWrongUsernameResource(_ string) string {
+	return `
+		resource "aiven_kafka_acl" "foo" {
+			project = "test-acc-pr-1"
+			service_name = "test-acc-sr-1"
+			topic = "test-acc-topic-1"
+			username = "*-user"
+			permission = "admin"
+		}
+		`
+}
+
+func testAccKafkaACLInvalidCharsResource(_ string) string {
 	return `
 		resource "aiven_kafka_acl" "foo" {
 			project = "test-acc-pr-1"


### PR DESCRIPTION
Add check that * is not first char of strings of length > 1
Some tests (KafkaACLWildcardPrefix) were reporting as being skipped so I will check if this is happening in CI as well.