### PR TITLE
update github.com/aiven/aiven-go-client to v1.5.13

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/aiven/terraform-provider-aiven
 go 1.16
 
 require (
-	github.com/aiven/aiven-go-client v1.5.12-0.20210701142609-bc899bc1da90
+	github.com/aiven/aiven-go-client v1.5.13
 	github.com/aws/aws-sdk-go v1.30.12 // indirect
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.7.0
 	github.com/mitchellh/mapstructure v1.3.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -49,6 +49,8 @@ github.com/agext/levenshtein v1.2.2 h1:0S/Yg6LYmFJ5stwQeRp6EeOcCbj7xiqQSdNelsXva
 github.com/agext/levenshtein v1.2.2/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=
 github.com/aiven/aiven-go-client v1.5.12-0.20210701142609-bc899bc1da90 h1:wS1fhRyb1LwFHIxc97S/Y7lbTiDvycpMOcGFX58IXGE=
 github.com/aiven/aiven-go-client v1.5.12-0.20210701142609-bc899bc1da90/go.mod h1:3+OtpccynSr5xvSGfn96jVM9dBUAr52HXlaZJi/Mz5o=
+github.com/aiven/aiven-go-client v1.5.13 h1:2rcC4tY4YbX2TWWFI7c7VA5qhowB0B/GfZfYQ+mHsNE=
+github.com/aiven/aiven-go-client v1.5.13/go.mod h1:3+OtpccynSr5xvSGfn96jVM9dBUAr52HXlaZJi/Mz5o=
 github.com/andybalholm/crlf v0.0.0-20171020200849-670099aa064f/go.mod h1:k8feO4+kXDxro6ErPXBRTJ/ro2mf0SsFG8s7doP9kJE=
 github.com/anmitsu/go-shlex v0.0.0-20161002113705-648efa622239/go.mod h1:2FmKhYUyUczH0OGQWaF5ceTx0UBShxjsH6f8oGKYe2c=
 github.com/apparentlymart/go-cidr v1.0.1 h1:NmIwLZ/KdsjIUlhf+/Np40atNXm/+lZ5txfTJ/SpF+U=


### PR DESCRIPTION
go.mod: update the dependency of github.com/aiven/aiven-go-client

addresses https://github.com/aiven/terraform-provider-aiven/issues/532