### PR TITLE
minor improvements and clean-ups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ nav_order: 1
 - Small static IP import fix
 - Add acceptance test for validating 404 error handling during import
 - Disable `fail-fast` on acceptance tests 
+- Replaced every `schema.Resource.Importer.StateContext` to `schema.ImportStatePassthroughContext`
+- Got rid of all unnecessary `d.SetId("")` calls
+- Replaced `vpc.parsePeeringVPCId` with `schemautil.SplitResourceID`
+- Made `schemautil.SplitResourceID` throw an error when the resulting amount of parts is not equal to expected
+- Marked deprecated resources deprecated
 
 ## [3.3.1] - 2022-07-15
 - Fix mark user config of `aiven_kafka_connector` as sensitive as it may contain credentials

--- a/internal/acctest/acctest.go
+++ b/internal/acctest/acctest.go
@@ -52,18 +52,20 @@ func TestAccCheckAivenServiceResourceDestroy(s *terraform.State) error {
 			continue
 		}
 
-		if len(schemautil.SplitResourceID(rs.Primary.ID, 2)) == 2 {
-			projectName, serviceName := schemautil.SplitResourceID2(rs.Primary.ID)
-			p, err := c.Services.Get(projectName, serviceName)
-			if err != nil {
-				if err.(aiven.Error).Status != 404 {
-					return err
-				}
-			}
+		projectName, serviceName, err := schemautil.SplitResourceID2(rs.Primary.ID)
+		if err != nil {
+			return err
+		}
 
-			if p != nil {
-				return fmt.Errorf("common (%s) still exists", rs.Primary.ID)
+		p, err := c.Services.Get(projectName, serviceName)
+		if err != nil {
+			if err.(aiven.Error).Status != 404 {
+				return err
 			}
+		}
+
+		if p != nil {
+			return fmt.Errorf("common (%s) still exists", rs.Primary.ID)
 		}
 	}
 

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -100,7 +100,7 @@ func Provider() *schema.Provider {
 			"aiven_gcp_vpc_peering_connection":     vpc.DatasourceGCPVPCPeeringConnection(),
 			"aiven_project_vpc":                    vpc.DatasourceProjectVPC(),
 			"aiven_transit_gateway_vpc_attachment": vpc.DatasourceTransitGatewayVPCAttachment(),
-			"aiven_vpc_peering_connection":         vpc.DatasourceVPCPeeringConnection(), // deprecated
+			"aiven_vpc_peering_connection":         vpc.DatasourceVPCPeeringConnection(), // Deprecated
 
 			// service integrations
 			"aiven_service_integration":          service_integration.DatasourceServiceIntegration(),
@@ -192,7 +192,7 @@ func Provider() *schema.Provider {
 			"aiven_gcp_vpc_peering_connection":            vpc.ResourceGCPVPCPeeringConnection(),
 			"aiven_project_vpc":                           vpc.ResourceProjectVPC(),
 			"aiven_transit_gateway_vpc_attachment":        vpc.ResourceTransitGatewayVPCAttachment(),
-			"aiven_vpc_peering_connection":                vpc.ResourceVPCPeeringConnection(), // deprecated
+			"aiven_vpc_peering_connection":                vpc.ResourceVPCPeeringConnection(), // Deprecated
 
 			// service integrations
 			"aiven_service_integration":          service_integration.ResourceServiceIntegration(),

--- a/internal/schemautil/schemautil.go
+++ b/internal/schemautil/schemautil.go
@@ -241,28 +241,35 @@ func BuildResourceID(parts ...string) string {
 	return strings.Join(finalParts, "/")
 }
 
-func SplitResourceID(resourceID string, n int) []string {
-	parts := strings.SplitN(resourceID, "/", n)
+func SplitResourceID(resourceID string, n int) (parts []string, err error) {
+	parts = strings.SplitN(resourceID, "/", n)
+
 	for idx, part := range parts {
 		part, _ := url.PathUnescape(part)
 		parts[idx] = part
 	}
-	return parts
+
+	if len(parts) != n {
+		err = fmt.Errorf("invalid resource id: %s", resourceID)
+		return nil, err
+	}
+
+	return
 }
 
-func SplitResourceID2(resourceID string) (string, string) {
-	parts := SplitResourceID(resourceID, 2)
-	return parts[0], parts[1]
+func SplitResourceID2(resourceID string) (string, string, error) {
+	parts, err := SplitResourceID(resourceID, 2)
+	return parts[0], parts[1], err
 }
 
-func SplitResourceID3(resourceID string) (string, string, string) {
-	parts := SplitResourceID(resourceID, 3)
-	return parts[0], parts[1], parts[2]
+func SplitResourceID3(resourceID string) (string, string, string, error) {
+	parts, err := SplitResourceID(resourceID, 3)
+	return parts[0], parts[1], parts[2], err
 }
 
-func SplitResourceID4(resourceID string) (string, string, string, string) {
-	parts := SplitResourceID(resourceID, 4)
-	return parts[0], parts[1], parts[2], parts[3]
+func SplitResourceID4(resourceID string) (string, string, string, string, error) {
+	parts, err := SplitResourceID(resourceID, 4)
+	return parts[0], parts[1], parts[2], parts[3], err
 }
 
 func FlattenToString(a []interface{}) []string {

--- a/internal/schemautil/schemautil_test.go
+++ b/internal/schemautil/schemautil_test.go
@@ -1,6 +1,7 @@
 package schemautil
 
 import (
+	"errors"
 	"reflect"
 	"testing"
 )
@@ -43,6 +44,50 @@ func Test_validateDurationString(t *testing.T) {
 			}
 			if !(tt.wantErrors == (len(gotErrors) > 0)) {
 				t.Errorf("validateDurationString() gotErrors = %v", gotErrors)
+			}
+		})
+	}
+}
+
+func Test_splitResourceID(t *testing.T) {
+	type args struct {
+		resourceID string
+		n          int
+	}
+	tests := []struct {
+		name      string
+		args      args
+		want      []string
+		wantError error
+	}{
+		{
+			"basic",
+			args{
+				resourceID: "test/identifier",
+				n:          2,
+			},
+			[]string{"test", "identifier"},
+			nil,
+		},
+		{
+			"invalid",
+			args{
+				resourceID: "invalid",
+				n:          2,
+			},
+			nil,
+			errors.New("invalid resource id: invalid"),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, gotError := SplitResourceID(tt.args.resourceID, tt.args.n)
+			if tt.wantError != nil {
+				if !reflect.DeepEqual(gotError, tt.wantError) {
+					t.Errorf("splitResourceID() gotError = %v, want %v", gotError, tt.wantError)
+				}
+			} else if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("splitResourceID() = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/internal/schemautil/service.go
+++ b/internal/schemautil/service.go
@@ -299,7 +299,11 @@ func ResourceServiceCreateWrapper(serviceType string) schema.CreateContextFunc {
 func ResourceServiceRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	client := m.(*aiven.Client)
 
-	projectName, serviceName := SplitResourceID2(d.Id())
+	projectName, serviceName, err := SplitResourceID2(d.Id())
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
 	s, err := client.Services.Get(projectName, serviceName)
 	if err != nil {
 		if err = ResourceReadHandleNotFound(err, d); err != nil {
@@ -407,7 +411,10 @@ func ResourceServiceUpdate(ctx context.Context, d *schema.ResourceData, m interf
 		return diag.FromErr(err)
 	}
 
-	projectName, serviceName := SplitResourceID2(d.Id())
+	projectName, serviceName, err := SplitResourceID2(d.Id())
+	if err != nil {
+		return diag.FromErr(err)
+	}
 
 	ass, dis, err := DiffStaticIps(ctx, d, m)
 	if err != nil {
@@ -484,7 +491,10 @@ func getDefaultDiskSpaceIfNotSet(ctx context.Context, d *schema.ResourceData, cl
 func ResourceServiceDelete(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	client := m.(*aiven.Client)
 
-	projectName, serviceName := SplitResourceID2(d.Id())
+	projectName, serviceName, err := SplitResourceID2(d.Id())
+	if err != nil {
+		return diag.FromErr(err)
+	}
 
 	if err := client.Services.Delete(projectName, serviceName); err != nil && !aiven.IsNotFound(err) {
 		return diag.FromErr(err)

--- a/internal/service/account/resource_account_authentication.go
+++ b/internal/service/account/resource_account_authentication.go
@@ -126,7 +126,11 @@ func resourceAccountAuthenticationCreate(ctx context.Context, d *schema.Resource
 func resourceAccountAuthenticationRead(_ context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	client := m.(*aiven.Client)
 
-	accountId, authId := schemautil.SplitResourceID2(d.Id())
+	accountId, authId, err := schemautil.SplitResourceID2(d.Id())
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
 	r, err := client.AccountAuthentications.Get(accountId, authId)
 	if err != nil {
 		return diag.FromErr(schemautil.ResourceReadHandleNotFound(err, d))
@@ -177,7 +181,10 @@ func resourceAccountAuthenticationRead(_ context.Context, d *schema.ResourceData
 
 func resourceAccountAuthenticationUpdate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	client := m.(*aiven.Client)
-	accountId, authId := schemautil.SplitResourceID2(d.Id())
+	accountId, authId, err := schemautil.SplitResourceID2(d.Id())
+	if err != nil {
+		return diag.FromErr(err)
+	}
 
 	r, err := client.AccountAuthentications.Update(accountId, aiven.AccountAuthenticationMethod{
 		Id:              authId,
@@ -203,9 +210,12 @@ func resourceAccountAuthenticationUpdate(ctx context.Context, d *schema.Resource
 func resourceAccountAuthenticationDelete(_ context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	client := m.(*aiven.Client)
 
-	accountId, teamId := schemautil.SplitResourceID2(d.Id())
+	accountId, teamId, err := schemautil.SplitResourceID2(d.Id())
+	if err != nil {
+		return diag.FromErr(err)
+	}
 
-	err := client.AccountAuthentications.Delete(accountId, teamId)
+	err = client.AccountAuthentications.Delete(accountId, teamId)
 	if err != nil && !aiven.IsNotFound(err) {
 		return diag.FromErr(err)
 	}

--- a/internal/service/account/resource_account_authentication_test.go
+++ b/internal/service/account/resource_account_authentication_test.go
@@ -8,7 +8,6 @@ import (
 	"github.com/aiven/aiven-go-client"
 	acc "github.com/aiven/terraform-provider-aiven/internal/acctest"
 	"github.com/aiven/terraform-provider-aiven/internal/schemautil"
-
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
@@ -123,7 +122,10 @@ func testAccCheckAivenAccountAuthenticationResourceDestroy(s *terraform.State) e
 			continue
 		}
 
-		accountId, authId := schemautil.SplitResourceID2(rs.Primary.ID)
+		accountId, authId, err := schemautil.SplitResourceID2(rs.Primary.ID)
+		if err != nil {
+			return err
+		}
 
 		r, err := c.Accounts.List()
 		if err != nil {
@@ -168,7 +170,10 @@ func testAccCheckAivenAccountAuthenticationWithAutoJoinTeamIDResourceDestroy(s *
 
 		isTeam := rs.Type == "aiven_account_team"
 
-		accountID, secondaryID := schemautil.SplitResourceID2(rs.Primary.ID)
+		accountID, secondaryID, err := schemautil.SplitResourceID2(rs.Primary.ID)
+		if err != nil {
+			return err
+		}
 
 		r, err := c.Accounts.List()
 		if err != nil {

--- a/internal/service/account/resource_account_team.go
+++ b/internal/service/account/resource_account_team.go
@@ -76,7 +76,11 @@ func resourceAccountTeamCreate(ctx context.Context, d *schema.ResourceData, m in
 func resourceAccountTeamRead(_ context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	client := m.(*aiven.Client)
 
-	accountId, teamId := schemautil.SplitResourceID2(d.Id())
+	accountId, teamId, err := schemautil.SplitResourceID2(d.Id())
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
 	r, err := client.AccountTeams.Get(accountId, teamId)
 	if err != nil {
 		return diag.FromErr(schemautil.ResourceReadHandleNotFound(err, d))
@@ -103,7 +107,10 @@ func resourceAccountTeamRead(_ context.Context, d *schema.ResourceData, m interf
 
 func resourceAccountTeamUpdate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	client := m.(*aiven.Client)
-	accountId, teamId := schemautil.SplitResourceID2(d.Id())
+	accountId, teamId, err := schemautil.SplitResourceID2(d.Id())
+	if err != nil {
+		return diag.FromErr(err)
+	}
 
 	r, err := client.AccountTeams.Update(accountId, teamId, aiven.AccountTeam{
 		Name: d.Get("name").(string),
@@ -120,9 +127,12 @@ func resourceAccountTeamUpdate(ctx context.Context, d *schema.ResourceData, m in
 func resourceAccountTeamDelete(_ context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	client := m.(*aiven.Client)
 
-	accountId, teamId := schemautil.SplitResourceID2(d.Id())
+	accountId, teamId, err := schemautil.SplitResourceID2(d.Id())
+	if err != nil {
+		return diag.FromErr(err)
+	}
 
-	err := client.AccountTeams.Delete(accountId, teamId)
+	err = client.AccountTeams.Delete(accountId, teamId)
 	if err != nil && !aiven.IsNotFound(err) {
 		return diag.FromErr(err)
 	}

--- a/internal/service/account/resource_account_team_member.go
+++ b/internal/service/account/resource_account_team_member.go
@@ -91,7 +91,11 @@ func resourceAccountTeamMemberCreate(ctx context.Context, d *schema.ResourceData
 func resourceAccountTeamMemberRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	var found bool
 	client := m.(*aiven.Client)
-	accountId, teamId, userEmail := schemautil.SplitResourceID3(d.Id())
+
+	accountId, teamId, userEmail, err := schemautil.SplitResourceID3(d.Id())
+	if err != nil {
+		return diag.FromErr(err)
+	}
 
 	r, err := client.AccountTeamInvites.List(accountId, teamId)
 	if err != nil {
@@ -171,10 +175,13 @@ func resourceAccountTeamMemberRead(ctx context.Context, d *schema.ResourceData, 
 func resourceAccountTeamMemberDelete(_ context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	client := m.(*aiven.Client)
 
-	accountId, teamId, userEmail := schemautil.SplitResourceID3(d.Id())
+	accountId, teamId, userEmail, err := schemautil.SplitResourceID3(d.Id())
+	if err != nil {
+		return diag.FromErr(err)
+	}
 
 	// delete account team user invitation
-	err := client.AccountTeamInvites.Delete(accountId, teamId, userEmail)
+	err = client.AccountTeamInvites.Delete(accountId, teamId, userEmail)
 	if err != nil && !aiven.IsNotFound(err) {
 		return diag.FromErr(err)
 	}

--- a/internal/service/account/resource_account_team_member_test.go
+++ b/internal/service/account/resource_account_team_member_test.go
@@ -8,7 +8,6 @@ import (
 	"github.com/aiven/aiven-go-client"
 	acc "github.com/aiven/terraform-provider-aiven/internal/acctest"
 	"github.com/aiven/terraform-provider-aiven/internal/schemautil"
-
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
@@ -70,7 +69,10 @@ func testAccCheckAivenAccountTeamMemberResourceDestroy(s *terraform.State) error
 			continue
 		}
 
-		accountId, teamId, userEmail := schemautil.SplitResourceID3(rs.Primary.ID)
+		accountId, teamId, userEmail, err := schemautil.SplitResourceID3(rs.Primary.ID)
+		if err != nil {
+			return err
+		}
 
 		r, err := c.Accounts.List()
 		if err != nil {

--- a/internal/service/account/resource_account_team_project.go
+++ b/internal/service/account/resource_account_team_project.go
@@ -83,7 +83,11 @@ func resourceAccountTeamProjectCreate(ctx context.Context, d *schema.ResourceDat
 func resourceAccountTeamProjectRead(_ context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	client := m.(*aiven.Client)
 
-	accountId, teamId, projectName := schemautil.SplitResourceID3(d.Id())
+	accountId, teamId, projectName, err := schemautil.SplitResourceID3(d.Id())
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
 	r, err := client.AccountTeamProjects.List(accountId, teamId)
 	if err != nil {
 		return diag.FromErr(schemautil.ResourceReadHandleNotFound(err, d))
@@ -119,11 +123,15 @@ func resourceAccountTeamProjectRead(_ context.Context, d *schema.ResourceData, m
 func resourceAccountTeamProjectUpdate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	client := m.(*aiven.Client)
 
-	accountId, teamId, _ := schemautil.SplitResourceID3(d.Id())
+	accountId, teamId, _, err := schemautil.SplitResourceID3(d.Id())
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
 	newProjectName := d.Get("project_name").(string)
 	teamType := d.Get("team_type").(string)
 
-	err := client.AccountTeamProjects.Update(accountId, teamId, aiven.AccountTeamProject{
+	err = client.AccountTeamProjects.Update(accountId, teamId, aiven.AccountTeamProject{
 		TeamType:    teamType,
 		ProjectName: newProjectName,
 	})
@@ -139,7 +147,12 @@ func resourceAccountTeamProjectUpdate(ctx context.Context, d *schema.ResourceDat
 func resourceAccountTeamProjectDelete(_ context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	client := m.(*aiven.Client)
 
-	err := client.AccountTeamProjects.Delete(schemautil.SplitResourceID3(d.Id()))
+	accountId, teamId, projectName, err := schemautil.SplitResourceID3(d.Id())
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	err = client.AccountTeamProjects.Delete(accountId, teamId, projectName)
 	if err != nil && !aiven.IsNotFound(err) {
 		return diag.FromErr(err)
 	}

--- a/internal/service/account/resource_account_team_project_test.go
+++ b/internal/service/account/resource_account_team_project_test.go
@@ -8,7 +8,6 @@ import (
 	"github.com/aiven/aiven-go-client"
 	acc "github.com/aiven/terraform-provider-aiven/internal/acctest"
 	"github.com/aiven/terraform-provider-aiven/internal/schemautil"
-
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
@@ -76,7 +75,10 @@ func testAccCheckAivenAccountTeamProjectResourceDestroy(s *terraform.State) erro
 			continue
 		}
 
-		accountId, teamId, projectName := schemautil.SplitResourceID3(rs.Primary.ID)
+		accountId, teamId, projectName, err := schemautil.SplitResourceID3(rs.Primary.ID)
+		if err != nil {
+			return err
+		}
 
 		r, err := c.Accounts.List()
 		if err != nil {

--- a/internal/service/account/resource_account_team_test.go
+++ b/internal/service/account/resource_account_team_test.go
@@ -8,7 +8,6 @@ import (
 	"github.com/aiven/aiven-go-client"
 	acc "github.com/aiven/terraform-provider-aiven/internal/acctest"
 	"github.com/aiven/terraform-provider-aiven/internal/schemautil"
-
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
@@ -62,7 +61,10 @@ func testAccCheckAivenAccountTeamResourceDestroy(s *terraform.State) error {
 			continue
 		}
 
-		accountId, teamId := schemautil.SplitResourceID2(rs.Primary.ID)
+		accountId, teamId, err := schemautil.SplitResourceID2(rs.Primary.ID)
+		if err != nil {
+			return err
+		}
 
 		r, err := c.Accounts.List()
 		if err != nil {

--- a/internal/service/cassandra/resource_cassandra_user.go
+++ b/internal/service/cassandra/resource_cassandra_user.go
@@ -54,7 +54,7 @@ func ResourceCassandraUser() *schema.Resource {
 		ReadContext:   schemautil.ResourceServiceUserRead,
 		DeleteContext: schemautil.ResourceServiceUserDelete,
 		Importer: &schema.ResourceImporter{
-			StateContext: schemautil.ResourceServiceUserState,
+			StateContext: schema.ImportStatePassthroughContext,
 		},
 
 		Schema: aivenCassandraUserSchema,

--- a/internal/service/cassandra/resource_cassandra_user_test.go
+++ b/internal/service/cassandra/resource_cassandra_user_test.go
@@ -5,9 +5,8 @@ import (
 	"os"
 	"testing"
 
-	acc "github.com/aiven/terraform-provider-aiven/internal/acctest"
-
 	"github.com/aiven/aiven-go-client"
+	acc "github.com/aiven/terraform-provider-aiven/internal/acctest"
 	"github.com/aiven/terraform-provider-aiven/internal/schemautil"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
@@ -47,7 +46,11 @@ func testAccCheckAivenCassandraUserResourceDestroy(s *terraform.State) error {
 			continue
 		}
 
-		projectName, serviceName, username := schemautil.SplitResourceID3(rs.Primary.ID)
+		projectName, serviceName, username, err := schemautil.SplitResourceID3(rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+
 		p, err := c.ServiceUsers.Get(projectName, serviceName, username)
 		if err != nil {
 			if err.(aiven.Error).Status != 404 {

--- a/internal/service/clickhouse/resource_clickhouse_grant.go
+++ b/internal/service/clickhouse/resource_clickhouse_grant.go
@@ -158,7 +158,10 @@ func setUserOrRole(d *schema.ResourceData, granteeType, userOrRole string) error
 func resourceClickhouseGrantRead(_ context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	client := m.(*aiven.Client)
 
-	projectName, serviceName, granteeType, userOrRole := schemautil.SplitResourceID4(d.Id())
+	projectName, serviceName, granteeType, userOrRole, err := schemautil.SplitResourceID4(d.Id())
+	if err != nil {
+		return diag.FromErr(err)
+	}
 
 	if err := d.Set("project", projectName); err != nil {
 		return diag.FromErr(err)
@@ -208,7 +211,6 @@ func resourceClickhouseGrantDelete(_ context.Context, d *schema.ResourceData, m 
 		}
 	}
 
-	d.SetId("")
 	return nil
 }
 

--- a/internal/service/clickhouse/resource_clickhouse_grant_test.go
+++ b/internal/service/clickhouse/resource_clickhouse_grant_test.go
@@ -5,9 +5,8 @@ import (
 	"os"
 	"testing"
 
-	"github.com/aiven/terraform-provider-aiven/internal/service/clickhouse"
-
 	acc "github.com/aiven/terraform-provider-aiven/internal/acctest"
+	"github.com/aiven/terraform-provider-aiven/internal/service/clickhouse"
 
 	"github.com/aiven/aiven-go-client"
 	"github.com/aiven/terraform-provider-aiven/internal/schemautil"
@@ -103,7 +102,10 @@ func testAccCheckAivenClickhouseGrantResourceDestroy(s *terraform.State) error {
 			continue
 		}
 
-		projectName, serviceName, granteeType, granteeName := schemautil.SplitResourceID4(rs.Primary.ID)
+		projectName, serviceName, granteeType, granteeName, err := schemautil.SplitResourceID4(rs.Primary.ID)
+		if err != nil {
+			return err
+		}
 
 		grantee := clickhouse.Grantee{}
 		switch granteeType {

--- a/internal/service/clickhouse/resource_clickhouse_role_test.go
+++ b/internal/service/clickhouse/resource_clickhouse_role_test.go
@@ -5,11 +5,10 @@ import (
 	"os"
 	"testing"
 
-	acc "github.com/aiven/terraform-provider-aiven/internal/acctest"
-	"github.com/aiven/terraform-provider-aiven/internal/service/clickhouse"
-
 	"github.com/aiven/aiven-go-client"
+	acc "github.com/aiven/terraform-provider-aiven/internal/acctest"
 	"github.com/aiven/terraform-provider-aiven/internal/schemautil"
+	"github.com/aiven/terraform-provider-aiven/internal/service/clickhouse"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -63,7 +62,11 @@ func testAccCheckAivenClickhouseRoleResourceDestroy(s *terraform.State) error {
 			continue
 		}
 
-		projectName, serviceName, roleName := schemautil.SplitResourceID3(rs.Primary.ID)
+		projectName, serviceName, roleName, err := schemautil.SplitResourceID3(rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+
 		if exists, err := clickhouse.RoleExists(c, projectName, serviceName, roleName); err != nil {
 			if aiven.IsNotFound(err) {
 				continue

--- a/internal/service/clickhouse/resource_clickhouse_user_test.go
+++ b/internal/service/clickhouse/resource_clickhouse_user_test.go
@@ -6,9 +6,8 @@ import (
 	"os"
 	"testing"
 
-	acc "github.com/aiven/terraform-provider-aiven/internal/acctest"
-
 	"github.com/aiven/aiven-go-client"
+	acc "github.com/aiven/terraform-provider-aiven/internal/acctest"
 	"github.com/aiven/terraform-provider-aiven/internal/schemautil"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
@@ -50,7 +49,11 @@ func testAccCheckAivenClickhouseUserResourceDestroy(s *terraform.State) error {
 			continue
 		}
 
-		projectName, serviceName, uuid := schemautil.SplitResourceID3(rs.Primary.ID)
+		projectName, serviceName, uuid, err := schemautil.SplitResourceID3(rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+
 		p, err := c.ClickhouseUser.Get(projectName, serviceName, uuid)
 		if err != nil {
 			if err.(aiven.Error).Status != 404 {

--- a/internal/service/connection_pool/resource_connection_pool_test.go
+++ b/internal/service/connection_pool/resource_connection_pool_test.go
@@ -8,7 +8,6 @@ import (
 	"github.com/aiven/aiven-go-client"
 	acc "github.com/aiven/terraform-provider-aiven/internal/acctest"
 	"github.com/aiven/terraform-provider-aiven/internal/schemautil"
-
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
@@ -187,7 +186,11 @@ func testAccCheckAivenConnectionPoolResourceDestroy(s *terraform.State) error {
 			continue
 		}
 
-		projectName, serviceName, databaseName := schemautil.SplitResourceID3(rs.Primary.ID)
+		projectName, serviceName, databaseName, err := schemautil.SplitResourceID3(rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+
 		pool, err := c.ConnectionPools.Get(projectName, serviceName, databaseName)
 		if err != nil {
 			if err.(aiven.Error).Status != 404 {

--- a/internal/service/database/datasource_database.go
+++ b/internal/service/database/datasource_database.go
@@ -10,6 +10,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
+// DatasourceDatabase
+// Deprecated
 func DatasourceDatabase() *schema.Resource {
 	return &schema.Resource{
 		ReadContext: datasourceDatabaseRead,

--- a/internal/service/database/resource_database_test.go
+++ b/internal/service/database/resource_database_test.go
@@ -5,9 +5,8 @@ import (
 	"os"
 	"testing"
 
-	acc "github.com/aiven/terraform-provider-aiven/internal/acctest"
-
 	"github.com/aiven/aiven-go-client"
+	acc "github.com/aiven/terraform-provider-aiven/internal/acctest"
 	"github.com/aiven/terraform-provider-aiven/internal/schemautil"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
@@ -60,7 +59,11 @@ func testAccCheckAivenDatabaseResourceDestroy(s *terraform.State) error {
 			continue
 		}
 
-		projectName, serviceName, databaseName := schemautil.SplitResourceID3(rs.Primary.ID)
+		projectName, serviceName, databaseName, err := schemautil.SplitResourceID3(rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+
 		db, err := c.Databases.Get(projectName, serviceName, databaseName)
 		if err != nil {
 			if err.(aiven.Error).Status != 404 {

--- a/internal/service/flink/resource_flink_job.go
+++ b/internal/service/flink/resource_flink_job.go
@@ -66,7 +66,10 @@ func ResourceFlinkJob() *schema.Resource {
 func resourceFlinkJobRead(_ context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	client := m.(*aiven.Client)
 
-	project, serviceName, jobId := schemautil.SplitResourceID3(d.Id())
+	project, serviceName, jobId, err := schemautil.SplitResourceID3(d.Id())
+	if err != nil {
+		return diag.FromErr(err)
+	}
 
 	r, err := client.FlinkJobs.Get(project, serviceName, aiven.GetFlinkJobRequest{JobId: jobId})
 	if err != nil {
@@ -161,9 +164,12 @@ func resourceFlinkJobCreate(ctx context.Context, d *schema.ResourceData, m inter
 func resourceFlinkJobDelete(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	client := m.(*aiven.Client)
 
-	project, serviceName, jobId := schemautil.SplitResourceID3(d.Id())
+	project, serviceName, jobId, err := schemautil.SplitResourceID3(d.Id())
+	if err != nil {
+		return diag.FromErr(err)
+	}
 
-	err := client.FlinkJobs.Patch(
+	err = client.FlinkJobs.Patch(
 		project,
 		serviceName,
 		aiven.PatchFlinkJobRequest{JobId: jobId},

--- a/internal/service/flink/resource_flink_table.go
+++ b/internal/service/flink/resource_flink_table.go
@@ -197,7 +197,10 @@ func ResourceFlinkTable() *schema.Resource {
 func resourceFlinkTableRead(_ context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	client := m.(*aiven.Client)
 
-	project, serviceName, tableId := schemautil.SplitResourceID3(d.Id())
+	project, serviceName, tableId, err := schemautil.SplitResourceID3(d.Id())
+	if err != nil {
+		return diag.FromErr(err)
+	}
 
 	r, err := client.FlinkTables.Get(project, serviceName, aiven.GetFlinkTableRequest{TableId: tableId})
 	if err != nil {
@@ -295,9 +298,12 @@ func readUpsertKafkaFromSchema(d *schema.ResourceData) *aiven.FlinkTableUpsertKa
 func resourceFlinkTableDelete(_ context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	client := m.(*aiven.Client)
 
-	project, serviceName, tableId := schemautil.SplitResourceID3(d.Id())
+	project, serviceName, tableId, err := schemautil.SplitResourceID3(d.Id())
+	if err != nil {
+		return diag.FromErr(err)
+	}
 
-	err := client.FlinkTables.Delete(
+	err = client.FlinkTables.Delete(
 		project,
 		serviceName,
 		aiven.DeleteFlinkTableRequest{

--- a/internal/service/flink/resource_flink_test.go
+++ b/internal/service/flink/resource_flink_test.go
@@ -8,9 +8,8 @@ import (
 	"strings"
 	"testing"
 
-	acc "github.com/aiven/terraform-provider-aiven/internal/acctest"
-
 	"github.com/aiven/aiven-go-client"
+	acc "github.com/aiven/terraform-provider-aiven/internal/acctest"
 	"github.com/aiven/terraform-provider-aiven/internal/schemautil"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
@@ -706,9 +705,12 @@ func testAccCheckAivenFlinkJobsAndTableResourcesDestroy(s *terraform.State) erro
 	for _, rs := range s.RootModule().Resources {
 		switch rs.Type {
 		case "aiven_flink_job":
-			project, serviceName, jobId := schemautil.SplitResourceID3(rs.Primary.ID)
+			project, serviceName, jobId, err := schemautil.SplitResourceID3(rs.Primary.ID)
+			if err != nil {
+				return err
+			}
 
-			_, err := c.Services.Get(project, serviceName)
+			_, err = c.Services.Get(project, serviceName)
 			if err != nil {
 				if aiven.IsNotFound(err) {
 					continue
@@ -728,9 +730,12 @@ func testAccCheckAivenFlinkJobsAndTableResourcesDestroy(s *terraform.State) erro
 				return fmt.Errorf("flink job (%s) still exists, id %s", jobId, rs.Primary.ID)
 			}
 		case "aiven_flink_table":
-			project, serviceName, tableId := schemautil.SplitResourceID3(rs.Primary.ID)
+			project, serviceName, tableId, err := schemautil.SplitResourceID3(rs.Primary.ID)
+			if err != nil {
+				return err
+			}
 
-			_, err := c.Services.Get(project, serviceName)
+			_, err = c.Services.Get(project, serviceName)
 			if err != nil {
 				if aiven.IsNotFound(err) {
 					continue

--- a/internal/service/influxdb/resource_influxdb_database.go
+++ b/internal/service/influxdb/resource_influxdb_database.go
@@ -2,8 +2,6 @@ package influxdb
 
 import (
 	"context"
-	"fmt"
-	"strings"
 	"time"
 
 	"github.com/aiven/aiven-go-client"
@@ -37,7 +35,7 @@ func ResourceInfluxDBDatabase() *schema.Resource {
 		DeleteContext: resourceInfluxDBDatabaseDelete,
 		UpdateContext: resourceInfluxDBDatabaseUpdate,
 		Importer: &schema.ResourceImporter{
-			StateContext: resourceInfluxDBDatabaseState,
+			StateContext: schema.ImportStatePassthroughContext,
 		},
 		Timeouts: &schema.ResourceTimeout{
 			Delete: schema.DefaultTimeout(2 * time.Minute),
@@ -78,7 +76,11 @@ func resourceInfluxDBDatabaseUpdate(ctx context.Context, d *schema.ResourceData,
 func resourceInfluxDBDatabaseRead(_ context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	client := m.(*aiven.Client)
 
-	projectName, serviceName, databaseName := schemautil.SplitResourceID3(d.Id())
+	projectName, serviceName, databaseName, err := schemautil.SplitResourceID3(d.Id())
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
 	database, err := client.Databases.Get(projectName, serviceName, databaseName)
 	if err != nil {
 		return diag.FromErr(schemautil.ResourceReadHandleNotFound(err, d))
@@ -100,7 +102,10 @@ func resourceInfluxDBDatabaseRead(_ context.Context, d *schema.ResourceData, m i
 func resourceInfluxDBDatabaseDelete(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	client := m.(*aiven.Client)
 
-	projectName, serviceName, databaseName := schemautil.SplitResourceID3(d.Id())
+	projectName, serviceName, databaseName, err := schemautil.SplitResourceID3(d.Id())
+	if err != nil {
+		return diag.FromErr(err)
+	}
 
 	if d.Get("termination_protection").(bool) {
 		return diag.Errorf("cannot delete a database termination_protection is enabled")
@@ -114,23 +119,10 @@ func resourceInfluxDBDatabaseDelete(ctx context.Context, d *schema.ResourceData,
 	}
 
 	timeout := d.Timeout(schema.TimeoutDelete)
-	_, err := waiter.Conf(timeout).WaitForStateContext(ctx)
+	_, err = waiter.Conf(timeout).WaitForStateContext(ctx)
 	if err != nil {
 		return diag.Errorf("error waiting for Aiven Database to be DELETED: %s", err)
 	}
 
 	return nil
-}
-
-func resourceInfluxDBDatabaseState(ctx context.Context, d *schema.ResourceData, m interface{}) ([]*schema.ResourceData, error) {
-	if len(strings.Split(d.Id(), "/")) != 3 {
-		return nil, fmt.Errorf("invalid identifier %v, expected <project_name>/<service_name>/<database_name>", d.Id())
-	}
-
-	di := resourceInfluxDBDatabaseRead(ctx, d, m)
-	if di.HasError() {
-		return nil, fmt.Errorf("cannot get database: %v", di)
-	}
-
-	return []*schema.ResourceData{d}, nil
 }

--- a/internal/service/influxdb/resource_influxdb_database_test.go
+++ b/internal/service/influxdb/resource_influxdb_database_test.go
@@ -7,9 +7,8 @@ import (
 	"strings"
 	"testing"
 
-	acc "github.com/aiven/terraform-provider-aiven/internal/acctest"
-
 	"github.com/aiven/aiven-go-client"
+	acc "github.com/aiven/terraform-provider-aiven/internal/acctest"
 	"github.com/aiven/terraform-provider-aiven/internal/schemautil"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
@@ -96,7 +95,11 @@ func testAccCheckAivenInfluxDBDatabaseResourceDestroy(s *terraform.State) error 
 			continue
 		}
 
-		projectName, serviceName, databaseName := schemautil.SplitResourceID3(rs.Primary.ID)
+		projectName, serviceName, databaseName, err := schemautil.SplitResourceID3(rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+
 		db, err := c.Databases.Get(projectName, serviceName, databaseName)
 		if err != nil {
 			if err.(aiven.Error).Status != 404 {

--- a/internal/service/influxdb/resource_influxdb_user.go
+++ b/internal/service/influxdb/resource_influxdb_user.go
@@ -54,7 +54,7 @@ func ResourceInfluxDBUser() *schema.Resource {
 		ReadContext:   schemautil.ResourceServiceUserRead,
 		DeleteContext: schemautil.ResourceServiceUserDelete,
 		Importer: &schema.ResourceImporter{
-			StateContext: schemautil.ResourceServiceUserState,
+			StateContext: schema.ImportStatePassthroughContext,
 		},
 
 		Schema: aivenInfluxDBUserSchema,

--- a/internal/service/influxdb/resource_influxdb_user_test.go
+++ b/internal/service/influxdb/resource_influxdb_user_test.go
@@ -5,9 +5,8 @@ import (
 	"os"
 	"testing"
 
-	acc "github.com/aiven/terraform-provider-aiven/internal/acctest"
-
 	"github.com/aiven/aiven-go-client"
+	acc "github.com/aiven/terraform-provider-aiven/internal/acctest"
 	"github.com/aiven/terraform-provider-aiven/internal/schemautil"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
@@ -47,7 +46,11 @@ func testAccCheckAivenInfluxDBUserResourceDestroy(s *terraform.State) error {
 			continue
 		}
 
-		projectName, serviceName, username := schemautil.SplitResourceID3(rs.Primary.ID)
+		projectName, serviceName, username, err := schemautil.SplitResourceID3(rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+
 		p, err := c.ServiceUsers.Get(projectName, serviceName, username)
 		if err != nil {
 			if err.(aiven.Error).Status != 404 {

--- a/internal/service/kafka/resource_kafka.go
+++ b/internal/service/kafka/resource_kafka.go
@@ -175,7 +175,12 @@ func resourceKafkaCreate(ctx context.Context, d *schema.ResourceData, m interfac
 func resourceKafkaRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	client := m.(*aiven.Client)
 
-	kafka, err := client.Services.Get(schemautil.SplitResourceID2(d.Id()))
+	project, service, err := schemautil.SplitResourceID2(d.Id())
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	kafka, err := client.Services.Get(project, service)
 	if err != nil {
 		return diag.FromErr(schemautil.ResourceReadHandleNotFound(err, d))
 	}

--- a/internal/service/kafka/resource_kafka_acl_test.go
+++ b/internal/service/kafka/resource_kafka_acl_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/aiven/aiven-go-client"
 	acc "github.com/aiven/terraform-provider-aiven/internal/acctest"
 	"github.com/aiven/terraform-provider-aiven/internal/schemautil"
-
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
@@ -249,7 +248,11 @@ func testAccCheckAivenKafkaACLResourceDestroy(s *terraform.State) error {
 			continue
 		}
 
-		project, serviceName, aclID := schemautil.SplitResourceID3(rs.Primary.ID)
+		project, serviceName, aclID, err := schemautil.SplitResourceID3(rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+
 		p, err := c.KafkaACLs.Get(project, serviceName, aclID)
 		if err != nil {
 			if err.(aiven.Error).Status != 404 {

--- a/internal/service/kafka/resource_kafka_connector_test.go
+++ b/internal/service/kafka/resource_kafka_connector_test.go
@@ -6,9 +6,8 @@ import (
 	"regexp"
 	"testing"
 
-	acc "github.com/aiven/terraform-provider-aiven/internal/acctest"
-
 	"github.com/aiven/aiven-go-client"
+	acc "github.com/aiven/terraform-provider-aiven/internal/acctest"
 	"github.com/aiven/terraform-provider-aiven/internal/schemautil"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
@@ -77,8 +76,12 @@ func testAccCheckAivenKafkaConnectorResourceDestroy(s *terraform.State) error {
 			continue
 		}
 
-		projectName, serviceName := schemautil.SplitResourceID2(rs.Primary.ID)
-		_, err := c.Services.Get(projectName, serviceName)
+		projectName, serviceName, err := schemautil.SplitResourceID2(rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+
+		_, err = c.Services.Get(projectName, serviceName)
 		if err != nil {
 			if err.(aiven.Error).Status == 404 {
 				return nil

--- a/internal/service/kafka/resource_kafka_schema.go
+++ b/internal/service/kafka/resource_kafka_schema.go
@@ -167,7 +167,11 @@ func resourceKafkaSchemaCreate(ctx context.Context, d *schema.ResourceData, m in
 }
 
 func resourceKafkaSchemaUpdate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	var project, serviceName, subjectName = schemautil.SplitResourceID3(d.Id())
+	project, serviceName, subjectName, err := schemautil.SplitResourceID3(d.Id())
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
 	client := m.(*aiven.Client)
 
 	if d.HasChange("schema") {
@@ -202,7 +206,11 @@ func resourceKafkaSchemaUpdate(ctx context.Context, d *schema.ResourceData, m in
 }
 
 func resourceKafkaSchemaRead(_ context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	var project, serviceName, subjectName = schemautil.SplitResourceID3(d.Id())
+	project, serviceName, subjectName, err := schemautil.SplitResourceID3(d.Id())
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
 	client := m.(*aiven.Client)
 
 	version, err := kafkaSchemaSubjectGetLastVersion(m, project, serviceName, subjectName)
@@ -249,9 +257,12 @@ func resourceKafkaSchemaRead(_ context.Context, d *schema.ResourceData, m interf
 }
 
 func resourceKafkaSchemaDelete(_ context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	var project, serviceName, schemaName = schemautil.SplitResourceID3(d.Id())
+	project, serviceName, schemaName, err := schemautil.SplitResourceID3(d.Id())
+	if err != nil {
+		return diag.FromErr(err)
+	}
 
-	err := m.(*aiven.Client).KafkaSubjectSchemas.Delete(project, serviceName, schemaName)
+	err = m.(*aiven.Client).KafkaSubjectSchemas.Delete(project, serviceName, schemaName)
 	if err != nil && !aiven.IsNotFound(err) {
 		return diag.FromErr(err)
 	}

--- a/internal/service/kafka/resource_kafka_schema_configuration.go
+++ b/internal/service/kafka/resource_kafka_schema_configuration.go
@@ -54,9 +54,12 @@ func ResourceKafkaSchemaConfiguration() *schema.Resource {
 }
 
 func resourceKafkaSchemaConfigurationUpdate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	project, serviceName := schemautil.SplitResourceID2(d.Id())
+	project, serviceName, err := schemautil.SplitResourceID2(d.Id())
+	if err != nil {
+		return diag.FromErr(err)
+	}
 
-	_, err := m.(*aiven.Client).KafkaGlobalSchemaConfig.Update(
+	_, err = m.(*aiven.Client).KafkaGlobalSchemaConfig.Update(
 		project,
 		serviceName,
 		aiven.KafkaSchemaConfig{
@@ -90,7 +93,10 @@ func resourceKafkaSchemaConfigurationCreate(ctx context.Context, d *schema.Resou
 }
 
 func resourceKafkaSchemaConfigurationRead(_ context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	project, serviceName := schemautil.SplitResourceID2(d.Id())
+	project, serviceName, err := schemautil.SplitResourceID2(d.Id())
+	if err != nil {
+		return diag.FromErr(err)
+	}
 
 	r, err := m.(*aiven.Client).KafkaGlobalSchemaConfig.Get(project, serviceName)
 	if err != nil {
@@ -113,9 +119,12 @@ func resourceKafkaSchemaConfigurationRead(_ context.Context, d *schema.ResourceD
 // resourceKafkaSchemaConfigurationDelete Kafka Schemas configuration cannot be deleted, therefore
 // on delete event configuration will be set to the default setting
 func resourceKafkaSchemaConfigurationDelete(_ context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	project, serviceName := schemautil.SplitResourceID2(d.Id())
+	project, serviceName, err := schemautil.SplitResourceID2(d.Id())
+	if err != nil {
+		return diag.FromErr(err)
+	}
 
-	_, err := m.(*aiven.Client).KafkaGlobalSchemaConfig.Update(
+	_, err = m.(*aiven.Client).KafkaGlobalSchemaConfig.Update(
 		project,
 		serviceName,
 		aiven.KafkaSchemaConfig{

--- a/internal/service/kafka/resource_kafka_schema_registry_acl_test.go
+++ b/internal/service/kafka/resource_kafka_schema_registry_acl_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/aiven/aiven-go-client"
 	acc "github.com/aiven/terraform-provider-aiven/internal/acctest"
 	"github.com/aiven/terraform-provider-aiven/internal/schemautil"
-
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
@@ -249,7 +248,11 @@ func testAccCheckAivenKafkaSchemaRegistryACLResourceDestroy(s *terraform.State) 
 			continue
 		}
 
-		project, serviceName, aclID := schemautil.SplitResourceID3(rs.Primary.ID)
+		project, serviceName, aclID, err := schemautil.SplitResourceID3(rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+
 		p, err := c.KafkaSchemaRegistryACLs.Get(project, serviceName, aclID)
 		if err != nil {
 			if err.(aiven.Error).Status != 404 {

--- a/internal/service/kafka/resource_kafka_schema_test.go
+++ b/internal/service/kafka/resource_kafka_schema_test.go
@@ -6,9 +6,8 @@ import (
 	"regexp"
 	"testing"
 
-	acc "github.com/aiven/terraform-provider-aiven/internal/acctest"
-
 	"github.com/aiven/aiven-go-client"
+	acc "github.com/aiven/terraform-provider-aiven/internal/acctest"
 	"github.com/aiven/terraform-provider-aiven/internal/schemautil"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
@@ -87,8 +86,12 @@ func testAccCheckAivenKafkaSchemaResourceDestroy(s *terraform.State) error {
 			continue
 		}
 
-		projectName, serviceName := schemautil.SplitResourceID2(rs.Primary.ID)
-		_, err := c.Services.Get(projectName, serviceName)
+		projectName, serviceName, err := schemautil.SplitResourceID2(rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+
+		_, err = c.Services.Get(projectName, serviceName)
 		if err != nil {
 			if err.(aiven.Error).Status == 404 {
 				return nil

--- a/internal/service/kafka/resource_kafka_topic_test.go
+++ b/internal/service/kafka/resource_kafka_topic_test.go
@@ -7,9 +7,8 @@ import (
 	"reflect"
 	"testing"
 
-	acc "github.com/aiven/terraform-provider-aiven/internal/acctest"
-
 	"github.com/aiven/aiven-go-client"
+	acc "github.com/aiven/terraform-provider-aiven/internal/acctest"
 	"github.com/aiven/terraform-provider-aiven/internal/schemautil"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
@@ -291,9 +290,12 @@ func testAccCheckAivenKafkaTopicResourceDestroy(s *terraform.State) error {
 			continue
 		}
 
-		project, serviceName, topicName := schemautil.SplitResourceID3(rs.Primary.ID)
+		project, serviceName, topicName, err := schemautil.SplitResourceID3(rs.Primary.ID)
+		if err != nil {
+			return err
+		}
 
-		_, err := c.Services.Get(project, serviceName)
+		_, err = c.Services.Get(project, serviceName)
 		if err != nil {
 			if aiven.IsNotFound(err) {
 				return nil

--- a/internal/service/kafka/resource_kafka_user.go
+++ b/internal/service/kafka/resource_kafka_user.go
@@ -53,7 +53,7 @@ func ResourceKafkaUser() *schema.Resource {
 		ReadContext:   schemautil.ResourceServiceUserRead,
 		DeleteContext: schemautil.ResourceServiceUserDelete,
 		Importer: &schema.ResourceImporter{
-			StateContext: schemautil.ResourceServiceUserState,
+			StateContext: schema.ImportStatePassthroughContext,
 		},
 
 		Schema: aivenKafkaUserSchema,

--- a/internal/service/kafka/resource_kafka_user_test.go
+++ b/internal/service/kafka/resource_kafka_user_test.go
@@ -5,9 +5,8 @@ import (
 	"os"
 	"testing"
 
-	acc "github.com/aiven/terraform-provider-aiven/internal/acctest"
-
 	"github.com/aiven/aiven-go-client"
+	acc "github.com/aiven/terraform-provider-aiven/internal/acctest"
 	"github.com/aiven/terraform-provider-aiven/internal/schemautil"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
@@ -47,7 +46,11 @@ func testAccCheckAivenKafkaUserResourceDestroy(s *terraform.State) error {
 			continue
 		}
 
-		projectName, serviceName, username := schemautil.SplitResourceID3(rs.Primary.ID)
+		projectName, serviceName, username, err := schemautil.SplitResourceID3(rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+
 		p, err := c.ServiceUsers.Get(projectName, serviceName, username)
 		if err != nil {
 			if err.(aiven.Error).Status != 404 {

--- a/internal/service/kafka/resource_mirrormaker_replication_flow_test.go
+++ b/internal/service/kafka/resource_mirrormaker_replication_flow_test.go
@@ -5,9 +5,8 @@ import (
 	"os"
 	"testing"
 
-	acc "github.com/aiven/terraform-provider-aiven/internal/acctest"
-
 	"github.com/aiven/aiven-go-client"
+	acc "github.com/aiven/terraform-provider-aiven/internal/acctest"
 	"github.com/aiven/terraform-provider-aiven/internal/schemautil"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
@@ -49,7 +48,10 @@ func testAccCheckAivenMirrorMakerReplicationFlowResourceDestroy(s *terraform.Sta
 			continue
 		}
 
-		project, serviceName, sourceCluster, targetCluster := schemautil.SplitResourceID4(rs.Primary.ID)
+		project, serviceName, sourceCluster, targetCluster, err := schemautil.SplitResourceID4(rs.Primary.ID)
+		if err != nil {
+			return err
+		}
 
 		s, err := c.Services.Get(project, serviceName)
 		if err != nil {

--- a/internal/service/m3db/resource_m3db_user.go
+++ b/internal/service/m3db/resource_m3db_user.go
@@ -42,7 +42,7 @@ func ResourceM3DBUser() *schema.Resource {
 		ReadContext:   schemautil.ResourceServiceUserRead,
 		DeleteContext: schemautil.ResourceServiceUserDelete,
 		Importer: &schema.ResourceImporter{
-			StateContext: schemautil.ResourceServiceUserState,
+			StateContext: schema.ImportStatePassthroughContext,
 		},
 
 		Schema: aivenM3DBUserSchema,

--- a/internal/service/m3db/resource_m3db_user_test.go
+++ b/internal/service/m3db/resource_m3db_user_test.go
@@ -5,9 +5,8 @@ import (
 	"os"
 	"testing"
 
-	acc "github.com/aiven/terraform-provider-aiven/internal/acctest"
-
 	"github.com/aiven/aiven-go-client"
+	acc "github.com/aiven/terraform-provider-aiven/internal/acctest"
 	"github.com/aiven/terraform-provider-aiven/internal/schemautil"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
@@ -47,7 +46,11 @@ func testAccCheckAivenM3DBUserResourceDestroy(s *terraform.State) error {
 			continue
 		}
 
-		projectName, serviceName, username := schemautil.SplitResourceID3(rs.Primary.ID)
+		projectName, serviceName, username, err := schemautil.SplitResourceID3(rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+
 		p, err := c.ServiceUsers.Get(projectName, serviceName, username)
 		if err != nil {
 			if err.(aiven.Error).Status != 404 {

--- a/internal/service/mysql/resource_mysql_database_test.go
+++ b/internal/service/mysql/resource_mysql_database_test.go
@@ -7,9 +7,8 @@ import (
 	"strings"
 	"testing"
 
-	acc "github.com/aiven/terraform-provider-aiven/internal/acctest"
-
 	"github.com/aiven/aiven-go-client"
+	acc "github.com/aiven/terraform-provider-aiven/internal/acctest"
 	"github.com/aiven/terraform-provider-aiven/internal/schemautil"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
@@ -96,7 +95,11 @@ func testAccCheckAivenMySQLDatabaseResourceDestroy(s *terraform.State) error {
 			continue
 		}
 
-		projectName, serviceName, databaseName := schemautil.SplitResourceID3(rs.Primary.ID)
+		projectName, serviceName, databaseName, err := schemautil.SplitResourceID3(rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+
 		db, err := c.Databases.Get(projectName, serviceName, databaseName)
 		if err != nil {
 			if err.(aiven.Error).Status != 404 {

--- a/internal/service/mysql/resource_mysql_user.go
+++ b/internal/service/mysql/resource_mysql_user.go
@@ -66,7 +66,7 @@ func ResourceMySQLUser() *schema.Resource {
 		ReadContext:   schemautil.DatasourceServiceUserRead,
 		DeleteContext: schemautil.ResourceServiceUserDelete,
 		Importer: &schema.ResourceImporter{
-			StateContext: schemautil.ResourceServiceUserState,
+			StateContext: schema.ImportStatePassthroughContext,
 		},
 
 		Schema: aivenMySQLUserSchema,
@@ -109,9 +109,12 @@ func resourceMySQLUserCreate(ctx context.Context, d *schema.ResourceData, m inte
 func resourceMySQLUserUpdate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	client := m.(*aiven.Client)
 
-	projectName, serviceName, username := schemautil.SplitResourceID3(d.Id())
+	projectName, serviceName, username, err := schemautil.SplitResourceID3(d.Id())
+	if err != nil {
+		return diag.FromErr(err)
+	}
 
-	_, err := client.ServiceUsers.Update(projectName, serviceName, username,
+	_, err = client.ServiceUsers.Update(projectName, serviceName, username,
 		aiven.ModifyServiceUserRequest{
 			Authentication: schemautil.OptionalStringPointer(d, "authentication"),
 			NewPassword:    schemautil.OptionalStringPointer(d, "password"),

--- a/internal/service/mysql/resource_mysql_user_test.go
+++ b/internal/service/mysql/resource_mysql_user_test.go
@@ -5,9 +5,8 @@ import (
 	"os"
 	"testing"
 
-	acc "github.com/aiven/terraform-provider-aiven/internal/acctest"
-
 	"github.com/aiven/aiven-go-client"
+	acc "github.com/aiven/terraform-provider-aiven/internal/acctest"
 	"github.com/aiven/terraform-provider-aiven/internal/schemautil"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
@@ -47,7 +46,11 @@ func testAccCheckAivenMySQLUserResourceDestroy(s *terraform.State) error {
 			continue
 		}
 
-		projectName, serviceName, username := schemautil.SplitResourceID3(rs.Primary.ID)
+		projectName, serviceName, username, err := schemautil.SplitResourceID3(rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+
 		p, err := c.ServiceUsers.Get(projectName, serviceName, username)
 		if err != nil {
 			if err.(aiven.Error).Status != 404 {

--- a/internal/service/opensearch/resource_opensearch.go
+++ b/internal/service/opensearch/resource_opensearch.go
@@ -1,12 +1,8 @@
 package opensearch
 
 import (
-	"context"
-	"fmt"
-	"strings"
 	"time"
 
-	"github.com/aiven/aiven-go-client"
 	"github.com/aiven/terraform-provider-aiven/internal/schemautil"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"
@@ -62,7 +58,7 @@ func ResourceOpensearch() *schema.Resource {
 			),
 		),
 		Importer: &schema.ResourceImporter{
-			StateContext: resourceOpensearchState,
+			StateContext: schema.ImportStatePassthroughContext,
 		},
 		Timeouts: &schema.ResourceTimeout{
 			Create: schema.DefaultTimeout(20 * time.Minute),
@@ -72,29 +68,4 @@ func ResourceOpensearch() *schema.Resource {
 
 		Schema: opensearchSchema(),
 	}
-}
-
-func resourceOpensearchState(ctx context.Context, d *schema.ResourceData, m interface{}) ([]*schema.ResourceData, error) {
-	client := m.(*aiven.Client)
-
-	if len(strings.Split(d.Id(), "/")) != 2 {
-		return nil, fmt.Errorf("invalid identifier %v, expected <project_name>/<service_name>", d.Id())
-	}
-
-	projectName, serviceName := schemautil.SplitResourceID2(d.Id())
-	s, err := client.Services.Get(projectName, serviceName)
-	if err != nil {
-		return nil, err
-	}
-
-	// Hybrid Opensearch service an Aiven service type Elasticsearch but has
-	// an opensearch_version user configuration option that indicates that this
-	// is a hybrid opensearch common
-	if _, ok := s.UserConfig["opensearch_version"]; ok && s.Type == schemautil.ServiceTypeElasticsearch {
-		if err := d.Set("service_type", schemautil.ServiceTypeOpensearch); err != nil {
-			return nil, err
-		}
-	}
-
-	return schema.ImportStatePassthroughContext(ctx, d, m)
 }

--- a/internal/service/opensearch/resource_opensearch_acl_config.go
+++ b/internal/service/opensearch/resource_opensearch_acl_config.go
@@ -45,7 +45,11 @@ func ResourceOpensearchACLConfig() *schema.Resource {
 func resourceOpensearchACLConfigRead(_ context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	client := m.(*aiven.Client)
 
-	project, serviceName := schemautil.SplitResourceID2(d.Id())
+	project, serviceName, err := schemautil.SplitResourceID2(d.Id())
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
 	r, err := client.ElasticsearchACLs.Get(project, serviceName)
 	if err != nil {
 		return diag.FromErr(schemautil.ResourceReadHandleNotFound(err, d))

--- a/internal/service/opensearch/resource_opensearch_acl_config_test.go
+++ b/internal/service/opensearch/resource_opensearch_acl_config_test.go
@@ -8,7 +8,6 @@ import (
 	"github.com/aiven/aiven-go-client"
 	acc "github.com/aiven/terraform-provider-aiven/internal/acctest"
 	"github.com/aiven/terraform-provider-aiven/internal/schemautil"
-
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
@@ -74,7 +73,10 @@ func testAccCheckAivenOpensearchACLConfigResourceDestroy(s *terraform.State) err
 			continue
 		}
 
-		projectName, serviceName := schemautil.SplitResourceID2(rs.Primary.ID)
+		projectName, serviceName, err := schemautil.SplitResourceID2(rs.Primary.ID)
+		if err != nil {
+			return err
+		}
 
 		r, err := c.ElasticsearchACLs.Get(projectName, serviceName)
 		if err != nil {

--- a/internal/service/opensearch/resource_opensearch_acl_rule.go
+++ b/internal/service/opensearch/resource_opensearch_acl_rule.go
@@ -67,15 +67,18 @@ func resourceElasticsearchACLRuleGetPermissionFromACLResponse(cfg aiven.ElasticS
 func resourceOpensearchACLRuleRead(_ context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	client := m.(*aiven.Client)
 
-	project, serviceName, username, index := schemautil.SplitResourceID4(d.Id())
+	project, serviceName, username, index, err := schemautil.SplitResourceID4(d.Id())
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
 	r, err := client.ElasticsearchACLs.Get(project, serviceName)
 	if err != nil {
 		return diag.FromErr(schemautil.ResourceReadHandleNotFound(err, d))
 	}
 	permission, found := resourceElasticsearchACLRuleGetPermissionFromACLResponse(r.ElasticSearchACLConfig, username, index)
 	if !found {
-		d.SetId("")
-		return nil
+		return diag.FromErr(schemautil.ResourceReadHandleNotFound(err, d))
 	}
 
 	if err := d.Set("project", project); err != nil {

--- a/internal/service/opensearch/resource_opensearch_acl_rule_test.go
+++ b/internal/service/opensearch/resource_opensearch_acl_rule_test.go
@@ -5,9 +5,8 @@ import (
 	"os"
 	"testing"
 
-	acc "github.com/aiven/terraform-provider-aiven/internal/acctest"
-
 	"github.com/aiven/aiven-go-client"
+	acc "github.com/aiven/terraform-provider-aiven/internal/acctest"
 	"github.com/aiven/terraform-provider-aiven/internal/schemautil"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
@@ -84,7 +83,10 @@ func testAccCheckAivenOpensearchACLRuleResourceDestroy(s *terraform.State) error
 			continue
 		}
 
-		projectName, serviceName, username, index := schemautil.SplitResourceID4(rs.Primary.ID)
+		projectName, serviceName, username, index, err := schemautil.SplitResourceID4(rs.Primary.ID)
+		if err != nil {
+			return err
+		}
 
 		r, err := c.ElasticsearchACLs.Get(projectName, serviceName)
 		if err != nil {

--- a/internal/service/opensearch/resource_opensearch_user.go
+++ b/internal/service/opensearch/resource_opensearch_user.go
@@ -42,7 +42,7 @@ func ResourceOpensearchUser() *schema.Resource {
 		ReadContext:   schemautil.ResourceServiceUserRead,
 		DeleteContext: schemautil.ResourceServiceUserDelete,
 		Importer: &schema.ResourceImporter{
-			StateContext: schemautil.ResourceServiceUserState,
+			StateContext: schema.ImportStatePassthroughContext,
 		},
 
 		Schema: aivenOpensearchUserSchema,

--- a/internal/service/opensearch/resource_opensearch_user_test.go
+++ b/internal/service/opensearch/resource_opensearch_user_test.go
@@ -5,9 +5,8 @@ import (
 	"os"
 	"testing"
 
-	acc "github.com/aiven/terraform-provider-aiven/internal/acctest"
-
 	"github.com/aiven/aiven-go-client"
+	acc "github.com/aiven/terraform-provider-aiven/internal/acctest"
 	"github.com/aiven/terraform-provider-aiven/internal/schemautil"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
@@ -47,7 +46,11 @@ func testAccCheckAivenOpensearchUserResourceDestroy(s *terraform.State) error {
 			continue
 		}
 
-		projectName, serviceName, username := schemautil.SplitResourceID3(rs.Primary.ID)
+		projectName, serviceName, username, err := schemautil.SplitResourceID3(rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+
 		p, err := c.ServiceUsers.Get(projectName, serviceName, username)
 		if err != nil {
 			if err.(aiven.Error).Status != 404 {

--- a/internal/service/pg/resource_pg.go
+++ b/internal/service/pg/resource_pg.go
@@ -122,7 +122,11 @@ func ResourcePG() *schema.Resource {
 func resourceServicePGUpdate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	client := m.(*aiven.Client)
 
-	projectName, serviceName := schemautil.SplitResourceID2(d.Id())
+	projectName, serviceName, err := schemautil.SplitResourceID2(d.Id())
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
 	userConfig := schemautil.ConvertTerraformUserConfigToAPICompatibleFormat(templates.UserConfigSchemaService, "pg", false, d)
 
 	if userConfig["pg_version"] != nil {

--- a/internal/service/pg/resource_pg_database_test.go
+++ b/internal/service/pg/resource_pg_database_test.go
@@ -7,9 +7,8 @@ import (
 	"strings"
 	"testing"
 
-	acc "github.com/aiven/terraform-provider-aiven/internal/acctest"
-
 	"github.com/aiven/aiven-go-client"
+	acc "github.com/aiven/terraform-provider-aiven/internal/acctest"
 	"github.com/aiven/terraform-provider-aiven/internal/schemautil"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
@@ -104,7 +103,11 @@ func testAccCheckAivenPGDatabaseResourceDestroy(s *terraform.State) error {
 			continue
 		}
 
-		projectName, serviceName, databaseName := schemautil.SplitResourceID3(rs.Primary.ID)
+		projectName, serviceName, databaseName, err := schemautil.SplitResourceID3(rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+
 		db, err := c.Databases.Get(projectName, serviceName, databaseName)
 		if err != nil {
 			if err.(aiven.Error).Status != 404 {

--- a/internal/service/pg/resource_pg_user_test.go
+++ b/internal/service/pg/resource_pg_user_test.go
@@ -5,9 +5,8 @@ import (
 	"os"
 	"testing"
 
-	acc "github.com/aiven/terraform-provider-aiven/internal/acctest"
-
 	"github.com/aiven/aiven-go-client"
+	acc "github.com/aiven/terraform-provider-aiven/internal/acctest"
 	"github.com/aiven/terraform-provider-aiven/internal/schemautil"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
@@ -92,7 +91,11 @@ func testAccCheckAivenPGUserResourceDestroy(s *terraform.State) error {
 			continue
 		}
 
-		projectName, serviceName, username := schemautil.SplitResourceID3(rs.Primary.ID)
+		projectName, serviceName, username, err := schemautil.SplitResourceID3(rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+
 		p, err := c.ServiceUsers.Get(projectName, serviceName, username)
 		if err != nil {
 			if err.(aiven.Error).Status != 404 {

--- a/internal/service/pg/resource_service_pg_test.go
+++ b/internal/service/pg/resource_service_pg_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/aiven/aiven-go-client"
 	acc "github.com/aiven/terraform-provider-aiven/internal/acctest"
 	"github.com/aiven/terraform-provider-aiven/internal/schemautil"
-
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
@@ -308,7 +307,10 @@ func testAccCheckAivenServiceTerminationProtection(n string) resource.TestCheckF
 		r := s.RootModule().Resources[n]
 		a := r.Primary.Attributes
 
-		projectName, serviceName := schemautil.SplitResourceID2(a["id"])
+		projectName, serviceName, err := schemautil.SplitResourceID2(a["id"])
+		if err != nil {
+			return err
+		}
 
 		c := acc.TestAccProvider.Meta().(*aiven.Client)
 

--- a/internal/service/project/resource_project.go
+++ b/internal/service/project/resource_project.go
@@ -2,7 +2,6 @@ package project
 
 import (
 	"context"
-	"fmt"
 	"log"
 	"os"
 	"regexp"
@@ -116,7 +115,7 @@ func ResourceProject() *schema.Resource {
 		UpdateContext: resourceProjectUpdate,
 		DeleteContext: resourceProjectDelete,
 		Importer: &schema.ResourceImporter{
-			StateContext: resourceProjectState,
+			StateContext: schema.ImportStatePassthroughContext,
 		},
 
 		Schema: aivenProjectSchema,
@@ -286,21 +285,6 @@ func resourceProjectDelete(_ context.Context, d *schema.ResourceData, m interfac
 	}
 
 	return nil
-}
-
-func resourceProjectState(_ context.Context, d *schema.ResourceData, m interface{}) ([]*schema.ResourceData, error) {
-	client := m.(*aiven.Client)
-
-	project, err := client.Projects.Get(d.Id())
-	if err != nil {
-		return nil, err
-	}
-
-	if d := setProjectTerraformProperties(d, client, project); d.HasError() {
-		return nil, fmt.Errorf("cannot set project properties")
-	}
-
-	return []*schema.ResourceData{d}, nil
 }
 
 func resourceProjectGetCACert(project string, client *aiven.Client, d *schema.ResourceData) diag.Diagnostics {

--- a/internal/service/project/resource_project_user_test.go
+++ b/internal/service/project/resource_project_user_test.go
@@ -7,7 +7,6 @@ import (
 	"github.com/aiven/aiven-go-client"
 	acc "github.com/aiven/terraform-provider-aiven/internal/acctest"
 	"github.com/aiven/terraform-provider-aiven/internal/schemautil"
-
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
@@ -53,7 +52,11 @@ func testAccCheckAivenProjectUserResourceDestroy(s *terraform.State) error {
 			continue
 		}
 
-		projectName, email := schemautil.SplitResourceID2(rs.Primary.ID)
+		projectName, email, err := schemautil.SplitResourceID2(rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+
 		p, i, err := c.ProjectUsers.Get(projectName, email)
 		if err != nil {
 			errStatus := err.(aiven.Error).Status

--- a/internal/service/redis/resource_redis_user_test.go
+++ b/internal/service/redis/resource_redis_user_test.go
@@ -5,9 +5,8 @@ import (
 	"os"
 	"testing"
 
-	acc "github.com/aiven/terraform-provider-aiven/internal/acctest"
-
 	"github.com/aiven/aiven-go-client"
+	acc "github.com/aiven/terraform-provider-aiven/internal/acctest"
 	"github.com/aiven/terraform-provider-aiven/internal/schemautil"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
@@ -46,7 +45,11 @@ func testAccCheckAivenRedisUserResourceDestroy(s *terraform.State) error {
 			continue
 		}
 
-		projectName, serviceName, username := schemautil.SplitResourceID3(rs.Primary.ID)
+		projectName, serviceName, username, err := schemautil.SplitResourceID3(rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+
 		p, err := c.ServiceUsers.Get(projectName, serviceName, username)
 		if err != nil {
 			if err.(aiven.Error).Status != 404 {

--- a/internal/service/service_integration/resource_service_integration_endpoint_test.go
+++ b/internal/service/service_integration/resource_service_integration_endpoint_test.go
@@ -5,9 +5,8 @@ import (
 	"os"
 	"testing"
 
-	acc "github.com/aiven/terraform-provider-aiven/internal/acctest"
-
 	"github.com/aiven/aiven-go-client"
+	acc "github.com/aiven/terraform-provider-aiven/internal/acctest"
 	"github.com/aiven/terraform-provider-aiven/internal/schemautil"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
@@ -100,7 +99,11 @@ func testAccCheckAivenServiceIntegraitonEndpointResourceDestroy(s *terraform.Sta
 			continue
 		}
 
-		projectName, endpointId := schemautil.SplitResourceID2(rs.Primary.ID)
+		projectName, endpointId, err := schemautil.SplitResourceID2(rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+
 		i, err := c.ServiceIntegrationEndpoints.Get(projectName, endpointId)
 		if err != nil {
 			if err.(aiven.Error).Status != 404 {

--- a/internal/service/service_integration/resource_service_integration_test.go
+++ b/internal/service/service_integration/resource_service_integration_test.go
@@ -6,9 +6,8 @@ import (
 	"regexp"
 	"testing"
 
-	acc "github.com/aiven/terraform-provider-aiven/internal/acctest"
-
 	"github.com/aiven/aiven-go-client"
+	acc "github.com/aiven/terraform-provider-aiven/internal/acctest"
 	"github.com/aiven/terraform-provider-aiven/internal/schemautil"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
@@ -467,7 +466,11 @@ func testAccCheckAivenServiceIntegrationResourceDestroy(s *terraform.State) erro
 			continue
 		}
 
-		projectName, integrationID := schemautil.SplitResourceID2(rs.Primary.ID)
+		projectName, integrationID, err := schemautil.SplitResourceID2(rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+
 		i, err := c.ServiceIntegrations.Get(projectName, integrationID)
 		if err != nil && !aiven.IsNotFound(err) {
 			return err

--- a/internal/service/service_user/datasource_service_user.go
+++ b/internal/service/service_user/datasource_service_user.go
@@ -10,6 +10,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
+// DatasourceServiceUser
+// Deprecated
 func DatasourceServiceUser() *schema.Resource {
 	return &schema.Resource{
 		ReadContext: datasourceServiceUserRead,

--- a/internal/service/service_user/resource_service_user_test.go
+++ b/internal/service/service_user/resource_service_user_test.go
@@ -6,9 +6,8 @@ import (
 	"os"
 	"testing"
 
-	acc "github.com/aiven/terraform-provider-aiven/internal/acctest"
-
 	"github.com/aiven/aiven-go-client"
+	acc "github.com/aiven/terraform-provider-aiven/internal/acctest"
 	"github.com/aiven/terraform-provider-aiven/internal/schemautil"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
@@ -117,7 +116,11 @@ func testAccCheckAivenServiceUserResourceDestroy(s *terraform.State) error {
 			continue
 		}
 
-		projectName, serviceName, username := schemautil.SplitResourceID3(rs.Primary.ID)
+		projectName, serviceName, username, err := schemautil.SplitResourceID3(rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+
 		p, err := c.ServiceUsers.Get(projectName, serviceName, username)
 		if err != nil {
 			if err.(aiven.Error).Status != 404 {

--- a/internal/service/static_ip/resource_static_ip.go
+++ b/internal/service/static_ip/resource_static_ip.go
@@ -59,7 +59,10 @@ func ResourceStaticIP() *schema.Resource {
 func resourceStaticIPRead(_ context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	client := m.(*aiven.Client)
 
-	project, staticIPAddressId := schemautil.SplitResourceID2(d.Id())
+	project, staticIPAddressId, err := schemautil.SplitResourceID2(d.Id())
+	if err != nil {
+		return diag.FromErr(err)
+	}
 
 	r, err := client.StaticIPs.List(project)
 	if err != nil {
@@ -74,7 +77,7 @@ func resourceStaticIPRead(_ context.Context, d *schema.ResourceData, m interface
 			return nil
 		}
 	}
-	d.SetId("")
+
 	return nil
 }
 func resourceStaticIPCreate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
@@ -100,7 +103,10 @@ func resourceStaticIPCreate(ctx context.Context, d *schema.ResourceData, m inter
 func resourceStaticIPDelete(_ context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	client := m.(*aiven.Client)
 
-	project, staticIPAddressId := schemautil.SplitResourceID2(d.Id())
+	project, staticIPAddressId, err := schemautil.SplitResourceID2(d.Id())
+	if err != nil {
+		return diag.FromErr(err)
+	}
 
 	staticIP, err := client.StaticIPs.Get(project, staticIPAddressId)
 	if err != nil {
@@ -132,7 +138,10 @@ func resourceStaticIPDelete(_ context.Context, d *schema.ResourceData, m interfa
 func resourceStaticIPWait(ctx context.Context, d *schema.ResourceData, m interface{}) error {
 	client := m.(*aiven.Client)
 
-	project, staticIPAddressId := schemautil.SplitResourceID2(d.Id())
+	project, staticIPAddressId, err := schemautil.SplitResourceID2(d.Id())
+	if err != nil {
+		return err
+	}
 
 	conf := resource.StateChangeConf{
 		Target:  []string{schemautil.StaticIpCreated},

--- a/internal/service/vpc/datasource_aws_vpc_peering_connection.go
+++ b/internal/service/vpc/datasource_aws_vpc_peering_connection.go
@@ -22,7 +22,11 @@ func DatasourceAWSVPCPeeringConnection() *schema.Resource {
 func datasourceAWSVPCPeeringConnectionRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	client := m.(*aiven.Client)
 
-	projectName, vpcID := schemautil.SplitResourceID2(d.Get("vpc_id").(string))
+	projectName, vpcID, err := schemautil.SplitResourceID2(d.Get("vpc_id").(string))
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
 	awsAccountId := d.Get("aws_account_id").(string)
 	awsVPCId := d.Get("aws_vpc_id").(string)
 	awsVPCRegion := d.Get("aws_vpc_region").(string)

--- a/internal/service/vpc/datasource_azure_vpc_peering_connection.go
+++ b/internal/service/vpc/datasource_azure_vpc_peering_connection.go
@@ -22,7 +22,11 @@ func DatasourceAzureVPCPeeringConnection() *schema.Resource {
 func datasourceAzureVPCPeeringConnectionRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	client := m.(*aiven.Client)
 
-	projectName, vpcID := schemautil.SplitResourceID2(d.Get("vpc_id").(string))
+	projectName, vpcID, err := schemautil.SplitResourceID2(d.Get("vpc_id").(string))
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
 	subscriptionId := d.Get("azure_subscription_id").(string)
 	vnetName := d.Get("vnet_name").(string)
 	appId := d.Get("peer_azure_app_id").(string)

--- a/internal/service/vpc/datasource_gcp_vpc_peering_connection.go
+++ b/internal/service/vpc/datasource_gcp_vpc_peering_connection.go
@@ -22,7 +22,11 @@ func DatasourceGCPVPCPeeringConnection() *schema.Resource {
 func datasourceGCPVPCPeeringConnectionRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	client := m.(*aiven.Client)
 
-	projectName, vpcID := schemautil.SplitResourceID2(d.Get("vpc_id").(string))
+	projectName, vpcID, err := schemautil.SplitResourceID2(d.Get("vpc_id").(string))
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
 	gcpProjectId := d.Get("gcp_project_id").(string)
 	peerVPC := d.Get("peer_vpc").(string)
 

--- a/internal/service/vpc/datasource_project_vpc.go
+++ b/internal/service/vpc/datasource_project_vpc.go
@@ -46,9 +46,9 @@ func datasourceProjectVPCRead(_ context.Context, d *schema.ResourceData, m inter
 
 		// We don't need to care about the cloud name if the ID is provided
 		if hasId {
-			splitId := schemautil.SplitResourceID(vpcId.(string), 2)
-			if len(splitId) < 2 {
-				return diag.Errorf("Invalid VPC id %s", vpcId.(string))
+			splitId, err := schemautil.SplitResourceID(vpcId.(string), 2)
+			if err != nil {
+				return diag.FromErr(err)
 			}
 
 			id := splitId[1]

--- a/internal/service/vpc/datasource_vpc_peering_connection.go
+++ b/internal/service/vpc/datasource_vpc_peering_connection.go
@@ -10,6 +10,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
+// DatasourceVPCPeeringConnection
+// Deprecated
 func DatasourceVPCPeeringConnection() *schema.Resource {
 	return &schema.Resource{
 		ReadContext: datasourceVPCPeeringConnectionRead,
@@ -22,7 +24,11 @@ func DatasourceVPCPeeringConnection() *schema.Resource {
 func datasourceVPCPeeringConnectionRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	client := m.(*aiven.Client)
 
-	projectName, vpcID := schemautil.SplitResourceID2(d.Get("vpc_id").(string))
+	projectName, vpcID, err := schemautil.SplitResourceID2(d.Get("vpc_id").(string))
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
 	peerCloudAccount := d.Get("peer_cloud_account").(string)
 	peerVPC := d.Get("peer_vpc").(string)
 

--- a/internal/service/vpc/resource_aws_privatelink.go
+++ b/internal/service/vpc/resource_aws_privatelink.go
@@ -93,7 +93,11 @@ func resourceAWSPrivatelinkCreate(ctx context.Context, d *schema.ResourceData, m
 func resourceAWSPrivatelinkRead(_ context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	client := m.(*aiven.Client)
 
-	project, serviceName := schemautil.SplitResourceID2(d.Id())
+	project, serviceName, err := schemautil.SplitResourceID2(d.Id())
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
 	p, err := client.AWSPrivatelink.Get(project, serviceName)
 	if err != nil {
 		return diag.FromErr(schemautil.ResourceReadHandleNotFound(err, d))
@@ -120,14 +124,17 @@ func resourceAWSPrivatelinkRead(_ context.Context, d *schema.ResourceData, m int
 func resourceAWSPrivatelinkUpdate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	client := m.(*aiven.Client)
 
-	project, serviceName := schemautil.SplitResourceID2(d.Id())
+	project, serviceName, err := schemautil.SplitResourceID2(d.Id())
+	if err != nil {
+		return diag.FromErr(err)
+	}
 
 	var principals []string
 	for _, p := range d.Get("principals").(*schema.Set).List() {
 		principals = append(principals, p.(string))
 	}
 
-	_, err := client.AWSPrivatelink.Update(
+	_, err = client.AWSPrivatelink.Update(
 		project,
 		serviceName,
 		principals,
@@ -154,7 +161,12 @@ func resourceAWSPrivatelinkUpdate(ctx context.Context, d *schema.ResourceData, m
 func resourceAWSPrivatelinkDelete(_ context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	client := m.(*aiven.Client)
 
-	err := client.AWSPrivatelink.Delete(schemautil.SplitResourceID2(d.Id()))
+	project, serviceName, err := schemautil.SplitResourceID2(d.Id())
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	err = client.AWSPrivatelink.Delete(project, serviceName)
 	if err != nil && !aiven.IsNotFound(err) {
 		return diag.FromErr(err)
 	}

--- a/internal/service/vpc/resource_aws_privatelink_test.go
+++ b/internal/service/vpc/resource_aws_privatelink_test.go
@@ -5,9 +5,8 @@ import (
 	"os"
 	"testing"
 
-	acc "github.com/aiven/terraform-provider-aiven/internal/acctest"
-
 	"github.com/aiven/aiven-go-client"
+	acc "github.com/aiven/terraform-provider-aiven/internal/acctest"
 	"github.com/aiven/terraform-provider-aiven/internal/schemautil"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
@@ -50,7 +49,12 @@ func testAccCheckAivenAWSPrivatelinkResourceDestroy(s *terraform.State) error {
 			continue
 		}
 
-		pv, err := c.AWSPrivatelink.Get(schemautil.SplitResourceID2(rs.Primary.ID))
+		project, serviceName, err := schemautil.SplitResourceID2(rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+
+		pv, err := c.AWSPrivatelink.Get(project, serviceName)
 		if err != nil && !aiven.IsNotFound(err) && err.(aiven.Error).Status != 500 {
 			return fmt.Errorf("error getting a AWS Privatelink: %w", err)
 		}

--- a/internal/service/vpc/resource_aws_vpc_peering_connection.go
+++ b/internal/service/vpc/resource_aws_vpc_peering_connection.go
@@ -2,9 +2,6 @@ package vpc
 
 import (
 	"context"
-	"errors"
-	"fmt"
-	"strings"
 	"time"
 
 	"github.com/aiven/aiven-go-client"
@@ -68,7 +65,7 @@ func ResourceAWSVPCPeeringConnection() *schema.Resource {
 		ReadContext:   resourceAWSVPCPeeringConnectionRead,
 		DeleteContext: resourceAWSVPCPeeringConnectionDelete,
 		Importer: &schema.ResourceImporter{
-			StateContext: resourceAWSVPCPeeringConnectionImport,
+			StateContext: schema.ImportStatePassthroughContext,
 		},
 		Timeouts: &schema.ResourceTimeout{
 			Create: schema.DefaultTimeout(2 * time.Minute),
@@ -87,7 +84,11 @@ func resourceAWSVPCPeeringConnectionCreate(ctx context.Context, d *schema.Resour
 	)
 
 	client := m.(*aiven.Client)
-	projectName, vpcID := schemautil.SplitResourceID2(d.Get("vpc_id").(string))
+	projectName, vpcID, err := schemautil.SplitResourceID2(d.Get("vpc_id").(string))
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
 	awsAccountId := d.Get("aws_account_id").(string)
 	awsVPCId := d.Get("aws_vpc_id").(string)
 	awsVPCRegion := d.Get("aws_vpc_region").(string)
@@ -218,27 +219,6 @@ func resourceAWSVPCPeeringConnectionDelete(ctx context.Context, d *schema.Resour
 		return diag.Errorf("Error waiting for AWS Aiven VPC Peering Connection to be DELETED: %s", err)
 	}
 	return nil
-}
-
-func resourceAWSVPCPeeringConnectionImport(ctx context.Context, d *schema.ResourceData, m interface{}) ([]*schema.ResourceData, error) {
-	if len(strings.Split(d.Id(), "/")) != 5 {
-		return nil, fmt.Errorf("invalid identifier %v, expected <project_name>/<vpc_id>/<aws_account_id>/<aws_vpc_id>/<aws_vpc_region>", d.Id())
-	}
-
-	client := m.(*aiven.Client)
-
-	projectName, vpcID, peerCloudAccount, peerVPC, peerRegion := parsePeeringVPCId(d.Id())
-	_, err := client.VPCPeeringConnections.GetVPCPeering(projectName, vpcID, peerCloudAccount, peerVPC, peerRegion)
-	if err != nil && schemautil.IsUnknownResource(err) {
-		return nil, errors.New("cannot find specified VPC peering connection")
-	}
-
-	dig := resourceAWSVPCPeeringConnectionRead(ctx, d, m)
-	if dig.HasError() {
-		return nil, errors.New("cannot get AWS VPC peering connection")
-	}
-
-	return []*schema.ResourceData{d}, nil
 }
 
 func copyAWSVPCPeeringConnectionPropertiesFromAPIResponseToTerraform(

--- a/internal/service/vpc/resource_azure_privatelink.go
+++ b/internal/service/vpc/resource_azure_privatelink.go
@@ -99,7 +99,10 @@ func resourceAzurePrivatelinkCreate(ctx context.Context, d *schema.ResourceData,
 
 func resourceAzurePrivatelinkRead(_ context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	client := m.(*aiven.Client)
-	project, serviceName := schemautil.SplitResourceID2(d.Id())
+	project, serviceName, err := schemautil.SplitResourceID2(d.Id())
+	if err != nil {
+		return diag.FromErr(err)
+	}
 
 	pl, err := client.AzurePrivatelink.Get(project, serviceName)
 	if err != nil {
@@ -134,13 +137,16 @@ func resourceAzurePrivatelinkUpdate(ctx context.Context, d *schema.ResourceData,
 	client := m.(*aiven.Client)
 
 	var subscriptionIDs []string
-	project, serviceName := schemautil.SplitResourceID2(d.Id())
+	project, serviceName, err := schemautil.SplitResourceID2(d.Id())
+	if err != nil {
+		return diag.FromErr(err)
+	}
 
 	for _, s := range d.Get("user_subscription_ids").(*schema.Set).List() {
 		subscriptionIDs = append(subscriptionIDs, s.(string))
 	}
 
-	_, err := client.AzurePrivatelink.Update(
+	_, err = client.AzurePrivatelink.Update(
 		project,
 		serviceName,
 		aiven.AzurePrivatelinkRequest{UserSubscriptionIDs: subscriptionIDs},
@@ -181,9 +187,12 @@ func waitForAzurePrivatelinkToBeActive(client *aiven.Client, project string, ser
 
 func resourceAzurePrivatelinkDelete(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	client := m.(*aiven.Client)
-	project, serviceName := schemautil.SplitResourceID2(d.Id())
+	project, serviceName, err := schemautil.SplitResourceID2(d.Id())
+	if err != nil {
+		return diag.FromErr(err)
+	}
 
-	err := client.AzurePrivatelink.Delete(project, serviceName)
+	err = client.AzurePrivatelink.Delete(project, serviceName)
 	if err != nil && !aiven.IsNotFound(err) {
 		return diag.FromErr(err)
 	}

--- a/internal/service/vpc/resource_azure_privatelink_connection_approve.go
+++ b/internal/service/vpc/resource_azure_privatelink_connection_approve.go
@@ -155,7 +155,10 @@ func resourcePrivatelinkConnectionApprovalCreateUpdate(ctx context.Context, d *s
 
 func resourcePrivatelinkConnectionApprovalRead(_ context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	client := m.(*aiven.Client)
-	project, service := schemautil.SplitResourceID2(d.Id())
+	project, service, err := schemautil.SplitResourceID2(d.Id())
+	if err != nil {
+		return diag.FromErr(err)
+	}
 
 	plConnectionID := d.Get("privatelink_connection_id").(string)
 	plConnection, err := client.AzurePrivatelink.ConnectionGet(project, service, plConnectionID)

--- a/internal/service/vpc/resource_azure_privatelink_test.go
+++ b/internal/service/vpc/resource_azure_privatelink_test.go
@@ -8,7 +8,6 @@ import (
 	"github.com/aiven/aiven-go-client"
 	acc "github.com/aiven/terraform-provider-aiven/internal/acctest"
 	"github.com/aiven/terraform-provider-aiven/internal/schemautil"
-
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
@@ -50,7 +49,12 @@ func testAccCheckAivenAzurePrivatelinkResourceDestroy(s *terraform.State) error 
 			continue
 		}
 
-		pv, err := c.AzurePrivatelink.Get(schemautil.SplitResourceID2(rs.Primary.ID))
+		project, serviceName, err := schemautil.SplitResourceID2(rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+
+		pv, err := c.AzurePrivatelink.Get(project, serviceName)
 		if err != nil && !aiven.IsNotFound(err) && err.(aiven.Error).Status != 500 {
 			return fmt.Errorf("error getting a Azure Privatelink: %w", err)
 		}

--- a/internal/service/vpc/resource_project_vpc_test.go
+++ b/internal/service/vpc/resource_project_vpc_test.go
@@ -8,7 +8,6 @@ import (
 	"github.com/aiven/aiven-go-client"
 	acc "github.com/aiven/terraform-provider-aiven/internal/acctest"
 	"github.com/aiven/terraform-provider-aiven/internal/schemautil"
-
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
@@ -143,7 +142,11 @@ func testAccCheckAivenProjectVPCResourceDestroy(s *terraform.State) error {
 			continue
 		}
 
-		projectName, vpcId := schemautil.SplitResourceID2(rs.Primary.ID)
+		projectName, vpcId, err := schemautil.SplitResourceID2(rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+
 		vpc, err := c.VPCs.Get(projectName, vpcId)
 		if err != nil {
 			errStatus := err.(aiven.Error).Status

--- a/internal/service/vpc/resource_transit_gateway_vpc_attachement.go
+++ b/internal/service/vpc/resource_transit_gateway_vpc_attachement.go
@@ -70,7 +70,7 @@ func ResourceTransitGatewayVPCAttachment() *schema.Resource {
 		UpdateContext: resourceTransitGatewayVPCAttachmentUpdate,
 		DeleteContext: resourceVPCPeeringConnectionDelete,
 		Importer: &schema.ResourceImporter{
-			StateContext: resourceVPCPeeringConnectionImport,
+			StateContext: schema.ImportStatePassthroughContext,
 		},
 		Timeouts: &schema.ResourceTimeout{
 			Create: schema.DefaultTimeout(2 * time.Minute),

--- a/internal/service/vpc/resource_vpc_peering_connection.go
+++ b/internal/service/vpc/resource_vpc_peering_connection.go
@@ -79,6 +79,8 @@ var aivenVPCPeeringConnectionSchema = map[string]*schema.Schema{
 	},
 }
 
+// ResourceVPCPeeringConnection
+// Deprecated
 func ResourceVPCPeeringConnection() *schema.Resource {
 	return &schema.Resource{
 		Description:   "The VPC Peering Connection resource allows the creation and management of Aiven VPC Peering Connections.",
@@ -107,7 +109,11 @@ func resourceVPCPeeringConnectionCreate(ctx context.Context, d *schema.ResourceD
 	)
 
 	client := m.(*aiven.Client)
-	projectName, vpcID := schemautil.SplitResourceID2(d.Get("vpc_id").(string))
+	projectName, vpcID, err := schemautil.SplitResourceID2(d.Get("vpc_id").(string))
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
 	peerCloudAccount := d.Get("peer_cloud_account").(string)
 	peerVPC := d.Get("peer_vpc").(string)
 	peerRegion := d.Get("peer_region").(string)


### PR DESCRIPTION
<!-- All contributors, please complete these sections, including maintainers. -->

## About this change—what it does

<!-- Provide a small sentence that summarizes the change. -->
- replaces every `schema.Resource.Importer.StateContext` to `schema.ImportStatePassthroughContext`
- gets rid of all unnecessary `d.SetId("")` calls
- replaces `vpc.parsePeeringVPCId` with `schemautil.SplitResourceID`
- makes `schemautil.SplitResourceID` throw an error when the resulting amount of parts is not equal to expected
- marks deprecated resources deprecated

## Why this way

<!-- Provide a small explanation on why this is the approach you took for solving this problem. -->
- to improve code quality
- to get rid of unnecessary stuff