### PR TITLE
kafka_schema: validate update in custom diff

### DIFF
--- a/aiven/resource_kafka_schema_test.go
+++ b/aiven/resource_kafka_schema_test.go
@@ -5,6 +5,7 @@ package aiven
 import (
 	"fmt"
 	"os"
+	"regexp"
 	"testing"
 
 	"github.com/aiven/aiven-go-client"
@@ -68,24 +69,43 @@ func sweepKafkaSchemas(region string) error {
 }
 
 func TestAccAivenKafkaSchema_basic(t *testing.T) {
-	resourceName := "aiven_kafka_schema.foo"
-	rName := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
+	t.Parallel()
 
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
-		ProviderFactories: testAccProviderFactories,
-		CheckDestroy:      testAccCheckAivenKafkaSchemaResourceDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccKafkaSchemaResource(rName),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAivenKafkaSchemaAttributes("data.aiven_kafka_schema.schema"),
-					resource.TestCheckResourceAttr(resourceName, "project", os.Getenv("AIVEN_PROJECT_NAME")),
-					resource.TestCheckResourceAttr(resourceName, "service_name", fmt.Sprintf("test-acc-sr-%s", rName)),
-					resource.TestCheckResourceAttr(resourceName, "subject_name", fmt.Sprintf("kafka-schema-%s", rName)),
-				),
+	t.Run("customize diff blocks incompatible updates", func(tt *testing.T) {
+		resourceName := "aiven_kafka_schema.foo"
+		rName := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
+
+		resource.ParallelTest(tt, resource.TestCase{
+			PreCheck:          func() { testAccPreCheck(tt) },
+			ProviderFactories: testAccProviderFactories,
+			CheckDestroy:      testAccCheckAivenKafkaSchemaResourceDestroy,
+			Steps: []resource.TestStep{
+				{
+					Config: testAccKafkaSchemaResource(rName),
+					Check: resource.ComposeTestCheckFunc(
+						testAccCheckAivenKafkaSchemaAttributes("data.aiven_kafka_schema.schema"),
+						resource.TestCheckResourceAttr(resourceName, "project", os.Getenv("AIVEN_PROJECT_NAME")),
+						resource.TestCheckResourceAttr(resourceName, "service_name", fmt.Sprintf("test-acc-sr-%s", rName)),
+						resource.TestCheckResourceAttr(resourceName, "subject_name", fmt.Sprintf("kafka-schema-%s", rName)),
+						resource.TestCheckResourceAttr(resourceName, "version", "1"),
+					),
+				},
+				{
+					Config: testAccKafkaSchemaResourceGoodUpdate(rName),
+					Check: resource.ComposeTestCheckFunc(
+						testAccCheckAivenKafkaSchemaAttributes("data.aiven_kafka_schema.schema"),
+						resource.TestCheckResourceAttr(resourceName, "project", os.Getenv("AIVEN_PROJECT_NAME")),
+						resource.TestCheckResourceAttr(resourceName, "service_name", fmt.Sprintf("test-acc-sr-%s", rName)),
+						resource.TestCheckResourceAttr(resourceName, "subject_name", fmt.Sprintf("kafka-schema-%s", rName)),
+						resource.TestCheckResourceAttr(resourceName, "version", "2"),
+					),
+				},
+				{
+					Config:      testAccKafkaSchemaResourceInvalidUpdate(rName),
+					ExpectError: regexp.MustCompile("schema is not compatible with previous version"),
+				},
 			},
-		},
+		})
 	})
 }
 
@@ -162,14 +182,14 @@ func testAccKafkaSchemaResource(name string) string {
 		}
 		
 		resource "aiven_kafka_schema_configuration" "foo" {
-			project = data.aiven_project.foo.project
+			project = aiven_kafka.bar.project
 			service_name = aiven_kafka.bar.service_name
 			compatibility_level = "BACKWARD"
 		}
 
 		resource "aiven_kafka_schema" "foo" {
-			project = data.aiven_project.foo.project
-			service_name = aiven_kafka.bar.service_name
+			project = aiven_kafka_schema_configuration.foo.project
+			service_name = aiven_kafka_schema_configuration.foo.service_name
 			subject_name = "kafka-schema-%s"
 			
 			schema = <<EOT
@@ -199,6 +219,135 @@ func testAccKafkaSchemaResource(name string) string {
 		`, os.Getenv("AIVEN_PROJECT_NAME"), name, name)
 }
 
+func testAccKafkaSchemaResourceInvalidUpdate(name string) string {
+	return fmt.Sprintf(`
+		data "aiven_project" "foo" {
+			project = "%s"
+		}
+
+		resource "aiven_kafka" "bar" {
+			project = data.aiven_project.foo.project
+			cloud_name = "google-europe-west1"
+			plan = "business-4"
+			service_name = "test-acc-sr-%s"
+			maintenance_window_dow = "monday"
+			maintenance_window_time = "10:00:00"
+			kafka_user_config {
+				schema_registry = true
+
+				kafka {
+				  group_max_session_timeout_ms = 70000
+				  log_retention_bytes = 1000000000
+				}
+			}
+		}
+
+		resource "aiven_kafka_schema_configuration" "foo" {
+			project = aiven_kafka.bar.project
+			service_name = aiven_kafka.bar.service_name
+			compatibility_level = "BACKWARD"
+		}
+
+		resource "aiven_kafka_schema" "foo" {
+			project = aiven_kafka_schema_configuration.foo.project
+			service_name = aiven_kafka_schema_configuration.foo.service_name
+			subject_name = "kafka-schema-%s"
+
+			schema = <<EOT
+				{
+					"doc": "example",
+					"fields": [{
+						"default": "foo",
+						"doc": "my test string",
+						"name": "test",
+						"namespace": "test",
+						"type": "string"
+					}],
+					"name": "example",
+					"namespace": "example",
+					"type": "record"
+				}
+			EOT
+		}
+
+		data "aiven_kafka_schema" "schema" {
+			project = aiven_kafka_schema.foo.project
+			service_name = aiven_kafka_schema.foo.service_name
+			subject_name = aiven_kafka_schema.foo.subject_name
+
+			depends_on = [aiven_kafka_schema.foo]
+		}
+		`, os.Getenv("AIVEN_PROJECT_NAME"), name, name)
+}
+
+func testAccKafkaSchemaResourceGoodUpdate(name string) string {
+	return fmt.Sprintf(`
+		data "aiven_project" "foo" {
+			project = "%s"
+		}
+
+		resource "aiven_kafka" "bar" {
+			project = data.aiven_project.foo.project
+			cloud_name = "google-europe-west1"
+			plan = "business-4"
+			service_name = "test-acc-sr-%s"
+			maintenance_window_dow = "monday"
+			maintenance_window_time = "10:00:00"
+			kafka_user_config {
+				schema_registry = true
+
+				kafka {
+				  group_max_session_timeout_ms = 70000
+				  log_retention_bytes = 1000000000
+				}
+			}
+		}
+
+		resource "aiven_kafka_schema_configuration" "foo" {
+			project = aiven_kafka.bar.project
+			service_name = aiven_kafka.bar.service_name
+			compatibility_level = "BACKWARD"
+		}
+
+		resource "aiven_kafka_schema" "foo" {
+			project = aiven_kafka_schema_configuration.foo.project
+			service_name = aiven_kafka_schema_configuration.foo.service_name
+			subject_name = "kafka-schema-%s"
+
+			schema = <<EOT
+				{
+					"doc": "example",
+					"fields": [{
+						"default": 5,
+						"doc": "my test number",
+						"name": "test",
+						"namespace": "test",
+						"type": "int"
+				  },{
+						"default": "str",
+						"doc": "my test string",
+						"name": "test_2",
+						"namespace": "test",
+						"type": "string"
+          }],
+					"doc": "example",
+					"name": "example",
+					"namespace": "example",
+					"type": "record"
+				}
+			EOT
+		}
+
+		data "aiven_kafka_schema" "schema" {
+			project = aiven_kafka_schema.foo.project
+			service_name = aiven_kafka_schema.foo.service_name
+			subject_name = aiven_kafka_schema.foo.subject_name
+
+			depends_on = [aiven_kafka_schema.foo]
+		}
+		`, os.Getenv("AIVEN_PROJECT_NAME"), name, name)
+}
+
 func testAccCheckAivenKafkaSchemaAttributes(n string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		r := s.RootModule().Resources[n]
@@ -209,19 +358,19 @@ func testAccCheckAivenKafkaSchemaAttributes(n string) resource.TestCheckFunc {
 		}
 
 		if a["service_name"] == "" {
-			return fmt.Errorf("expected to get a service_name from Aiven)")
+			return fmt.Errorf("expected to get a service_name from Aiven")
 		}
 
 		if a["subject_name"] == "" {
-			return fmt.Errorf("expected to get a subject_name from Aiven)")
+			return fmt.Errorf("expected to get a subject_name from Aiven")
 		}
 
 		if a["schema"] == "" {
-			return fmt.Errorf("expected to get a schema from Aiven)")
+			return fmt.Errorf("expected to get a schema from Aiven")
 		}
 
 		if a["compatibility_level"] != "" {
-			return fmt.Errorf("expected to get a corect compatibility_level from Aiven)")
+			return fmt.Errorf("expected to get a corect compatibility_level from Aiven")
 		}
 
 		return nil


### PR DESCRIPTION
This PR adds kafka schema validation, such that we can block updates that violate the compatibility rules