### PR TITLE
kafka topic v2

### DIFF
--- a/aiven/kafka_topic_create.go
+++ b/aiven/kafka_topic_create.go
@@ -62,7 +62,7 @@ func (w *KafkaTopicCreateWaiter) Conf(timeout time.Duration) *resource.StateChan
 		Pending:    []string{"CREATING"},
 		Target:     []string{"CREATED"},
 		Refresh:    w.RefreshFunc(),
-		Delay:      10 * time.Second,
+		Delay:      5 * time.Second,
 		Timeout:    timeout,
 		MinTimeout: 10 * time.Second,
 	}

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/aiven/terraform-provider-aiven
 go 1.15
 
 require (
-	github.com/aiven/aiven-go-client v1.5.12-0.20210120083640-034790ddf7cb
+	github.com/aiven/aiven-go-client v1.5.12-0.20210126101622-c6cb3f424339
 	github.com/aws/aws-sdk-go v1.30.12 // indirect
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.4.2
 	github.com/mitchellh/mapstructure v1.3.2 // indirect

--- a/pkg/cache/kafka_topic_cache_test.go
+++ b/pkg/cache/kafka_topic_cache_test.go
@@ -40,6 +40,7 @@ func TestGetTopicCache(t *testing.T) {
 			},
 			&TopicCache{
 				internal: make(map[string]map[string]aiven.KafkaTopic),
+				inQueue:  make(map[string][]string),
 			},
 		},
 	}


### PR DESCRIPTION
We are using v2 Kafka Topic API endpoint as a default way of getting Kafka Topics, and if it is not available for a particular Kafka service, we do have a fallback of v1 Endpoint.

Also logic is a bit different, now the first TF goroutine from the batch will warm up the cache by adding topic names to cache queue by running v1 API endpoint get all Kafka topics for a service. All topic names from the cache queue will be bundled in batches up to 100 topics at the time, and v2 API endpoint will be queried until we get data for all topics in the cache.  

Please note that v1 fallback logic was not tested, since it is hard to find any old Kafka nodes that do not support  v2.