### PR TITLE
Change VPC peering connection state handling

### DIFF
--- a/aiven/datasource_transit_gateway_vpc_attachement.go
+++ b/aiven/datasource_transit_gateway_vpc_attachement.go
@@ -4,7 +4,7 @@ import "github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
 func datasourceTransitGatewayVPCAttachment() *schema.Resource {
 	return &schema.Resource{
-		Read: datasourceVPCPeeringConnectionRead,
+		ReadContext: datasourceVPCPeeringConnectionRead,
 		Schema: resourceSchemaAsDatasourceSchema(aivenTransitGatewayVPCAttachmentSchema,
 			"vpc_id", "peer_cloud_account", "peer_vpc"),
 	}


### PR DESCRIPTION
- We update the VPC peering connection code eliminating all TF SDK v2 deprecated function, updating them with the context. 
- Change creation function, such that only when VPC peering connection is in the `ACTIVE` state - TF resource is created. Also, the extended error messages aim to communicate a guide a user to achieve the `ACTIVE` state. 