### PR TITLE
add examples using external kafka schema file

### DIFF
--- a/docs/resources/kafka_schema.md
+++ b/docs/resources/kafka_schema.md
@@ -29,6 +29,19 @@ resource "aiven_kafka_schema" "kafka-schema1" {
 }
 ```
 
+You can also load the schema from an external file:
+
+```hcl
+resource "aiven_kafka_schema" "kafka-schema2" {
+    project = aiven_project.kafka-schemas-project1.project
+    service_name = aiven_service.kafka-service1.service_name
+    subject_name = "kafka-schema2"
+    compatibility_level = "FORWARD"
+    
+    schema = file("${path.module}/external_schema.avsc")
+}
+```
+
 ## Argument Reference
 
 * `project` and `service_name` - (Required) define the project and service the Kafka Schemas belongs to. 

--- a/examples/kafka_schemas/external_schema.avsc
+++ b/examples/kafka_schemas/external_schema.avsc
@@ -1,0 +1,13 @@
+{
+  "doc": "example",
+  "fields": [{
+    "default": 5,
+    "doc": "my test number",
+    "name": "test",
+    "namespace": "test",
+    "type": "int"
+  }],
+  "name": "example",
+  "namespace": "example",
+  "type": "record"
+}

--- a/examples/kafka_schemas/kafka_schema.tf
+++ b/examples/kafka_schemas/kafka_schema.tf
@@ -27,3 +27,12 @@ resource "aiven_kafka_schema" "kafka-schema1" {
       }
     EOT
 }
+
+# External schema file
+resource "aiven_kafka_schema" "kafka-schema2" {
+  project = aiven_project.kafka-schemas-project1.project
+  service_name = aiven_kafka.kafka-service1.service_name
+  subject_name = "kafka-schema2"
+
+  schema = file("${path.module}/external_schema.avsc")
+}


### PR DESCRIPTION
A customer was wondering how they could avoid having to inline their Avro schema in the Terraform file when using the `aiven_kafka_schema` resource. I think it's a good enough reason for us to demonstrate the use of the [Terraform file function](https://www.terraform.io/docs/language/functions/file.html) in these examples.