### PR TITLE
RFC: split elasticsearch resource ACLs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ parent: README
 nav_order: 1
 ---# Changelog
 
+## [2.1.20] - not yet released
+- split `aiven_elasticsearch_acl` into `aiven_elasticsearch_acl_config` and `aiven_elasticsearch_acl_rule`
+- deprecated `aiven_elasticsearch_acl`
+
 ## [2.1.19] - 2021-08-26
 - Add code of conduct
 - Improve acceptance tests and documentation

--- a/aiven/datasource_elasticsearch_acl.go
+++ b/aiven/datasource_elasticsearch_acl.go
@@ -11,9 +11,9 @@ import (
 
 func datasourceElasticsearchACL() *schema.Resource {
 	return &schema.Resource{
-		ReadContext: datasourceElasticsearchACLRead,
-		Schema: resourceSchemaAsDatasourceSchema(aivenElasticsearchACLSchema,
-			"project", "service_name"),
+		DeprecationMessage: "ElasticsearchACL is deprecated please use ElasticsearchACLConfig and ElasticsearchACLRule",
+		ReadContext:        datasourceElasticsearchACLRead,
+		Schema:             resourceSchemaAsDatasourceSchema(aivenElasticsearchACLSchema, "project", "service_name"),
 	}
 }
 
@@ -34,6 +34,5 @@ func datasourceElasticsearchACLRead(ctx context.Context, d *schema.ResourceData,
 		return resourceElasticsearchACLRead(ctx, d, m)
 	}
 
-	return diag.Errorf("elasticsearch acl %s/%s not found",
-		projectName, serviceName)
+	return diag.Errorf("elasticsearch acl %s/%s not found", projectName, serviceName)
 }

--- a/aiven/datasource_elasticsearch_acl_config.go
+++ b/aiven/datasource_elasticsearch_acl_config.go
@@ -1,0 +1,37 @@
+// Copyright (c) 2021 Aiven, Helsinki, Finland. https://aiven.io/
+package aiven
+
+import (
+	"context"
+
+	"github.com/aiven/aiven-go-client"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func datasourceElasticsearchACLConfig() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: datasourceElasticsearchACLConfigRead,
+		Schema:      resourceSchemaAsDatasourceSchema(aivenElasticsearchACLConfigSchema, "project", "service_name"),
+	}
+}
+
+func datasourceElasticsearchACLConfigRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	client := m.(*aiven.Client)
+
+	projectName := d.Get("project").(string)
+	serviceName := d.Get("service_name").(string)
+
+	acl, err := client.ElasticsearchACLs.Get(projectName, serviceName)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	if acl != nil {
+		d.SetId(buildResourceID(projectName, serviceName))
+
+		return resourceElasticsearchACLConfigRead(ctx, d, m)
+	}
+
+	return diag.Errorf("elasticsearch acl config %s/%s not found", projectName, serviceName)
+}

--- a/aiven/datasource_elasticsearch_acl_rule.go
+++ b/aiven/datasource_elasticsearch_acl_rule.go
@@ -1,0 +1,39 @@
+// Copyright (c) 2021 Aiven, Helsinki, Finland. https://aiven.io/
+package aiven
+
+import (
+	"context"
+
+	"github.com/aiven/aiven-go-client"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func datasourceElasticsearchACLRule() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: datasourceElasticsearchACLRuleRead,
+		Schema:      resourceSchemaAsDatasourceSchema(aivenElasticsearchACLRuleSchema, "project", "service_name", "username", "index", "permission"),
+	}
+}
+
+func datasourceElasticsearchACLRuleRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	client := m.(*aiven.Client)
+
+	projectName := d.Get("project").(string)
+	serviceName := d.Get("service_name").(string)
+	username := d.Get("username").(string)
+	index := d.Get("index").(string)
+
+	r, err := client.ElasticsearchACLs.Get(projectName, serviceName)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	if _, found := resourceElasticsearchACLRuleGetPermissionFromACLResponse(r.ElasticSearchACLConfig, username, index); !found {
+		return diag.Errorf("elasticsearch acl rule %s/%s/%s/%s not found", projectName, serviceName, username, index)
+	}
+
+	d.SetId(buildResourceID(projectName, serviceName, username, index))
+
+	return resourceElasticsearchACLRuleRead(ctx, d, m)
+}

--- a/aiven/provider.go
+++ b/aiven/provider.go
@@ -38,7 +38,6 @@ func Provider() *schema.Provider {
 			"aiven_kafka_connector":                datasourceKafkaConnector(),
 			"aiven_kafka_schema":                   datasourceKafkaSchema(),
 			"aiven_kafka_schema_configuration":     datasourceKafkaSchemaConfiguration(),
-			"aiven_elasticsearch_acl":              datasourceElasticsearchACL(),
 			"aiven_project":                        datasourceProject(),
 			"aiven_project_user":                   datasourceProjectUser(),
 			"aiven_project_vpc":                    datasourceProjectVPC(),
@@ -60,6 +59,8 @@ func Provider() *schema.Provider {
 			"aiven_mysql":                          datasourceMySQL(),
 			"aiven_cassandra":                      datasourceCassandra(),
 			"aiven_elasticsearch":                  datasourceElasticsearch(),
+			"aiven_elasticsearch_acl_config":       datasourceElasticsearchACLConfig(),
+			"aiven_elasticsearch_acl_rule":         datasourceElasticsearchACLRule(),
 			"aiven_grafana":                        datasourceGrafana(),
 			"aiven_influxdb":                       datasourceInfluxDB(),
 			"aiven_redis":                          datasourceRedis(),
@@ -68,6 +69,9 @@ func Provider() *schema.Provider {
 			"aiven_m3db":                           datasourceM3DB(),
 			"aiven_m3aggregator":                   datasourceM3Aggregator(),
 			"aiven_aws_privatelink":                datasourceAWSPrivatelink(),
+
+			// deprecated
+			"aiven_elasticsearch_acl": datasourceElasticsearchACL(),
 		},
 
 		ResourcesMap: map[string]*schema.Resource{
@@ -78,7 +82,6 @@ func Provider() *schema.Provider {
 			"aiven_kafka_connector":                resourceKafkaConnector(),
 			"aiven_kafka_schema":                   resourceKafkaSchema(),
 			"aiven_kafka_schema_configuration":     resourceKafkaSchemaConfiguration(),
-			"aiven_elasticsearch_acl":              resourceElasticsearchACL(),
 			"aiven_project":                        resourceProject(),
 			"aiven_project_user":                   resourceProjectUser(),
 			"aiven_project_vpc":                    resourceProjectVPC(),
@@ -100,6 +103,8 @@ func Provider() *schema.Provider {
 			"aiven_mysql":                          resourceMySQL(),
 			"aiven_cassandra":                      resourceCassandra(),
 			"aiven_elasticsearch":                  resourceElasticsearch(),
+			"aiven_elasticsearch_acl_config":       resourceElasticsearchACLConfig(),
+			"aiven_elasticsearch_acl_rule":         resourceElasticsearchACLRule(),
 			"aiven_grafana":                        resourceGrafana(),
 			"aiven_influxdb":                       resourceInfluxDB(),
 			"aiven_redis":                          resourceRedis(),
@@ -108,6 +113,9 @@ func Provider() *schema.Provider {
 			"aiven_m3aggregator":                   resourceM3Aggregator(),
 			"aiven_billing_group":                  resourceBillingGroup(),
 			"aiven_aws_privatelink":                resourceAWSPrivatelink(),
+
+			// deprecated
+			"aiven_elasticsearch_acl": resourceElasticsearchACL(),
 		},
 	}
 

--- a/aiven/resource_elasticsearch_acl_common.go
+++ b/aiven/resource_elasticsearch_acl_common.go
@@ -1,0 +1,65 @@
+package aiven
+
+import (
+	"sync"
+
+	"github.com/aiven/aiven-go-client"
+)
+
+var (
+	// this mutex is needed to serialize calls to modify the remote config
+	// since its an abstraction that first GETs, modifies and then PUTs again
+	resourceElasticsearchACLModifierMutex sync.Mutex
+)
+
+// GETs the remote config, applies the modifiers and PUTs it again
+// The Config that is passed to the modifiers is guaranteed to be not nil
+func resourceElasticsearchACLModifyRemoteConfig(project, serviceName string, client *aiven.Client, modifiers ...func(*aiven.ElasticSearchACLConfig)) error {
+	resourceElasticsearchACLModifierMutex.Lock()
+	defer resourceElasticsearchACLModifierMutex.Unlock()
+
+	r, err := client.ElasticsearchACLs.Get(project, serviceName)
+	if err != nil {
+		return err
+	}
+
+	config := r.ElasticSearchACLConfig
+	for i := range modifiers {
+		modifiers[i](&config)
+	}
+
+	_, err = client.ElasticsearchACLs.Update(
+		project,
+		serviceName,
+		aiven.ElasticsearchACLRequest{ElasticSearchACLConfig: config})
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// some modifiers
+
+func resourceElasticsearchACLModifierUpdateACLRule(username, index, permission string) func(*aiven.ElasticSearchACLConfig) {
+	return func(cfg *aiven.ElasticSearchACLConfig) {
+		cfg.Add(resourceElasticsearchACLRuleMkAivenACL(username, index, permission))
+
+		// delete the old acl if its there
+		if prevPerm, ok := resourceElasticsearchACLRuleGetPermissionFromACLResponse(*cfg, username, index); ok && prevPerm != permission {
+			cfg.Delete(resourceElasticsearchACLRuleMkAivenACL(username, index, prevPerm))
+		}
+	}
+}
+
+func resourceElasticsearchACLModifierDeleteACLRule(username, index, permission string) func(*aiven.ElasticSearchACLConfig) {
+	return func(cfg *aiven.ElasticSearchACLConfig) {
+		cfg.Delete(resourceElasticsearchACLRuleMkAivenACL(username, index, permission))
+	}
+}
+
+func resourceElasticsearchACLModiferToggleConfigFields(enabled, extednedAcl bool) func(*aiven.ElasticSearchACLConfig) {
+	return func(cfg *aiven.ElasticSearchACLConfig) {
+		cfg.Enabled = true
+		cfg.ExtendedAcl = true
+	}
+}

--- a/aiven/resource_elasticsearch_acl_config.go
+++ b/aiven/resource_elasticsearch_acl_config.go
@@ -1,0 +1,116 @@
+package aiven
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/aiven/aiven-go-client"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+var aivenElasticsearchACLConfigSchema = map[string]*schema.Schema{
+	"project": {
+		Type:        schema.TypeString,
+		Description: "Project to link the Elasticsearch ACLs to",
+		Required:    true,
+		ForceNew:    true,
+	},
+	"service_name": {
+		Type:        schema.TypeString,
+		Description: "Service to link the Elasticsearch ACLs to",
+		Required:    true,
+		ForceNew:    true,
+	},
+	"enabled": {
+		Type:        schema.TypeBool,
+		Description: "Enable Elasticsearch ACLs. When disabled authenticated service users have unrestricted access",
+		Optional:    true,
+		Default:     true,
+	},
+	"extended_acl": {
+		Type:        schema.TypeBool,
+		Description: "Index rules can be applied in a limited fashion to the _mget, _msearch and _bulk APIs (and only those) by enabling the ExtendedAcl option for the service. When it is enabled, users can use these APIs as long as all operations only target indexes they have been granted access to",
+		Optional:    true,
+		Default:     true,
+	},
+}
+
+func resourceElasticsearchACLConfig() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceElasticsearchACLConfigUpdate,
+		ReadContext:   resourceElasticsearchACLConfigRead,
+		UpdateContext: resourceElasticsearchACLConfigUpdate,
+		DeleteContext: resourceElasticsearchACLConfigDelete,
+		Importer: &schema.ResourceImporter{
+			StateContext: resourceElasticsearchACLConfigState,
+		},
+
+		Schema: aivenElasticsearchACLConfigSchema,
+	}
+}
+
+func resourceElasticsearchACLConfigRead(_ context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	client := m.(*aiven.Client)
+
+	project, serviceName := splitResourceID2(d.Id())
+	r, err := client.ElasticsearchACLs.Get(project, serviceName)
+	if err != nil {
+		return diag.FromErr(resourceReadHandleNotFound(err, d))
+	}
+
+	if err := d.Set("project", project); err != nil {
+		return diag.Errorf("error setting Elasticsearch ACLs `project` for resource %s: %s", d.Id(), err)
+	}
+	if err := d.Set("service_name", serviceName); err != nil {
+		return diag.Errorf("error setting Elasticsearch ACLs `service_name` for resource %s: %s", d.Id(), err)
+	}
+	if err := d.Set("extended_acl", r.ElasticSearchACLConfig.ExtendedAcl); err != nil {
+		return diag.Errorf("error setting Elasticsearch ACLs `extended_acl` for resource %s: %s", d.Id(), err)
+	}
+	if err := d.Set("enabled", r.ElasticSearchACLConfig.Enabled); err != nil {
+		return diag.Errorf("error setting Elasticsearch ACLs `enable` for resource %s: %s", d.Id(), err)
+	}
+	return nil
+}
+
+func resourceElasticsearchACLConfigState(ctx context.Context, d *schema.ResourceData, m interface{}) ([]*schema.ResourceData, error) {
+	di := resourceElasticsearchACLConfigRead(ctx, d, m)
+	if di.HasError() {
+		return nil, fmt.Errorf("cannot get elasticsearch acl: %v", di)
+	}
+
+	return []*schema.ResourceData{d}, nil
+}
+
+func resourceElasticsearchACLConfigUpdate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	client := m.(*aiven.Client)
+
+	project := d.Get("project").(string)
+	serviceName := d.Get("service_name").(string)
+
+	modifier := resourceElasticsearchACLModiferToggleConfigFields(d.Get("enabled").(bool), d.Get("extended_acl").(bool))
+	err := resourceElasticsearchACLModifyRemoteConfig(project, serviceName, client, modifier)
+	if err != nil {
+		return diag.FromErr(resourceReadHandleNotFound(err, d))
+	}
+
+	d.SetId(buildResourceID(project, serviceName))
+
+	return resourceElasticsearchACLConfigRead(ctx, d, m)
+}
+
+func resourceElasticsearchACLConfigDelete(_ context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	client := m.(*aiven.Client)
+
+	project := d.Get("project").(string)
+	serviceName := d.Get("service_name").(string)
+
+	modifier := resourceElasticsearchACLModiferToggleConfigFields(false, false)
+	err := resourceElasticsearchACLModifyRemoteConfig(project, serviceName, client, modifier)
+	if err != nil {
+		return diag.FromErr(resourceReadHandleNotFound(err, d))
+	}
+
+	return nil
+}

--- a/aiven/resource_elasticsearch_acl_config_test.go
+++ b/aiven/resource_elasticsearch_acl_config_test.go
@@ -1,0 +1,91 @@
+package aiven
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/aiven/aiven-go-client"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+func TestAccAivenElasticsearchACLConfig_basic(t *testing.T) {
+	resourceName := "aiven_elasticsearch_acl_config.foo"
+	rName := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviderFactories,
+		CheckDestroy:      testAccCheckAivenAleasticsearchACLConfigResourceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccElasticsearchACLConfigResource(rName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "project", os.Getenv("AIVEN_PROJECT_NAME")),
+					resource.TestCheckResourceAttr(resourceName, "service_name", fmt.Sprintf("test-acc-sr-%s", rName)),
+					resource.TestCheckResourceAttr(resourceName, "enabled", "true"),
+					resource.TestCheckResourceAttr(resourceName, "extended_acl", "false"),
+				),
+			},
+		},
+	})
+}
+
+func testAccElasticsearchACLConfigResource(name string) string {
+	return fmt.Sprintf(`
+		data "aiven_project" "foo" {
+			project = "%s"
+		}
+
+		resource "aiven_service" "bar" {
+			project = data.aiven_project.foo.project
+			cloud_name = "google-europe-west1"
+			plan = "startup-4"
+			service_name = "test-acc-sr-%s"
+			service_type = "elasticsearch"
+			maintenance_window_dow = "monday"
+			maintenance_window_time = "10:00:00"
+		}
+
+		resource "aiven_service_user" "foo" {
+			service_name = aiven_service.bar.service_name
+			project = data.aiven_project.foo.project
+			username = "user-%s"
+		}
+
+		resource "aiven_elasticsearch_acl_config" "foo" {
+			project = data.aiven_project.foo.project
+			service_name = aiven_service.bar.service_name
+			enabled = true
+			extended_acl = false
+    }
+		`, os.Getenv("AIVEN_PROJECT_NAME"), name, name)
+}
+
+func testAccCheckAivenAleasticsearchACLConfigResourceDestroy(s *terraform.State) error {
+	c := testAccProvider.Meta().(*aiven.Client)
+
+	// loop through the resources in state, verifying each ES ACL Config is destroyed
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "aiven_elasticsearch_acl_config" {
+			continue
+		}
+
+		projectName, serviceName := splitResourceID2(rs.Primary.ID)
+
+		r, err := c.ElasticsearchACLs.Get(projectName, serviceName)
+		if err != nil {
+			if err.(aiven.Error).Status != 404 {
+				return err
+			}
+		}
+		if r == nil {
+			return nil
+		}
+		return fmt.Errorf("elasticsearch acl config (%s) still exists", rs.Primary.ID)
+	}
+
+	return nil
+}

--- a/aiven/resource_elasticsearch_acl_rule.go
+++ b/aiven/resource_elasticsearch_acl_rule.go
@@ -1,0 +1,164 @@
+package aiven
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/aiven/aiven-go-client"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+)
+
+var aivenElasticsearchACLRuleSchema = map[string]*schema.Schema{
+	"project": {
+		Type:        schema.TypeString,
+		Description: "Project to link the Elasticsearch ACLs to",
+		Required:    true,
+		ForceNew:    true,
+	},
+	"service_name": {
+		Type:        schema.TypeString,
+		Description: "Service to link the Elasticsearch ACLs to",
+		Required:    true,
+		ForceNew:    true,
+	},
+	"username": {
+		Type:         schema.TypeString,
+		Description:  "Username for the ACL entry",
+		Required:     true,
+		ForceNew:     true,
+		ValidateFunc: validation.StringLenBetween(1, 40),
+	},
+	"index": {
+		Type:         schema.TypeString,
+		Description:  "Elasticsearch index pattern",
+		Required:     true,
+		ForceNew:     true,
+		ValidateFunc: validation.StringLenBetween(1, 249),
+	},
+	"permission": {
+		Type:         schema.TypeString,
+		Description:  "Elasticsearch permission",
+		Required:     true,
+		ValidateFunc: validation.StringInSlice([]string{"deny", "admin", "read", "readwrite", "write"}, false),
+	},
+}
+
+func resourceElasticsearchACLRule() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceElasticsearchACLRuleUpdate,
+		ReadContext:   resourceElasticsearchACLRuleRead,
+		UpdateContext: resourceElasticsearchACLRuleUpdate,
+		DeleteContext: resourceElasticsearchACLRuleDelete,
+		Importer: &schema.ResourceImporter{
+			StateContext: resourceElasticsearchACLRuleState,
+		},
+
+		Schema: aivenElasticsearchACLRuleSchema,
+	}
+}
+
+func resourceElasticsearchACLRuleGetPermissionFromACLResponse(cfg aiven.ElasticSearchACLConfig, username, index string) (string, bool) {
+	for _, acl := range cfg.ACLs {
+		if acl.Username != username {
+			continue
+		}
+		for _, rule := range acl.Rules {
+			if rule.Index == index {
+				return rule.Permission, true
+			}
+		}
+	}
+	return "", false
+}
+
+func resourceElasticsearchACLRuleRead(_ context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	client := m.(*aiven.Client)
+
+	project, serviceName, username, index := splitResourceID4(d.Id())
+	r, err := client.ElasticsearchACLs.Get(project, serviceName)
+	if err != nil {
+		return diag.FromErr(resourceReadHandleNotFound(err, d))
+	}
+	permission, found := resourceElasticsearchACLRuleGetPermissionFromACLResponse(r.ElasticSearchACLConfig, username, index)
+	if !found {
+		d.SetId("")
+		return nil
+	}
+
+	if err := d.Set("project", project); err != nil {
+		return diag.Errorf("error setting Elasticsearch ACL Rules `project` for resource %s: %s", d.Id(), err)
+	}
+	if err := d.Set("service_name", serviceName); err != nil {
+		return diag.Errorf("error setting Elasticsearch ACL Rules `service_name` for resource %s: %s", d.Id(), err)
+	}
+	if err := d.Set("username", username); err != nil {
+		return diag.Errorf("error setting Elasticsearch ACLs Rules `username` for resource %s: %s", d.Id(), err)
+	}
+	if err := d.Set("index", index); err != nil {
+		return diag.Errorf("error setting Elasticsearch ACLs Rules `index` for resource %s: %s", d.Id(), err)
+	}
+	if err := d.Set("permission", permission); err != nil {
+		return diag.Errorf("error setting Elasticsearch ACLs Rules `permission` for resource %s: %s", d.Id(), err)
+	}
+
+	return nil
+}
+
+func resourceElasticsearchACLRuleState(ctx context.Context, d *schema.ResourceData, m interface{}) ([]*schema.ResourceData, error) {
+	di := resourceElasticsearchACLRuleRead(ctx, d, m)
+	if di.HasError() {
+		return nil, fmt.Errorf("cannot get elasticsearch acl rule: %v", di)
+	}
+	return []*schema.ResourceData{d}, nil
+}
+
+func resourceElasticsearchACLRuleMkAivenACL(username, index, permission string) aiven.ElasticSearchACL {
+	return aiven.ElasticSearchACL{
+		Username: username,
+		Rules: []aiven.ElasticsearchACLRule{
+			{
+				Index:      index,
+				Permission: permission,
+			},
+		},
+	}
+}
+
+func resourceElasticsearchACLRuleUpdate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	client := m.(*aiven.Client)
+
+	project := d.Get("project").(string)
+	serviceName := d.Get("service_name").(string)
+	username := d.Get("username").(string)
+	index := d.Get("index").(string)
+	permission := d.Get("permission").(string)
+
+	modifier := resourceElasticsearchACLModifierUpdateACLRule(username, index, permission)
+	err := resourceElasticsearchACLModifyRemoteConfig(project, serviceName, client, modifier)
+	if err != nil {
+		return diag.FromErr(resourceReadHandleNotFound(err, d))
+	}
+
+	d.SetId(buildResourceID(project, serviceName, username, index))
+
+	return resourceElasticsearchACLRuleRead(ctx, d, m)
+}
+
+func resourceElasticsearchACLRuleDelete(_ context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	client := m.(*aiven.Client)
+
+	project := d.Get("project").(string)
+	serviceName := d.Get("service_name").(string)
+	username := d.Get("username").(string)
+	index := d.Get("index").(string)
+	permission := d.Get("permission").(string)
+
+	modifier := resourceElasticsearchACLModifierDeleteACLRule(username, index, permission)
+	err := resourceElasticsearchACLModifyRemoteConfig(project, serviceName, client, modifier)
+	if err != nil {
+		return diag.FromErr(resourceReadHandleNotFound(err, d))
+	}
+	return nil
+}

--- a/aiven/resource_elasticsearch_acl_rule_test.go
+++ b/aiven/resource_elasticsearch_acl_rule_test.go
@@ -1,0 +1,109 @@
+package aiven
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/aiven/aiven-go-client"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+func TestAccAivenElasticsearchACLRule_basic(t *testing.T) {
+	resourceName := "aiven_elasticsearch_acl_rule.foo"
+	rName := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviderFactories,
+		CheckDestroy:      testAccCheckAivenAleasticsearchACLRuleResourceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccElasticsearchACLRuleResource(rName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "project", os.Getenv("AIVEN_PROJECT_NAME")),
+					resource.TestCheckResourceAttr(resourceName, "service_name", fmt.Sprintf("test-acc-sr-%s", rName)),
+					resource.TestCheckResourceAttr(resourceName, "index", "test-index"),
+					resource.TestCheckResourceAttr(resourceName, "username", fmt.Sprintf("user-%s", rName)),
+					resource.TestCheckResourceAttr(resourceName, "permission", "readwrite"),
+				),
+			},
+		},
+	})
+}
+
+func testAccElasticsearchACLRuleResource(name string) string {
+	return fmt.Sprintf(`
+    data "aiven_project" "foo" {
+      project = "%s"
+    }
+
+    resource "aiven_service" "bar" {
+      project = data.aiven_project.foo.project
+      cloud_name = "google-europe-west1"
+      plan = "startup-4"
+      service_name = "test-acc-sr-%s"
+      service_type = "elasticsearch"
+      maintenance_window_dow = "monday"
+      maintenance_window_time = "10:00:00"
+    }
+
+    resource "aiven_service_user" "foo" {
+      service_name = aiven_service.bar.service_name
+      project = data.aiven_project.foo.project
+      username = "user-%s"
+    }
+
+    resource "aiven_elasticsearch_acl_config" "foo" {
+      project = data.aiven_project.foo.project
+      service_name = aiven_service.bar.service_name
+      enabled = true
+      extended_acl = false
+    }
+
+    resource "aiven_elasticsearch_acl_rule" "foo" {
+      project = data.aiven_project.foo.project
+      service_name = aiven_service.bar.service_name
+      username = aiven_service_user.foo.username
+      index = "test-index"
+      permission = "readwrite"
+    }
+    `, os.Getenv("AIVEN_PROJECT_NAME"), name, name)
+}
+
+func testAccCheckAivenAleasticsearchACLRuleResourceDestroy(s *terraform.State) error {
+	c := testAccProvider.Meta().(*aiven.Client)
+
+	// loop through the resources in state, verifying each ES ACL is destroyed
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "aiven_elasticsearch_acl_rule" {
+			continue
+		}
+
+		projectName, serviceName, username, index := splitResourceID4(rs.Primary.ID)
+
+		r, err := c.ElasticsearchACLs.Get(projectName, serviceName)
+		if err != nil {
+			if err.(aiven.Error).Status != 404 {
+				return err
+			}
+		}
+		if r == nil {
+			return nil
+		}
+
+		for _, acl := range r.ElasticSearchACLConfig.ACLs {
+			if acl.Username != username {
+				continue
+			}
+			for _, rule := range acl.Rules {
+				if rule.Index == index {
+					return fmt.Errorf("elasticsearch acl (%s) still exists", rs.Primary.ID)
+				}
+			}
+		}
+	}
+	return nil
+}

--- a/aiven/resource_elasticsearch_acl_test.go
+++ b/aiven/resource_elasticsearch_acl_test.go
@@ -3,10 +3,10 @@ package aiven
 import (
 	"fmt"
 	"os"
-	"reflect"
 	"testing"
 
 	"github.com/aiven/aiven-go-client"
+	"github.com/google/go-cmp/cmp"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
@@ -207,8 +207,8 @@ func TestFlattenElasticsearchACL(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := flattenElasticsearchACL(tt.args.r); !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("flattenElasticsearchACL() = %v, want %v", got, tt.want)
+			if got := resourceElasticsearchFlattenACLResponse(tt.args.r); !cmp.Equal(got, tt.want) {
+				t.Errorf("flattenElasticsearchACL() = \n%v, want \n%v", got, tt.want)
 			}
 		})
 	}

--- a/docs/resources/elasticsearch_acl.md
+++ b/docs/resources/elasticsearch_acl.md
@@ -1,5 +1,7 @@
 # Elasticsearch ACL Resource
 
+** This resource is deprecated, please use `aiven_elasticsearch_acl_config` and `aiven_elasticsearch_acl_rule` **
+
 The Elasticsearch ACL resource allows the creation and management of ACLs 
 for an Aiven Elasticsearch service.
 
@@ -36,7 +38,7 @@ resource "aiven_elasticsearch_acl" "es-acls" {
             permission = "read"
         }
     }
-    }
+}
 ```
 
 ## Argument Reference

--- a/docs/resources/elasticsearch_acl_config.md
+++ b/docs/resources/elasticsearch_acl_config.md
@@ -1,0 +1,28 @@
+# Elasticsearch ACL Config Resource
+
+The Elasticsearch ACL Config resource allows the configuration of ACL management on an Aiven Elasticsearch service.
+
+## Example Usage
+
+```hcl
+resource "aiven_elasticsearch_acl_config" "es-acl-config" {
+    project = aiven_project.es-project.project
+    service_name = aiven_service.es.service_name
+    enabled = true
+    extended_acl = false
+}
+```
+
+## Argument Reference
+
+* `project` and `service_name` - (Required) define the project and service the ACL belongs to. 
+They should be defined using reference as shown above to set up dependencies correctly.
+
+All other properties except `project` and `service_name` can be changed after creation of the 
+resource and will not trigger recreation of Elasticsearch entire ACL's. 
+
+* `enabled` - (Optional) enables of disables Elasticsearch ACL's.
+
+* `extended_acl` - (Optional) Index rules can be applied in a limited fashion to the _mget, _msearch and _bulk APIs 
+(and only those) by enabling the ExtendedAcl option for the service. When it is enabled, users can use 
+ these APIs as long as all operations only target indexes they have been granted access to.

--- a/docs/resources/elasticsearch_acl_rule.md
+++ b/docs/resources/elasticsearch_acl_rule.md
@@ -1,0 +1,78 @@
+# Elasticsearch ACL Rule Resource
+
+The Elasticsearch ACL Rule resource models a single ACL Rule for an Aiven Elasticsearch service.
+
+## Example Usage
+
+```hcl
+
+resource "aiven_service_user" "es_user" {
+    project = var.aiven_project_name
+    service_name = aiven_elasticsearch.es_test.service_name
+    username = "documentation-user-1"
+}
+
+resource "aiven_service_user" "es_user_2" {
+    project = var.aiven_project_name
+    service_name = aiven_elasticsearch.es_test.service_name
+    username = "documentation-user-2"
+}
+
+resource "aiven_elasticsearch_acl_config" "es_acls_config" {
+  project = var.aiven_project_name
+  service_name = aiven_elasticsearch.es_test.service_name
+  enabled = true
+  extended_acl = false
+}
+
+locals {
+  acl_rules = [
+    {
+      username = aiven_service_user.es_user.username
+      index = "index2"
+      permission = "readwrite"
+    },
+    {
+      username = aiven_service_user.es_user.username
+      index = "index3"
+      permission = "read"
+    },
+    {
+      username = aiven_service_user.es_user.username
+      index = "index5"
+      permission = "deny"
+    },
+    {
+      username = aiven_service_user.es_user_2.username
+      index = "index3"
+      permission = "write"
+    },
+    {
+      username = aiven_service_user.es_user_2.username
+      index = "index7"
+      permission = "readwrite"
+    }
+  ]
+}
+
+resource "aiven_elasticsearch_acl_rule" "es_acl_rule" {
+  for_each = { for i, v in local.acl_rules:  i => v }
+
+  project = aiven_elasticsearch_acl_config.es_acls_config.project
+  service_name = aiven_elasticsearch_acl_config.es_acls_config.service_name
+  username = each.value.username
+  index = each.value.index
+  permission = each.value.permission
+}
+
+```
+
+## Argument Reference
+
+* `project` and `service_name` - (Required) define the project and service the ACL belongs to. 
+* `username` and `index` - (Required) define the username and index the ACL rule should apply to.
+
+Changes to `project`, `service_name`, `username` or `index` will trigger recreation of the Elasticsearch ACL rule.
+
+* `permission` - (Required) is the Elasticsearch permission, list of supported permissions: 
+`deny`, `admin`, `read`, `readwrite`, `write`.

--- a/examples/elasticsearch/elasticsearch_acl.tf
+++ b/examples/elasticsearch/elasticsearch_acl.tf
@@ -1,33 +1,45 @@
-# Elasticsearch ACLs
-resource "aiven_elasticsearch_acl" "es-acls" {
-  project = aiven_project.es-project.project
+locals {
+  acl_rules = [
+    {
+      username = aiven_service_user.es-user.username
+      index = "_*"
+      permission = "admin"
+    },
+    {
+      username = aiven_service_user.es-user.username
+      index = "*"
+      permission = "admin"
+    },
+
+    # avnadmin is a default user created by Aivan for Elasticsearch service, and it has admin ACL by default
+
+    {
+      username = "avnadmin"
+      index = "_*"
+      permission = "read"
+    },
+    {
+      username = "avnadmin"
+      index = "*"
+      permission = "read"
+    },
+  ]
+}
+
+resource "aiven_elasticsearch_acl_config" "es_acls_config" {
+  project = aiven_elasticsearch.es.project
   service_name = aiven_elasticsearch.es.service_name
   enabled = true
   extended_acl = false
-  acl {
-    username = aiven_service_user.es-user.username
-    rule {
-      index = "_*"
-      permission = "admin"
-    }
+}
 
-    rule {
-      index = "*"
-      permission = "admin"
-    }
-  }
+resource "aiven_elasticsearch_acl_rule" "es_acl_rule" {
+  for_each = { for i, v in local.acl_rules:  i => v }
 
-  acl {
-    # avnadmin is a default user created by Aivan for Elasticsearch service, and it has admin ACL by default
-    username = "avnadmin"
-    rule {
-      index = "_*"
-      permission = "read"
-    }
+  project = aiven_elasticsearch_acl_config.es_acls_config.project
+  service_name = aiven_elasticsearch_acl_config.es_acls_config.service_name
 
-    rule {
-      index = "*"
-      permission = "read"
-    }
-  }
+  username = each.value.username
+  index = each.value.index
+  permission = each.value.permission
 }


### PR DESCRIPTION
This PR aims to split `elasticsearch_acl` into `elasticsearch_acl_config` to configure acls  and `elasticsearch_acl_set` to create the acl rules. This way we can add acls in different resources and attempt to make our terraform configuration more modularizable. 