### PR TITLE
Add .idea to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,4 @@ dist/
 
 # Editors
 .vscode
+.idea


### PR DESCRIPTION
## About this change—what it does

JetBrains GoLand generates files in `.idea`-directory. These files can be ignored.
