### PR TITLE
Use original Project Name which fixes Project name updates

### DIFF
--- a/aiven/resource_project.go
+++ b/aiven/resource_project.go
@@ -341,7 +341,7 @@ func resourceProjectUpdate(_ context.Context, d *schema.ResourceData, m interfac
 	projectName := d.Get("project").(string)
 	if billingGroupId, ok := d.GetOk("billing_group"); ok {
 		project, err = client.Projects.Update(
-			projectName,
+			d.Id(),
 			aiven.UpdateProjectRequest{
 				Name:             projectName,
 				BillingAddress:   optionalStringPointerForUndefined(d, "billing_address"),
@@ -366,7 +366,7 @@ func resourceProjectUpdate(_ context.Context, d *schema.ResourceData, m interfac
 		}
 	} else {
 		project, err = client.Projects.Update(
-			projectName,
+			d.Id(),
 			aiven.UpdateProjectRequest{
 				Name:             projectName,
 				BillingAddress:   optionalStringPointer(d, "billing_address"),


### PR DESCRIPTION
Project Name updates fail with the following error because the update attempts to use the "new" projectName instead of the original projectName:

```
Error: 404: {"errors":[{"message":"Project does not exist","status":404}],"message":"Project does not exist"} -
```

This change uses the projectName that is currently set in the state file prior to the name update.