### PR TITLE
examples: modify GCP Marketplace project name

### DIFF
--- a/examples/gcp_marketplace/main.tf
+++ b/examples/gcp_marketplace/main.tf
@@ -31,7 +31,7 @@ data "aiven_account" "test_account" {
 }
 
 resource "aiven_project" "new_project" {
-  project    = "new_project"
+  project    = "new-project"
   account_id = data.aiven_account.test_account.id # This is required for new marketplace projects
 }
 


### PR DESCRIPTION
The API does not allow underscores in project names, but
it supports dashes