### PR TITLE
Fix testAccKafkaACLWrongUsernameResource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ nav_order: 1
 - Fix `CustomizeDiffCheckStaticIpDisassociation` behavior
 - Made it possible to delete static IPs in a single step, without dissociating them
 - Fix typo in sweeper
+- Fix acceptance test `TestAccAivenKafkaACL_basic`
 
 ## [3.2.1] - 2022-06-29
 

--- a/internal/service/kafka/resource_kafka_acl_test.go
+++ b/internal/service/kafka/resource_kafka_acl_test.go
@@ -173,7 +173,7 @@ resource "aiven_kafka_acl" "foo" {
   project      = "test-acc-pr-1"
   service_name = "test-acc-sr-1"
   topic        = "test-acc-topic-1"
-  username     = "*-user"
+  username     = "#-user"
   permission   = "admin"
 }`
 


### PR DESCRIPTION
## About this change—what it does

Change the username in the test to an invalid value. The test was failing.

