### PR TITLE
add acceptance test for modifying service's user config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,8 @@ nav_order: 1
 - Update the 404 error handling behavior during import
 - Use SDKv2 `schema.ImportStatePassthroughContext` as the importer state function
 - Add Kafka `aiven_kafka_user.username` validation similar to Kafka ACL resource
-- Add CI job sweep 
+- Add CI job sweep
+- Add acceptance test for modifying service's user config
 
 ## [3.2.1] - 2022-06-29
 

--- a/internal/service/grafana/resource_grafana_test.go
+++ b/internal/service/grafana/resource_grafana_test.go
@@ -47,6 +47,139 @@ func TestAccAiven_grafana(t *testing.T) {
 	})
 }
 
+func TestAccAiven_grafana_user_config(t *testing.T) {
+	resourceName := "aiven_grafana.bar"
+	rName := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acc.TestAccPreCheck(t) },
+		ProviderFactories: acc.TestAccProviderFactories,
+		CheckDestroy:      acc.TestAccCheckAivenServiceResourceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccGrafanaResource(rName),
+				Check: resource.ComposeTestCheckFunc(
+					acc.TestAccCheckAivenServiceCommonAttributes("data.aiven_grafana.common"),
+					testAccCheckAivenServiceGrafanaAttributes("data.aiven_grafana.common"),
+					resource.TestCheckResourceAttr(resourceName, "service_name", fmt.Sprintf("test-acc-sr-%s", rName)),
+					resource.TestCheckResourceAttr(resourceName, "grafana_user_config.0.ip_filter.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "grafana_user_config.0.alerting_enabled", "true"),
+					resource.TestCheckResourceAttr(resourceName, "grafana_user_config.0.public_access.0.grafana", "true"),
+				),
+			},
+			{
+				Config: fmt.Sprintf(`
+data "aiven_project" "foo" {
+  project = "%s"
+}
+
+resource "aiven_grafana" "bar" {
+  project                 = data.aiven_project.foo.project
+  cloud_name              = "google-europe-west1"
+  plan                    = "startup-1"
+  service_name            = "test-acc-sr-%s"
+  maintenance_window_dow  = "monday"
+  maintenance_window_time = "10:00:00"
+
+  tag {
+    key   = "test"
+    value = "val"
+  }
+
+  grafana_user_config {
+    alerting_enabled = true
+    ip_filter        = ["127.0.0.1/32", "10.13.37.0/24"]
+
+    public_access {
+      grafana = false
+    }
+  }
+}
+
+data "aiven_grafana" "common" {
+  service_name = aiven_grafana.bar.service_name
+  project      = data.aiven_project.foo.project
+
+  depends_on = [aiven_grafana.bar]
+}`, os.Getenv("AIVEN_PROJECT_NAME"), rName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "grafana_user_config.0.ip_filter.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "grafana_user_config.0.alerting_enabled", "true"),
+					resource.TestCheckResourceAttr(resourceName, "grafana_user_config.0.public_access.0.grafana", "false"),
+				),
+			},
+			{
+				Config: fmt.Sprintf(`
+data "aiven_project" "foo" {
+  project = "%s"
+}
+
+resource "aiven_grafana" "bar" {
+  project                 = data.aiven_project.foo.project
+  cloud_name              = "google-europe-west1"
+  plan                    = "startup-1"
+  service_name            = "test-acc-sr-%s"
+  maintenance_window_dow  = "monday"
+  maintenance_window_time = "10:00:00"
+
+  tag {
+    key   = "test"
+    value = "val"
+  }
+
+  grafana_user_config {
+    ip_filter = ["10.13.37.0/24", "127.0.0.1/32"]
+  }
+}
+
+data "aiven_grafana" "common" {
+  service_name = aiven_grafana.bar.service_name
+  project      = data.aiven_project.foo.project
+
+  depends_on = [aiven_grafana.bar]
+}`, os.Getenv("AIVEN_PROJECT_NAME"), rName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "grafana_user_config.0.ip_filter.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "grafana_user_config.0.alerting_enabled", "true"),
+					resource.TestCheckResourceAttr(resourceName, "grafana_user_config.0.public_access.0.grafana", "false"),
+				),
+			},
+			{
+				Config: fmt.Sprintf(`
+data "aiven_project" "foo" {
+  project = "%s"
+}
+
+resource "aiven_grafana" "bar" {
+  project                 = data.aiven_project.foo.project
+  cloud_name              = "google-europe-west1"
+  plan                    = "startup-1"
+  service_name            = "test-acc-sr-%s"
+  maintenance_window_dow  = "monday"
+  maintenance_window_time = "10:00:00"
+
+  tag {
+    key   = "test"
+    value = "val"
+  }
+}
+
+data "aiven_grafana" "common" {
+  service_name = aiven_grafana.bar.service_name
+  project      = data.aiven_project.foo.project
+
+  depends_on = [aiven_grafana.bar]
+}`, os.Getenv("AIVEN_PROJECT_NAME"), rName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "grafana_user_config.0.ip_filter.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "grafana_user_config.0.alerting_enabled", "true"),
+					resource.TestCheckResourceAttr(resourceName, "grafana_user_config.0.public_access.0.grafana", "false"),
+				),
+			},
+		},
+	})
+}
+
 func testAccGrafanaResource(name string) string {
 	return fmt.Sprintf(`
 data "aiven_project" "foo" {


### PR DESCRIPTION
<!-- All contributors, please complete these sections, including maintainers. -->

## About this change—what it does

<!-- Provide a small sentence that summarizes the change. -->
add acceptance test for modifying service's user config

<!-- Provide the issue number below, if it exists. -->

## Why this way

<!-- Provide a small explanation on why this is the approach you took for solving this problem. -->
since all user config options are being handled by `schemautil.ConvertAPIUserConfigToTerraformCompatibleFormat`, we only need one test to be able to cover every user config