### PR TITLE
update the 404 error handling behavior during import and use SDKv2 functionality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ nav_order: 1
 
 ## [X.X.X] - not yet released
 - Fix auto generated documentation by bumping tfplugindocs to latest version
+- Update the 404 error handling behavior during import
+- Use SDKv2 `schema.ImportStatePassthroughContext` as the importer state function
 
 ## [3.2.1] - 2022-06-29
 

--- a/internal/schemautil/service.go
+++ b/internal/schemautil/service.go
@@ -740,7 +740,7 @@ func IsUnknownResource(err error) bool {
 }
 
 func ResourceReadHandleNotFound(err error, d *schema.ResourceData) error {
-	if err != nil && IsUnknownResource(err) {
+	if err != nil && IsUnknownResource(err) && !d.IsNewResource() {
 		d.SetId("")
 		return nil
 	}

--- a/internal/schemautil/service.go
+++ b/internal/schemautil/service.go
@@ -498,48 +498,6 @@ func ResourceServiceDelete(ctx context.Context, d *schema.ResourceData, m interf
 	return nil
 }
 
-func ResourceServiceState(ctx context.Context, d *schema.ResourceData, m interface{}) ([]*schema.ResourceData, error) {
-	client := m.(*aiven.Client)
-
-	if len(strings.Split(d.Id(), "/")) != 2 {
-		return nil, fmt.Errorf("invalid identifier %v, expected <project_name>/<service_name>", d.Id())
-	}
-
-	projectName, serviceName := SplitResourceID2(d.Id())
-	s, err := client.Services.Get(projectName, serviceName)
-	if err != nil {
-		return nil, fmt.Errorf("unable to GET service %s: %s", d.Id(), err)
-	}
-	servicePlanParams, err := GetServicePlanParametersFromServiceResponse(ctx, client, projectName, s)
-	if err != nil {
-		return nil, fmt.Errorf("unable to get service plan parameters: %w", err)
-	}
-
-	err = copyServicePropertiesFromAPIResponseToTerraform(d, s, servicePlanParams, projectName)
-	if err != nil {
-		return nil, fmt.Errorf("unable to copy api response into terraform schema: %w", err)
-	}
-
-	allocatedStaticIps, err := CurrentlyAllocatedStaticIps(ctx, projectName, serviceName, m)
-	if err != nil {
-		return nil, fmt.Errorf("unable to currently allocated static ips: %w", err)
-	}
-	if err = d.Set("static_ips", allocatedStaticIps); err != nil {
-		return nil, fmt.Errorf("unable to set static ips field in schema: %w", err)
-	}
-
-	t, err := client.ServiceTags.Get(projectName, serviceName)
-	if err != nil {
-		return nil, fmt.Errorf("unable to get service tags: %w", err)
-	}
-
-	if err := d.Set("tag", SetTagsTerraformProperties(t.Tags)); err != nil {
-		return nil, fmt.Errorf("unable to set tag's in schema: %w", err)
-	}
-
-	return []*schema.ResourceData{d}, nil
-}
-
 func copyServicePropertiesFromAPIResponseToTerraform(
 	d *schema.ResourceData,
 	s *aiven.Service,

--- a/internal/service/account/resource_account.go
+++ b/internal/service/account/resource_account.go
@@ -2,7 +2,6 @@ package account
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/aiven/terraform-provider-aiven/internal/schemautil"
 
@@ -58,7 +57,7 @@ func ResourceAccount() *schema.Resource {
 		UpdateContext: resourceAccountUpdate,
 		DeleteContext: resourceAccountDelete,
 		Importer: &schema.ResourceImporter{
-			StateContext: resourceAccountState,
+			StateContext: schema.ImportStatePassthroughContext,
 		},
 
 		Schema: aivenAccountSchema,
@@ -143,13 +142,4 @@ func resourceAccountDelete(_ context.Context, d *schema.ResourceData, m interfac
 	}
 
 	return nil
-}
-
-func resourceAccountState(ctx context.Context, d *schema.ResourceData, m interface{}) ([]*schema.ResourceData, error) {
-	di := resourceAccountRead(ctx, d, m)
-	if di.HasError() {
-		return nil, fmt.Errorf("cannot get account %v", di)
-	}
-
-	return []*schema.ResourceData{d}, nil
 }

--- a/internal/service/account/resource_account_authentication.go
+++ b/internal/service/account/resource_account_authentication.go
@@ -2,7 +2,6 @@ package account
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/aiven/aiven-go-client"
 	"github.com/aiven/terraform-provider-aiven/internal/schemautil"
@@ -84,7 +83,7 @@ func ResourceAccountAuthentication() *schema.Resource {
 		UpdateContext: resourceAccountAuthenticationUpdate,
 		DeleteContext: resourceAccountAuthenticationDelete,
 		Importer: &schema.ResourceImporter{
-			StateContext: resourceAccountAuthenticationState,
+			StateContext: schema.ImportStatePassthroughContext,
 		},
 
 		Schema: aivenAccountAuthenticationSchema,
@@ -202,13 +201,4 @@ func resourceAccountAuthenticationDelete(_ context.Context, d *schema.ResourceDa
 	}
 
 	return nil
-}
-
-func resourceAccountAuthenticationState(ctx context.Context, d *schema.ResourceData, m interface{}) ([]*schema.ResourceData, error) {
-	di := resourceAccountAuthenticationRead(ctx, d, m)
-	if di.HasError() {
-		return nil, fmt.Errorf("cannot get account authentication %v", di)
-	}
-
-	return []*schema.ResourceData{d}, nil
 }

--- a/internal/service/account/resource_account_team.go
+++ b/internal/service/account/resource_account_team.go
@@ -2,7 +2,6 @@ package account
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/aiven/aiven-go-client"
 	"github.com/aiven/terraform-provider-aiven/internal/schemautil"
@@ -47,7 +46,7 @@ func ResourceAccountTeam() *schema.Resource {
 		UpdateContext: resourceAccountTeamUpdate,
 		DeleteContext: resourceAccountTeamDelete,
 		Importer: &schema.ResourceImporter{
-			StateContext: resourceAccountTeamState,
+			StateContext: schema.ImportStatePassthroughContext,
 		},
 
 		Schema: aivenAccountTeamSchema,
@@ -129,13 +128,4 @@ func resourceAccountTeamDelete(_ context.Context, d *schema.ResourceData, m inte
 	}
 
 	return nil
-}
-
-func resourceAccountTeamState(ctx context.Context, d *schema.ResourceData, m interface{}) ([]*schema.ResourceData, error) {
-	di := resourceAccountTeamRead(ctx, d, m)
-	if di.HasError() {
-		return nil, fmt.Errorf("cannot get account team %v", di)
-	}
-
-	return []*schema.ResourceData{d}, nil
 }

--- a/internal/service/account/resource_account_team_member.go
+++ b/internal/service/account/resource_account_team_member.go
@@ -2,7 +2,6 @@ package account
 
 import (
 	"context"
-	"fmt"
 	"log"
 
 	"github.com/aiven/aiven-go-client"
@@ -63,7 +62,7 @@ eliminate an account team member if one has accepted an invitation previously.
 		ReadContext:   resourceAccountTeamMemberRead,
 		DeleteContext: resourceAccountTeamMemberDelete,
 		Importer: &schema.ResourceImporter{
-			StateContext: resourceAccountTeamMemberState,
+			StateContext: schema.ImportStatePassthroughContext,
 		},
 
 		Schema: aivenAccountTeamMemberSchema,
@@ -196,13 +195,4 @@ func resourceAccountTeamMemberDelete(_ context.Context, d *schema.ResourceData, 
 	}
 
 	return nil
-}
-
-func resourceAccountTeamMemberState(ctx context.Context, d *schema.ResourceData, m interface{}) ([]*schema.ResourceData, error) {
-	di := resourceAccountTeamMemberRead(ctx, d, m)
-	if di.HasError() {
-		return nil, fmt.Errorf("cannot get account team member: %v", di)
-	}
-
-	return []*schema.ResourceData{d}, nil
 }

--- a/internal/service/account/resource_account_team_project.go
+++ b/internal/service/account/resource_account_team_project.go
@@ -2,7 +2,6 @@ package account
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/aiven/aiven-go-client"
 	"github.com/aiven/terraform-provider-aiven/internal/schemautil"
@@ -50,7 +49,7 @@ account team you are trying to link to this project.
 		UpdateContext: resourceAccountTeamProjectUpdate,
 		DeleteContext: resourceAccountTeamProjectDelete,
 		Importer: &schema.ResourceImporter{
-			StateContext: resourceAccountTeamProjectState,
+			StateContext: schema.ImportStatePassthroughContext,
 		},
 		Schema: aivenAccountTeamProjectSchema,
 	}
@@ -146,13 +145,4 @@ func resourceAccountTeamProjectDelete(_ context.Context, d *schema.ResourceData,
 	}
 
 	return nil
-}
-
-func resourceAccountTeamProjectState(ctx context.Context, d *schema.ResourceData, m interface{}) ([]*schema.ResourceData, error) {
-	di := resourceAccountTeamProjectRead(ctx, d, m)
-	if di.HasError() {
-		return nil, fmt.Errorf("cannot get account team project: %v", di)
-	}
-
-	return []*schema.ResourceData{d}, nil
 }

--- a/internal/service/cassandra/resource_cassandra.go
+++ b/internal/service/cassandra/resource_cassandra.go
@@ -50,7 +50,7 @@ func ResourceCassandra() *schema.Resource {
 			),
 		),
 		Importer: &schema.ResourceImporter{
-			StateContext: schemautil.ResourceServiceState,
+			StateContext: schema.ImportStatePassthroughContext,
 		},
 		Timeouts: &schema.ResourceTimeout{
 			Create: schema.DefaultTimeout(20 * time.Minute),

--- a/internal/service/clickhouse/resource_clickhouse.go
+++ b/internal/service/clickhouse/resource_clickhouse.go
@@ -50,7 +50,7 @@ func ResourceClickhouse() *schema.Resource {
 			),
 		),
 		Importer: &schema.ResourceImporter{
-			StateContext: schemautil.ResourceServiceState,
+			StateContext: schema.ImportStatePassthroughContext,
 		},
 		Timeouts: &schema.ResourceTimeout{
 			Create: schema.DefaultTimeout(20 * time.Minute),

--- a/internal/service/flink/resource_flink.go
+++ b/internal/service/flink/resource_flink.go
@@ -63,7 +63,7 @@ func ResourceFlink() *schema.Resource {
 			),
 		),
 		Importer: &schema.ResourceImporter{
-			StateContext: schemautil.ResourceServiceState,
+			StateContext: schema.ImportStatePassthroughContext,
 		},
 		Timeouts: &schema.ResourceTimeout{
 			Create: schema.DefaultTimeout(20 * time.Minute),

--- a/internal/service/flink/resource_flink_table.go
+++ b/internal/service/flink/resource_flink_table.go
@@ -2,7 +2,6 @@ package flink
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 
@@ -189,7 +188,7 @@ func ResourceFlinkTable() *schema.Resource {
 		ReadContext:   resourceFlinkTableRead,
 		DeleteContext: resourceFlinkTableDelete,
 		Importer: &schema.ResourceImporter{
-			StateContext: resourceFlinkTableState,
+			StateContext: schema.ImportStatePassthroughContext,
 		},
 		Schema: aivenFlinkTableSchema,
 	}
@@ -354,13 +353,4 @@ func getFlinkTableKafkaScanStartupModes() []string {
 		startupModeLatestOffset   = "latest-offset"
 	)
 	return []string{startupModeEarliestOffset, startupModeLatestOffset}
-}
-
-func resourceFlinkTableState(ctx context.Context, d *schema.ResourceData, m interface{}) ([]*schema.ResourceData, error) {
-	di := resourceFlinkTableRead(ctx, d, m)
-	if di.HasError() {
-		return nil, fmt.Errorf("cannot get flink table %v", di)
-	}
-
-	return []*schema.ResourceData{d}, nil
 }

--- a/internal/service/grafana/resource_grafana.go
+++ b/internal/service/grafana/resource_grafana.go
@@ -50,7 +50,7 @@ func ResourceGrafana() *schema.Resource {
 			),
 		),
 		Importer: &schema.ResourceImporter{
-			StateContext: schemautil.ResourceServiceState,
+			StateContext: schema.ImportStatePassthroughContext,
 		},
 		Timeouts: &schema.ResourceTimeout{
 			Create: schema.DefaultTimeout(20 * time.Minute),

--- a/internal/service/influxdb/resource_influxdb.go
+++ b/internal/service/influxdb/resource_influxdb.go
@@ -56,7 +56,7 @@ func ResourceInfluxDB() *schema.Resource {
 			),
 		),
 		Importer: &schema.ResourceImporter{
-			StateContext: schemautil.ResourceServiceState,
+			StateContext: schema.ImportStatePassthroughContext,
 		},
 		Timeouts: &schema.ResourceTimeout{
 			Create: schema.DefaultTimeout(20 * time.Minute),

--- a/internal/service/kafka/resource_kafka.go
+++ b/internal/service/kafka/resource_kafka.go
@@ -86,7 +86,7 @@ func ResourceKafka() *schema.Resource {
 		UpdateContext: schemautil.ResourceServiceUpdate,
 		DeleteContext: schemautil.ResourceServiceDelete,
 		Importer: &schema.ResourceImporter{
-			StateContext: schemautil.ResourceServiceState,
+			StateContext: schema.ImportStatePassthroughContext,
 		},
 		Timeouts: &schema.ResourceTimeout{
 			Create: schema.DefaultTimeout(20 * time.Minute),

--- a/internal/service/kafka/resource_kafka_connect.go
+++ b/internal/service/kafka/resource_kafka_connect.go
@@ -46,7 +46,7 @@ func ResourceKafkaConnect() *schema.Resource {
 			),
 		),
 		Importer: &schema.ResourceImporter{
-			StateContext: schemautil.ResourceServiceState,
+			StateContext: schema.ImportStatePassthroughContext,
 		},
 		Timeouts: &schema.ResourceTimeout{
 			Create: schema.DefaultTimeout(20 * time.Minute),

--- a/internal/service/kafka/resource_kafka_connector.go
+++ b/internal/service/kafka/resource_kafka_connector.go
@@ -92,7 +92,7 @@ func ResourceKafkaConnector() *schema.Resource {
 		UpdateContext: resourceKafkaTConnectorUpdate,
 		DeleteContext: resourceKafkaConnectorDelete,
 		Importer: &schema.ResourceImporter{
-			StateContext: resourceKafkaConnectorState,
+			StateContext: schema.ImportStatePassthroughContext,
 		},
 		Timeouts: &schema.ResourceTimeout{
 			Read: schema.DefaultTimeout(2 * time.Minute),
@@ -268,13 +268,4 @@ func resourceKafkaTConnectorUpdate(ctx context.Context, d *schema.ResourceData, 
 	}
 
 	return resourceKafkaConnectorRead(ctx, d, m)
-}
-
-func resourceKafkaConnectorState(ctx context.Context, d *schema.ResourceData, m interface{}) ([]*schema.ResourceData, error) {
-	di := resourceKafkaConnectorRead(ctx, d, m)
-	if di.HasError() {
-		return nil, fmt.Errorf("cannot get kafka connector: %v", di)
-	}
-
-	return []*schema.ResourceData{d}, nil
 }

--- a/internal/service/kafka/resource_kafka_mirrormaker.go
+++ b/internal/service/kafka/resource_kafka_mirrormaker.go
@@ -46,7 +46,7 @@ func ResourceKafkaMirrormaker() *schema.Resource {
 			),
 		),
 		Importer: &schema.ResourceImporter{
-			StateContext: schemautil.ResourceServiceState,
+			StateContext: schema.ImportStatePassthroughContext,
 		},
 		Timeouts: &schema.ResourceTimeout{
 			Create: schema.DefaultTimeout(20 * time.Minute),

--- a/internal/service/kafka/resource_kafka_schema.go
+++ b/internal/service/kafka/resource_kafka_schema.go
@@ -87,7 +87,7 @@ func ResourceKafkaSchema() *schema.Resource {
 		ReadContext:   resourceKafkaSchemaRead,
 		DeleteContext: resourceKafkaSchemaDelete,
 		Importer: &schema.ResourceImporter{
-			StateContext: resourceKafkaSchemaState,
+			StateContext: schema.ImportStatePassthroughContext,
 		},
 		CustomizeDiff: resourceKafkaSchemaCustomizeDiff,
 
@@ -257,15 +257,6 @@ func resourceKafkaSchemaDelete(_ context.Context, d *schema.ResourceData, m inte
 	}
 
 	return nil
-}
-
-func resourceKafkaSchemaState(ctx context.Context, d *schema.ResourceData, m interface{}) ([]*schema.ResourceData, error) {
-	di := resourceKafkaSchemaRead(ctx, d, m)
-	if di.HasError() {
-		return nil, fmt.Errorf("cannot get kafka schema: %v", di)
-	}
-
-	return []*schema.ResourceData{d}, nil
 }
 
 func resourceKafkaSchemaCustomizeDiff(_ context.Context, d *schema.ResourceDiff, m interface{}) error {

--- a/internal/service/kafka/resource_kafka_schema_configuration.go
+++ b/internal/service/kafka/resource_kafka_schema_configuration.go
@@ -2,7 +2,6 @@ package kafka
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/aiven/aiven-go-client"
 	"github.com/aiven/terraform-provider-aiven/internal/schemautil"
@@ -47,7 +46,7 @@ func ResourceKafkaSchemaConfiguration() *schema.Resource {
 		ReadContext:   resourceKafkaSchemaConfigurationRead,
 		DeleteContext: resourceKafkaSchemaConfigurationDelete,
 		Importer: &schema.ResourceImporter{
-			StateContext: resourceKafkaSchemaConfigurationState,
+			StateContext: schema.ImportStatePassthroughContext,
 		},
 
 		Schema: aivenKafkaSchemaConfigurationSchema,
@@ -127,13 +126,4 @@ func resourceKafkaSchemaConfigurationDelete(_ context.Context, d *schema.Resourc
 	}
 
 	return nil
-}
-
-func resourceKafkaSchemaConfigurationState(ctx context.Context, d *schema.ResourceData, m interface{}) ([]*schema.ResourceData, error) {
-	di := resourceKafkaSchemaConfigurationRead(ctx, d, m)
-	if di.HasError() {
-		return nil, fmt.Errorf("cannot get kafka schema configuration: %v", di)
-	}
-
-	return []*schema.ResourceData{d}, nil
 }

--- a/internal/service/m3db/resource_m3aggregator.go
+++ b/internal/service/m3db/resource_m3aggregator.go
@@ -45,7 +45,7 @@ func ResourceM3Aggregator() *schema.Resource {
 			),
 		),
 		Importer: &schema.ResourceImporter{
-			StateContext: schemautil.ResourceServiceState,
+			StateContext: schema.ImportStatePassthroughContext,
 		},
 		Timeouts: &schema.ResourceTimeout{
 			Create: schema.DefaultTimeout(20 * time.Minute),

--- a/internal/service/m3db/resource_m3db.go
+++ b/internal/service/m3db/resource_m3db.go
@@ -49,7 +49,7 @@ func ResourceM3DB() *schema.Resource {
 			),
 		),
 		Importer: &schema.ResourceImporter{
-			StateContext: schemautil.ResourceServiceState,
+			StateContext: schema.ImportStatePassthroughContext,
 		},
 		Timeouts: &schema.ResourceTimeout{
 			Create: schema.DefaultTimeout(20 * time.Minute),

--- a/internal/service/mysql/resource_mysql.go
+++ b/internal/service/mysql/resource_mysql.go
@@ -49,7 +49,7 @@ func ResourceMySQL() *schema.Resource {
 			),
 		),
 		Importer: &schema.ResourceImporter{
-			StateContext: schemautil.ResourceServiceState,
+			StateContext: schema.ImportStatePassthroughContext,
 		},
 		Timeouts: &schema.ResourceTimeout{
 			Create: schema.DefaultTimeout(20 * time.Minute),

--- a/internal/service/opensearch/resource_opensearch.go
+++ b/internal/service/opensearch/resource_opensearch.go
@@ -96,5 +96,5 @@ func resourceOpensearchState(ctx context.Context, d *schema.ResourceData, m inte
 		}
 	}
 
-	return schemautil.ResourceServiceState(ctx, d, m)
+	return schema.ImportStatePassthroughContext(ctx, d, m)
 }

--- a/internal/service/opensearch/resource_opensearch_acl_config.go
+++ b/internal/service/opensearch/resource_opensearch_acl_config.go
@@ -2,7 +2,6 @@ package opensearch
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/aiven/aiven-go-client"
 	"github.com/aiven/terraform-provider-aiven/internal/schemautil"
@@ -36,7 +35,7 @@ func ResourceOpensearchACLConfig() *schema.Resource {
 		UpdateContext: resourceOpensearchACLConfigUpdate,
 		DeleteContext: resourceOpensearchACLConfigDelete,
 		Importer: &schema.ResourceImporter{
-			StateContext: resourceOpensearchACLConfigState,
+			StateContext: schema.ImportStatePassthroughContext,
 		},
 
 		Schema: aivenOpensearchACLConfigSchema,
@@ -65,15 +64,6 @@ func resourceOpensearchACLConfigRead(_ context.Context, d *schema.ResourceData, 
 		return diag.Errorf("error setting ACLs `enable` for resource %s: %s", d.Id(), err)
 	}
 	return nil
-}
-
-func resourceOpensearchACLConfigState(ctx context.Context, d *schema.ResourceData, m interface{}) ([]*schema.ResourceData, error) {
-	di := resourceOpensearchACLConfigRead(ctx, d, m)
-	if di.HasError() {
-		return nil, fmt.Errorf("cannot get elasticsearch acl: %v", di)
-	}
-
-	return []*schema.ResourceData{d}, nil
 }
 
 func resourceOpensearchACLConfigUpdate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {

--- a/internal/service/opensearch/resource_opensearch_acl_rule.go
+++ b/internal/service/opensearch/resource_opensearch_acl_rule.go
@@ -2,7 +2,6 @@ package opensearch
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/aiven/aiven-go-client"
 	"github.com/aiven/terraform-provider-aiven/internal/schemautil"
@@ -44,7 +43,7 @@ func ResourceOpensearchACLRule() *schema.Resource {
 		UpdateContext: resourceOpensearchACLRuleUpdate,
 		DeleteContext: resourceOpensearchACLRuleDelete,
 		Importer: &schema.ResourceImporter{
-			StateContext: resourceElasticsearchACLRuleState,
+			StateContext: schema.ImportStatePassthroughContext,
 		},
 
 		Schema: aivenOpensearchACLRuleSchema,
@@ -96,14 +95,6 @@ func resourceOpensearchACLRuleRead(_ context.Context, d *schema.ResourceData, m 
 	}
 
 	return nil
-}
-
-func resourceElasticsearchACLRuleState(ctx context.Context, d *schema.ResourceData, m interface{}) ([]*schema.ResourceData, error) {
-	di := resourceOpensearchACLRuleRead(ctx, d, m)
-	if di.HasError() {
-		return nil, fmt.Errorf("cannot get elasticsearch acl rule: %v", di)
-	}
-	return []*schema.ResourceData{d}, nil
 }
 
 func resourceOpensearchACLRuleMkAivenACL(username, index, permission string) aiven.ElasticSearchACL {

--- a/internal/service/pg/resource_pg.go
+++ b/internal/service/pg/resource_pg.go
@@ -106,7 +106,7 @@ func ResourcePG() *schema.Resource {
 			),
 		),
 		Importer: &schema.ResourceImporter{
-			StateContext: schemautil.ResourceServiceState,
+			StateContext: schema.ImportStatePassthroughContext,
 		},
 		Timeouts: &schema.ResourceTimeout{
 			Create:  schema.DefaultTimeout(20 * time.Minute),

--- a/internal/service/project/resource_billing_group.go
+++ b/internal/service/project/resource_billing_group.go
@@ -2,7 +2,6 @@ package project
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/aiven/aiven-go-client"
 	"github.com/aiven/terraform-provider-aiven/internal/schemautil"
@@ -107,7 +106,7 @@ func ResourceBillingGroup() *schema.Resource {
 		UpdateContext: resourceBillingGroupUpdate,
 		DeleteContext: resourceBillingGroupDelete,
 		Importer: &schema.ResourceImporter{
-			StateContext: resourceBillingGroupState,
+			StateContext: schema.ImportStatePassthroughContext,
 		},
 
 		Schema: aivenBillingGroupSchema,
@@ -254,13 +253,4 @@ func resourceBillingGroupDelete(_ context.Context, d *schema.ResourceData, m int
 	}
 
 	return nil
-}
-
-func resourceBillingGroupState(ctx context.Context, d *schema.ResourceData, m interface{}) ([]*schema.ResourceData, error) {
-	di := resourceBillingGroupRead(ctx, d, m)
-	if di.HasError() {
-		return nil, fmt.Errorf("cannot get a billing group: %v", di)
-	}
-
-	return []*schema.ResourceData{d}, nil
 }

--- a/internal/service/redis/resource_redis.go
+++ b/internal/service/redis/resource_redis.go
@@ -52,7 +52,7 @@ func ResourceRedis() *schema.Resource {
 			),
 		),
 		Importer: &schema.ResourceImporter{
-			StateContext: schemautil.ResourceServiceState,
+			StateContext: schema.ImportStatePassthroughContext,
 		},
 		Timeouts: &schema.ResourceTimeout{
 			Create: schema.DefaultTimeout(20 * time.Minute),

--- a/internal/service/vpc/resource_aws_privatelink.go
+++ b/internal/service/vpc/resource_aws_privatelink.go
@@ -2,7 +2,6 @@ package vpc
 
 import (
 	"context"
-	"fmt"
 	"log"
 	"time"
 
@@ -43,7 +42,7 @@ func ResourceAWSPrivatelink() *schema.Resource {
 		UpdateContext: resourceAWSPrivatelinkUpdate,
 		DeleteContext: resourceAWSPrivatelinkDelete,
 		Importer: &schema.ResourceImporter{
-			StateContext: resourceAWSPrivatelinkState,
+			StateContext: schema.ImportStatePassthroughContext,
 		},
 		Timeouts: &schema.ResourceTimeout{
 			Create: schema.DefaultTimeout(20 * time.Minute),
@@ -161,15 +160,6 @@ func resourceAWSPrivatelinkDelete(_ context.Context, d *schema.ResourceData, m i
 	}
 
 	return nil
-}
-
-func resourceAWSPrivatelinkState(ctx context.Context, d *schema.ResourceData, m interface{}) ([]*schema.ResourceData, error) {
-	di := resourceAWSPrivatelinkRead(ctx, d, m)
-	if di.HasError() {
-		return nil, fmt.Errorf("cannot get AWS privatelink %v", di)
-	}
-
-	return []*schema.ResourceData{d}, nil
 }
 
 // AWSPrivatelinkWaiter is used to wait for Aiven to build a AWS privatelink

--- a/internal/service/vpc/resource_azure_privatelink.go
+++ b/internal/service/vpc/resource_azure_privatelink.go
@@ -2,7 +2,6 @@ package vpc
 
 import (
 	"context"
-	"fmt"
 	"log"
 	"time"
 
@@ -55,7 +54,7 @@ func ResourceAzurePrivatelink() *schema.Resource {
 		UpdateContext: resourceAzurePrivatelinkUpdate,
 		DeleteContext: resourceAzurePrivatelinkDelete,
 		Importer: &schema.ResourceImporter{
-			StateContext: resourceAzurePrivatelinkState,
+			StateContext: schema.ImportStatePassthroughContext,
 		},
 		Timeouts: &schema.ResourceTimeout{
 			Create: schema.DefaultTimeout(20 * time.Minute),
@@ -215,13 +214,4 @@ func resourceAzurePrivatelinkDelete(ctx context.Context, d *schema.ResourceData,
 	}
 
 	return nil
-}
-
-func resourceAzurePrivatelinkState(ctx context.Context, d *schema.ResourceData, m interface{}) ([]*schema.ResourceData, error) {
-	di := resourceAzurePrivatelinkRead(ctx, d, m)
-	if di.HasError() {
-		return nil, fmt.Errorf("cannot get Azure privatelink %v", di)
-	}
-
-	return []*schema.ResourceData{d}, nil
 }

--- a/internal/service/vpc/resource_azure_privatelink_connection_approve.go
+++ b/internal/service/vpc/resource_azure_privatelink_connection_approve.go
@@ -2,7 +2,6 @@ package vpc
 
 import (
 	"context"
-	"fmt"
 	"log"
 	"time"
 
@@ -43,7 +42,7 @@ func ResourceAzurePrivatelinkConnectionApproval() *schema.Resource {
 		UpdateContext: resourcePrivatelinkConnectionApprovalCreateUpdate,
 		DeleteContext: resourcePrivatelinkConnectionApprovalDelete,
 		Importer: &schema.ResourceImporter{
-			StateContext: resourcePrivatelinkConnectionApprovalState,
+			StateContext: schema.ImportStatePassthroughContext,
 		},
 		Timeouts: &schema.ResourceTimeout{
 			Create: schema.DefaultTimeout(20 * time.Minute),
@@ -187,13 +186,4 @@ func resourcePrivatelinkConnectionApprovalRead(_ context.Context, d *schema.Reso
 func resourcePrivatelinkConnectionApprovalDelete(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
 	/// API only supports approve/list/update. approved connection is deleted with the associated azure_privatelink resource
 	return nil
-}
-
-func resourcePrivatelinkConnectionApprovalState(ctx context.Context, d *schema.ResourceData, m interface{}) ([]*schema.ResourceData, error) {
-	di := resourcePrivatelinkConnectionApprovalRead(ctx, d, m)
-	if di.HasError() {
-		return nil, fmt.Errorf("cannot get aiven azure privatelink connection state %v", di)
-	}
-
-	return []*schema.ResourceData{d}, nil
 }


### PR DESCRIPTION
<!-- All contributors, please complete these sections, including maintainers. -->

## About this change—what it does

<!-- Provide a small sentence that summarizes the change. -->
- update the 404 error handling behavior during import
- use SDKv2 schema.ImportStatePassthroughContext as the importer state function

<!-- Provide the issue number below, if it exists. -->

## Why this way
- doing 404 error handling improperly prevents import from working properly in some cases
- SDKv2 exists :)

<!-- Provide a small explanation on why this is the approach you took for solving this problem. -->