### PR TITLE
Add example initial configuration for Timescale Cloud

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -119,6 +119,7 @@ Other examples can be found in the [examples](https://github.com/aiven/terraform
 * [Deploying a MirrorMaker service](https://github.com/aiven/terraform-provider-aiven/tree/master/examples/kafka_mirrormaker)
 * [Deploying PostgreSQL services to multiple clouds and regions](https://github.com/aiven/terraform-provider-aiven/tree/master/examples/postgres)
 * [Deploying M3 and M3 Aggregator services](https://github.com/aiven/terraform-provider-aiven/tree/master/examples/m3)
+* [Deploying on Timescale Cloud](https://github.com/aiven/terraform-provider-aiven/tree/master/examples/timescale)
 
 ## Importing existing infrastructure
 

--- a/examples/timescale/main.tf
+++ b/examples/timescale/main.tf
@@ -1,0 +1,36 @@
+terraform {
+  required_providers {
+    aiven = {
+      source  = "aiven/aiven"
+      version = "2.X.X"
+    }
+  }
+}
+
+
+provider "aiven" {
+  api_token = var.timescale_api_token
+}
+
+data "aiven_project" "test" {
+  project = var.aiven_project_id
+}
+
+resource "aiven_pg" "timescaledb" {
+  project      = data.aiven_project.test.id
+  cloud_name   = "timescale-google-europe-north1"
+  plan         = "timescale-basic-100-compute-optimized"
+  service_name = "timescaledb"
+
+  pg_user_config {
+    pg_version = 12          # Choose an available postgres version
+    variant    = "timescale" # Do not forget to specify this variant
+  }
+}
+
+resource "aiven_grafana" "grafana" {
+  project      = data.aiven_project.test.id
+  cloud_name   = "timescale-google-europe-north1"
+  plan         = "dashboard-1" # Grafana plans are also available in Timescale Cloud
+  service_name = "grafana"
+}

--- a/examples/timescale/variables.tf
+++ b/examples/timescale/variables.tf
@@ -1,0 +1,9 @@
+# Find an id from an existing project in the Timescale Cloud console
+variable "aiven_project_id" {
+  type = string
+}
+
+# Create a token at https://portal.timescale.cloud/profile/auth
+variable "timescale_api_token" {
+  type = string
+}


### PR DESCRIPTION
Here's an example configuration showing how to deploy a TimescaleDB service in Timescale Cloud. The required `variant` option is slightly unexpected for users so I think it is worth including in an explicit example like this.