### PR TITLE
optimise kafka topic resource performance

### DIFF
--- a/aiven/kafka_topic_availability.go
+++ b/aiven/kafka_topic_availability.go
@@ -122,7 +122,7 @@ func (w *KafkaTopicAvailabilityWaiter) Conf(timeout time.Duration) *resource.Sta
 		Target:     []string{"ACTIVE"},
 		Refresh:    w.RefreshFunc(),
 		Timeout:    timeout,
-		MinTimeout: 1 * time.Second,
+		MinTimeout: 10 * time.Second,
 	}
 }
 

--- a/aiven/resource_kafka_topic.go
+++ b/aiven/resource_kafka_topic.go
@@ -285,7 +285,7 @@ func resourceKafkaTopicCreate(d *schema.ResourceData, m interface{}) error {
 
 	d.SetId(buildResourceID(project, serviceName, topicName))
 
-	return resourceKafkaTopicRead(d, m)
+	return nil
 }
 
 func getKafkaTopicConfig(d *schema.ResourceData) aiven.KafkaTopicConfig {
@@ -425,7 +425,7 @@ func resourceKafkaTopicUpdate(d *schema.ResourceData, m interface{}) error {
 		return err
 	}
 
-	return resourceKafkaTopicRead(d, m)
+	return nil
 }
 
 func resourceKafkaTopicDelete(d *schema.ResourceData, m interface{}) error {
@@ -437,7 +437,15 @@ func resourceKafkaTopicDelete(d *schema.ResourceData, m interface{}) error {
 		return fmt.Errorf("cannot delete kafka topic when termination_protection is enabled")
 	}
 
-	return client.KafkaTopics.Delete(projectName, serviceName, topicName)
+	err := client.KafkaTopics.Delete(projectName, serviceName, topicName)
+	if err != nil {
+		if aiven.IsNotFound(err) {
+			return nil
+		}
+		return err
+	}
+
+	return nil
 }
 
 func resourceKafkaTopicExists(d *schema.ResourceData, m interface{}) (bool, error) {


### PR DESCRIPTION
The idea of PR is to optimise Kafka Topic performance. Since we are using a new Kafka Topic API endpoint to get Kafka Topic configuration in addition to list endpoint, it drastically increases the number of API calls. Kafka Topic endpoint may behave unstable when a user has 200+ topics and Terraform client performing multiple operations simultaneously. 

To remedy this, we reduce the number of API calls where possible, tune timings and improve error handling to reduce the number of API calls.