### PR TITLE
project_vpc: fix project vpc error handling

### DIFF
--- a/aiven/datasource_project_vpc.go
+++ b/aiven/datasource_project_vpc.go
@@ -21,7 +21,6 @@ func datasourceProjectVPCRead(ctx context.Context, d *schema.ResourceData, m int
 
 	projectName := d.Get("project").(string)
 	cloudName := d.Get("cloud_name").(string)
-	foundVPC := false
 
 	vpcs, err := client.VPCs.List(projectName)
 	if err != nil {
@@ -30,19 +29,16 @@ func datasourceProjectVPCRead(ctx context.Context, d *schema.ResourceData, m int
 
 	for _, vpc := range vpcs {
 		if vpc.CloudName == cloudName {
-			foundVPC = true
 			d.SetId(buildResourceID(projectName, vpc.ProjectVPCID))
 			err = copyVPCPropertiesFromAPIResponseToTerraform(d, vpc, projectName)
 			if err != nil {
 				return diag.FromErr(err)
 			}
+
+			return nil
 		}
 	}
 
-	if !foundVPC {
-		return diag.Errorf("project %s has no VPC defined for %s",
-			projectName, cloudName)
-	}
-
-	return nil
+	return diag.Errorf("project %s has no VPC defined for %s",
+		projectName, cloudName)
 }


### PR DESCRIPTION
This test `TestAccAivenProjectVPC_basic` fails with the following:
```
=== CONT  TestAccAivenProjectVPC_basic
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x18 pc=0x1062073]

goroutine 7076 [running]:
github.com/hashicorp/terraform-plugin-sdk/v2/diag.FromErr(...)
	/srv/jenkins/workspace/terraform-provider-aiven-testacc/terraform-provider-aiven/gopath/pkg/mod/github.com/hashicorp/terraform-plugin-sdk/v2@v2.3.0/diag/helpers.go:16
github.com/aiven/terraform-provider-aiven/aiven.datasourceProjectVPCRead(0x17ac380, 0xc000031e00, 0xc000c10d80, 0x130e4e0, 0xc000beac00, 0xc00104d950, 0x0, 0x0)
	/srv/jenkins/workspace/terraform-provider-aiven-testacc/terraform-provider-aiven/aiven/datasource_project_vpc.go:33 +0x293
github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.(*Resource).read(0xc000270840, 0x17ac380, 0xc000031e00, 0xc000c10d80, 0x130e4e0, 0xc000beac00, 0x0, 0x0, 0x0)
```
**Modifications:**
Updated the `datasourceProjectVPCRead` to handle correctly the error.
And, return en error message **only** if we don't find any VPC.

With this approach the test run successfully in local my box.

