### PR TITLE
resource_service_integration: only allow read_replica as preexisting resource

### DIFF
--- a/.semgrep.yml
+++ b/.semgrep.yml
@@ -40,7 +40,7 @@ rules:
     Aiven copyright should be included in all go files
   severity: WARNING
 
-- id: schema-resource without description
+- id: schema-resource-without-description
   languages: [go]
   paths:
     include:
@@ -57,7 +57,7 @@ rules:
     Each schema resource should have a description
   severity: WARNING
 
-- id: schema-element without description
+- id: schema-element-without-description
   languages: [go]
   paths:
     include:
@@ -73,4 +73,3 @@ rules:
   message: |
     Each schema field should have a description
   severity: WARNING
-

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ parent: README
 nav_order: 1
 ---# Changelog
 
+## [2.3.2] - not yet released
+- Fix bug in `resource_service_integration` that would lead to configs that are doubly applied, resulting in API errors
+
 ## [2.3.1] - 2021-11-05
 - Fix `aiven_transit_gateway_vpc_attachment` update operation
 - Fix `ip_filter` sorting order issue 


### PR DESCRIPTION
resource_service_integration: simplify handling of preexisting service integrations

currently it is allowed to import arbitary service integrations which is non canonical behaviour. preexisting resources should be imported as opt-in. This PR restricts the allowed preexisting integrations to be of `read_replica` type since that is the only type that can be created alongside a service by terraform itself.