### PR TITLE
Remove old version reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ terraform {
   required_providers {
     aiven = {
       source  = "aiven/aiven"
-      version = "2.1.12" # check out the latest version in the release section
+      version = "x.y.z" # check out the latest version in the release section
     }
   }
 }


### PR DESCRIPTION
I could just update the version reference, but it would be obsolete soon.

Removing the version here would force people to check the latest version :)