### PR TITLE
tests: add card_id to project resource

### DIFF
--- a/aiven/datasource_project_test.go
+++ b/aiven/datasource_project_test.go
@@ -20,7 +20,6 @@ func TestAccAivenProjectDataSource_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrPair(datasourceName, "project", resourceName, "project"),
 					resource.TestCheckResourceAttrPair(datasourceName, "ca_cert", resourceName, "ca_cert"),
-					resource.TestCheckResourceAttrPair(datasourceName, "card_id", resourceName, "card_id"),
 				),
 			},
 		},

--- a/aiven/resource_project_test.go
+++ b/aiven/resource_project_test.go
@@ -138,6 +138,7 @@ func testAccProjectResource(name string) string {
 			default_cloud = "aws-eu-west-2"
 			billing_currency = "EUR"
 			vat_id = "123"
+			card_id = ""
 		}
 
 		data "aiven_project" "project" {

--- a/aiven/resource_project_test.go
+++ b/aiven/resource_project_test.go
@@ -138,7 +138,6 @@ func testAccProjectResource(name string) string {
 			default_cloud = "aws-eu-west-2"
 			billing_currency = "EUR"
 			vat_id = "123"
-			card_id = ""
 		}
 
 		data "aiven_project" "project" {


### PR DESCRIPTION
When we run this test `TestAccAivenProjectDataSource_basic` we have the following failure:

`--- FAIL: TestAccAivenProjectDataSource_basic (3.33s)
    datasource_project_test.go:14: Step 1/1 error: Check failed: Check 3/3 error: data.aiven_project.project: Attribute "card_id" is "", but "card_id" is not set in aiven_project.foo`

This fix the test but, I'm wondering if it's normal: the `card_id` is  `""`. Should this attribute (card_id) have some value?
