### PR TITLE
remove unneeded makefile directives, repair testing step, add linter for doc generation

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -22,3 +22,14 @@ jobs:
           go-version: 1.16
 
       - uses: golangci/golangci-lint-action@v2.5.2
+
+  check_docs_were_generated:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-go@v2
+        with:
+          go-version: 1.16
+
+      - run: make docs
+      - run: git diff --exit-code

--- a/Makefile
+++ b/Makefile
@@ -4,25 +4,6 @@ short_version = $(shell echo $(version) | sed 's/-.*//')
 GO=CGO_ENABLED=0 go
 BUILDFLAGS=-ldflags "-X main.version=${version}" 
 
-.PHONY: ci
-ci: lint bins release
-
-#################################################
-# Building
-#################################################
-
-.PHONY: plugins
-plugins:
-	mkdir -p plugins/linux_amd64 plugins/darwin_amd64
-
-.PHONY: bins
-bins: plugins
-	$(GO) generate
-	GOOS=linux GOARCH=amd64 $(GO) build $(BUILDFLAGS) -o plugins/linux_amd64/terraform-provider-aiven_$(short_version) .
-	GOOS=darwin GOARCH=amd64 $(GO) build $(BUILDFLAGS) -o plugins/darwin_amd64/terraform-provider-aiven_$(short_version) .
-	GOOS=windows GOARCH=amd64 $(GO) build $(BUILDFLAGS) -o plugins/windows_amd64/terraform-provider-aiven_$(short_version).exe .
-	GOOS=windows GOARCH=386 $(GO) build $(BUILDFLAGS) -o plugins/windows_386/terraform-provider-aiven_$(short_version).exe .
-
 #################################################
 # Tools
 #################################################
@@ -37,19 +18,6 @@ $(TFPLUGINDOCS): $(TOOLS_BIN_DIR) $(TOOLS_DIR)/go.mod ## Build tfplugindocs from
 
 $(TOOLS_BIN_DIR):
 	mkdir -p $(TOOLS_BIN_DIR)
-
-#################################################
-# Artifacts for release
-#################################################
-
-.PHONY: release
-release: bins
-	tar cvzf terraform-provider-aiven.tar.gz -C plugins \
-	    linux_amd64/terraform-provider-aiven_$(short_version) \
-	    darwin_amd64/terraform-provider-aiven_$(short_version) \
-	    windows_amd64/terraform-provider-aiven_$(short_version).exe \
-	    windows_386/terraform-provider-aiven_$(short_version).exe
-
 
 #################################################
 # Docs
@@ -68,19 +36,19 @@ docs-lint: $(TFPLUGINDOCS)
 # Testing and linting
 #################################################
 
+.PHONY: test
+test:
+	CGO_ENABLED=0 go test -v --cover ./...
+
+.PHONY: testacc
 testacc:
 	TF_ACC=1 CGO_ENABLED=0 go test -v -count 1 -parallel 30 --cover ./... -timeout 120m ${TESTARGS}
 
+.PHONY: sweep
 sweep:
 	@echo "WARNING: This will destroy infrastructure. Use only in development accounts."
 	go test -v ./aiven -sweep=global -timeout 60m
 
+.PHONY: lint
 lint:
 	golangci-lint run --issues-exit-code=0 --timeout=30m ./...
-
-clean:
-	rm -rf vendor
-	rm -rf plugins
-	rm -f terraform-provider-aiven.tar.gz
-
-.PHONY: test lint


### PR DESCRIPTION
This PR performs a few cleanup duties and adds a linter that fails if doc generation was forgotten