### PR TITLE
enforce changelog entry for every PR

### DIFF
--- a/.github/workflows/changelog-checker.yml
+++ b/.github/workflows/changelog-checker.yml
@@ -7,8 +7,6 @@ on:
 
 jobs:
   check_changelog:
-    if: contains(github.event.pull_request.labels.*.name, 'needs-changelog')
-
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1


### PR DESCRIPTION
<!-- All contributors, please complete these sections, including maintainers. -->

## About this change—what it does

<!-- Provide a small sentence that summarizes the change. -->
enforces `CHANGELOG.md` entry to be expected for every PR, i.e. enables `.github/workflow/changelog-checker.yml` to run on every PR

<!-- Provide the issue number below, if it exists. -->

## Why this way

<!-- Provide a small explanation on why this is the approach you took for solving this problem. -->
it's difficult for maintainers to put everything in place when preparing a release
