### PR TITLE
test modification of `static_ips` in Terraform configs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,9 +12,13 @@ nav_order: 1
 - Update the 404 error handling behavior during import
 - Use SDKv2 `schema.ImportStatePassthroughContext` as the importer state function
 - Add Kafka `aiven_kafka_user.username` validation similar to Kafka ACL resource
-- Add CI job sweep
+- Add scheduled CI sweep job
 - Add acceptance test for modifying service's user config
 - Add support for `auto_join_team_id` in account authentication resource
+- Fix PostgreSQL acceptance test with `static_ips` to actually check for their existence after service's creation
+- Add acceptance test coverage for modification of `static_ips` in Terraform configs (via PostgreSQL)
+- Fix `CustomizeDiffCheckStaticIpDisassociation` behavior
+- Made it possible to delete static IPs in a single step, without dissociating them
 
 ## [3.2.1] - 2022-06-29
 

--- a/internal/acctest/acctest.go
+++ b/internal/acctest/acctest.go
@@ -16,16 +16,12 @@ import (
 )
 
 var (
-	TestAccProviders         map[string]*schema.Provider
 	TestAccProvider          *schema.Provider
 	TestAccProviderFactories map[string]func() (*schema.Provider, error)
 )
 
 func init() {
 	TestAccProvider = provider.Provider()
-	TestAccProviders = map[string]*schema.Provider{
-		"aiven": TestAccProvider,
-	}
 	TestAccProviderFactories = map[string]func() (*schema.Provider, error){
 		"aiven": func() (*schema.Provider, error) {
 			return TestAccProvider, nil

--- a/internal/schemautil/custom_diff.go
+++ b/internal/schemautil/custom_diff.go
@@ -28,7 +28,7 @@ func TagsShouldNotBeEmpty(_ context.Context, _, new, _ interface{}) bool {
 	return len(new.(*schema.Set).List()) != 0
 }
 
-func CustomizeDiffCheckUniqueTag(ctx context.Context, d *schema.ResourceDiff, m interface{}) error {
+func CustomizeDiffCheckUniqueTag(_ context.Context, d *schema.ResourceDiff, _ interface{}) error {
 	t := make(map[string]bool)
 	for _, tag := range d.Get("tag").(*schema.Set).List() {
 		tagVal := tag.(map[string]interface{})

--- a/internal/schemautil/custom_diff.go
+++ b/internal/schemautil/custom_diff.go
@@ -144,14 +144,7 @@ func CustomizeDiffCheckStaticIpDisassociation(_ context.Context, d *schema.Resou
 
 	// Check that we block deletions that will fail because the ip belongs to the service
 	for _, sip := range resp.StaticIPs {
-		assignedToTheService := sip.ServiceName == serviceName && sip.State == staticIpAssigned
-		aboutToBeDisassigned := !contains(plannedStaticIps, sip.StaticIPAddressID)
-		if assignedToTheService && aboutToBeDisassigned {
-			return fmt.Errorf("the static ip '%s' is currently assigned and cannot be disassociated from service '%s'", sip.StaticIPAddressID, serviceName)
-		}
-
 		associatedWithDifferentService := sip.ServiceName != "" && sip.ServiceName != serviceName
-
 		if associatedWithDifferentService && contains(plannedStaticIps, sip.StaticIPAddressID) {
 			return fmt.Errorf("the static ip '%s' is currently associated with service '%s'", sip.StaticIPAddressID, sip.ServiceName)
 		}

--- a/internal/schemautil/static_ips.go
+++ b/internal/schemautil/static_ips.go
@@ -10,8 +10,10 @@ import (
 )
 
 const (
-	staticIpAssigned  = "assigned"
-	staticIpAvailable = "available"
+	StaticIpCreating  = "creating"
+	StaticIpCreated   = "created"
+	StaticIpAvailable = "available"
+	StaticIpAssigned  = "assigned"
 )
 
 func CurrentlyAllocatedStaticIps(_ context.Context, projectName, serviceName string, m interface{}) ([]string, error) {

--- a/internal/schemautil/wait.go
+++ b/internal/schemautil/wait.go
@@ -284,7 +284,7 @@ func staticIpsReady(d *schema.ResourceData, m interface{}) (bool, error) {
 L:
 	for _, eip := range expectedStaticIps {
 		for _, sip := range staticIpsList.StaticIPs {
-			assignedOrAvailable := sip.State == staticIpAssigned || sip.State == staticIpAvailable
+			assignedOrAvailable := sip.State == StaticIpAssigned || sip.State == StaticIpAvailable
 			belongsToService := sip.ServiceName == serviceName
 			isExpectedIp := sip.StaticIPAddressID == eip
 
@@ -318,7 +318,7 @@ func staticIpsDisassociatedAfterServiceDeletion(d *schema.ResourceData, m interf
 		for _, sip := range staticIpsList.StaticIPs {
 			// no check for service name since after deletion the field is gone, but the
 			// static ip lingers in the assigned state for a while until it gets usable again
-			ipIsAssigned := sip.State == staticIpAssigned
+			ipIsAssigned := sip.State == StaticIpAssigned
 			isExpectedIp := sip.StaticIPAddressID == eip
 
 			if isExpectedIp && ipIsAssigned {

--- a/internal/service/pg/resource_pg_test.go
+++ b/internal/service/pg/resource_pg_test.go
@@ -102,6 +102,27 @@ func TestAccAivenPG_static_ips(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "static_ips.#", "2"),
 				),
 			},
+			{
+				Config: testAccPGWithStaticIpsAddition(rName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "service_name", fmt.Sprintf("test-acc-sr-%s", rName)),
+					resource.TestCheckResourceAttr(resourceName, "static_ips.#", "3"),
+				),
+			},
+			{
+				Config: testAccPGWithStaticIpsPreDeletion(rName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "service_name", fmt.Sprintf("test-acc-sr-%s", rName)),
+					resource.TestCheckResourceAttr(resourceName, "static_ips.#", "2"),
+				),
+			},
+			{
+				Config: testAccPGWithStaticIpsDeletion(rName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "service_name", fmt.Sprintf("test-acc-sr-%s", rName)),
+					resource.TestCheckResourceAttr(resourceName, "static_ips.#", "2"),
+				),
+			},
 		},
 	})
 }
@@ -237,6 +258,111 @@ func TestAccAivenPG_changing_disc_size(t *testing.T) {
 }
 
 func testAccPGWithStaticIps(name string) string {
+	return fmt.Sprintf(`
+data "aiven_project" "foo" {
+  project = "%s"
+}
+
+resource "aiven_static_ip" "ips" {
+  count      = 2
+  project    = data.aiven_project.foo.project
+  cloud_name = "google-europe-west1"
+}
+
+resource "aiven_pg" "bar" {
+  project                 = data.aiven_project.foo.project
+  cloud_name              = "google-europe-west1"
+  plan                    = "startup-4"
+  service_name            = "test-acc-sr-%s"
+  maintenance_window_dow  = "monday"
+  maintenance_window_time = "10:00:00"
+  static_ips              = toset(aiven_static_ip.ips[*].static_ip_address_id)
+
+  pg_user_config {
+    static_ips = true
+  }
+}
+
+data "aiven_pg" "common" {
+  service_name = aiven_pg.bar.service_name
+  project      = aiven_pg.bar.project
+
+  depends_on = [aiven_pg.bar]
+}`, os.Getenv("AIVEN_PROJECT_NAME"), name)
+}
+
+func testAccPGWithStaticIpsAddition(name string) string {
+	return fmt.Sprintf(`
+data "aiven_project" "foo" {
+  project = "%s"
+}
+
+resource "aiven_static_ip" "ips" {
+  count      = 3
+  project    = data.aiven_project.foo.project
+  cloud_name = "google-europe-west1"
+}
+
+resource "aiven_pg" "bar" {
+  project                 = data.aiven_project.foo.project
+  cloud_name              = "google-europe-west1"
+  plan                    = "startup-4"
+  service_name            = "test-acc-sr-%s"
+  maintenance_window_dow  = "monday"
+  maintenance_window_time = "10:00:00"
+  static_ips              = toset(aiven_static_ip.ips[*].static_ip_address_id)
+
+  pg_user_config {
+    static_ips = true
+  }
+}
+
+data "aiven_pg" "common" {
+  service_name = aiven_pg.bar.service_name
+  project      = aiven_pg.bar.project
+
+  depends_on = [aiven_pg.bar]
+}`, os.Getenv("AIVEN_PROJECT_NAME"), name)
+}
+
+func testAccPGWithStaticIpsPreDeletion(name string) string {
+	return fmt.Sprintf(`
+data "aiven_project" "foo" {
+  project = "%s"
+}
+
+resource "aiven_static_ip" "ips" {
+  count      = 3
+  project    = data.aiven_project.foo.project
+  cloud_name = "google-europe-west1"
+}
+
+resource "aiven_pg" "bar" {
+  project                 = data.aiven_project.foo.project
+  cloud_name              = "google-europe-west1"
+  plan                    = "startup-4"
+  service_name            = "test-acc-sr-%s"
+  maintenance_window_dow  = "monday"
+  maintenance_window_time = "10:00:00"
+  static_ips = toset([
+    aiven_static_ip.ips[0].static_ip_address_id,
+    aiven_static_ip.ips[1].static_ip_address_id,
+  ])
+
+  pg_user_config {
+    static_ips = true
+  }
+}
+
+data "aiven_pg" "common" {
+  service_name = aiven_pg.bar.service_name
+  project      = aiven_pg.bar.project
+
+  depends_on = [aiven_pg.bar]
+}`, os.Getenv("AIVEN_PROJECT_NAME"), name)
+}
+
+func testAccPGWithStaticIpsDeletion(name string) string {
 	return fmt.Sprintf(`
 data "aiven_project" "foo" {
   project = "%s"

--- a/internal/service/pg/resource_pg_test.go
+++ b/internal/service/pg/resource_pg_test.go
@@ -99,8 +99,7 @@ func TestAccAivenPG_static_ips(t *testing.T) {
 					resource.TestCheckResourceAttrSet(resourceName, "service_host"),
 					resource.TestCheckResourceAttrSet(resourceName, "service_port"),
 					resource.TestCheckResourceAttrSet(resourceName, "service_uri"),
-					// issue with the testing framework? this is always set in manual tests
-					// resource.TestCheckResourceAttrSet(resourceName, "static_ips"),
+					resource.TestCheckResourceAttr(resourceName, "static_ips.#", "2"),
 				),
 			},
 		},


### PR DESCRIPTION
<!-- All contributors, please complete these sections, including maintainers. -->

## About this change—what it does

<!-- Provide a small sentence that summarizes the change. -->
- fixes PostgreSQL acceptance test with `static_ips` to actually check for their existence after service's creation
- adds acceptance test coverage for modification of `static_ips` in Terraform configs (via PostgreSQL)
- fixes `CustomizeDiffCheckStaticIpDisassociation` behavior
- made it possible to delete static IPs in a single step, without dissociating them

<!-- Provide the issue number below, if it exists. -->

## Why this way

<!-- Provide a small explanation on why this is the approach you took for solving this problem. -->
- to make acceptance tests better
- to improve user experience
