### PR TITLE
add delete_retention_ms to kafka topic read method

### DIFF
--- a/aiven/resource_kafka_topic.go
+++ b/aiven/resource_kafka_topic.go
@@ -539,6 +539,7 @@ func flattenKafkaTopicConfig(t aiven.KafkaTopic) []map[string]interface{} {
 		{
 			"cleanup_policy":                      toOptionalString(t.Config.CleanupPolicy.Value),
 			"compression_type":                    toOptionalString(t.Config.CompressionType.Value),
+			"delete_retention_ms":                 toOptionalString(t.Config.DeleteRetentionMs.Value),
 			"file_delete_delay_ms":                toOptionalString(t.Config.FileDeleteDelayMs.Value),
 			"flush_messages":                      toOptionalString(t.Config.FlushMessages.Value),
 			"flush_ms":                            toOptionalString(t.Config.FlushMs.Value),

--- a/aiven/resource_kafka_topic_test.go
+++ b/aiven/resource_kafka_topic_test.go
@@ -266,6 +266,7 @@ func testAccKafkaTopicResource(name string) string {
 				unclean_leader_election_enable = true
 				cleanup_policy = "compact"
 				min_cleanable_dirty_ratio = 0.01
+				delete_retention_ms = 50000
 			}
 		}
 


### PR DESCRIPTION
Terraform Kafka topic resource's `delete_retention_ms` state was not tracked by the provider, this PR fixes that