### PR TITLE
remove specific version from acceptance tests

### DIFF
--- a/aiven/datasource_service_component_test.go
+++ b/aiven/datasource_service_component_test.go
@@ -103,7 +103,6 @@ func testAccServiceComponentDataSource(name string) string {
 				kafka_rest = true
 				kafka_connect = true
 				schema_registry = true
-				kafka_version = "2.4"
 
 				kafka {
 					group_max_session_timeout_ms = 70000

--- a/aiven/resource_aws_privatelink_test.go
+++ b/aiven/resource_aws_privatelink_test.go
@@ -78,7 +78,6 @@ func testAccAWSPrivatelinkResource(name string) string {
 			project_vpc_id = "%s"
 			
 			kafka_user_config {
-				kafka_version = "2.4"
 				kafka {
 				  group_max_session_timeout_ms = 70000
 				  log_retention_bytes = 1000000000

--- a/aiven/resource_connection_pool_test.go
+++ b/aiven/resource_connection_pool_test.go
@@ -101,10 +101,6 @@ func testAccConnectionPoolResource(name string) string {
 			service_type = "pg"
 			maintenance_window_dow = "monday"
 			maintenance_window_time = "10:00:00"
-			
-			pg_user_config {
-				pg_version = 11
-			}
 		}
 		
 		resource "aiven_service_user" "foo" {

--- a/aiven/resource_database_test.go
+++ b/aiven/resource_database_test.go
@@ -144,8 +144,6 @@ func testAccDatabaseResource(name string) string {
 			maintenance_window_time = "10:00:00"
 			
 			pg_user_config {
-				pg_version = 11
-
 				public_access {
 					pg = true
 					prometheus = false
@@ -191,8 +189,6 @@ func testAccDatabaseTerminationProtectionResource(name string) string {
 			maintenance_window_time = "10:00:00"
 			
 			pg_user_config {
-				pg_version = 11
-
 				public_access {
 					pg = true
 					prometheus = false

--- a/aiven/resource_elasticsearch_acl_test.go
+++ b/aiven/resource_elasticsearch_acl_test.go
@@ -49,10 +49,6 @@ func testAccElasticsearchAclResource(name string) string {
 			service_type = "elasticsearch"
 			maintenance_window_dow = "monday"
 			maintenance_window_time = "10:00:00"
-			
-			elasticsearch_user_config {
-				elasticsearch_version = 7
-			}
 		}
 
 		resource "aiven_service_user" "foo" {

--- a/aiven/resource_elasticsearch_test.go
+++ b/aiven/resource_elasticsearch_test.go
@@ -53,8 +53,6 @@ func testAccElasticsearchResource(name string) string {
 			maintenance_window_time = "10:00:00"
 			
 			elasticsearch_user_config {
-				elasticsearch_version = 7
-
 				kibana {
 					enabled = true
 					elasticsearch_request_timeout = 30000

--- a/aiven/resource_kafka_acl_test.go
+++ b/aiven/resource_kafka_acl_test.go
@@ -203,7 +203,6 @@ func testAccKafkaACLResource(name string) string {
 			maintenance_window_time = "10:00:00"
 			
 			kafka_user_config {
-				kafka_version = "2.4"
 				kafka {
 				  group_max_session_timeout_ms = 70000
 				  log_retention_bytes = 1000000000

--- a/aiven/resource_kafka_connector_test.go
+++ b/aiven/resource_kafka_connector_test.go
@@ -176,7 +176,6 @@ func testAccKafkaConnectorResource(name string) string {
 			maintenance_window_time = "10:00:00"
 			
 			kafka_user_config {
-				kafka_version = "2.4"
 				kafka_connect = true
 
 				kafka {
@@ -202,10 +201,6 @@ func testAccKafkaConnectorResource(name string) string {
 			service_type = "elasticsearch"
 			maintenance_window_dow = "monday"
 			maintenance_window_time = "10:00:00"
-			
-			elasticsearch_user_config {
-				elasticsearch_version = "7"
-			}
 		}
 
 		resource "aiven_kafka_connector" "foo" {
@@ -247,7 +242,6 @@ func testAccKafkaConnectorMonoSinkResource(name string) string {
 			maintenance_window_time = "10:00:00"
 			
 			kafka_user_config {
-				kafka_version = "2.4"
 				kafka_connect = true
 				schema_registry = true
 

--- a/aiven/resource_kafka_schema.go
+++ b/aiven/resource_kafka_schema.go
@@ -229,7 +229,9 @@ func resourceKafkaSchemaRead(_ context.Context, d *schema.ResourceData, m interf
 
 	c, err := client.KafkaSubjectSchemas.GetConfiguration(project, serviceName, subjectName)
 	if err != nil {
-		return diag.FromErr(resourceReadHandleNotFound(err, d))
+		if !aiven.IsNotFound(err) {
+			return diag.FromErr(err)
+		}
 	} else {
 		// only update if was set to not empty values by the user
 		if _, ok := d.GetOk("compatibility_level"); ok {

--- a/aiven/resource_kafka_schema_configuration_test.go
+++ b/aiven/resource_kafka_schema_configuration_test.go
@@ -54,7 +54,6 @@ func testAccKafkaSchemaConfigurationResource(name string) string {
 			
 			kafka_user_config {
 				schema_registry = true
-				kafka_version = "2.4"
 				kafka {
 				  group_max_session_timeout_ms = 70000
 				  log_retention_bytes = 1000000000

--- a/aiven/resource_kafka_schema_test.go
+++ b/aiven/resource_kafka_schema_test.go
@@ -152,7 +152,6 @@ func testAccKafkaSchemaResource(name string) string {
 			
 			kafka_user_config {
 				schema_registry = true
-				kafka_version = "2.4"
 
 				kafka {
 				  group_max_session_timeout_ms = 70000

--- a/aiven/resource_kafka_test.go
+++ b/aiven/resource_kafka_test.go
@@ -74,7 +74,6 @@ func testAccKafkaResource(name string) string {
 				kafka_rest = true
 				kafka_connect = true
 				schema_registry = true
-				kafka_version = "2.4"
 
 				kafka {
 					group_max_session_timeout_ms = 70000
@@ -115,7 +114,6 @@ func testAccKafkaWithoutDefaultACLResource(name string) string {
 				kafka_rest = true
 				kafka_connect = true
 				schema_registry = true
-				kafka_version = "2.4"
 				kafka {
 					group_max_session_timeout_ms = 70000
 					log_retention_bytes = 1000000000

--- a/aiven/resource_kafka_topic_test.go
+++ b/aiven/resource_kafka_topic_test.go
@@ -300,10 +300,6 @@ func testAccKafkaTopicCustomTimeoutsResource(name string) string {
 				create = "25m"
 				update = "20m"
 			}
-			
-			kafka_user_config {
-				kafka_version = "2.4"
-			}
 		}
 		
 		resource "aiven_kafka_topic" "foo" {
@@ -346,7 +342,6 @@ func testAccKafkaTopicTerminationProtectionResource(name string) string {
 			maintenance_window_time = "10:00:00"
 			
 			kafka_user_config {
-				kafka_version = "2.4"
 				kafka {
 				  group_max_session_timeout_ms = 70000
 				  log_retention_bytes = 1000000000

--- a/aiven/resource_m3aggregator_test.go
+++ b/aiven/resource_m3aggregator_test.go
@@ -50,8 +50,6 @@ func testAccM3AggregatorResource(name string) string {
 			service_name = "test-acc-m3d-%s"
 
 			m3db_user_config {
-				m3db_version = "1.0"
-							
 				namespaces {
 					name = "%s"
 					type = "unaggregated"
@@ -66,10 +64,6 @@ func testAccM3AggregatorResource(name string) string {
 			service_name = "test-acc-m3a-%s"
 			maintenance_window_dow = "monday"
 			maintenance_window_time = "10:00:00"
-
-			m3aggregator_user_config {
-				m3aggregator_version = "1.0"
-			}
 		}
 
 		resource "aiven_service_integration" "int-m3db-aggr" {

--- a/aiven/resource_m3db_test.go
+++ b/aiven/resource_m3db_test.go
@@ -52,8 +52,6 @@ func testAccM3DBResource(name string) string {
 			maintenance_window_time = "10:00:00"
 			
 			m3db_user_config {
-				m3db_version = "1.0"
-							
 				namespaces {
 					name = "%s"
 					type = "unaggregated"
@@ -66,10 +64,6 @@ func testAccM3DBResource(name string) string {
 			cloud_name = "google-europe-west1"
 			service_name = "test-acc-sr-pg-%s"
 			plan = "startup-4"
-
-			pg_user_config {
-				pg_version = 12
-			}
 		}
 		
 		resource "aiven_service_integration" "int-m3db-pg" {

--- a/aiven/resource_mirrormaker_replication_flow_test.go
+++ b/aiven/resource_mirrormaker_replication_flow_test.go
@@ -88,7 +88,6 @@ func testAccMirrorMakerReplicationFlowResource(name string) string {
 			maintenance_window_time = "10:00:00"
 			
 			kafka_user_config {
-				kafka_version = "2.4"
 				kafka {
 				  group_max_session_timeout_ms = 70000
 				  log_retention_bytes = 1000000000
@@ -113,7 +112,6 @@ func testAccMirrorMakerReplicationFlowResource(name string) string {
 			maintenance_window_time = "10:00:00"
 			
 			kafka_user_config {
-				kafka_version = "2.4"
 				kafka {
 				  group_max_session_timeout_ms = 70000
 				  log_retention_bytes = 1000000000

--- a/aiven/resource_mysql_test.go
+++ b/aiven/resource_mysql_test.go
@@ -53,8 +53,6 @@ func testAccMysqlResource(name string) string {
 			maintenance_window_time = "10:00:00"
 			
 			mysql_user_config {
-				mysql_version = 8
-							
 				mysql {
 					sql_mode = "ANSI,ERROR_FOR_DIVISION_BY_ZERO,NO_ENGINE_SUBSTITUTION,NO_ZERO_DATE,NO_ZERO_IN_DATE"
 					sql_require_primary_key = true

--- a/aiven/resource_pg_test.go
+++ b/aiven/resource_pg_test.go
@@ -53,8 +53,6 @@ func testAccPGResource(name string) string {
 			maintenance_window_time = "10:00:00"
 			
 			pg_user_config {
-				pg_version = 11
-
 				public_access {
 					pg = true
 					prometheus = false

--- a/aiven/resource_service_elasticsearch_test.go
+++ b/aiven/resource_service_elasticsearch_test.go
@@ -57,8 +57,6 @@ func testAccElasticsearchServiceResource(name string) string {
 			maintenance_window_time = "10:00:00"
 			
 			elasticsearch_user_config {
-				elasticsearch_version = 7
-
 				kibana {
 					enabled = true
 					elasticsearch_request_timeout = 30000
@@ -101,10 +99,6 @@ func testAccCheckAivenServiceESAttributes(n string) resource.TestCheckFunc {
 
 		if a["elasticsearch.0.kibana_uri"] == "" {
 			return fmt.Errorf("expected to get kibana_uri from Aiven")
-		}
-
-		if a["elasticsearch_user_config.0.elasticsearch_version"] != "7" {
-			return fmt.Errorf("expected to get a correct elasticsearch_version from Aiven")
 		}
 
 		if a["elasticsearch_user_config.0.ip_filter.0"] != "0.0.0.0/0" {

--- a/aiven/resource_service_integration_endpoint_test.go
+++ b/aiven/resource_service_integration_endpoint_test.go
@@ -49,8 +49,6 @@ func testAccServiceIntegrationEndpointResource(name string) string {
 			maintenance_window_time = "10:00:00"
 			
 			pg_user_config {
-				pg_version = 11
-
 				public_access {
 					pg = true
 					prometheus = false

--- a/aiven/resource_service_integration_test.go
+++ b/aiven/resource_service_integration_test.go
@@ -77,8 +77,6 @@ func testAccServiceIntegrationResource(name string) string {
 			maintenance_window_time = "10:00:00"
 			
 			pg_user_config {
-				pg_version = 11
-
 				public_access {
 					pg = true
 					prometheus = false
@@ -140,10 +138,6 @@ func testAccServiceIntegrationKafkaConnectResource(name string) string {
 			service_type = "kafka"
 			maintenance_window_dow = "monday"
 			maintenance_window_time = "10:00:00"
-			
-			kafka_user_config {
-				kafka_version = "2.4"
-			}
 		}
 		
 		resource "aiven_service" "kafka_connect1" {
@@ -210,7 +204,6 @@ func testAccServiceIntegrationMirrorMakerResource(name string) string {
 			maintenance_window_time = "10:00:00"
 			
 			kafka_user_config {
-				kafka_version = "2.4"
 				kafka {
 				  group_max_session_timeout_ms = 70000
 				  log_retention_bytes = 1000000000
@@ -236,7 +229,6 @@ func testAccServiceIntegrationMirrorMakerResource(name string) string {
 			maintenance_window_time = "10:00:00"
 			
 			kafka_user_config {
-				kafka_version = "2.4"
 				kafka {
 				  group_max_session_timeout_ms = 70000
 				  log_retention_bytes = 1000000000

--- a/aiven/resource_service_kafka_test.go
+++ b/aiven/resource_service_kafka_test.go
@@ -59,7 +59,6 @@ func testAccKafkaServiceResource(name string) string {
 				kafka_rest = true
 				kafka_connect = true
 				schema_registry = true
-				kafka_version = "2.4"
 
 				kafka {
 					group_max_session_timeout_ms = 70000
@@ -97,10 +96,6 @@ func testAccCheckAivenServiceKafkaAttributes(n string) resource.TestCheckFunc {
 
 		if a["kafka_user_config.0.kafka_rest"] != "true" {
 			return fmt.Errorf("expected to get a correct kafka_rest from Aiven")
-		}
-
-		if a["kafka_user_config.0.kafka_version"] != "2.4" {
-			return fmt.Errorf("expected to get a correct kafka_version from Aiven")
 		}
 
 		if a["kafka_user_config.0.public_access.0.kafka_connect"] != "true" {

--- a/aiven/resource_service_mysql_test.go
+++ b/aiven/resource_service_mysql_test.go
@@ -56,8 +56,6 @@ func testAccMysqlServiceResource(name string) string {
 			maintenance_window_time = "10:00:00"
 			
 			mysql_user_config {
-				mysql_version = 8
-							
 				mysql {
 					sql_mode = "ANSI,ERROR_FOR_DIVISION_BY_ZERO,NO_ENGINE_SUBSTITUTION,NO_ZERO_DATE,NO_ZERO_IN_DATE"
 					sql_require_primary_key = true
@@ -93,10 +91,6 @@ func testAccCheckAivenServiceMysqlAttributes(n string) resource.TestCheckFunc {
 
 		if a["mysql_user_config.0.public_access.0.mysql"] != "true" {
 			return fmt.Errorf("expected to get a correct public_access.mysql from Aiven")
-		}
-
-		if a["mysql_user_config.0.mysql_version"] != "8" {
-			return fmt.Errorf("expected to get a correct mysql_version from Aiven")
 		}
 
 		if a["mysql_user_config.0.public_access.0.prometheus"] != "" {

--- a/aiven/resource_service_pg_test.go
+++ b/aiven/resource_service_pg_test.go
@@ -108,8 +108,6 @@ func testAccPGServiceResource(name string) string {
 			maintenance_window_time = "10:00:00"
 			
 			pg_user_config {
-				pg_version = 11
-
 				public_access {
 					pg = true
 					prometheus = false
@@ -150,8 +148,6 @@ func testAccPGServiceCustomTimeoutsResource(name string) string {
 			}
 			
 			pg_user_config {
-				pg_version = 11
-
 				public_access {
 					pg = true
 					prometheus = false
@@ -188,8 +184,6 @@ func testAccPGTerminationProtectionServiceResource(name string) string {
 			termination_protection = true
 			
 			pg_user_config {
-				pg_version = 11
-
 				public_access {
 					pg = true
 					prometheus = false
@@ -225,8 +219,6 @@ func testAccPGReadReplicaServiceResource(name string) string {
 			maintenance_window_time = "10:00:00"
 			
 			pg_user_config {
-				pg_version = 11
-
 				public_access {
 					pg = true
 					prometheus = false
@@ -249,8 +241,6 @@ func testAccPGReadReplicaServiceResource(name string) string {
 			pg_user_config {
 				backup_hour = 19
 				backup_minute = 30
-				pg_version = 11
-
 				public_access {
 					pg = true
 					prometheus = false
@@ -338,10 +328,6 @@ func testAccCheckAivenServicePGAttributes(n string) resource.TestCheckFunc {
 
 		if !strings.Contains(a["service_type"], "pg") {
 			return fmt.Errorf("expected to get a correct service type from Aiven, got :%s", a["service_type"])
-		}
-
-		if a["pg_user_config.0.pg_version"] != "11" {
-			return fmt.Errorf("expected to get a correct PG version from Aiven, got :%s", a["pg_user_config.0.pg_version"])
 		}
 
 		if a["pg_user_config.0.ip_filter.0"] != "0.0.0.0/0" {

--- a/aiven/resource_service_user_test.go
+++ b/aiven/resource_service_user_test.go
@@ -119,10 +119,6 @@ func testAccServiceUserNewPasswordResource(name string) string {
 			service_name = "test-acc-sr-%s"
 			maintenance_window_dow = "monday"
 			maintenance_window_time = "10:00:00"
-			
-			pg_user_config {
-				pg_version = 11
-			}
 		}
 		
 		resource "aiven_service_user" "foo" {


### PR DESCRIPTION
It is not a good idea to use a specific service version for acceptance testing since Aiven services always evolve, and certain versions get old and eventually reach EOL, which will break tests.