### PR TITLE
fix: type in lc_ctype postgresql database parameter

### DIFF
--- a/aiven/resource_database.go
+++ b/aiven/resource_database.go
@@ -94,7 +94,7 @@ func resourceDatabaseCreate(ctx context.Context, d *schema.ResourceData, m inter
 		aiven.CreateDatabaseRequest{
 			Database:  databaseName,
 			LcCollate: optionalString(d, "lc_collate"),
-			LcType:    optionalString(d, "lc_type"),
+			LcType:    optionalString(d, "lc_ctype"),
 		},
 	)
 	if err != nil && !aiven.IsAlreadyExists(err) {


### PR DESCRIPTION
Fixes wrong lc_ctype used during database creation and avoid destroying a database on next apply.

```
# module.postgresql.aiven_database.users must be replaced
-/+ resource "aiven_database" "mydb" {
        database_name          = "mydb"
      ~ id                     = "test/postgres/users" -> (known after apply)
        lc_collate             = "C.UTF-8"
      ~ lc_ctype               = "en_US.UTF-8" -> "C.UTF-8" # forces replacement
        project                = "test"
        service_name           = "postgres"
        termination_protection = false
    }
Plan: 1 to add, 1 to change, 1 to destroy.
```