### PR TITLE
change service integration behaviour

### DIFF
--- a/aiven/resource_service.go
+++ b/aiven/resource_service.go
@@ -135,10 +135,9 @@ func serviceCommonSchema() map[string]*schema.Schema {
 			Description: "Service state",
 		},
 		"service_integrations": {
-			Type:             schema.TypeList,
-			Optional:         true,
-			Description:      "Service integrations to specify when creating a service. Not applied after initial service creation",
-			DiffSuppressFunc: createOnlyDiffSuppressFunc,
+			Type:        schema.TypeList,
+			Optional:    true,
+			Description: "Service integrations to specify when creating a service. Not applied after initial service creation",
 			Elem: &schema.Resource{
 				Schema: map[string]*schema.Schema{
 					"source_service_name": {
@@ -272,10 +271,9 @@ var aivenServiceSchema = map[string]*schema.Schema{
 		Description: "Service hostname",
 	},
 	"service_integrations": {
-		Type:             schema.TypeList,
-		Optional:         true,
-		Description:      "Service integrations to specify when creating a service. Not applied after initial service creation",
-		DiffSuppressFunc: createOnlyDiffSuppressFunc,
+		Type:        schema.TypeList,
+		Optional:    true,
+		Description: "Service integrations to specify when creating a service. Not applied after initial service creation",
 		Elem: &schema.Resource{
 			Schema: map[string]*schema.Schema{
 				"source_service_name": {
@@ -816,6 +814,10 @@ func resourceServiceRead(_ context.Context, d *schema.ResourceData, m interface{
 
 func resourceServiceUpdate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	client := m.(*aiven.Client)
+
+	if d.HasChanges("service_integrations") && len(d.Get("service_integrations").([]interface{})) != 0 {
+		return diag.Errorf("service_integrations field can only be set during creation of a service")
+	}
 
 	projectName, serviceName := splitResourceID2(d.Id())
 	userConfig := ConvertTerraformUserConfigToAPICompatibleFormat("service", d.Get("service_type").(string), false, d)

--- a/aiven/resource_service_integration_test.go
+++ b/aiven/resource_service_integration_test.go
@@ -14,6 +14,8 @@ import (
 func TestAccAivenServiceIntegration_basic(t *testing.T) {
 	resourceName := "aiven_service_integration.bar"
 	rName := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
+	rName1 := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
+	rName2 := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },
@@ -36,22 +38,22 @@ func TestAccAivenServiceIntegration_basic(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccServiceIntegrationKafkaConnectResource(rName),
+				Config: testAccServiceIntegrationKafkaConnectResource(rName1),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAivenServiceIntegrationAttributes("data.aiven_service_integration.int"),
 					resource.TestCheckResourceAttr(resourceName, "integration_type", "kafka_connect"),
 					resource.TestCheckResourceAttr(resourceName, "project", os.Getenv("AIVEN_PROJECT_NAME")),
-					resource.TestCheckResourceAttr(resourceName, "source_service_name", fmt.Sprintf("test-acc-sr-kafka-%s", rName)),
-					resource.TestCheckResourceAttr(resourceName, "destination_service_name", fmt.Sprintf("test-acc-sr-kafka-con-%s", rName)),
+					resource.TestCheckResourceAttr(resourceName, "source_service_name", fmt.Sprintf("test-acc-sr-kafka-%s", rName1)),
+					resource.TestCheckResourceAttr(resourceName, "destination_service_name", fmt.Sprintf("test-acc-sr-kafka-con-%s", rName1)),
 				),
 			},
 			{
-				Config: testAccServiceIntegrationMirrorMakerResource(rName),
+				Config: testAccServiceIntegrationMirrorMakerResource(rName2),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "integration_type", "kafka_mirrormaker"),
 					resource.TestCheckResourceAttr(resourceName, "project", os.Getenv("AIVEN_PROJECT_NAME")),
-					resource.TestCheckResourceAttr(resourceName, "source_service_name", fmt.Sprintf("test-acc-sr-source-%s", rName)),
-					resource.TestCheckResourceAttr(resourceName, "destination_service_name", fmt.Sprintf("test-acc-sr-mm-%s", rName)),
+					resource.TestCheckResourceAttr(resourceName, "source_service_name", fmt.Sprintf("test-acc-sr-source-%s", rName2)),
+					resource.TestCheckResourceAttr(resourceName, "destination_service_name", fmt.Sprintf("test-acc-sr-mm-%s", rName2)),
 				),
 			},
 		},
@@ -108,6 +110,8 @@ func testAccServiceIntegrationResource(name string) string {
 			integration_type = "metrics"
 			source_service_name = aiven_service.bar-pg.service_name
 			destination_service_name = aiven_service.bar-influxdb.service_name
+
+			depends_on = [ aiven_service.bar-pg,aiven_service.bar-influxdb]
 		}
 
 		data "aiven_service_integration" "int" {
@@ -174,6 +178,8 @@ func testAccServiceIntegrationKafkaConnectResource(name string) string {
 					offset_storage_topic = "__connect_offsets"
 				}
 			}
+
+			depends_on = [aiven_service.kafka1,aiven_service.kafka_connect1]
 		}
 
 		data "aiven_service_integration" "int" {
@@ -288,18 +294,18 @@ func testAccServiceIntegrationMirrorMakerResource(name string) string {
 }
 
 func testAccServiceIntegrationShouldFailResource() string {
-	return fmt.Sprintf(`
-		resource "aiven_service_integration" "bar" {
-			project = "test"
-			integration_type = "kafka_mirrormaker"
-			source_endpoint_id = "test"
-			destination_endpoint_id = "test"
-	
-			kafka_mirrormaker_user_config {
-				cluster_alias = "source"
+	return `
+			resource "aiven_service_integration" "bar" {
+				project = "test"
+				integration_type = "kafka_mirrormaker"
+				source_endpoint_id = "test"
+				destination_endpoint_id = "test"
+		
+				kafka_mirrormaker_user_config {
+					cluster_alias = "source"
+				}
 			}
-		}
-		`)
+			`
 }
 
 func testAccCheckAivenServiceIntegrationResourceDestroy(s *terraform.State) error {

--- a/aiven/resource_service_pg_test.go
+++ b/aiven/resource_service_pg_test.go
@@ -13,7 +13,7 @@ import (
 
 // PG service tests
 func TestAccAivenService_pg(t *testing.T) {
-	resourceName := "aiven_service.bar-pg"
+	resourceName := "aiven_pg.bar-pg"
 	rName := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -25,12 +25,11 @@ func TestAccAivenService_pg(t *testing.T) {
 			{
 				Config: testAccPGServiceResource(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAivenServiceCommonAttributes("data.aiven_service.service-pg"),
-					testAccCheckAivenServicePGAttributes("data.aiven_service.service-pg"),
+					testAccCheckAivenServiceCommonAttributes("data.aiven_pg.service-pg"),
+					testAccCheckAivenServicePGAttributes("data.aiven_pg.service-pg"),
 					resource.TestCheckResourceAttr(resourceName, "service_name", fmt.Sprintf("test-acc-sr-%s", rName)),
 					resource.TestCheckResourceAttr(resourceName, "state", "RUNNING"),
 					resource.TestCheckResourceAttr(resourceName, "project", os.Getenv("AIVEN_PROJECT_NAME")),
-					resource.TestCheckResourceAttr(resourceName, "service_type", "pg"),
 					resource.TestCheckResourceAttr(resourceName, "cloud_name", "google-europe-west1"),
 					resource.TestCheckResourceAttr(resourceName, "maintenance_window_dow", "monday"),
 					resource.TestCheckResourceAttr(resourceName, "maintenance_window_time", "10:00:00"),
@@ -42,12 +41,11 @@ func TestAccAivenService_pg(t *testing.T) {
 			{
 				Config: testAccPGServiceCustomTimeoutsResource(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAivenServiceCommonAttributes("data.aiven_service.service-pg"),
-					testAccCheckAivenServicePGAttributes("data.aiven_service.service-pg"),
+					testAccCheckAivenServiceCommonAttributes("data.aiven_pg.service-pg"),
+					testAccCheckAivenServicePGAttributes("data.aiven_pg.service-pg"),
 					resource.TestCheckResourceAttr(resourceName, "service_name", fmt.Sprintf("test-acc-sr-%s", rName)),
 					resource.TestCheckResourceAttr(resourceName, "state", "RUNNING"),
 					resource.TestCheckResourceAttr(resourceName, "project", os.Getenv("AIVEN_PROJECT_NAME")),
-					resource.TestCheckResourceAttr(resourceName, "service_type", "pg"),
 					resource.TestCheckResourceAttr(resourceName, "cloud_name", "google-europe-west1"),
 					resource.TestCheckResourceAttr(resourceName, "maintenance_window_dow", "monday"),
 					resource.TestCheckResourceAttr(resourceName, "maintenance_window_time", "10:00:00"),
@@ -60,12 +58,11 @@ func TestAccAivenService_pg(t *testing.T) {
 				Config:                    testAccPGReadReplicaServiceResource(rName),
 				PreventPostDestroyRefresh: true,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAivenServiceCommonAttributes("data.aiven_service.service-pg"),
-					testAccCheckAivenServicePGAttributes("data.aiven_service.service-pg"),
+					testAccCheckAivenServiceCommonAttributes("data.aiven_pg.service-pg"),
+					testAccCheckAivenServicePGAttributes("data.aiven_pg.service-pg"),
 					resource.TestCheckResourceAttr(resourceName, "service_name", fmt.Sprintf("test-acc-sr-%s", rName)),
 					resource.TestCheckResourceAttr(resourceName, "state", "RUNNING"),
 					resource.TestCheckResourceAttr(resourceName, "project", os.Getenv("AIVEN_PROJECT_NAME")),
-					resource.TestCheckResourceAttr(resourceName, "service_type", "pg"),
 					resource.TestCheckResourceAttr(resourceName, "cloud_name", "google-europe-west1"),
 					resource.TestCheckResourceAttr(resourceName, "maintenance_window_dow", "monday"),
 					resource.TestCheckResourceAttr(resourceName, "maintenance_window_time", "10:00:00"),
@@ -77,13 +74,12 @@ func TestAccAivenService_pg(t *testing.T) {
 			{
 				Config: testAccPGTerminationProtectionServiceResource(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAivenServiceTerminationProtection("data.aiven_service.service-pg"),
-					testAccCheckAivenServiceCommonAttributes("data.aiven_service.service-pg"),
-					testAccCheckAivenServicePGAttributes("data.aiven_service.service-pg"),
+					testAccCheckAivenServiceTerminationProtection("data.aiven_pg.service-pg"),
+					testAccCheckAivenServiceCommonAttributes("data.aiven_pg.service-pg"),
+					testAccCheckAivenServicePGAttributes("data.aiven_pg.service-pg"),
 					resource.TestCheckResourceAttr(resourceName, "service_name", fmt.Sprintf("test-acc-sr-%s", rName)),
 					resource.TestCheckResourceAttr(resourceName, "state", "RUNNING"),
 					resource.TestCheckResourceAttr(resourceName, "project", os.Getenv("AIVEN_PROJECT_NAME")),
-					resource.TestCheckResourceAttr(resourceName, "service_type", "pg"),
 					resource.TestCheckResourceAttr(resourceName, "cloud_name", "google-europe-west1"),
 					resource.TestCheckResourceAttr(resourceName, "maintenance_window_dow", "monday"),
 					resource.TestCheckResourceAttr(resourceName, "maintenance_window_time", "10:00:00"),
@@ -102,12 +98,11 @@ func testAccPGServiceResource(name string) string {
 			project = "%s"
 		}
 		
-		resource "aiven_service" "bar-pg" {
+		resource "aiven_pg" "bar-pg" {
 			project = data.aiven_project.foo-pg.project
 			cloud_name = "google-europe-west1"
 			plan = "startup-4"
 			service_name = "test-acc-sr-%s"
-			service_type = "pg"
 			maintenance_window_dow = "monday"
 			maintenance_window_time = "10:00:00"
 			
@@ -125,11 +120,11 @@ func testAccPGServiceResource(name string) string {
 			}
 		}
 		
-		data "aiven_service" "service-pg" {
-			service_name = aiven_service.bar-pg.service_name
-			project = aiven_service.bar-pg.project
+		data "aiven_pg" "service-pg" {
+			service_name = aiven_pg.bar-pg.service_name
+			project = aiven_pg.bar-pg.project
 
-			depends_on = [aiven_service.bar-pg]
+			depends_on = [aiven_pg.bar-pg]
 		}
 		`, os.Getenv("AIVEN_PROJECT_NAME"), name)
 }
@@ -140,12 +135,11 @@ func testAccPGServiceCustomTimeoutsResource(name string) string {
 			project = "%s"
 		}
 		
-		resource "aiven_service" "bar-pg" {
+		resource "aiven_pg" "bar-pg" {
 			project = data.aiven_project.foo-pg.project
 			cloud_name = "google-europe-west1"
 			plan = "startup-4"
 			service_name = "test-acc-sr-%s"
-			service_type = "pg"
 			maintenance_window_dow = "monday"
 			maintenance_window_time = "10:00:00"
 			
@@ -168,11 +162,11 @@ func testAccPGServiceCustomTimeoutsResource(name string) string {
 			}
 		}
 		
-		data "aiven_service" "service-pg" {
-			service_name = aiven_service.bar-pg.service_name
-			project = aiven_service.bar-pg.project
+		data "aiven_pg" "service-pg" {
+			service_name = aiven_pg.bar-pg.service_name
+			project = aiven_pg.bar-pg.project
 
-			depends_on = [aiven_service.bar-pg]
+			depends_on = [aiven_pg.bar-pg]
 		}
 		`, os.Getenv("AIVEN_PROJECT_NAME"), name)
 }
@@ -183,12 +177,11 @@ func testAccPGTerminationProtectionServiceResource(name string) string {
 			project = "%s"
 		}
 		
-		resource "aiven_service" "bar-pg" {
+		resource "aiven_pg" "bar-pg" {
 			project = data.aiven_project.foo-pg.project
 			cloud_name = "google-europe-west1"
 			plan = "startup-4"
 			service_name = "test-acc-sr-%s"
-			service_type = "pg"
 			maintenance_window_dow = "monday"
 			maintenance_window_time = "10:00:00"
 			termination_protection = true
@@ -207,11 +200,11 @@ func testAccPGTerminationProtectionServiceResource(name string) string {
 			}
 		}
 		
-		data "aiven_service" "service-pg" {
-			service_name = aiven_service.bar-pg.service_name
-			project = aiven_service.bar-pg.project
+		data "aiven_pg" "service-pg" {
+			service_name = aiven_pg.bar-pg.service_name
+			project = aiven_pg.bar-pg.project
 
-			depends_on = [aiven_service.bar-pg]
+			depends_on = [aiven_pg.bar-pg]
 		}
 		`, os.Getenv("AIVEN_PROJECT_NAME"), name)
 }
@@ -222,12 +215,11 @@ func testAccPGReadReplicaServiceResource(name string) string {
 			project = "%s"
 		}
 		
-		resource "aiven_service" "bar-pg" {
+		resource "aiven_pg" "bar-pg" {
 			project = data.aiven_project.foo-pg.project
 			cloud_name = "google-europe-west1"
 			plan = "startup-4"
 			service_name = "test-acc-sr-%s"
-			service_type = "pg"
 			maintenance_window_dow = "monday"
 			maintenance_window_time = "10:00:00"
 			
@@ -245,12 +237,11 @@ func testAccPGReadReplicaServiceResource(name string) string {
 			}
 		}
 
-		resource "aiven_service" "bar-replica" {
+		resource "aiven_pg" "bar-replica" {
 			project = data.aiven_project.foo-pg.project
 			cloud_name = "google-europe-west1"
 			plan = "startup-4"
 			service_name = "test-acc-sr-repica-%s"
-			service_type = "pg"
 			maintenance_window_dow = "monday"
 			maintenance_window_time = "10:00:00"
 			
@@ -271,17 +262,26 @@ func testAccPGReadReplicaServiceResource(name string) string {
 
 			service_integrations {
 				integration_type = "read_replica"
-				source_service_name = aiven_service.bar-pg.service_name
+				source_service_name = aiven_pg.bar-pg.service_name
 			}
 
-			 depends_on = [aiven_service.bar-pg]
+			 depends_on = [aiven_pg.bar-pg]
+		}
+
+		resource "aiven_service_integration" "pg-readreplica" {
+			project = data.aiven_project.foo-pg.project
+			integration_type = "read_replica"
+			source_service_name = aiven_pg.bar-pg.service_name
+			destination_service_name = aiven_pg.bar-replica.service_name
+
+			depends_on = [aiven_pg.bar-replica]
 		}
 		
-		data "aiven_service" "service-pg" {
-			service_name = aiven_service.bar-pg.service_name
-			project = aiven_service.bar-pg.project
+		data "aiven_pg" "service-pg" {
+			service_name = aiven_pg.bar-pg.service_name
+			project = aiven_pg.bar-pg.project
 
-			depends_on = [aiven_service.bar-pg]
+			depends_on = [aiven_pg.bar-pg]
 		}
 		`, os.Getenv("AIVEN_PROJECT_NAME"), name, name)
 }

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.16
 require (
 	github.com/aiven/aiven-go-client v1.5.13
 	github.com/aws/aws-sdk-go v1.30.12 // indirect
+	github.com/google/go-cmp v0.5.6
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.7.0
 	github.com/mitchellh/mapstructure v1.3.2 // indirect
 	github.com/stretchr/testify v1.7.0


### PR DESCRIPTION
In some cases, service creation may trigger the creation of service integration. For example, PG read replica service integration does that. PG replica service is created with service integration user configuration options that trigger the creation of service integration. To handle such cases correctly, we update the creation logic for the service_integration resource; it should work correctly when a service integration already exists.