### PR TITLE
Handle non-existent resource

### DIFF
--- a/aiven/provider.go
+++ b/aiven/provider.go
@@ -353,3 +353,17 @@ func flattenToString(a []interface{}) []string {
 
 	return r
 }
+
+func resourceReadHandleNotFound(err error, d *schema.ResourceData, derr diag.Diagnostics) diag.Diagnostics {
+	if err != nil {
+		if aiven.IsNotFound(err) {
+			d.SetId("")
+			return nil
+		}
+		if derr == nil {
+			return diag.FromErr(err)
+		}
+		return derr
+	}
+	return nil
+}

--- a/aiven/provider.go
+++ b/aiven/provider.go
@@ -354,16 +354,10 @@ func flattenToString(a []interface{}) []string {
 	return r
 }
 
-func resourceReadHandleNotFound(err error, d *schema.ResourceData, derr diag.Diagnostics) diag.Diagnostics {
-	if err != nil {
-		if aiven.IsNotFound(err) {
-			d.SetId("")
-			return nil
-		}
-		if derr == nil {
-			return diag.FromErr(err)
-		}
-		return derr
+func resourceReadHandleNotFound(err error, d *schema.ResourceData) error {
+	if err != nil && aiven.IsNotFound(err) {
+		d.SetId("")
+		return nil
 	}
-	return nil
+	return err
 }

--- a/aiven/resource_account.go
+++ b/aiven/resource_account.go
@@ -83,7 +83,7 @@ func resourceAccountRead(_ context.Context, d *schema.ResourceData, m interface{
 
 	r, err := client.Accounts.Get(d.Id())
 	if err != nil {
-		return resourceReadHandleNotFound(err, d, nil)
+		return diag.FromErr(resourceReadHandleNotFound(err, d))
 	}
 
 	if err := d.Set("account_id", r.Account.Id); err != nil {

--- a/aiven/resource_account.go
+++ b/aiven/resource_account.go
@@ -83,7 +83,7 @@ func resourceAccountRead(_ context.Context, d *schema.ResourceData, m interface{
 
 	r, err := client.Accounts.Get(d.Id())
 	if err != nil {
-		return diag.FromErr(err)
+		return resourceReadHandleNotFound(err, d, nil)
 	}
 
 	if err := d.Set("account_id", r.Account.Id); err != nil {

--- a/aiven/resource_account_authentication.go
+++ b/aiven/resource_account_authentication.go
@@ -127,7 +127,7 @@ func resourceAccountAuthenticationRead(_ context.Context, d *schema.ResourceData
 	accountId, authId := splitResourceID2(d.Id())
 	r, err := client.AccountAuthentications.Get(accountId, authId)
 	if err != nil {
-		return resourceReadHandleNotFound(err, d, nil)
+		return diag.FromErr(resourceReadHandleNotFound(err, d))
 	}
 
 	if err := d.Set("account_id", r.AuthenticationMethod.AccountId); err != nil {

--- a/aiven/resource_account_authentication.go
+++ b/aiven/resource_account_authentication.go
@@ -127,7 +127,7 @@ func resourceAccountAuthenticationRead(_ context.Context, d *schema.ResourceData
 	accountId, authId := splitResourceID2(d.Id())
 	r, err := client.AccountAuthentications.Get(accountId, authId)
 	if err != nil {
-		return diag.FromErr(err)
+		return resourceReadHandleNotFound(err, d, nil)
 	}
 
 	if err := d.Set("account_id", r.AuthenticationMethod.AccountId); err != nil {

--- a/aiven/resource_account_team.go
+++ b/aiven/resource_account_team.go
@@ -79,7 +79,7 @@ func resourceAccountTeamRead(_ context.Context, d *schema.ResourceData, m interf
 	accountId, teamId := splitResourceID2(d.Id())
 	r, err := client.AccountTeams.Get(accountId, teamId)
 	if err != nil {
-		return resourceReadHandleNotFound(err, d, nil)
+		return diag.FromErr(resourceReadHandleNotFound(err, d))
 	}
 
 	if err := d.Set("account_id", r.Team.AccountId); err != nil {

--- a/aiven/resource_account_team.go
+++ b/aiven/resource_account_team.go
@@ -79,7 +79,7 @@ func resourceAccountTeamRead(_ context.Context, d *schema.ResourceData, m interf
 	accountId, teamId := splitResourceID2(d.Id())
 	r, err := client.AccountTeams.Get(accountId, teamId)
 	if err != nil {
-		return diag.FromErr(err)
+		return resourceReadHandleNotFound(err, d, nil)
 	}
 
 	if err := d.Set("account_id", r.Team.AccountId); err != nil {

--- a/aiven/resource_account_team_project.go
+++ b/aiven/resource_account_team_project.go
@@ -79,7 +79,7 @@ func resourceAccountTeamProjectRead(_ context.Context, d *schema.ResourceData, m
 	accountId, teamId, projectName := splitResourceID3(d.Id())
 	r, err := client.AccountTeamProjects.List(accountId, teamId)
 	if err != nil {
-		return diag.FromErr(err)
+		return resourceReadHandleNotFound(err, d, nil)
 	}
 
 	var project aiven.AccountTeamProject

--- a/aiven/resource_account_team_project.go
+++ b/aiven/resource_account_team_project.go
@@ -79,7 +79,7 @@ func resourceAccountTeamProjectRead(_ context.Context, d *schema.ResourceData, m
 	accountId, teamId, projectName := splitResourceID3(d.Id())
 	r, err := client.AccountTeamProjects.List(accountId, teamId)
 	if err != nil {
-		return resourceReadHandleNotFound(err, d, nil)
+		return diag.FromErr(resourceReadHandleNotFound(err, d))
 	}
 
 	var project aiven.AccountTeamProject

--- a/aiven/resource_connection_pool.go
+++ b/aiven/resource_connection_pool.go
@@ -109,7 +109,7 @@ func resourceConnectionPoolRead(_ context.Context, d *schema.ResourceData, m int
 	project, serviceName, poolName := splitResourceID3(d.Id())
 	pool, err := client.ConnectionPools.Get(project, serviceName, poolName)
 	if err != nil {
-		return resourceReadHandleNotFound(err, d, nil)
+		return diag.FromErr(resourceReadHandleNotFound(err, d))
 	}
 
 	err = copyConnectionPoolPropertiesFromAPIResponseToTerraform(d, pool, project, serviceName)

--- a/aiven/resource_connection_pool.go
+++ b/aiven/resource_connection_pool.go
@@ -109,7 +109,7 @@ func resourceConnectionPoolRead(_ context.Context, d *schema.ResourceData, m int
 	project, serviceName, poolName := splitResourceID3(d.Id())
 	pool, err := client.ConnectionPools.Get(project, serviceName, poolName)
 	if err != nil {
-		return diag.FromErr(err)
+		return resourceReadHandleNotFound(err, d, nil)
 	}
 
 	err = copyConnectionPoolPropertiesFromAPIResponseToTerraform(d, pool, project, serviceName)

--- a/aiven/resource_database.go
+++ b/aiven/resource_database.go
@@ -121,7 +121,7 @@ func resourceDatabaseRead(_ context.Context, d *schema.ResourceData, m interface
 	projectName, serviceName, databaseName := splitResourceID3(d.Id())
 	database, err := client.Databases.Get(projectName, serviceName, databaseName)
 	if err != nil {
-		return resourceReadHandleNotFound(err, d, nil)
+		return diag.FromErr(resourceReadHandleNotFound(err, d))
 	}
 
 	if err := d.Set("database_name", database.DatabaseName); err != nil {

--- a/aiven/resource_database.go
+++ b/aiven/resource_database.go
@@ -121,7 +121,7 @@ func resourceDatabaseRead(_ context.Context, d *schema.ResourceData, m interface
 	projectName, serviceName, databaseName := splitResourceID3(d.Id())
 	database, err := client.Databases.Get(projectName, serviceName, databaseName)
 	if err != nil {
-		return diag.FromErr(err)
+		return resourceReadHandleNotFound(err, d, nil)
 	}
 
 	if err := d.Set("database_name", database.DatabaseName); err != nil {

--- a/aiven/resource_elasticsearch_acl.go
+++ b/aiven/resource_elasticsearch_acl.go
@@ -119,7 +119,7 @@ func resourceElasticsearchACLRead(_ context.Context, d *schema.ResourceData, m i
 	project, serviceName := splitResourceID2(d.Id())
 	r, err := client.ElasticsearchACLs.Get(project, serviceName)
 	if err != nil {
-		return resourceReadHandleNotFound(err, d, nil)
+		return diag.FromErr(resourceReadHandleNotFound(err, d))
 	}
 
 	if err := d.Set("project", project); err != nil {

--- a/aiven/resource_elasticsearch_acl.go
+++ b/aiven/resource_elasticsearch_acl.go
@@ -119,7 +119,7 @@ func resourceElasticsearchACLRead(_ context.Context, d *schema.ResourceData, m i
 	project, serviceName := splitResourceID2(d.Id())
 	r, err := client.ElasticsearchACLs.Get(project, serviceName)
 	if err != nil {
-		return diag.FromErr(err)
+		return resourceReadHandleNotFound(err, d, nil)
 	}
 
 	if err := d.Set("project", project); err != nil {

--- a/aiven/resource_kafka_acl.go
+++ b/aiven/resource_kafka_acl.go
@@ -97,7 +97,7 @@ func resourceKafkaACLRead(_ context.Context, d *schema.ResourceData, m interface
 	project, serviceName, aclID := splitResourceID3(d.Id())
 	acl, err := cache.ACLCache{}.Read(project, serviceName, aclID, client)
 	if err != nil {
-		return resourceReadHandleNotFound(err, d, nil)
+		return diag.FromErr(resourceReadHandleNotFound(err, d))
 	}
 
 	err = copyKafkaACLPropertiesFromAPIResponseToTerraform(d, &acl, project, serviceName)

--- a/aiven/resource_kafka_acl.go
+++ b/aiven/resource_kafka_acl.go
@@ -97,7 +97,7 @@ func resourceKafkaACLRead(_ context.Context, d *schema.ResourceData, m interface
 	project, serviceName, aclID := splitResourceID3(d.Id())
 	acl, err := cache.ACLCache{}.Read(project, serviceName, aclID, client)
 	if err != nil {
-		return diag.FromErr(err)
+		return resourceReadHandleNotFound(err, d, nil)
 	}
 
 	err = copyKafkaACLPropertiesFromAPIResponseToTerraform(d, &acl, project, serviceName)

--- a/aiven/resource_kafka_schema.go
+++ b/aiven/resource_kafka_schema.go
@@ -203,12 +203,12 @@ func resourceKafkaSchemaRead(_ context.Context, d *schema.ResourceData, m interf
 
 	version, err := kafkaSchemaSubjectGetLastVersion(m, project, serviceName, subjectName)
 	if err != nil {
-		return diag.FromErr(err)
+		return resourceReadHandleNotFound(err, d, nil)
 	}
 
 	r, err := client.KafkaSubjectSchemas.Get(project, serviceName, subjectName, version)
 	if err != nil {
-		return diag.FromErr(err)
+		return resourceReadHandleNotFound(err, d, nil)
 	}
 
 	if err := d.Set("project", project); err != nil {

--- a/aiven/resource_kafka_schema.go
+++ b/aiven/resource_kafka_schema.go
@@ -203,12 +203,12 @@ func resourceKafkaSchemaRead(_ context.Context, d *schema.ResourceData, m interf
 
 	version, err := kafkaSchemaSubjectGetLastVersion(m, project, serviceName, subjectName)
 	if err != nil {
-		return resourceReadHandleNotFound(err, d, nil)
+		return diag.FromErr(resourceReadHandleNotFound(err, d))
 	}
 
 	r, err := client.KafkaSubjectSchemas.Get(project, serviceName, subjectName, version)
 	if err != nil {
-		return resourceReadHandleNotFound(err, d, nil)
+		return diag.FromErr(resourceReadHandleNotFound(err, d))
 	}
 
 	if err := d.Set("project", project); err != nil {

--- a/aiven/resource_kafka_schema_configuration.go
+++ b/aiven/resource_kafka_schema_configuration.go
@@ -95,7 +95,7 @@ func resourceKafkaSchemaConfigurationRead(_ context.Context, d *schema.ResourceD
 
 	r, err := m.(*aiven.Client).KafkaGlobalSchemaConfig.Get(project, serviceName)
 	if err != nil {
-		return diag.FromErr(err)
+		return resourceReadHandleNotFound(err, d, nil)
 	}
 
 	if err := d.Set("project", project); err != nil {

--- a/aiven/resource_kafka_schema_configuration.go
+++ b/aiven/resource_kafka_schema_configuration.go
@@ -95,7 +95,7 @@ func resourceKafkaSchemaConfigurationRead(_ context.Context, d *schema.ResourceD
 
 	r, err := m.(*aiven.Client).KafkaGlobalSchemaConfig.Get(project, serviceName)
 	if err != nil {
-		return resourceReadHandleNotFound(err, d, nil)
+		return diag.FromErr(resourceReadHandleNotFound(err, d))
 	}
 
 	if err := d.Set("project", project); err != nil {

--- a/aiven/resource_kafka_topic.go
+++ b/aiven/resource_kafka_topic.go
@@ -378,7 +378,7 @@ func resourceKafkaTopicRead(ctx context.Context, d *schema.ResourceData, m inter
 	project, serviceName, topicName := splitResourceID3(d.Id())
 	topic, err := getTopic(ctx, d, m, false)
 	if err != nil {
-		return resourceReadHandleNotFound(err, d, nil)
+		return diag.FromErr(resourceReadHandleNotFound(err, d))
 	}
 
 	if err := d.Set("project", project); err != nil {

--- a/aiven/resource_kafka_topic.go
+++ b/aiven/resource_kafka_topic.go
@@ -378,7 +378,7 @@ func resourceKafkaTopicRead(ctx context.Context, d *schema.ResourceData, m inter
 	project, serviceName, topicName := splitResourceID3(d.Id())
 	topic, err := getTopic(ctx, d, m, false)
 	if err != nil {
-		return diag.FromErr(err)
+		return resourceReadHandleNotFound(err, d, nil)
 	}
 
 	if err := d.Set("project", project); err != nil {

--- a/aiven/resource_mirrormaker_replication_flow.go
+++ b/aiven/resource_mirrormaker_replication_flow.go
@@ -114,7 +114,7 @@ func resourceMirrorMakerReplicationFlowRead(ctx context.Context, d *schema.Resou
 	project, serviceName, sourceCluster, targetCluster := splitResourceID4(d.Id())
 	replicationFlow, err := client.KafkaMirrorMakerReplicationFlow.Get(project, serviceName, sourceCluster, targetCluster)
 	if err != nil {
-		return resourceReadHandleNotFound(err, d, nil)
+		return diag.FromErr(resourceReadHandleNotFound(err, d))
 	}
 
 	if err := d.Set("project", project); err != nil {

--- a/aiven/resource_mirrormaker_replication_flow.go
+++ b/aiven/resource_mirrormaker_replication_flow.go
@@ -114,7 +114,7 @@ func resourceMirrorMakerReplicationFlowRead(ctx context.Context, d *schema.Resou
 	project, serviceName, sourceCluster, targetCluster := splitResourceID4(d.Id())
 	replicationFlow, err := client.KafkaMirrorMakerReplicationFlow.Get(project, serviceName, sourceCluster, targetCluster)
 	if err != nil {
-		return diag.FromErr(err)
+		return resourceReadHandleNotFound(err, d, nil)
 	}
 
 	if err := d.Set("project", project); err != nil {

--- a/aiven/resource_project_vpc.go
+++ b/aiven/resource_project_vpc.go
@@ -95,7 +95,7 @@ func resourceProjectVPCRead(_ context.Context, d *schema.ResourceData, m interfa
 	projectName, vpcID := splitResourceID2(d.Id())
 	vpc, err := client.VPCs.Get(projectName, vpcID)
 	if err != nil {
-		return resourceReadHandleNotFound(err, d, nil)
+		return diag.FromErr(resourceReadHandleNotFound(err, d))
 	}
 
 	err = copyVPCPropertiesFromAPIResponseToTerraform(d, vpc, projectName)

--- a/aiven/resource_project_vpc.go
+++ b/aiven/resource_project_vpc.go
@@ -95,7 +95,7 @@ func resourceProjectVPCRead(_ context.Context, d *schema.ResourceData, m interfa
 	projectName, vpcID := splitResourceID2(d.Id())
 	vpc, err := client.VPCs.Get(projectName, vpcID)
 	if err != nil {
-		return diag.FromErr(err)
+		return resourceReadHandleNotFound(err, d, nil)
 	}
 
 	err = copyVPCPropertiesFromAPIResponseToTerraform(d, vpc, projectName)

--- a/aiven/resource_service.go
+++ b/aiven/resource_service.go
@@ -802,7 +802,7 @@ func resourceServiceRead(_ context.Context, d *schema.ResourceData, m interface{
 	projectName, serviceName := splitResourceID2(d.Id())
 	service, err := client.Services.Get(projectName, serviceName)
 	if err != nil {
-		return resourceReadHandleNotFound(err, d, nil)
+		return diag.FromErr(resourceReadHandleNotFound(err, d))
 	}
 
 	err = copyServicePropertiesFromAPIResponseToTerraform(d, service, projectName)

--- a/aiven/resource_service.go
+++ b/aiven/resource_service.go
@@ -802,7 +802,7 @@ func resourceServiceRead(_ context.Context, d *schema.ResourceData, m interface{
 	projectName, serviceName := splitResourceID2(d.Id())
 	service, err := client.Services.Get(projectName, serviceName)
 	if err != nil {
-		return diag.FromErr(err)
+		return resourceReadHandleNotFound(err, d, nil)
 	}
 
 	err = copyServicePropertiesFromAPIResponseToTerraform(d, service, projectName)

--- a/aiven/resource_service_integration.go
+++ b/aiven/resource_service_integration.go
@@ -342,7 +342,7 @@ func resourceServiceIntegrationRead(_ context.Context, d *schema.ResourceData, m
 	projectName, integrationID := splitResourceID2(d.Id())
 	integration, err := client.ServiceIntegrations.Get(projectName, integrationID)
 	if err != nil {
-		return diag.Errorf("cannot get service integration: %s; id: %s", err, integrationID)
+		return resourceReadHandleNotFound(err, d, diag.Errorf("cannot get service integration: %s; id: %s", err, integrationID))
 	}
 
 	err = copyServiceIntegrationPropertiesFromAPIResponseToTerraform(d, integration, projectName)

--- a/aiven/resource_service_integration.go
+++ b/aiven/resource_service_integration.go
@@ -342,7 +342,11 @@ func resourceServiceIntegrationRead(_ context.Context, d *schema.ResourceData, m
 	projectName, integrationID := splitResourceID2(d.Id())
 	integration, err := client.ServiceIntegrations.Get(projectName, integrationID)
 	if err != nil {
-		return resourceReadHandleNotFound(err, d, diag.Errorf("cannot get service integration: %s; id: %s", err, integrationID))
+		err = resourceReadHandleNotFound(err, d)
+		if err != nil {
+			return diag.Errorf("cannot get service integration: %s; id: %s", err, integrationID)
+		}
+		return nil
 	}
 
 	err = copyServiceIntegrationPropertiesFromAPIResponseToTerraform(d, integration, projectName)

--- a/aiven/resource_service_integration_endpoint.go
+++ b/aiven/resource_service_integration_endpoint.go
@@ -192,7 +192,7 @@ func resourceServiceIntegrationEndpointRead(_ context.Context, d *schema.Resourc
 	projectName, endpointID := splitResourceID2(d.Id())
 	endpoint, err := client.ServiceIntegrationEndpoints.Get(projectName, endpointID)
 	if err != nil {
-		return diag.FromErr(err)
+		return resourceReadHandleNotFound(err, d, nil)
 	}
 
 	err = copyServiceIntegrationEndpointPropertiesFromAPIResponseToTerraform(d, endpoint, projectName)

--- a/aiven/resource_service_integration_endpoint.go
+++ b/aiven/resource_service_integration_endpoint.go
@@ -192,7 +192,7 @@ func resourceServiceIntegrationEndpointRead(_ context.Context, d *schema.Resourc
 	projectName, endpointID := splitResourceID2(d.Id())
 	endpoint, err := client.ServiceIntegrationEndpoints.Get(projectName, endpointID)
 	if err != nil {
-		return resourceReadHandleNotFound(err, d, nil)
+		return diag.FromErr(resourceReadHandleNotFound(err, d))
 	}
 
 	err = copyServiceIntegrationEndpointPropertiesFromAPIResponseToTerraform(d, endpoint, projectName)

--- a/aiven/resource_service_user.go
+++ b/aiven/resource_service_user.go
@@ -224,7 +224,7 @@ func resourceServiceUserRead(_ context.Context, d *schema.ResourceData, m interf
 	projectName, serviceName, username := splitResourceID3(d.Id())
 	user, err := client.ServiceUsers.Get(projectName, serviceName, username)
 	if err != nil {
-		return resourceReadHandleNotFound(err, d, nil)
+		return diag.FromErr(resourceReadHandleNotFound(err, d))
 	}
 
 	err = copyServiceUserPropertiesFromAPIResponseToTerraform(d, user, projectName, serviceName)

--- a/aiven/resource_service_user.go
+++ b/aiven/resource_service_user.go
@@ -224,7 +224,7 @@ func resourceServiceUserRead(_ context.Context, d *schema.ResourceData, m interf
 	projectName, serviceName, username := splitResourceID3(d.Id())
 	user, err := client.ServiceUsers.Get(projectName, serviceName, username)
 	if err != nil {
-		return diag.FromErr(err)
+		return resourceReadHandleNotFound(err, d, nil)
 	}
 
 	err = copyServiceUserPropertiesFromAPIResponseToTerraform(d, user, projectName, serviceName)


### PR DESCRIPTION
Before the SDK v2 upgrade ([here](https://github.com/aiven/terraform-provider-aiven/commit/0b0aa87) and [here](https://github.com/aiven/terraform-provider-aiven/commit/514649b)), those existence checking functions (`resourceXYZExists`) [were not returning errors](https://github.com/aiven/terraform-provider-aiven/blob/514649bad3e734e8b8d6a276528fbf6e0fb50bc5/aiven/provider.go#L261) in the case of non-existent resources (status `404`). [According to this upgrade guide](https://www.terraform.io/docs/extend/guides/v2-upgrade-guide.html#deprecation-of-helper-schema-existsfunc), these functions are deprecated, but their logic needs to be moved to Read functions (by `SetId("")` and returning no errors). 

This PR will revert those non-existent checks back to the Read functions. I tried to cover every place where the change was made.



