### PR TITLE
Kafka Topic waiter optimizations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ nav_order: 1
 
 ## [X.X.X] - Not yet released
 - Fix mark user config of `aiven_kafka_connector` as sensitive as it may contain credentials
+- Kafka Topic availability waiter optimization
 
 ## [3.3.0] - 2022-07-14
 - Fix auto generated documentation by bumping tfplugindocs to latest version

--- a/internal/service/kafka/kafka_topic_availability.go
+++ b/internal/service/kafka/kafka_topic_availability.go
@@ -125,11 +125,10 @@ func (w *KafkaTopicAvailabilityWaiter) Conf(timeout time.Duration) *resource.Sta
 	log.Printf("[DEBUG] Kafka Topic availability waiter timeout %.0f minutes", timeout.Minutes())
 
 	return &resource.StateChangeConf{
-		Pending:        []string{"CONFIGURING"},
-		Target:         []string{"ACTIVE"},
-		Refresh:        w.RefreshFunc(),
-		Timeout:        timeout,
-		PollInterval:   30 * time.Second,
-		NotFoundChecks: 50,
+		Pending:      []string{"CONFIGURING"},
+		Target:       []string{"ACTIVE"},
+		Refresh:      w.RefreshFunc(),
+		Timeout:      timeout,
+		PollInterval: 5 * time.Second,
 	}
 }

--- a/internal/service/kafka/kafka_topic_availability.go
+++ b/internal/service/kafka/kafka_topic_availability.go
@@ -107,15 +107,6 @@ func (w *KafkaTopicAvailabilityWaiter) refresh() error {
 		log.Printf("[DEBUG] Kafka Topic queue: %+v", queue)
 		v2Topics, err := w.Client.KafkaTopics.V2List(w.Project, w.ServiceName, queue)
 		if err != nil {
-			// if v2 endpoint retrieves 409 response code, it means that Kafka service has old nodes and
-			// v2 endpoint is not available, therefore using v1.
-			if err.(aiven.Error).Status == 409 {
-				err = w.v1Refresh(queue)
-				if err != nil {
-					return err
-				}
-			}
-
 			if aiven.IsNotFound(err) {
 				return fmt.Errorf("one of the Kafka Topics from the queue [%+v] is not found: %w", queue, err)
 			}
@@ -126,19 +117,6 @@ func (w *KafkaTopicAvailabilityWaiter) refresh() error {
 		cache.GetTopicCache().StoreByProjectAndServiceName(w.Project, w.ServiceName, v2Topics)
 	}
 
-	return nil
-}
-
-func (w *KafkaTopicAvailabilityWaiter) v1Refresh(queue []string) error {
-	log.Printf("[DEBUG] Kafka Topic V2 endpoit is not available, using v1!")
-	for _, t := range queue {
-		topic, err := w.Client.KafkaTopics.Get(w.Project, w.ServiceName, t)
-		if err != nil {
-			return err
-		}
-
-		cache.GetTopicCache().StoreByProjectAndServiceName(w.Project, w.ServiceName, []*aiven.KafkaTopic{topic})
-	}
 	return nil
 }
 

--- a/internal/service/kafka/resource_kafka_topic.go
+++ b/internal/service/kafka/resource_kafka_topic.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"log"
-	"strings"
 	"time"
 
 	"github.com/aiven/aiven-go-client"
@@ -231,7 +230,7 @@ func ResourceKafkaTopic() *schema.Resource {
 		UpdateContext: resourceKafkaTopicUpdate,
 		DeleteContext: resourceKafkaTopicDelete,
 		Importer: &schema.ResourceImporter{
-			StateContext: resourceKafkaTopicState,
+			StateContext: schema.ImportStatePassthroughContext,
 		},
 		Timeouts: &schema.ResourceTimeout{
 			Create: schema.DefaultTimeout(5 * time.Minute),
@@ -460,19 +459,6 @@ func resourceKafkaTopicDelete(ctx context.Context, d *schema.ResourceData, m int
 	}
 
 	return nil
-}
-
-func resourceKafkaTopicState(ctx context.Context, d *schema.ResourceData, m interface{}) ([]*schema.ResourceData, error) {
-	if len(strings.Split(d.Id(), "/")) != 3 {
-		return nil, fmt.Errorf("invalid identifier %v, expected <project_name>/<service_name>/<topic_name>", d.Id())
-	}
-
-	di := resourceKafkaTopicRead(ctx, d, m)
-	if di.HasError() {
-		return nil, fmt.Errorf("cannot get kafka topic: %v", di)
-	}
-
-	return []*schema.ResourceData{d}, nil
 }
 
 func flattenKafkaTopicConfig(t aiven.KafkaTopic) []map[string]interface{} {


### PR DESCRIPTION
<!-- All contributors, please complete these sections, including maintainers. -->

- User `ImportStatePassthroughContext` for Kafka Topic importer
- Remove v1 API fallback functionality for Kafka Topic availability waiter
- Kafka topic availability waiter optimization by reducing `PollInterval` to `5s`

## Why this way

Before TF v2 (v2.0.7), we've been using the Kafka Topics List endpoint that retrieves a list of all Kafka Topics for service. Around that time, Aiven added support for Kafka Topic config. Unfortunately, the config wasn't included in the Kafka Topic List API response `GET v1/project/{$project}/service/${service}/topic`. As a result, we had to query each topic one by one `GET v1/project/{$project}/service/${service}/topic/${topic_name}`, which is not optimal from the requests per second to API point of view and customer perspective (clearly, this approach would jeopardize performance). Finally, Kafka Topic v2 endpoint was created `POST v2/project/{$project}/service/${service}/topic`, which allowed us to query up to 100 Kafka Topics at the time, and we still use it today. 

Kafka Topic availability waiter is gathering Kafka Topics that need to be refreshed in a batch (up to 100 Topics). Therefore, the waiter queries the v2 endpoint sequentially despite Terraform's asynchronous management of the resources. 

That leads us to the`-parallelism` parameter usage; the default value is 10. But unfortunately, there is no correct number for everyone, since it depends on the number of Kafka topics in manifest and on the virtual machine (available CPU/RAM) where the Terraform command is executed. So from the waiter implementation, it doesn't make sense to have `-parallelism > 100`. 

In my tests, I was using `-parallelism=60` for the 2k Topics clusters; here are results:

**v3.3.0**
```
terraform apply --parallelism=60 | gnomon 
Total   609.3299s
```
**this PR**

```
terraform apply --parallelism=60 | gnomon 
Total   188.6568s
```

As you can see there is some performance gain, and amount of API calls per second is OK. 