### PR TITLE
kafka topic availability improvements

### DIFF
--- a/aiven/kafka_topic_availability.go
+++ b/aiven/kafka_topic_availability.go
@@ -71,7 +71,7 @@ func (w *KafkaTopicAvailabilityWaiter) RefreshFunc() resource.StateRefreshFunc {
 }
 
 func (w *KafkaTopicAvailabilityWaiter) refresh() error {
-	if !kafkaTopicAvailabilitySem.TryAcquire(1) {
+	if !kafkaTopicAvailabilitySem.TryAcquire(5) {
 		log.Printf("[TRACE] Kafka Topic Availability cache refresh already in progress ...")
 		return nil
 	}
@@ -92,11 +92,12 @@ func (w *KafkaTopicAvailabilityWaiter) Conf(timeout time.Duration) *resource.Sta
 	log.Printf("[DEBUG] Kafka Topic availability waiter timeout %.0f minutes", timeout.Minutes())
 
 	return &resource.StateChangeConf{
-		Pending:    []string{"CONFIGURING"},
-		Target:     []string{"ACTIVE"},
-		Refresh:    w.RefreshFunc(),
-		Timeout:    timeout,
-		MinTimeout: 10 * time.Second,
+		Pending:        []string{"CONFIGURING"},
+		Target:         []string{"ACTIVE"},
+		Refresh:        w.RefreshFunc(),
+		Timeout:        timeout,
+		MinTimeout:     20 * time.Second,
+		NotFoundChecks: 50,
 	}
 }
 

--- a/aiven/resource_kafka_topic.go
+++ b/aiven/resource_kafka_topic.go
@@ -247,7 +247,7 @@ func resourceKafkaTopic() *schema.Resource {
 		},
 		Timeouts: &schema.ResourceTimeout{
 			Create: schema.DefaultTimeout(1 * time.Minute),
-			Read:   schema.DefaultTimeout(4 * time.Minute),
+			Read:   schema.DefaultTimeout(10 * time.Minute),
 		},
 		Schema: aivenKafkaTopicSchema,
 	}

--- a/aiven/resource_kafka_topic_test.go
+++ b/aiven/resource_kafka_topic_test.go
@@ -187,7 +187,7 @@ func TestAccAivenKafkaTopic_basic(t *testing.T) {
 	})
 }
 
-func TestAccAivenKafkaTopic_100topics(t *testing.T) {
+func TestAccAivenKafkaTopic_450topics(t *testing.T) {
 	resourceName := "aiven_kafka_topic.foo"
 	rName := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
 
@@ -197,7 +197,7 @@ func TestAccAivenKafkaTopic_100topics(t *testing.T) {
 		CheckDestroy:      testAccCheckAivenKafkaTopicResourceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccKafka101TopicResource(rName),
+				Config: testAccKafka451TopicResource(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAivenKafkaTopicAttributes("data.aiven_kafka_topic.topic"),
 					resource.TestCheckResourceAttr(resourceName, "project", os.Getenv("AIVEN_PROJECT_NAME")),
@@ -211,11 +211,11 @@ func TestAccAivenKafkaTopic_100topics(t *testing.T) {
 	})
 }
 
-func testAccKafka101TopicResource(name string) string {
+func testAccKafka451TopicResource(name string) string {
 	s := testAccKafkaTopicResource(name)
 
 	// add extra 100 Kafka topics to test caching layer and creation waiter functionality
-	for i := 1; i < 100; i++ {
+	for i := 1; i < 450; i++ {
 		s += fmt.Sprintf(`
 			resource "aiven_kafka_topic" "foo%s" {
 				project = data.aiven_project.foo.project


### PR DESCRIPTION
Some customers with 450+ topics per Kafka service report `error: error waiting for Aiven Kafka topic to be ACTIVE: couldn't find resource (21 retries)`, even after upgrading to `2.1.4`, after analyzing log files I found that many TF goroutines are waiting for the semaphore to unlock the refresh cache function, lots of messages like `Kafka Topic Availability cache refresh already in progress ...`.

Also, I can reproduce that on my box with 500 topics all present in the state file. Terraform is waiting for all of them to be created and accessible. Sometimes, it takes quite some time before TF waiters internal limit accedes. Also, we only allow one request to API at the time, which makes things drastically slower.

So I have added the following improvements:
- Let semaphore run 5 goroutines to refresh the cache simultaneously.
- Increase default waiting time (though the customer might easily update it)
- Increase interval for querying Kafka Topic availability 
- And increase the number of attempts to refresh Topic availability.

In my tests was able to create a Kafka service with 750 Topics per service without any issues, if we go beyond this (talking about 1k+ topics) waiting time is so significant that we even this version is failing with `error: error waiting for Aiven Kafka topic to be ACTIVE: couldn't find resource (51 retries)`, but I think to support such massive amount of topics we would need to use `/v2/project/<project>/service/<service_name>/topic` endpoint and change waiter logic completely. 