### PR TITLE
change service user_config array behaviour

### DIFF
--- a/aiven/resource_cassandra.go
+++ b/aiven/resource_cassandra.go
@@ -3,7 +3,6 @@ package aiven
 import (
 	"time"
 
-	"github.com/aiven/terraform-provider-aiven/aiven/templates"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
@@ -19,17 +18,7 @@ func cassandraSchema() map[string]*schema.Schema {
 			Schema: map[string]*schema.Schema{},
 		},
 	}
-	s[ServiceTypeCassandra+"_user_config"] = &schema.Schema{
-		Type:             schema.TypeList,
-		MaxItems:         1,
-		Optional:         true,
-		Description:      "Cassandra user configurable settings",
-		DiffSuppressFunc: emptyObjectDiffSuppressFunc,
-		Elem: &schema.Resource{
-			Schema: GenerateTerraformUserConfigSchema(
-				templates.GetUserConfigSchema("service")[ServiceTypeCassandra].(map[string]interface{})),
-		},
-	}
+	s[ServiceTypeCassandra+"_user_config"] = generateServiceUserConfiguration(ServiceTypeCassandra)
 
 	return s
 }

--- a/aiven/resource_elasticsearch.go
+++ b/aiven/resource_elasticsearch.go
@@ -1,10 +1,8 @@
 package aiven
 
 import (
-	"strings"
 	"time"
 
-	"github.com/aiven/terraform-provider-aiven/aiven/templates"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
@@ -27,22 +25,7 @@ func elasticsearchSchema() map[string]*schema.Schema {
 			},
 		},
 	}
-	s[ServiceTypeElasticsearch+"_user_config"] = &schema.Schema{
-		Type:        schema.TypeList,
-		MaxItems:    1,
-		Optional:    true,
-		Description: "Elasticsearch user configurable settings",
-		DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
-			if strings.Contains(k, "index_patterns") {
-				return false
-			}
-			return emptyObjectDiffSuppressFunc(k, old, new, d)
-		},
-		Elem: &schema.Resource{
-			Schema: GenerateTerraformUserConfigSchema(
-				templates.GetUserConfigSchema("service")[ServiceTypeElasticsearch].(map[string]interface{})),
-		},
-	}
+	s[ServiceTypeElasticsearch+"_user_config"] = generateServiceUserConfiguration(ServiceTypeElasticsearch)
 
 	return s
 }

--- a/aiven/resource_flink.go
+++ b/aiven/resource_flink.go
@@ -3,7 +3,6 @@ package aiven
 import (
 	"time"
 
-	"github.com/aiven/terraform-provider-aiven/aiven/templates"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
@@ -29,17 +28,7 @@ func aivenFlinkSchema() map[string]*schema.Schema {
 			},
 		},
 	}
-	aivenFlinkSchema[ServiceTypeFlink+"_user_config"] = &schema.Schema{
-		Type:             schema.TypeList,
-		MaxItems:         1,
-		Optional:         true,
-		Description:      "Flink user configurable settings",
-		DiffSuppressFunc: emptyObjectDiffSuppressFunc,
-		Elem: &schema.Resource{
-			Schema: GenerateTerraformUserConfigSchema(
-				templates.GetUserConfigSchema("service")[ServiceTypeFlink].(map[string]interface{})),
-		},
-	}
+	aivenFlinkSchema[ServiceTypeFlink+"_user_config"] = generateServiceUserConfiguration(ServiceTypeFlink)
 
 	return aivenFlinkSchema
 }

--- a/aiven/resource_grafana.go
+++ b/aiven/resource_grafana.go
@@ -3,7 +3,6 @@ package aiven
 import (
 	"time"
 
-	"github.com/aiven/terraform-provider-aiven/aiven/templates"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
@@ -19,17 +18,7 @@ func grafanaSchema() map[string]*schema.Schema {
 			Schema: map[string]*schema.Schema{},
 		},
 	}
-	s[ServiceTypeGrafana+"_user_config"] = &schema.Schema{
-		Type:             schema.TypeList,
-		MaxItems:         1,
-		Optional:         true,
-		Description:      "Grafana user configurable settings",
-		DiffSuppressFunc: emptyObjectDiffSuppressFunc,
-		Elem: &schema.Resource{
-			Schema: GenerateTerraformUserConfigSchema(
-				templates.GetUserConfigSchema("service")[ServiceTypeGrafana].(map[string]interface{})),
-		},
-	}
+	s[ServiceTypeGrafana+"_user_config"] = generateServiceUserConfiguration(ServiceTypeGrafana)
 
 	return s
 }

--- a/aiven/resource_influxdb.go
+++ b/aiven/resource_influxdb.go
@@ -3,7 +3,6 @@ package aiven
 import (
 	"time"
 
-	"github.com/aiven/terraform-provider-aiven/aiven/templates"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
@@ -25,17 +24,7 @@ func influxDBSchema() map[string]*schema.Schema {
 			},
 		},
 	}
-	s[ServiceTypeInfluxDB+"_user_config"] = &schema.Schema{
-		Type:             schema.TypeList,
-		MaxItems:         1,
-		Optional:         true,
-		Description:      "InfluxDB user configurable settings",
-		DiffSuppressFunc: emptyObjectDiffSuppressFunc,
-		Elem: &schema.Resource{
-			Schema: GenerateTerraformUserConfigSchema(
-				templates.GetUserConfigSchema("service")[ServiceTypeInfluxDB].(map[string]interface{})),
-		},
-	}
+	s[ServiceTypeInfluxDB+"_user_config"] = generateServiceUserConfiguration(ServiceTypeInfluxDB)
 
 	return s
 }

--- a/aiven/resource_kafka.go
+++ b/aiven/resource_kafka.go
@@ -5,7 +5,6 @@ import (
 	"time"
 
 	"github.com/aiven/aiven-go-client"
-	"github.com/aiven/terraform-provider-aiven/aiven/templates"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
@@ -64,17 +63,7 @@ func aivenKafkaSchema() map[string]*schema.Schema {
 			},
 		},
 	}
-	aivenKafkaSchema[ServiceTypeKafka+"_user_config"] = &schema.Schema{
-		Type:             schema.TypeList,
-		MaxItems:         1,
-		Optional:         true,
-		Description:      "Kafka user configurable settings",
-		DiffSuppressFunc: emptyObjectDiffSuppressFunc,
-		Elem: &schema.Resource{
-			Schema: GenerateTerraformUserConfigSchema(
-				templates.GetUserConfigSchema("service")[ServiceTypeKafka].(map[string]interface{})),
-		},
-	}
+	aivenKafkaSchema[ServiceTypeKafka+"_user_config"] = generateServiceUserConfiguration(ServiceTypeKafka)
 
 	return aivenKafkaSchema
 }

--- a/aiven/resource_kafka_connect.go
+++ b/aiven/resource_kafka_connect.go
@@ -3,7 +3,6 @@ package aiven
 import (
 	"time"
 
-	"github.com/aiven/terraform-provider-aiven/aiven/templates"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
@@ -19,17 +18,7 @@ func aivenKafkaConnectSchema() map[string]*schema.Schema {
 			Schema: map[string]*schema.Schema{},
 		},
 	}
-	kafkaConnectSchema[ServiceTypeKafkaConnect+"_user_config"] = &schema.Schema{
-		Type:             schema.TypeList,
-		MaxItems:         1,
-		Optional:         true,
-		Description:      "Kafka Connect user configurable settings",
-		DiffSuppressFunc: emptyObjectDiffSuppressFunc,
-		Elem: &schema.Resource{
-			Schema: GenerateTerraformUserConfigSchema(
-				templates.GetUserConfigSchema("service")[ServiceTypeKafkaConnect].(map[string]interface{})),
-		},
-	}
+	kafkaConnectSchema[ServiceTypeKafkaConnect+"_user_config"] = generateServiceUserConfiguration(ServiceTypeKafkaConnect)
 
 	return kafkaConnectSchema
 }

--- a/aiven/resource_kafka_mirrormaker.go
+++ b/aiven/resource_kafka_mirrormaker.go
@@ -3,7 +3,6 @@ package aiven
 import (
 	"time"
 
-	"github.com/aiven/terraform-provider-aiven/aiven/templates"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
@@ -19,17 +18,8 @@ func aivenKafkaMirrormakerSchema() map[string]*schema.Schema {
 			Schema: map[string]*schema.Schema{},
 		},
 	}
-	kafkaMMSchema[ServiceTypeKafkaMirrormaker+"_user_config"] = &schema.Schema{
-		Type:             schema.TypeList,
-		MaxItems:         1,
-		Optional:         true,
-		Description:      "Kafka MirrorMaker 2 specific user configurable settings",
-		DiffSuppressFunc: emptyObjectDiffSuppressFunc,
-		Elem: &schema.Resource{
-			Schema: GenerateTerraformUserConfigSchema(
-				templates.GetUserConfigSchema("service")[ServiceTypeKafkaMirrormaker].(map[string]interface{})),
-		},
-	}
+	kafkaMMSchema[ServiceTypeKafkaMirrormaker+"_user_config"] =
+		generateServiceUserConfiguration(ServiceTypeKafkaMirrormaker)
 
 	return kafkaMMSchema
 }

--- a/aiven/resource_m3aggregator.go
+++ b/aiven/resource_m3aggregator.go
@@ -3,7 +3,6 @@ package aiven
 import (
 	"time"
 
-	"github.com/aiven/terraform-provider-aiven/aiven/templates"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
@@ -19,17 +18,7 @@ func aivenM3AggregatorSchema() map[string]*schema.Schema {
 			Schema: map[string]*schema.Schema{},
 		},
 	}
-	schemaM3[ServiceTypeM3Aggregator+"_user_config"] = &schema.Schema{
-		Type:             schema.TypeList,
-		MaxItems:         1,
-		Optional:         true,
-		Description:      "M3 aggregator specific user configurable settings",
-		DiffSuppressFunc: emptyObjectDiffSuppressFunc,
-		Elem: &schema.Resource{
-			Schema: GenerateTerraformUserConfigSchema(
-				templates.GetUserConfigSchema("service")[ServiceTypeM3Aggregator].(map[string]interface{})),
-		},
-	}
+	schemaM3[ServiceTypeM3Aggregator+"_user_config"] = generateServiceUserConfiguration(ServiceTypeM3Aggregator)
 
 	return schemaM3
 }

--- a/aiven/resource_m3db.go
+++ b/aiven/resource_m3db.go
@@ -3,7 +3,6 @@ package aiven
 import (
 	"time"
 
-	"github.com/aiven/terraform-provider-aiven/aiven/templates"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
@@ -19,17 +18,7 @@ func aivenM3DBSchema() map[string]*schema.Schema {
 			Schema: map[string]*schema.Schema{},
 		},
 	}
-	schemaM3[ServiceTypeM3+"_user_config"] = &schema.Schema{
-		Type:             schema.TypeList,
-		MaxItems:         1,
-		Optional:         true,
-		Description:      "M3 specific user configurable settings",
-		DiffSuppressFunc: emptyObjectDiffSuppressFunc,
-		Elem: &schema.Resource{
-			Schema: GenerateTerraformUserConfigSchema(
-				templates.GetUserConfigSchema("service")[ServiceTypeM3].(map[string]interface{})),
-		},
-	}
+	schemaM3[ServiceTypeM3+"_user_config"] = generateServiceUserConfiguration(ServiceTypeM3)
 
 	return schemaM3
 }

--- a/aiven/resource_mysql.go
+++ b/aiven/resource_mysql.go
@@ -3,7 +3,6 @@ package aiven
 import (
 	"time"
 
-	"github.com/aiven/terraform-provider-aiven/aiven/templates"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
@@ -19,17 +18,7 @@ func aivenMySQLSchema() map[string]*schema.Schema {
 			Schema: map[string]*schema.Schema{},
 		},
 	}
-	schemaMySQL[ServiceTypeMySQL+"_user_config"] = &schema.Schema{
-		Type:             schema.TypeList,
-		MaxItems:         1,
-		Optional:         true,
-		Description:      "MySQL specific user configurable settings",
-		DiffSuppressFunc: emptyObjectDiffSuppressFunc,
-		Elem: &schema.Resource{
-			Schema: GenerateTerraformUserConfigSchema(
-				templates.GetUserConfigSchema("service")[ServiceTypeMySQL].(map[string]interface{})),
-		},
-	}
+	schemaMySQL[ServiceTypeMySQL+"_user_config"] = generateServiceUserConfiguration(ServiceTypeMySQL)
 
 	return schemaMySQL
 }

--- a/aiven/resource_opensearch.go
+++ b/aiven/resource_opensearch.go
@@ -1,10 +1,8 @@
 package aiven
 
 import (
-	"strings"
 	"time"
 
-	"github.com/aiven/terraform-provider-aiven/aiven/templates"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
@@ -27,22 +25,7 @@ func opensearchSchema() map[string]*schema.Schema {
 			},
 		},
 	}
-	s[ServiceTypeOpensearch+"_user_config"] = &schema.Schema{
-		Type:        schema.TypeList,
-		MaxItems:    1,
-		Optional:    true,
-		Description: "Opensearch user configurable settings",
-		DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
-			if strings.Contains(k, "index_patterns") {
-				return false
-			}
-			return emptyObjectDiffSuppressFunc(k, old, new, d)
-		},
-		Elem: &schema.Resource{
-			Schema: GenerateTerraformUserConfigSchema(
-				templates.GetUserConfigSchema("service")[ServiceTypeOpensearch].(map[string]interface{})),
-		},
-	}
+	s[ServiceTypeOpensearch+"_user_config"] = generateServiceUserConfiguration(ServiceTypeOpensearch)
 
 	return s
 }

--- a/aiven/resource_pg.go
+++ b/aiven/resource_pg.go
@@ -6,7 +6,6 @@ import (
 	"time"
 
 	"github.com/aiven/aiven-go-client"
-	"github.com/aiven/terraform-provider-aiven/aiven/templates"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -69,17 +68,7 @@ func aivenPGSchema() map[string]*schema.Schema {
 			},
 		},
 	}
-	schemaPG[ServiceTypePG+"_user_config"] = &schema.Schema{
-		Type:             schema.TypeList,
-		MaxItems:         1,
-		Optional:         true,
-		Description:      "PostgreSQL specific user configurable settings",
-		DiffSuppressFunc: emptyObjectDiffSuppressFunc,
-		Elem: &schema.Resource{
-			Schema: GenerateTerraformUserConfigSchema(
-				templates.GetUserConfigSchema("service")[ServiceTypePG].(map[string]interface{})),
-		},
-	}
+	schemaPG[ServiceTypePG+"_user_config"] = generateServiceUserConfiguration(ServiceTypePG)
 
 	return schemaPG
 }

--- a/aiven/resource_redis.go
+++ b/aiven/resource_redis.go
@@ -3,7 +3,6 @@ package aiven
 import (
 	"time"
 
-	"github.com/aiven/terraform-provider-aiven/aiven/templates"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
@@ -19,17 +18,7 @@ func redisSchema() map[string]*schema.Schema {
 			Schema: map[string]*schema.Schema{},
 		},
 	}
-	s[ServiceTypeRedis+"_user_config"] = &schema.Schema{
-		Type:             schema.TypeList,
-		MaxItems:         1,
-		Optional:         true,
-		Description:      "Redis user configurable settings",
-		DiffSuppressFunc: emptyObjectDiffSuppressFunc,
-		Elem: &schema.Resource{
-			Schema: GenerateTerraformUserConfigSchema(
-				templates.GetUserConfigSchema("service")[ServiceTypeRedis].(map[string]interface{})),
-		},
-	}
+	s[ServiceTypeRedis+"_user_config"] = generateServiceUserConfiguration(ServiceTypeRedis)
 
 	return s
 }

--- a/aiven/resource_service.go
+++ b/aiven/resource_service.go
@@ -400,17 +400,7 @@ var aivenServiceSchema = map[string]*schema.Schema{
 			},
 		},
 	},
-	"elasticsearch_user_config": {
-		Type:             schema.TypeList,
-		MaxItems:         1,
-		Optional:         true,
-		Description:      "Elasticsearch specific user configurable settings",
-		DiffSuppressFunc: emptyObjectDiffSuppressFunc,
-		Elem: &schema.Resource{
-			Schema: GenerateTerraformUserConfigSchema(
-				templates.GetUserConfigSchema("service")[ServiceTypeElasticsearch].(map[string]interface{})),
-		},
-	},
+	"elasticsearch_user_config": generateServiceUserConfiguration(ServiceTypeElasticsearch),
 	"opensearch": {
 		Type:        schema.TypeList,
 		MaxItems:    1,
@@ -428,17 +418,7 @@ var aivenServiceSchema = map[string]*schema.Schema{
 			},
 		},
 	},
-	"opensearch_user_config": {
-		Type:             schema.TypeList,
-		MaxItems:         1,
-		Optional:         true,
-		Description:      "Opensearch specific user configurable settings",
-		DiffSuppressFunc: emptyObjectDiffSuppressFunc,
-		Elem: &schema.Resource{
-			Schema: GenerateTerraformUserConfigSchema(
-				templates.GetUserConfigSchema("service")[ServiceTypeOpensearch].(map[string]interface{})),
-		},
-	},
+	"opensearch_user_config": generateServiceUserConfiguration(ServiceTypeOpensearch),
 	"grafana": {
 		Type:        schema.TypeList,
 		MaxItems:    1,
@@ -449,17 +429,7 @@ var aivenServiceSchema = map[string]*schema.Schema{
 			Schema: map[string]*schema.Schema{},
 		},
 	},
-	"grafana_user_config": {
-		Type:             schema.TypeList,
-		MaxItems:         1,
-		Optional:         true,
-		Description:      "Grafana specific user configurable settings",
-		DiffSuppressFunc: emptyObjectDiffSuppressFunc,
-		Elem: &schema.Resource{
-			Schema: GenerateTerraformUserConfigSchema(
-				templates.GetUserConfigSchema("service")[ServiceTypeGrafana].(map[string]interface{})),
-		},
-	},
+	"grafana_user_config": generateServiceUserConfiguration(ServiceTypeGrafana),
 	"influxdb": {
 		Type:        schema.TypeList,
 		MaxItems:    1,
@@ -476,17 +446,7 @@ var aivenServiceSchema = map[string]*schema.Schema{
 			},
 		},
 	},
-	"influxdb_user_config": {
-		Type:             schema.TypeList,
-		MaxItems:         1,
-		Optional:         true,
-		Description:      "InfluxDB specific user configurable settings",
-		DiffSuppressFunc: emptyObjectDiffSuppressFunc,
-		Elem: &schema.Resource{
-			Schema: GenerateTerraformUserConfigSchema(
-				templates.GetUserConfigSchema("service")[ServiceTypeInfluxDB].(map[string]interface{})),
-		},
-	},
+	"influxdb_user_config": generateServiceUserConfiguration(ServiceTypeInfluxDB),
 	"kafka": {
 		Type:        schema.TypeList,
 		MaxItems:    1,
@@ -533,17 +493,7 @@ var aivenServiceSchema = map[string]*schema.Schema{
 			},
 		},
 	},
-	"kafka_user_config": {
-		Type:             schema.TypeList,
-		MaxItems:         1,
-		Optional:         true,
-		Description:      "Kafka specific user configurable settings",
-		DiffSuppressFunc: emptyObjectDiffSuppressFunc,
-		Elem: &schema.Resource{
-			Schema: GenerateTerraformUserConfigSchema(
-				templates.GetUserConfigSchema("service")[ServiceTypeKafka].(map[string]interface{})),
-		},
-	},
+	"kafka_user_config": generateServiceUserConfiguration(ServiceTypeKafka),
 	"kafka_connect": {
 		Type:        schema.TypeList,
 		MaxItems:    1,
@@ -554,17 +504,7 @@ var aivenServiceSchema = map[string]*schema.Schema{
 			Schema: map[string]*schema.Schema{},
 		},
 	},
-	"kafka_connect_user_config": {
-		Type:             schema.TypeList,
-		MaxItems:         1,
-		Optional:         true,
-		Description:      "Kafka Connect specific user configurable settings",
-		DiffSuppressFunc: emptyObjectDiffSuppressFunc,
-		Elem: &schema.Resource{
-			Schema: GenerateTerraformUserConfigSchema(
-				templates.GetUserConfigSchema("service")[ServiceTypeKafkaConnect].(map[string]interface{})),
-		},
-	},
+	"kafka_connect_user_config": generateServiceUserConfiguration(ServiceTypeKafkaConnect),
 	"mysql": {
 		Type:        schema.TypeList,
 		MaxItems:    1,
@@ -575,17 +515,7 @@ var aivenServiceSchema = map[string]*schema.Schema{
 			Schema: map[string]*schema.Schema{},
 		},
 	},
-	"mysql_user_config": {
-		Type:             schema.TypeList,
-		MaxItems:         1,
-		Optional:         true,
-		Description:      "MySQL specific user configurable settings",
-		DiffSuppressFunc: emptyObjectDiffSuppressFunc,
-		Elem: &schema.Resource{
-			Schema: GenerateTerraformUserConfigSchema(
-				templates.GetUserConfigSchema("service")[ServiceTypeMySQL].(map[string]interface{})),
-		},
-	},
+	"mysql_user_config": generateServiceUserConfiguration(ServiceTypeMySQL),
 	"kafka_mirrormaker": {
 		Type:        schema.TypeList,
 		MaxItems:    1,
@@ -596,17 +526,7 @@ var aivenServiceSchema = map[string]*schema.Schema{
 			Schema: map[string]*schema.Schema{},
 		},
 	},
-	"kafka_mirrormaker_user_config": {
-		Type:             schema.TypeList,
-		MaxItems:         1,
-		Optional:         true,
-		Description:      "Kafka MirrorMaker 2 specific user configurable settings",
-		DiffSuppressFunc: emptyObjectDiffSuppressFunc,
-		Elem: &schema.Resource{
-			Schema: GenerateTerraformUserConfigSchema(
-				templates.GetUserConfigSchema("service")[ServiceTypeKafkaMirrormaker].(map[string]interface{})),
-		},
-	},
+	"kafka_mirrormaker_user_config": generateServiceUserConfiguration(ServiceTypeKafkaMirrormaker),
 	"pg": {
 		Type:        schema.TypeList,
 		MaxItems:    1,
@@ -662,17 +582,7 @@ var aivenServiceSchema = map[string]*schema.Schema{
 			},
 		},
 	},
-	"pg_user_config": {
-		Type:             schema.TypeList,
-		MaxItems:         1,
-		Optional:         true,
-		Description:      "PostgreSQL specific user configurable settings",
-		DiffSuppressFunc: emptyObjectDiffSuppressFunc,
-		Elem: &schema.Resource{
-			Schema: GenerateTerraformUserConfigSchema(
-				templates.GetUserConfigSchema("service")[ServiceTypePG].(map[string]interface{})),
-		},
-	},
+	"pg_user_config": generateServiceUserConfiguration(ServiceTypePG),
 	"redis": {
 		Type:        schema.TypeList,
 		MaxItems:    1,
@@ -683,17 +593,7 @@ var aivenServiceSchema = map[string]*schema.Schema{
 			Schema: map[string]*schema.Schema{},
 		},
 	},
-	"redis_user_config": {
-		Type:             schema.TypeList,
-		MaxItems:         1,
-		Optional:         true,
-		Description:      "Redis specific user configurable settings",
-		DiffSuppressFunc: emptyObjectDiffSuppressFunc,
-		Elem: &schema.Resource{
-			Schema: GenerateTerraformUserConfigSchema(
-				templates.GetUserConfigSchema("service")[ServiceTypeRedis].(map[string]interface{})),
-		},
-	},
+	"redis_user_config": generateServiceUserConfiguration(ServiceTypeRedis),
 	"flink": {
 		Type:        schema.TypeList,
 		MaxItems:    1,
@@ -714,17 +614,7 @@ var aivenServiceSchema = map[string]*schema.Schema{
 			},
 		},
 	},
-	"flink_user_config": {
-		Type:             schema.TypeList,
-		MaxItems:         1,
-		Optional:         true,
-		Description:      "Flink specific user configurable settings",
-		DiffSuppressFunc: emptyObjectDiffSuppressFunc,
-		Elem: &schema.Resource{
-			Schema: GenerateTerraformUserConfigSchema(
-				templates.GetUserConfigSchema("service")[ServiceTypeFlink].(map[string]interface{})),
-		},
-	},
+	"flink_user_config": generateServiceUserConfiguration(ServiceTypeFlink),
 }
 
 func resourceService() *schema.Resource {

--- a/aiven/user_config.go
+++ b/aiven/user_config.go
@@ -41,7 +41,7 @@ func generateTerraformUserConfigSchema(key string, definition map[string]interfa
 	if createOnly, ok := definition["createOnly"]; ok && createOnly.(bool) {
 		diffFunction = createOnlyDiffSuppressFunc
 	} else if valueType == "object" {
-		diffFunction = emptyObjectDiffSuppressFunc
+		diffFunction = emptyObjectDiffSuppressFuncSkipArrays(GenerateTerraformUserConfigSchema(definition))
 	}
 
 	title := definition["title"].(string)
@@ -385,9 +385,7 @@ func convertTerraformUserConfigValueToAPICompatibleFormatArray(value interface{}
 	omit := true
 
 	var empty []interface{}
-	// Elasticsearch index_patterns empty array behaviour should be
-	// different other user configuration options
-	if !newResource && strings.Contains(key, "index_patterns") {
+	if !newResource {
 		empty = []interface{}{}
 		omit = false
 	}


### PR DESCRIPTION
To delete the array-based user configuration on the Aiven side, we must send an empty slice in an API request. Before that change, if all array elements were deleted, the user configuration field was gone from the PUT request, replacing that behaviour with an empty slice.