### PR TITLE
Removing the flashy warning and repositioning the warning message

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,13 +3,6 @@ The Terraform provider for [Aiven.io](https://aiven.io/), an open source data pl
 
 **See the [official documentation](https://registry.terraform.io/providers/aiven/aiven/latest/docs) to learn about all the possible services and resources.**
 
-## 🚨 A word of caution 🚨
-Recreating stateful services with Terraform will possibly **delete** the service and all its data before creating it again. Whenever the Terraform plan indicates that a service will be **deleted** or **replaced**, a catastrophic action is possibly about to happen.
-
-Some properties, like **project** and the **resource name**, cannot be changed and it will trigger a resource replacement.
-
-To avoid any issues, **please set the `termination_protection` property to `true` on all production services**, it will prevent Terraform to remove the service until the flag is set back to `false` again. While it prevents a service to be deleted, any logical databases, topics or other configurations may be removed **even when this section is enabled**. Be very careful! 
-
 ## Quick Start
 - [Signup for Aiven](https://console.aiven.io/signup?utm_source=github&utm_medium=organic&utm_campaign=terraform&utm_content=signup)
 - [Get your authentication token and project name](https://help.aiven.io/en/articles/2059201-authentication-tokens)
@@ -52,6 +45,13 @@ $ psql "$(terraform output -raw postgresql_service_uri)"
 ```
 
 Voilà, a PostgreSQL database.
+
+## A word of caution
+Recreating stateful services with Terraform will possibly **delete** the service and all its data before creating it again. Whenever the Terraform plan indicates that a service will be **deleted** or **replaced**, a catastrophic action is possibly about to happen.
+
+Some properties, like **project** and the **resource name**, cannot be changed and it will trigger a resource replacement.
+
+To avoid any issues, **please set the `termination_protection` property to `true` on all production services**, it will prevent Terraform to remove the service until the flag is set back to `false` again. While it prevents a service to be deleted, any logical databases, topics or other configurations may be removed **even when this section is enabled**. Be very careful! 
 
 ## Developing
 ### Requirements

--- a/docs/index.md
+++ b/docs/index.md
@@ -42,3 +42,4 @@ Recreating stateful services with Terraform will possibly **delete** the service
 Some properties, like **project** and the **resource name**, cannot be changed and it will trigger a resource replacement.
 
 To avoid any issues, **please set the `termination_protection` property to `true` on all production services**, it will prevent Terraform to remove the service until the flag is set back to `false` again. While it prevents a service to be deleted, any logical databases, topics or other configurations may be removed **even when this section is enabled**. Be very careful!
+ 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,13 +1,6 @@
 # Aiven Terraform Provider
 The Terraform provider for [Aiven.io](https://aiven.io/), an open source data platform as a service. 
 
-## 🚨 A word of caution 🚨 
-Recreating stateful services with Terraform will possibly **delete** the service and all its data before creating it again. Whenever the Terraform plan indicates that a service will be **deleted** or **replaced**, a catastrophic action is possibly about to happen.
-
-Some properties, like **project** and the **resource name**, cannot be changed and it will trigger a resource replacement.
-
-To avoid any issues, **please set the `termination_protection` property to `true` on all production services**, it will prevent Terraform to remove the service until the flag is set back to `false` again. While it prevents a service to be deleted, any logical databases, topics or other configurations may be removed **even when this section is enabled**. Be very careful! 
-
 ## Authentication token
 [Signup at Aiven](https://console.aiven.io/signup?utm_source=terraformregistry&utm_medium=organic&utm_campaign=terraform&utm_content=signup) and see the [official instructions](https://help.aiven.io/en/articles/2059201-authentication-tokens) to create an API Authentication Token.
 
@@ -42,3 +35,10 @@ Look at the [Sample Project Guide](guides/sample-project.md) and the [Examples G
 The list of options in this document is not comprehensive, for most part they map directly to the [Aiven REST API](https://api.aiven.io/doc/) properties.
 
 For various objects called `x_user_config`, the exact configuration options are available in [Service User Config](https://github.com/aiven/terraform-provider-aiven/tree/master/aiven/templates/service_user_config_schema.json), [Integration User Config](https://github.com/aiven/terraform-provider-aiven/tree/master/aiven/templates/integrations_user_config_schema.json) and in [Integration Endpoint User Config](https://github.com/aiven/terraform-provider-aiven/tree/master/aiven/templates/integration_endpoints_user_config_schema.json) schema files.
+
+## A word of caution
+Recreating stateful services with Terraform will possibly **delete** the service and all its data before creating it again. Whenever the Terraform plan indicates that a service will be **deleted** or **replaced**, a catastrophic action is possibly about to happen.
+
+Some properties, like **project** and the **resource name**, cannot be changed and it will trigger a resource replacement.
+
+To avoid any issues, **please set the `termination_protection` property to `true` on all production services**, it will prevent Terraform to remove the service until the flag is set back to `false` again. While it prevents a service to be deleted, any logical databases, topics or other configurations may be removed **even when this section is enabled**. Be very careful! 

--- a/docs/index.md
+++ b/docs/index.md
@@ -41,4 +41,4 @@ Recreating stateful services with Terraform will possibly **delete** the service
 
 Some properties, like **project** and the **resource name**, cannot be changed and it will trigger a resource replacement.
 
-To avoid any issues, **please set the `termination_protection` property to `true` on all production services**, it will prevent Terraform to remove the service until the flag is set back to `false` again. While it prevents a service to be deleted, any logical databases, topics or other configurations may be removed **even when this section is enabled**. Be very careful! 
+To avoid any issues, **please set the `termination_protection` property to `true` on all production services**, it will prevent Terraform to remove the service until the flag is set back to `false` again. While it prevents a service to be deleted, any logical databases, topics or other configurations may be removed **even when this section is enabled**. Be very careful!

--- a/templates/index.md
+++ b/templates/index.md
@@ -41,4 +41,5 @@ Recreating stateful services with Terraform will possibly **delete** the service
 
 Some properties, like **project** and the **resource name**, cannot be changed and it will trigger a resource replacement.
 
-To avoid any issues, **please set the `termination_protection` property to `true` on all production services**, it will prevent Terraform to remove the service until the flag is set back to `false` again. While it prevents a service to be deleted, any logical databases, topics or other configurations may be removed **even when this section is enabled**. Be very careful! 
+To avoid any issues, **please set the `termination_protection` property to `true` on all production services**, it will prevent Terraform to remove the service until the flag is set back to `false` again. While it prevents a service to be deleted, any logical databases, topics or other configurations may be removed **even when this section is enabled**. Be very careful!
+ 

--- a/templates/index.md
+++ b/templates/index.md
@@ -1,13 +1,6 @@
 # Aiven Terraform Provider
 The Terraform provider for [Aiven.io](https://aiven.io/), an open source data platform as a service. 
 
-## 🚨 A word of caution 🚨 
-Recreating stateful services with Terraform will possibly **delete** the service and all its data before creating it again. Whenever the Terraform plan indicates that a service will be **deleted** or **replaced**, a catastrophic action is possibly about to happen.
-
-Some properties, like **project** and the **resource name**, cannot be changed and it will trigger a resource replacement.
-
-To avoid any issues, **please set the `termination_protection` property to `true` on all production services**, it will prevent Terraform to remove the service until the flag is set back to `false` again. While it prevents a service to be deleted, any logical databases, topics or other configurations may be removed **even when this section is enabled**. Be very careful! 
-
 ## Authentication token
 [Signup at Aiven](https://console.aiven.io/signup?utm_source=terraformregistry&utm_medium=organic&utm_campaign=terraform&utm_content=signup) and see the [official instructions](https://help.aiven.io/en/articles/2059201-authentication-tokens) to create an API Authentication Token.
 
@@ -42,3 +35,10 @@ Look at the [Sample Project Guide](guides/sample-project.md) and the [Examples G
 The list of options in this document is not comprehensive, for most part they map directly to the [Aiven REST API](https://api.aiven.io/doc/) properties.
 
 For various objects called `x_user_config`, the exact configuration options are available in [Service User Config](https://github.com/aiven/terraform-provider-aiven/tree/master/aiven/templates/service_user_config_schema.json), [Integration User Config](https://github.com/aiven/terraform-provider-aiven/tree/master/aiven/templates/integrations_user_config_schema.json) and in [Integration Endpoint User Config](https://github.com/aiven/terraform-provider-aiven/tree/master/aiven/templates/integration_endpoints_user_config_schema.json) schema files.
+
+## A word of caution
+Recreating stateful services with Terraform will possibly **delete** the service and all its data before creating it again. Whenever the Terraform plan indicates that a service will be **deleted** or **replaced**, a catastrophic action is possibly about to happen.
+
+Some properties, like **project** and the **resource name**, cannot be changed and it will trigger a resource replacement.
+
+To avoid any issues, **please set the `termination_protection` property to `true` on all production services**, it will prevent Terraform to remove the service until the flag is set back to `false` again. While it prevents a service to be deleted, any logical databases, topics or other configurations may be removed **even when this section is enabled**. Be very careful! 


### PR DESCRIPTION
This PR removes the flashy [🚨](https://registry.terraform.io/providers/aiven/aiven/latest/docs#%F0%9F%9A%A8-a-word-of-caution-%F0%9F%9A%A8) and repositions the warning message. Based on some feedback, I understand that the warning message, while much needed, is too flashy and can deter developers from trying the provider. The warning sign shouldn't be the first thing a developer should see for this provider.

For some website preview, only the [🚨](https://registry.terraform.io/providers/aiven/aiven/latest/docs#%F0%9F%9A%A8-a-word-of-caution-%F0%9F%9A%A8) warning sign shows up.

Moving the warning message on the same page. 