### PR TITLE
actions: enable long acc tests in nightly test runs

### DIFF
--- a/.github/workflows/acceptance-tests.yml
+++ b/.github/workflows/acceptance-tests.yml
@@ -30,6 +30,7 @@ jobs:
       env:
         AIVEN_TOKEN: ${{ secrets.AIVEN_TOKEN }}
         AIVEN_PROJECT_NAME: ${{ secrets.AIVEN_PROJECT_NAME }} 
+        AIVEN_ACC_LONG: YES
 
     - uses: nick-invision/retry@v2
       if: always()


### PR DESCRIPTION
This PR enables long acc test for kafka topics in nightly runs where we do not care about the time too much.