### PR TITLE
Convert connection pool username field to optional

### DIFF
--- a/aiven/resource_connection_pool.go
+++ b/aiven/resource_connection_pool.go
@@ -52,7 +52,7 @@ var aivenConnectionPoolSchema = map[string]*schema.Schema{
 	},
 	"username": {
 		Type:        schema.TypeString,
-		Required:    true,
+		Optional:    true,
 		Description: "Name of the service user used to connect to the database",
 	},
 	"connection_uri": {

--- a/aiven/resource_connection_pool.go
+++ b/aiven/resource_connection_pool.go
@@ -91,7 +91,7 @@ func resourceConnectionPoolCreate(ctx context.Context, d *schema.ResourceData, m
 			PoolMode: d.Get("pool_mode").(string),
 			PoolName: poolName,
 			PoolSize: d.Get("pool_size").(int),
-			Username: d.Get("username").(string),
+			Username: optionalStringPointer(d, "username"),
 		},
 	)
 	if err != nil {
@@ -132,7 +132,7 @@ func resourceConnectionPoolUpdate(ctx context.Context, d *schema.ResourceData, m
 			Database: d.Get("database_name").(string),
 			PoolMode: d.Get("pool_mode").(string),
 			PoolSize: d.Get("pool_size").(int),
-			Username: d.Get("username").(string),
+			Username: optionalStringPointer(d, "username"),
 		},
 	)
 	if err != nil {

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/aiven/terraform-provider-aiven
 go 1.16
 
 require (
-	github.com/aiven/aiven-go-client v1.6.1
+	github.com/aiven/aiven-go-client v1.6.2-0.20210922162241-f938fd9c827e
 	github.com/aws/aws-sdk-go v1.30.12 // indirect
 	github.com/google/go-cmp v0.5.6
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.7.0
@@ -12,5 +12,3 @@ require (
 	golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208
 	gopkg.in/yaml.v3 v3.0.0-20200615113413-eeeca48fe776 // indirect
 )
-
-replace github.com/aiven/aiven-go-client => ../aiven-go-client

--- a/go.mod
+++ b/go.mod
@@ -12,3 +12,5 @@ require (
 	golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208
 	gopkg.in/yaml.v3 v3.0.0-20200615113413-eeeca48fe776 // indirect
 )
+
+replace github.com/aiven/aiven-go-client => ../aiven-go-client

--- a/go.sum
+++ b/go.sum
@@ -53,6 +53,8 @@ github.com/aiven/aiven-go-client v1.6.1-0.20210920121729-0d9a116a5e78 h1:Nsun8hh
 github.com/aiven/aiven-go-client v1.6.1-0.20210920121729-0d9a116a5e78/go.mod h1:3+OtpccynSr5xvSGfn96jVM9dBUAr52HXlaZJi/Mz5o=
 github.com/aiven/aiven-go-client v1.6.1 h1:/zNc2igFqaKWfwxMqGoBUsi6WlkLTCwkKgVABYAoJXk=
 github.com/aiven/aiven-go-client v1.6.1/go.mod h1:3+OtpccynSr5xvSGfn96jVM9dBUAr52HXlaZJi/Mz5o=
+github.com/aiven/aiven-go-client v1.6.2-0.20210922162241-f938fd9c827e h1:yple5XQhHn8pyrNdDyj6zwhVFOB3+X4LYkTqE4jMA2E=
+github.com/aiven/aiven-go-client v1.6.2-0.20210922162241-f938fd9c827e/go.mod h1:3+OtpccynSr5xvSGfn96jVM9dBUAr52HXlaZJi/Mz5o=
 github.com/andybalholm/crlf v0.0.0-20171020200849-670099aa064f/go.mod h1:k8feO4+kXDxro6ErPXBRTJ/ro2mf0SsFG8s7doP9kJE=
 github.com/anmitsu/go-shlex v0.0.0-20161002113705-648efa622239/go.mod h1:2FmKhYUyUczH0OGQWaF5ceTx0UBShxjsH6f8oGKYe2c=
 github.com/apparentlymart/go-cidr v1.0.1 h1:NmIwLZ/KdsjIUlhf+/Np40atNXm/+lZ5txfTJ/SpF+U=


### PR DESCRIPTION
The API allows pools to be created with no pool-specific username specified.
This switches the field on the aiven_connection_pool resource similarly
and allows to reuse the incoming user by not specifying a username,
which matches behavior of the UI.

Depends on changes top aiven-go-client via https://github.com/aiven/aiven-go-client/pull/134