### PR TITLE
tests: disable fail-fast

### DIFF
--- a/.github/workflows/acceptance-tests.yml
+++ b/.github/workflows/acceptance-tests.yml
@@ -15,8 +15,9 @@ jobs:
 
     strategy:
       max-parallel: 5
+      fail-fast: false
       matrix:
-        Pkg: [
+        pkg: [
           kafka,
           account,
           cassandra,
@@ -39,7 +40,6 @@ jobs:
         ]
 
     steps:
-
       - uses: softprops/turnstyle@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -64,7 +64,7 @@ jobs:
         env:
           AIVEN_TOKEN: ${{ secrets.AIVEN_TOKEN }}
           AIVEN_PROJECT_NAME: ${{ secrets.AIVEN_PROJECT_NAME }}
-          PKG: ${{matrix.Pkg}}
+          PKG: ${{matrix.pkg}}
 
   sweep:
     if: ${{ always() }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ nav_order: 1
 
 ## [MAJOR.MINOR.PATCH] - YYYY-MM-DD
 - Small static IP import fix
+- Disable `fail-fast` on acceptance tests 
 
 ## [3.3.1] - 2022-07-15
 - Fix mark user config of `aiven_kafka_connector` as sensitive as it may contain credentials


### PR DESCRIPTION
To get a better picture of the pipeline in case of flakiness