### PR TITLE
add support for `auto_join_team_id` in account authentication resource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ nav_order: 1
 - Add Kafka `aiven_kafka_user.username` validation similar to Kafka ACL resource
 - Add CI job sweep
 - Add acceptance test for modifying service's user config
+- Add support for `auto_join_team_id` in account authentication resource
 
 ## [3.2.1] - 2022-06-29
 

--- a/docs/data-sources/account_authentication.md
+++ b/docs/data-sources/account_authentication.md
@@ -30,6 +30,7 @@ data "aiven_account_authentication" "foo" {
 ### Read-Only
 
 - `authentication_id` (String) Account authentication id
+- `auto_join_team_id` (String) Team ID
 - `create_time` (String) Time of creation
 - `enabled` (Boolean) Status of account authentication method. The default value is `false`.
 - `id` (String) The ID of this resource.

--- a/docs/resources/account_authentication.md
+++ b/docs/resources/account_authentication.md
@@ -35,6 +35,7 @@ resource "aiven_account_authentication" "foo" {
 
 ### Optional
 
+- `auto_join_team_id` (String) Team ID
 - `enabled` (Boolean) Status of account authentication method. The default value is `false`.
 - `saml_certificate` (String) SAML Certificate
 - `saml_entity_id` (String) SAML Entity id

--- a/internal/service/account/resource_account_authentication.go
+++ b/internal/service/account/resource_account_authentication.go
@@ -16,22 +16,27 @@ var aivenAccountAuthenticationSchema = map[string]*schema.Schema{
 		Required:    true,
 		Description: "The unique id of the account.",
 	},
+	"name": {
+		Type:        schema.TypeString,
+		Required:    true,
+		Description: "The name of the account authentication.",
+	},
 	"type": {
 		Type:         schema.TypeString,
 		Required:     true,
 		ValidateFunc: validation.StringInSlice([]string{"internal", "saml"}, false),
 		Description:  schemautil.Complex("The account authentication type.").PossibleValues("internal", "saml").Build(),
 	},
-	"name": {
-		Type:        schema.TypeString,
-		Required:    true,
-		Description: "The name of the account authentication.",
-	},
 	"enabled": {
 		Type:        schema.TypeBool,
 		Optional:    true,
 		Default:     false,
 		Description: schemautil.Complex("Status of account authentication method.").DefaultValue(false).Build(),
+	},
+	"auto_join_team_id": {
+		Type:        schema.TypeString,
+		Optional:    true,
+		Description: "Team ID",
 	},
 	"saml_certificate": {
 		Type:        schema.TypeString,
@@ -48,6 +53,11 @@ var aivenAccountAuthenticationSchema = map[string]*schema.Schema{
 		Optional:    true,
 		Description: "SAML Entity id",
 	},
+	"authentication_id": {
+		Type:        schema.TypeString,
+		Computed:    true,
+		Description: "Account authentication id",
+	},
 	"saml_acs_url": {
 		Type:        schema.TypeString,
 		Computed:    true,
@@ -57,11 +67,6 @@ var aivenAccountAuthenticationSchema = map[string]*schema.Schema{
 		Type:        schema.TypeString,
 		Computed:    true,
 		Description: "SAML Metadata URL",
-	},
-	"authentication_id": {
-		Type:        schema.TypeString,
-		Computed:    true,
-		Description: "Account authentication id",
 	},
 	"create_time": {
 		Type:        schema.TypeString,
@@ -101,6 +106,7 @@ func resourceAccountAuthenticationCreate(ctx context.Context, d *schema.Resource
 			Enabled:         d.Get("enabled").(bool),
 			Name:            d.Get("name").(string),
 			Type:            d.Get("type").(string),
+			AutoJoinTeamId:  d.Get("auto_join_team_id").(string),
 			SAMLCertificate: d.Get("saml_certificate").(string),
 			SAMLIdpUrl:      d.Get("saml_idp_url").(string),
 			SAMLEntity:      d.Get("saml_entity_id").(string),
@@ -136,6 +142,9 @@ func resourceAccountAuthenticationRead(_ context.Context, d *schema.ResourceData
 		return diag.FromErr(err)
 	}
 	if err := d.Set("enabled", r.AuthenticationMethod.Enabled); err != nil {
+		return diag.FromErr(err)
+	}
+	if err := d.Set("auto_join_team_id", r.AuthenticationMethod.AutoJoinTeamId); err != nil {
 		return diag.FromErr(err)
 	}
 	if err := d.Set("saml_certificate", r.AuthenticationMethod.SAMLCertificate); err != nil {
@@ -175,6 +184,7 @@ func resourceAccountAuthenticationUpdate(ctx context.Context, d *schema.Resource
 		Enabled:         d.Get("enabled").(bool),
 		Name:            d.Get("name").(string),
 		Type:            d.Get("type").(string),
+		AutoJoinTeamId:  d.Get("auto_join_team_id").(string),
 		SAMLCertificate: d.Get("saml_certificate").(string),
 		SAMLIdpUrl:      d.Get("saml_idp_url").(string),
 		SAMLEntity:      d.Get("saml_entity_id").(string),


### PR DESCRIPTION
## About this change—what it does

<!-- Provide a small sentence that summarizes the change. -->
adds support for `auto_join_team_id` in account authentication resource

<!-- Provide the issue number below, if it exists. -->
resolves: #794

## Why this way

<!-- Provide a small explanation on why this is the approach you took for solving this problem. -->
to match API docs