### PR TITLE
Fix invalid argument name in opensearch example

### DIFF
--- a/docs/resources/opensearch.md
+++ b/docs/resources/opensearch.md
@@ -18,7 +18,7 @@ resource "aiven_opensearch" "os1" {
 
     opensearch_dashboards {
       enabled = true
-      opensearch_dashboards_request_timeout = 30000
+      opensearch_request_timeout = 30000
     }
 
     public_access {


### PR DESCRIPTION
The `opensearch_dashboards_request_timeout` in the opensearch docs example is an invalid argument name and presumably should be `opensearch_request_timeout`