### PR TITLE
resource service user: mark password as computed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ parent: README
 nav_order: 1
 ---# Changelog
 
+## [2.4.2] - 2022-01-12
+- mark service_user.password as computed again
 
 ## [2.4.1] - 2022-01-11
 - Reformat embedded terraform manifests

--- a/aiven/resource_service_user.go
+++ b/aiven/resource_service_user.go
@@ -25,8 +25,9 @@ var aivenServiceUserSchema = map[string]*schema.Schema{
 	},
 	"password": {
 		Type:             schema.TypeString,
-		Sensitive:        true,
 		Optional:         true,
+		Sensitive:        true,
+		Computed:         true,
 		DiffSuppressFunc: emptyObjectDiffSuppressFunc,
 		Description:      "The password of the service user ( not applicable for all services ).",
 	},


### PR DESCRIPTION
This PR fixes the service_user.password field by adding the `Computed` attribute. That way it can be referenced in template interpolations again.