### PR TITLE
remove default values for user configuration options

### DIFF
--- a/aiven/user_config.go
+++ b/aiven/user_config.go
@@ -44,13 +44,11 @@ func generateTerraformUserConfigSchema(key string, definition map[string]interfa
 		diffFunction = emptyObjectDiffSuppressFunc
 	}
 
-	defaultValue := getAivenSchemaDefaultValue(definition)
 	title := definition["title"].(string)
 
 	switch valueType {
 	case "string", "integer", "boolean", "number":
 		return &schema.Schema{
-			Default:          defaultValue,
 			Description:      title,
 			DiffSuppressFunc: diffFunction,
 			Optional:         true,
@@ -133,20 +131,16 @@ func getAivenSchemaType(value interface{}) (string, bool) {
 }
 
 func getAivenSchemaDefaultValue(definition map[string]interface{}) interface{} {
-	valueType, _ := getAivenSchemaType(definition["type"])
-	defaultValue, ok := definition["default"]
-	if !ok || defaultValue == nil {
-		defaultValue = ""
+	var defaultValue interface{}
 
-		if valueType == "string" {
-			// Terraform has no way of indicating unset values.
-			// Convert "<<value not set>>" to unset when handling request
-			defaultValue = ""
-		} else if valueType == "array" {
-			defaultValue = []interface{}{}
-		} else if valueType == "object" {
-			defaultValue = []map[string]interface{}{}
-		}
+	valueType, _ := getAivenSchemaType(definition["type"])
+	switch valueType {
+	case "array":
+		defaultValue = []interface{}{}
+	case "object":
+		defaultValue = []map[string]interface{}{}
+	default:
+		defaultValue = ""
 	}
 
 	return defaultValue

--- a/aiven/user_config_test.go
+++ b/aiven/user_config_test.go
@@ -25,7 +25,6 @@ func TestGenerateTerraformUserConfigSchema(t *testing.T) {
 					"properties": map[string]interface{}{
 						"admin_password": map[string]interface{}{
 							"createOnly": true,
-							"default":    nil,
 							"example":    "z66o9QXqKM",
 							"maxLength":  256,
 							"minLength":  8,
@@ -51,7 +50,6 @@ func TestGenerateTerraformUserConfigSchema(t *testing.T) {
 					Sensitive:        true,
 					DiffSuppressFunc: createOnlyDiffSuppressFunc,
 					Description:      "Custom password for admin user",
-					Default:          "",
 				},
 			},
 			false,
@@ -63,7 +61,6 @@ func TestGenerateTerraformUserConfigSchema(t *testing.T) {
 					"properties": map[string]interface{}{
 						"admin_password": map[string]interface{}{
 							"createOnly": true,
-							"default":    nil,
 							"example":    "z66o9QXqKM",
 							"maxLength":  256,
 							"minLength":  8,
@@ -85,7 +82,6 @@ func TestGenerateTerraformUserConfigSchema(t *testing.T) {
 					"properties": map[string]interface{}{
 						"admin_password": map[string]interface{}{
 							"createOnly": true,
-							"default":    nil,
 							"example":    "z66o9QXqKM",
 							"maxLength":  256,
 							"minLength":  8,
@@ -106,7 +102,6 @@ func TestGenerateTerraformUserConfigSchema(t *testing.T) {
 				data: map[string]interface{}{
 					"admin_password": map[string]interface{}{
 						"createOnly": true,
-						"default":    nil,
 						"example":    "z66o9QXqKM",
 						"maxLength":  256,
 						"minLength":  8,


### PR DESCRIPTION
It will prevent services from REBUILDING when updated to the new TF provider version, which has some new default values to be propagated.