### PR TITLE
fix kafka topic empty config issues

### DIFF
--- a/aiven/resource_kafka_topic.go
+++ b/aiven/resource_kafka_topic.go
@@ -293,6 +293,10 @@ func getKafkaTopicConfig(d *schema.ResourceData) aiven.KafkaTopicConfig {
 		return aiven.KafkaTopicConfig{}
 	}
 
+	if d.Get("config").([]interface{})[0] == nil {
+		return aiven.KafkaTopicConfig{}
+	}
+
 	configRaw := d.Get("config").([]interface{})[0].(map[string]interface{})
 
 	return aiven.KafkaTopicConfig{


### PR DESCRIPTION
It only appears when topics are without config are automatically created using the for_each loop.