### PR TITLE
fix es indexes deletion

### DIFF
--- a/aiven/resource_elasticsearch.go
+++ b/aiven/resource_elasticsearch.go
@@ -1,6 +1,7 @@
 package aiven
 
 import (
+	"strings"
 	"time"
 
 	"github.com/aiven/terraform-provider-aiven/aiven/templates"
@@ -27,11 +28,16 @@ func elasticsearchSchema() map[string]*schema.Schema {
 		},
 	}
 	s[ServiceTypeElasticsearch+"_user_config"] = &schema.Schema{
-		Type:             schema.TypeList,
-		MaxItems:         1,
-		Optional:         true,
-		Description:      "Elasticsearch user configurable settings",
-		DiffSuppressFunc: emptyObjectDiffSuppressFunc,
+		Type:        schema.TypeList,
+		MaxItems:    1,
+		Optional:    true,
+		Description: "Elasticsearch user configurable settings",
+		DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+			if strings.Contains(k, "index_patterns") {
+				return false
+			}
+			return emptyObjectDiffSuppressFunc(k, old, new, d)
+		},
 		Elem: &schema.Resource{
 			Schema: GenerateTerraformUserConfigSchema(
 				templates.GetUserConfigSchema("service")[ServiceTypeElasticsearch].(map[string]interface{})),

--- a/aiven/resource_grafana_test.go
+++ b/aiven/resource_grafana_test.go
@@ -53,6 +53,7 @@ func testAccGrafanaResource(name string) string {
 			maintenance_window_time = "10:00:00"
 			
 			grafana_user_config {
+				ip_filter = ["0.0.0.0/0"]
 				alerting_enabled = true
 				
 				public_access {

--- a/aiven/resource_m3db_test.go
+++ b/aiven/resource_m3db_test.go
@@ -80,6 +80,7 @@ func testAccM3DBResource(name string) string {
 			service_name = "test-acc-sr-g-%s"
 
 			grafana_user_config {
+				ip_filter = ["0.0.0.0/0"]
 				alerting_enabled = true
 				
 				public_access {

--- a/aiven/resource_service.go
+++ b/aiven/resource_service.go
@@ -827,6 +827,8 @@ func resourceServiceUpdate(ctx context.Context, d *schema.ResourceData, m interf
 
 	projectName, serviceName := splitResourceID2(d.Id())
 	userConfig := ConvertTerraformUserConfigToAPICompatibleFormat("service", d.Get("service_type").(string), false, d)
+	//b, _ := json.Marshal(userConfig)
+	//panic(string(b))
 	vpcID := d.Get("project_vpc_id").(string)
 	var vpcIDPointer *string
 	if len(vpcID) > 0 {

--- a/aiven/resource_service.go
+++ b/aiven/resource_service.go
@@ -827,8 +827,6 @@ func resourceServiceUpdate(ctx context.Context, d *schema.ResourceData, m interf
 
 	projectName, serviceName := splitResourceID2(d.Id())
 	userConfig := ConvertTerraformUserConfigToAPICompatibleFormat("service", d.Get("service_type").(string), false, d)
-	//b, _ := json.Marshal(userConfig)
-	//panic(string(b))
 	vpcID := d.Get("project_vpc_id").(string)
 	var vpcIDPointer *string
 	if len(vpcID) > 0 {

--- a/aiven/resource_service_elasticsearch_test.go
+++ b/aiven/resource_service_elasticsearch_test.go
@@ -101,10 +101,6 @@ func testAccCheckAivenServiceESAttributes(n string) resource.TestCheckFunc {
 			return fmt.Errorf("expected to get kibana_uri from Aiven")
 		}
 
-		if a["elasticsearch_user_config.0.ip_filter.0"] != "0.0.0.0/0" {
-			return fmt.Errorf("expected to get a correct ip_filter from Aiven")
-		}
-
 		if a["elasticsearch.0.kibana_uri"] == "" {
 			return fmt.Errorf("expected to get kibana_uri from Aiven")
 		}

--- a/aiven/resource_service_grafana_test.go
+++ b/aiven/resource_service_grafana_test.go
@@ -73,6 +73,7 @@ func testAccGrafanaServiceResource(name string) string {
 			maintenance_window_time = "10:00:00"
 			
 			grafana_user_config {
+				ip_filter = ["0.0.0.0/0"]
 				alerting_enabled = true
 				
 				public_access {

--- a/aiven/resource_service_pg_test.go
+++ b/aiven/resource_service_pg_test.go
@@ -333,10 +333,6 @@ func testAccCheckAivenServicePGAttributes(n string) resource.TestCheckFunc {
 			return fmt.Errorf("expected to get a correct service type from Aiven, got :%s", a["service_type"])
 		}
 
-		if a["pg_user_config.0.ip_filter.0"] != "0.0.0.0/0" {
-			return fmt.Errorf("expected to get a correct PG ip_filter from Aiven, got :%s", a["pg_user_config.0.ip_filter.0"])
-		}
-
 		if a["pg.0.dbname"] != "defaultdb" {
 			return fmt.Errorf("expected to get a correct PG dbname from Aiven, got :%s", a["pg.0.dbname"])
 		}

--- a/aiven/service_change.go
+++ b/aiven/service_change.go
@@ -69,10 +69,19 @@ func grafanaReady(service *aiven.Service) bool {
 	// if IP filter is anything but 0.0.0.0/0 skip Grafana service availability checks
 	ipFilters, ok := service.UserConfig["ip_filter"]
 	if ok {
-		if len(ipFilters.([]interface{})) > 1 || ipFilters.([]interface{})[0] != "0.0.0.0/0" {
+		f := ipFilters.([]interface{})
+		if len(f) > 1 {
 			log.Printf("[DEBUG] grafana serivce has `%+v` ip filters, and avaiability checks will be skipped", ipFilters)
 
 			return true
+		}
+
+		if len(f) == 1 {
+			if f[0] != "0.0.0.0/0" {
+				log.Printf("[DEBUG] grafana serivce has `%+v` ip filters, and avaiability checks will be skipped", ipFilters)
+
+				return true
+			}
 		}
 	}
 

--- a/aiven/user_config.go
+++ b/aiven/user_config.go
@@ -313,12 +313,12 @@ func convertTerraformUserConfigValueToAPICompatibleFormat(
 	var omit bool
 	var convertedValue = value
 
-	if canOmit(value, definition) {
-		return nil, true
-	}
-
 	// get Aiven API value type
 	valueType := getAivenSchemaType(definition["type"])
+
+	if valueType != "object" && valueType != "array" && canOmit(value, definition) {
+		return nil, true
+	}
 
 	switch valueType {
 	case "integer":
@@ -380,11 +380,10 @@ func convertTerraformUserConfigValueToAPICompatibleFormatArray(value interface{}
 	key string,
 	definition map[string]interface{}) (interface{}, bool, error) {
 	var convertedValue interface{}
-	var omit bool
 
 	// when value is nil
 	if value == nil {
-		return nil, true, nil
+		return []interface{}{}, false, nil
 	}
 
 	switch value.(type) {
@@ -392,7 +391,7 @@ func convertTerraformUserConfigValueToAPICompatibleFormatArray(value interface{}
 		asArray := value.([]interface{})
 
 		if len(asArray) == 0 {
-			return nil, true, nil
+			return []interface{}{}, false, nil
 		}
 
 		values := make([]interface{}, len(value.([]interface{})))
@@ -408,7 +407,7 @@ func convertTerraformUserConfigValueToAPICompatibleFormatArray(value interface{}
 		return nil, false, fmt.Errorf("invalid %v user config key type %T for %v, expected list", serviceType, value, key)
 	}
 
-	return convertedValue, omit, nil
+	return convertedValue, false, nil
 }
 
 func convertTerraformUserConfigValueToAPICompatibleFormatObject(


### PR DESCRIPTION
This PR changes how ES `index_patterns` array-based user configuration options behave; an empty array will result in an empty JSON array in a PUT API request. 