### PR TITLE
Fix missing resource service user attribute "pg_allow_replication"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ parent: README
 nav_order: 1
 ---# Changelog
 
+## [2.5.0] - not released yet
+- Add a new field to `aiven_service_user` resource - Postgres Allow Replication
+
 ## [2.4.3] - 2022-01-13
 - add forgotten 'disk_space_used' attribute to the deprecated service resource
 

--- a/docs/data-sources/service_user.md
+++ b/docs/data-sources/service_user.md
@@ -39,6 +39,7 @@ data "aiven_service_user" "myserviceuser" {
 - **access_key** (String, Sensitive) Access certificate key for the user if applicable for the service in question
 - **authentication** (String) Authentication details. The possible values are `caching_sha2_password` and `mysql_native_password`.
 - **password** (String, Sensitive) The password of the service user ( not applicable for all services ).
+- **pg_allow_replication** (Boolean) Postgres specific field, defines whether replication is allowed. This property cannot be changed, doing so forces recreation of the resource.
 - **redis_acl_categories** (List of String) Redis specific field, defines command category rules. The field is required with`redis_acl_commands` and `redis_acl_keys`. This property cannot be changed, doing so forces recreation of the resource.
 - **redis_acl_channels** (List of String) Redis specific field, defines the permitted pub/sub channel patterns. This property cannot be changed, doing so forces recreation of the resource.
 - **redis_acl_commands** (List of String) Redis specific field, defines rules for individual commands. The field is required with`redis_acl_categories` and `redis_acl_keys`. This property cannot be changed, doing so forces recreation of the resource.

--- a/docs/resources/service_user.md
+++ b/docs/resources/service_user.md
@@ -34,6 +34,7 @@ resource "aiven_service_user" "myserviceuser" {
 - **authentication** (String) Authentication details. The possible values are `caching_sha2_password` and `mysql_native_password`.
 - **id** (String) The ID of this resource.
 - **password** (String, Sensitive) The password of the service user ( not applicable for all services ).
+- **pg_allow_replication** (Boolean) Postgres specific field, defines whether replication is allowed. This property cannot be changed, doing so forces recreation of the resource.
 - **redis_acl_categories** (List of String) Redis specific field, defines command category rules. The field is required with`redis_acl_commands` and `redis_acl_keys`. This property cannot be changed, doing so forces recreation of the resource.
 - **redis_acl_channels** (List of String) Redis specific field, defines the permitted pub/sub channel patterns. This property cannot be changed, doing so forces recreation of the resource.
 - **redis_acl_commands** (List of String) Redis specific field, defines rules for individual commands. The field is required with`redis_acl_categories` and `redis_acl_keys`. This property cannot be changed, doing so forces recreation of the resource.

--- a/docs/resources/service_user.md
+++ b/docs/resources/service_user.md
@@ -39,7 +39,6 @@ resource "aiven_service_user" "myserviceuser" {
 - **redis_acl_channels** (List of String) Redis specific field, defines the permitted pub/sub channel patterns. This property cannot be changed, doing so forces recreation of the resource.
 - **redis_acl_commands** (List of String) Redis specific field, defines rules for individual commands. The field is required with`redis_acl_categories` and `redis_acl_keys`. This property cannot be changed, doing so forces recreation of the resource.
 - **redis_acl_keys** (List of String) Redis specific field, defines key access rules. The field is required with`redis_acl_categories` and `redis_acl_keys`. This property cannot be changed, doing so forces recreation of the resource.
-- **pg_allow_replication** (Boolean) Postgres specific field, defines whether replication is allowed or not. This property cannot be changed, doing so forces recreation of the resource.
 
 ### Read-Only
 


### PR DESCRIPTION
The attribute "pg_allow_replication" is available to be set via the Aiven Golang API, but it is not exposed within the terraform layer.

**We are unable to currently assign this role via terraform. This PR fixes the missing attribute.**

I would be very grateful for a review. Many thanks.