### PR TITLE
Support retrieving multiple project vpcs datasource

### DIFF
--- a/internal/service/vpc/datasource_project_vpc.go
+++ b/internal/service/vpc/datasource_project_vpc.go
@@ -2,6 +2,8 @@ package vpc
 
 import (
 	"context"
+	"strconv"
+	"time"
 
 	"github.com/aiven/aiven-go-client"
 	"github.com/aiven/terraform-provider-aiven/internal/schemautil"
@@ -11,11 +13,39 @@ import (
 )
 
 func DatasourceProjectVPC() *schema.Resource {
+	vpc_schema := schemautil.ResourceSchemaAsDatasourceSchema(
+		aivenProjectVPCSchema,
+		"project",
+		"cloud_name",
+	)
+	vpc_schema["vpcs"] = &schema.Schema{
+		Type:        schema.TypeList,
+		Computed:    true,
+		Description: "VPCs",
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				"network_cidr": {
+					Required:    true,
+					ForceNew:    true,
+					Type:        schema.TypeString,
+					Description: "Network address range used by the VPC like 192.168.0.0/24",
+				},
+				"state": {
+					Computed:    true,
+					Type:        schema.TypeString,
+					Description: schemautil.Complex("State of the VPC.").PossibleValues("APPROVED", "ACTIVE", "DELETING", "DELETED").Build(),
+				},
+				"id": {
+					Computed: true,
+					Type:     schema.TypeString,
+				},
+			},
+		},
+	}
 	return &schema.Resource{
 		ReadContext: datasourceProjectVPCRead,
 		Description: "The Project VPC data source provides information about the existing Aiven Project VPC.",
-		Schema: schemautil.ResourceSchemaAsDatasourceSchema(aivenProjectVPCSchema,
-			"project", "cloud_name"),
+		Schema:      vpc_schema,
 	}
 }
 
@@ -25,23 +55,58 @@ func datasourceProjectVPCRead(_ context.Context, d *schema.ResourceData, m inter
 	projectName := d.Get("project").(string)
 	cloudName := d.Get("cloud_name").(string)
 
+	vpcs_list := make([]map[string]string, 0)
+
 	vpcs, err := client.VPCs.List(projectName)
 	if err != nil {
 		return diag.FromErr(err)
 	}
 
+	filtered_vpcs := make([]*aiven.VPC, 0)
 	for _, vpc := range vpcs {
 		if vpc.CloudName == cloudName {
-			d.SetId(schemautil.BuildResourceID(projectName, vpc.ProjectVPCID))
-			err = copyVPCPropertiesFromAPIResponseToTerraform(d, vpc, projectName)
-			if err != nil {
-				return diag.FromErr(err)
-			}
-
-			return nil
+			filtered_vpcs = append(filtered_vpcs, vpc)
 		}
 	}
 
-	return diag.Errorf("project %s has no VPC defined for %s",
-		projectName, cloudName)
+	if len(filtered_vpcs) == 0 {
+		return diag.Errorf("project %s has no VPC defined for %s",
+			projectName, cloudName)
+	}
+
+	if len(filtered_vpcs) == 1 {
+		vpc := filtered_vpcs[0]
+		d.SetId(schemautil.BuildResourceID(projectName, vpc.ProjectVPCID))
+		err = copyVPCPropertiesFromAPIResponseToTerraform(d, vpc, projectName)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+		return nil
+	}
+
+	for _, vpc := range filtered_vpcs {
+		data := map[string]string{
+			"network_cidr": vpc.NetworkCIDR,
+			"state":        vpc.State,
+			"id":           schemautil.BuildResourceID(projectName, vpc.ProjectVPCID),
+		}
+
+		vpcs_list = append(vpcs_list, data)
+	}
+
+	d.SetId(strconv.FormatInt(time.Now().Unix(), 10))
+
+	if err := d.Set("project", projectName); err != nil {
+		return diag.FromErr(err)
+	}
+
+	if err := d.Set("cloud_name", cloudName); err != nil {
+		return diag.FromErr(err)
+	}
+
+	if err := d.Set("vpcs", vpcs_list); err != nil {
+		return diag.FromErr(err)
+	}
+
+	return nil
 }


### PR DESCRIPTION
Normally Aiven limits the number of VPC per cloud to 1, meaning user cannot have multiple VPCs for the same cloud region. However, for some special case, Aiven can allow user to have more than 1 VPC in the same cloud region.

Adjust the `DatasourceProjectVPC` schema and `datasourceProjectVPCRead` to support showing multiple vpcs data, by adding a list field "vpcs" to the schema. However, to maintain the backward compatibility, the `vpcs` field is only populated when the retrieved data has more than 1 results.
For example, if the retrieved data has only one result, the format of the data source returned would be more or less the same as it's before:
```
foo = {
  "cloud_name" = "aws-eu-north-1"
  "id" = "test/9fbd9d2b-b4fb-4b9e-8195-df4d08a3a272"
  "network_cidr" = "10.2.0.0/24"
  "project" = "test"
  "state" = "ACTIVE"
  "vpcs" = tolist(null) /* of object */
}
```

But when there are more than 1 results returned, the format of the data source would be:
```
foo2 = {
  "cloud_name" = "azure-westeurope"
  "id" = "1655368395"
  "network_cidr" = tostring(null)
  "project" = "test"
  "state" = tostring(null)
  "vpcs" = tolist([
    {
      "id" = "test/2531a193-8afd-4ada-be03-0881ef3f9230"
      "network_cidr" = "10.0.0.0/24"
      "state" = "ACTIVE"
    },
    {
      "id" = "test/5ac8fe5c-785d-4d20-aac7-8d380802d394"
      "network_cidr" = "10.1.0.0/24"
      "state" = "ACTIVE"
    },
  ])
}

```

[DARK-628]

[DARK-628]: https://aiven.atlassian.net/browse/DARK-628?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ