### PR TITLE
kafka topic acc tests fix naming to avoid `service with this name alr…

### DIFF
--- a/aiven/resource_kafka_topic_test.go
+++ b/aiven/resource_kafka_topic_test.go
@@ -69,6 +69,7 @@ func TestAccAivenKafkaTopic_basic(t *testing.T) {
 	rName := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
 	rName2 := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
 	rName3 := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
+	rName4 := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },
@@ -96,7 +97,7 @@ func TestAccAivenKafkaTopic_basic(t *testing.T) {
 					s, err := client.Services.Create(os.Getenv("AIVEN_PROJECT_NAME"), aiven.CreateServiceRequest{
 						Cloud:       "google-europe-west1",
 						Plan:        "business-4",
-						ServiceName: fmt.Sprintf("test-acc-sr-%s", rName),
+						ServiceName: fmt.Sprintf("test-acc-sr-%s", rName2),
 						ServiceType: "kafka",
 						MaintenanceWindow: &aiven.MaintenanceWindow{
 							DayOfWeek: "monday",
@@ -141,20 +142,7 @@ func TestAccAivenKafkaTopic_basic(t *testing.T) {
 						t.Fatalf("Cannot create Kafka Topic in PreConfig %s:", err.Error())
 					}
 				},
-				Config: testAccKafkaTopicResource(rName),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAivenKafkaTopicAttributes("data.aiven_kafka_topic.topic"),
-					resource.TestCheckResourceAttr(resourceName, "project", os.Getenv("AIVEN_PROJECT_NAME")),
-					resource.TestCheckResourceAttr(resourceName, "service_name", fmt.Sprintf("test-acc-sr-%s", rName)),
-					resource.TestCheckResourceAttr(resourceName, "topic_name", fmt.Sprintf("test-acc-topic-%s", rName)),
-					resource.TestCheckResourceAttr(resourceName, "partitions", "3"),
-					resource.TestCheckResourceAttr(resourceName, "replication", "2"),
-					resource.TestCheckResourceAttr(resourceName, "termination_protection", "false"),
-				),
-			},
-			// custom TF client timeouts test
-			{
-				Config: testAccKafkaTopicCustomTimeoutsResource(rName2),
+				Config: testAccKafkaTopicResource(rName2),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAivenKafkaTopicAttributes("data.aiven_kafka_topic.topic"),
 					resource.TestCheckResourceAttr(resourceName, "project", os.Getenv("AIVEN_PROJECT_NAME")),
@@ -163,19 +151,32 @@ func TestAccAivenKafkaTopic_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "partitions", "3"),
 					resource.TestCheckResourceAttr(resourceName, "replication", "2"),
 					resource.TestCheckResourceAttr(resourceName, "termination_protection", "false"),
+				),
+			},
+			// custom TF client timeouts test
+			{
+				Config: testAccKafkaTopicCustomTimeoutsResource(rName3),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAivenKafkaTopicAttributes("data.aiven_kafka_topic.topic"),
+					resource.TestCheckResourceAttr(resourceName, "project", os.Getenv("AIVEN_PROJECT_NAME")),
+					resource.TestCheckResourceAttr(resourceName, "service_name", fmt.Sprintf("test-acc-sr-%s", rName3)),
+					resource.TestCheckResourceAttr(resourceName, "topic_name", fmt.Sprintf("test-acc-topic-%s", rName3)),
+					resource.TestCheckResourceAttr(resourceName, "partitions", "3"),
+					resource.TestCheckResourceAttr(resourceName, "replication", "2"),
+					resource.TestCheckResourceAttr(resourceName, "termination_protection", "false"),
 					resource.TestCheckResourceAttr(resourceName, "retention_hours", "100"),
 				),
 			},
 			// termination protection test
 			{
-				Config:                    testAccKafkaTopicTerminationProtectionResource(rName3),
+				Config:                    testAccKafkaTopicTerminationProtectionResource(rName4),
 				PreventPostDestroyRefresh: true,
 				ExpectNonEmptyPlan:        true,
 				PlanOnly:                  true,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "project", os.Getenv("AIVEN_PROJECT_NAME")),
-					resource.TestCheckResourceAttr(resourceName, "service_name", fmt.Sprintf("test-acc-sr-%s", rName3)),
-					resource.TestCheckResourceAttr(resourceName, "topic_name", fmt.Sprintf("test-acc-topic-%s", rName3)),
+					resource.TestCheckResourceAttr(resourceName, "service_name", fmt.Sprintf("test-acc-sr-%s", rName4)),
+					resource.TestCheckResourceAttr(resourceName, "topic_name", fmt.Sprintf("test-acc-topic-%s", rName4)),
 					resource.TestCheckResourceAttr(resourceName, "partitions", "3"),
 					resource.TestCheckResourceAttr(resourceName, "replication", "2"),
 					resource.TestCheckResourceAttr(resourceName, "termination_protection", "true"),


### PR DESCRIPTION
…eady exists` error