### PR TITLE
v2: project resource fix import and read for deprecated billing group fields

### DIFF
--- a/aiven/resource_billing_group_test.go
+++ b/aiven/resource_billing_group_test.go
@@ -71,7 +71,8 @@ func testAccCheckAivenBillingGroupResourceDestroy(s *terraform.State) error {
 func testAccBillingGroupResource(name string) string {
 	return fmt.Sprintf(`
 		resource "aiven_billing_group" "foo" {
-		  name = "test-acc-bg-%s"
+		  name           = "test-acc-bg-%s"
+		  billing_emails = ["ivan.savciuc+test1@aiven.fi", "ivan.savciuc+test2@aiven.fi"]
 		}
 		
 		data "aiven_billing_group" "bar" {

--- a/docs/resources/project.md
+++ b/docs/resources/project.md
@@ -50,6 +50,6 @@ resource "aiven_project" "myproject" {
 
 - **ca_cert** (String, Sensitive) The CA certificate of the project. This is required for configuring clients that connect to certain services like Kafka.
 - **estimated_balance** (String) The current accumulated bill for this project in the current billing period.
-- **payment_method** (String) The method of invoicing used for payments for this project, e.g. `card`.
+- **payment_method** (String, Deprecated) The method of invoicing used for payments for this project, e.g. `card`.
 
 

--- a/go.mod
+++ b/go.mod
@@ -6,13 +6,12 @@ require (
 	cloud.google.com/go v0.97.0 // indirect
 	cloud.google.com/go/storage v1.17.0 // indirect
 	github.com/agext/levenshtein v1.2.3 // indirect
-	github.com/aiven/aiven-go-client v1.7.1-0.20220211091656-c6ebd57986ed
+	github.com/aiven/aiven-go-client v1.7.1-0.20220414113907-5a32f70bb86e
 	github.com/aws/aws-sdk-go v1.40.55 // indirect
 	github.com/docker/go-units v0.4.0
 	github.com/fatih/color v1.13.0 // indirect
 	github.com/fsnotify/fsnotify v1.5.1 // indirect
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
-	github.com/google/go-cmp v0.5.6
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/hashicorp/go-getter v1.5.9 // indirect
 	github.com/hashicorp/go-hclog v0.16.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -64,8 +64,8 @@ github.com/agext/levenshtein v1.2.1/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki
 github.com/agext/levenshtein v1.2.2/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=
 github.com/agext/levenshtein v1.2.3 h1:YB2fHEn0UJagG8T1rrWknE3ZQzWM06O8AMAatNn7lmo=
 github.com/agext/levenshtein v1.2.3/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=
-github.com/aiven/aiven-go-client v1.7.1-0.20220211091656-c6ebd57986ed h1:hvaoNBMDjwNQ+KatizyRW5s3eC4rBdyjZb7LITYaZQQ=
-github.com/aiven/aiven-go-client v1.7.1-0.20220211091656-c6ebd57986ed/go.mod h1:3+OtpccynSr5xvSGfn96jVM9dBUAr52HXlaZJi/Mz5o=
+github.com/aiven/aiven-go-client v1.7.1-0.20220414113907-5a32f70bb86e h1:kKQlUHqSrT7d5YMpdhv8ideYih/dxljyqzA5O4NttFg=
+github.com/aiven/aiven-go-client v1.7.1-0.20220414113907-5a32f70bb86e/go.mod h1:3+OtpccynSr5xvSGfn96jVM9dBUAr52HXlaZJi/Mz5o=
 github.com/andybalholm/crlf v0.0.0-20171020200849-670099aa064f/go.mod h1:k8feO4+kXDxro6ErPXBRTJ/ro2mf0SsFG8s7doP9kJE=
 github.com/anmitsu/go-shlex v0.0.0-20161002113705-648efa622239/go.mod h1:2FmKhYUyUczH0OGQWaF5ceTx0UBShxjsH6f8oGKYe2c=
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=


### PR DESCRIPTION
Project resource has deprecated fields related to billing group, and in a scenario when a project is associated with a billing group and these deprecated fields are not set in Terraform manifest TF refresh generates none empty plan. With this patch, we will only refresh those fields if they are set to any non zero value since API retrieves back values transferred from associated billing groups.

v3 has no such problem