### PR TITLE
Updating Kafka connector example to modify config params

### DIFF
--- a/docs/resources/kafka_connector.md
+++ b/docs/resources/kafka_connector.md
@@ -13,19 +13,17 @@ The Kafka connectors resource allows the creation and management of Aiven Kafka 
 ## Example Usage
 
 ```terraform
-resource "aiven_kafka_connector" "kafka-os-con1" {
+resource "aiven_kafka_connector" "kafka-es-con1" {
   project        = aiven_project.kafka-con-project1.project
   service_name   = aiven_kafka.kafka-service1.service_name
-  connector_name = "kafka-os-con1"
+  connector_name = "kafka-es-con1"
 
   config = {
     "topics" = aiven_kafka_topic.kafka-topic1.topic_name
-    "connector.class" : "io.aiven.kafka.connect.opensearch.OpensearchSinkConnector"
-    "type.name"      = "os-connector"
-    "name"           = "kafka-os-con1"
-    "connection.url" = "${aiven_opensearch.os-service1.service_host}:${aiven_opensearch.os-service1.service_port}"
-    "connection.username" = aiven_opensearch.os-service1.service_username
-    "connection.password" = aiven_opensearch.os-service1.service_password
+    "connector.class" : "io.aiven.connect.elasticsearch.ElasticsearchSinkConnector"
+    "type.name"      = "es-connector"
+    "name"           = "kafka-es-con1"
+    "connection.url" = aiven_elasticsearch.es-service1.service_uri
   }
 }
 ```

--- a/docs/resources/kafka_connector.md
+++ b/docs/resources/kafka_connector.md
@@ -13,17 +13,19 @@ The Kafka connectors resource allows the creation and management of Aiven Kafka 
 ## Example Usage
 
 ```terraform
-resource "aiven_kafka_connector" "kafka-es-con1" {
+resource "aiven_kafka_connector" "kafka-os-con1" {
   project        = aiven_project.kafka-con-project1.project
   service_name   = aiven_kafka.kafka-service1.service_name
-  connector_name = "kafka-es-con1"
+  connector_name = "kafka-os-con1"
 
   config = {
     "topics" = aiven_kafka_topic.kafka-topic1.topic_name
-    "connector.class" : "io.aiven.connect.elasticsearch.ElasticsearchSinkConnector"
-    "type.name"      = "es-connector"
-    "name"           = "kafka-es-con1"
-    "connection.url" = aiven_elasticsearch.es-service1.service_uri
+    "connector.class" : "io.aiven.kafka.connect.opensearch.OpensearchSinkConnector"
+    "type.name"      = "os-connector"
+    "name"           = "kafka-os-con1"
+    "connection.url" = "${aiven_opensearch.os-service1.service_host}:${aiven_opensearch.os-service1.service_port}"
+    "connection.username" = aiven_opensearch.os-service1.service_username
+    "connection.password" = aiven_opensearch.os-service1.service_password
   }
 }
 ```

--- a/examples/resources/aiven_kafka_connector/resource.tf
+++ b/examples/resources/aiven_kafka_connector/resource.tf
@@ -1,13 +1,15 @@
-resource "aiven_kafka_connector" "kafka-es-con1" {
+resource "aiven_kafka_connector" "kafka-os-con1" {
   project        = aiven_project.kafka-con-project1.project
   service_name   = aiven_kafka.kafka-service1.service_name
-  connector_name = "kafka-es-con1"
+  connector_name = "kafka-os-con1"
 
   config = {
     "topics" = aiven_kafka_topic.kafka-topic1.topic_name
-    "connector.class" : "io.aiven.connect.elasticsearch.ElasticsearchSinkConnector"
-    "type.name"      = "es-connector"
-    "name"           = "kafka-es-con1"
-    "connection.url" = aiven_elasticsearch.es-service1.service_uri
+    "connector.class" : "io.aiven.kafka.connect.opensearch.OpensearchSinkConnector"
+    "type.name"      = "os-connector"
+    "name"           = "kafka-os-con1"
+    "connection.url" = "${aiven_opensearch.os-service1.service_host}:${aiven_opensearch.os-service1.service_port}"
+    "connection.username" = aiven_opensearch.os-service1.service_username
+    "connection.password" = aiven_opensearch.os-service1.service_password
   }
 }


### PR DESCRIPTION
This PR addresses the following issues:

1. Breaks down the ``connection.url`` into **host**, **port**, **username**, and **password**. It was **service_uri** and there was a risk of basic auth to be logged as a part of the URL.
2. Uses OpenSearch instead of ElasticSearch example.