### PR TITLE
service project vpc id error handling

### DIFF
--- a/.github/workflows/acceptance-tests.yml
+++ b/.github/workflows/acceptance-tests.yml
@@ -36,7 +36,8 @@ jobs:
           service_component,
           service_user,
           static_ip,
-          service_integration
+          service_integration,
+          vpc
         ]
 
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ parent: README
 nav_order: 1
 ---# Changelog
 
+## [MAJOR.MINOR.PATCH] - YYYY-MM-DD
+
+- Add error handling for service `project_vpc_id` field
+
 ## [3.4.0] - 2022-07-26
 
 - Small static IP import fix

--- a/internal/schemautil/helpers.go
+++ b/internal/schemautil/helpers.go
@@ -41,15 +41,18 @@ func GetAPIServiceIntegrations(d ResourceStateOrResourceDiff) []aiven.NewService
 	return apiServiceIntegrations
 }
 
-func GetProjectVPCIdPointer(d ResourceStateOrResourceDiff) *string {
+func GetProjectVPCIdPointer(d ResourceStateOrResourceDiff) (*string, error) {
 	vpcID := d.Get("project_vpc_id").(string)
 	var vpcIDPointer *string
-	if len(vpcID) > 0 {
-		parts := strings.SplitN(vpcID, "/", 2)
-		vpcID := parts[1]
-		vpcIDPointer = &vpcID
+
+	parts := strings.SplitN(vpcID, "/", 2)
+	if len(parts) != 2 {
+		return nil, fmt.Errorf("invalid project_vpc_id, should have the following format {project_name}/{project_vpc_id}")
 	}
-	return vpcIDPointer
+
+	p1 := parts[1]
+	vpcIDPointer = &p1
+	return vpcIDPointer, nil
 }
 
 func GetMaintenanceWindow(d ResourceStateOrResourceDiff) *aiven.MaintenanceWindow {

--- a/internal/schemautil/service.go
+++ b/internal/schemautil/service.go
@@ -307,35 +307,35 @@ func ResourceServiceRead(ctx context.Context, d *schema.ResourceData, m interfac
 	s, err := client.Services.Get(projectName, serviceName)
 	if err != nil {
 		if err = ResourceReadHandleNotFound(err, d); err != nil {
-			return diag.FromErr(fmt.Errorf("unable to GET service %s: %s", d.Id(), err))
+			return diag.Errorf("unable to GET service %s: %s", d.Id(), err)
 		}
 		return nil
 	}
 	servicePlanParams, err := GetServicePlanParametersFromServiceResponse(ctx, client, projectName, s)
 	if err != nil {
-		return diag.FromErr(fmt.Errorf("unable to get service plan parameters: %w", err))
+		return diag.Errorf("unable to get service plan parameters: %w", err)
 	}
 
 	err = copyServicePropertiesFromAPIResponseToTerraform(d, s, servicePlanParams, projectName)
 	if err != nil {
-		return diag.FromErr(fmt.Errorf("unable to copy api response into terraform schema: %w", err))
+		return diag.Errorf("unable to copy api response into terraform schema: %w", err)
 	}
 
 	allocatedStaticIps, err := CurrentlyAllocatedStaticIps(ctx, projectName, serviceName, m)
 	if err != nil {
-		return diag.FromErr(fmt.Errorf("unable to currently allocated static ips: %w", err))
+		return diag.Errorf("unable to currently allocated static ips: %w", err)
 	}
 	if err = d.Set("static_ips", allocatedStaticIps); err != nil {
-		return diag.FromErr(fmt.Errorf("unable to set static ips field in schema: %w", err))
+		return diag.Errorf("unable to set static ips field in schema: %w", err)
 	}
 
 	t, err := client.ServiceTags.Get(projectName, serviceName)
 	if err != nil {
-		return diag.FromErr(fmt.Errorf("unable to get service tags: %w", err))
+		return diag.Errorf("unable to get service tags: %w", err)
 	}
 
 	if err := d.Set("tag", SetTagsTerraformProperties(t.Tags)); err != nil {
-		return diag.FromErr(fmt.Errorf("unable to set tag's in schema: %w", err))
+		return diag.Errorf("unable to set tag's in schema: %w", err)
 	}
 
 	return nil
@@ -355,12 +355,17 @@ func resourceServiceCreate(ctx context.Context, d *schema.ResourceData, m interf
 		diskSpace = ConvertToDiskSpaceMB(ds.(string))
 	}
 
-	_, err := client.Services.Create(
+	vpcId, err := GetProjectVPCIdPointer(d)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	_, err = client.Services.Create(
 		project,
 		aiven.CreateServiceRequest{
 			Cloud:                 d.Get("cloud_name").(string),
 			Plan:                  d.Get("plan").(string),
-			ProjectVPCID:          GetProjectVPCIdPointer(d),
+			ProjectVPCID:          vpcId,
 			ServiceIntegrations:   GetAPIServiceIntegrations(d),
 			MaintenanceWindow:     GetMaintenanceWindow(d),
 			ServiceName:           d.Get("service_name").(string),
@@ -428,6 +433,12 @@ func ResourceServiceUpdate(ctx context.Context, d *schema.ResourceData, m interf
 		}
 	}
 
+	var vpcId *string
+	vpcId, err = GetProjectVPCIdPointer(d)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
 	if _, err := client.Services.Update(
 		projectName,
 		serviceName,
@@ -435,7 +446,7 @@ func ResourceServiceUpdate(ctx context.Context, d *schema.ResourceData, m interf
 			Cloud:                 d.Get("cloud_name").(string),
 			Plan:                  d.Get("plan").(string),
 			MaintenanceWindow:     GetMaintenanceWindow(d),
-			ProjectVPCID:          GetProjectVPCIdPointer(d),
+			ProjectVPCID:          vpcId,
 			Powered:               true,
 			TerminationProtection: d.Get("termination_protection").(bool),
 			DiskSpaceMB:           diskSpace,

--- a/internal/schemautil/service.go
+++ b/internal/schemautil/service.go
@@ -313,29 +313,29 @@ func ResourceServiceRead(ctx context.Context, d *schema.ResourceData, m interfac
 	}
 	servicePlanParams, err := GetServicePlanParametersFromServiceResponse(ctx, client, projectName, s)
 	if err != nil {
-		return diag.Errorf("unable to get service plan parameters: %w", err)
+		return diag.Errorf("unable to get service plan parameters: %s", err)
 	}
 
 	err = copyServicePropertiesFromAPIResponseToTerraform(d, s, servicePlanParams, projectName)
 	if err != nil {
-		return diag.Errorf("unable to copy api response into terraform schema: %w", err)
+		return diag.Errorf("unable to copy api response into terraform schema: %s", err)
 	}
 
 	allocatedStaticIps, err := CurrentlyAllocatedStaticIps(ctx, projectName, serviceName, m)
 	if err != nil {
-		return diag.Errorf("unable to currently allocated static ips: %w", err)
+		return diag.Errorf("unable to currently allocated static ips: %s", err)
 	}
 	if err = d.Set("static_ips", allocatedStaticIps); err != nil {
-		return diag.Errorf("unable to set static ips field in schema: %w", err)
+		return diag.Errorf("unable to set static ips field in schema: %s", err)
 	}
 
 	t, err := client.ServiceTags.Get(projectName, serviceName)
 	if err != nil {
-		return diag.Errorf("unable to get service tags: %w", err)
+		return diag.Errorf("unable to get service tags: %s", err)
 	}
 
 	if err := d.Set("tag", SetTagsTerraformProperties(t.Tags)); err != nil {
-		return diag.Errorf("unable to set tag's in schema: %w", err)
+		return diag.Errorf("unable to set tag's in schema: %s", err)
 	}
 
 	return nil

--- a/internal/service/service_integration/datasource_service_integration.go
+++ b/internal/service/service_integration/datasource_service_integration.go
@@ -2,6 +2,7 @@ package service_integration
 
 import (
 	"context"
+
 	"github.com/aiven/aiven-go-client"
 	"github.com/aiven/terraform-provider-aiven/internal/schemautil"
 

--- a/internal/service/service_integration/datasource_service_integration.go
+++ b/internal/service/service_integration/datasource_service_integration.go
@@ -2,8 +2,6 @@ package service_integration
 
 import (
 	"context"
-	"fmt"
-
 	"github.com/aiven/aiven-go-client"
 	"github.com/aiven/terraform-provider-aiven/internal/schemautil"
 
@@ -30,7 +28,7 @@ func datasourceServiceIntegrationRead(ctx context.Context, d *schema.ResourceDat
 
 	integrations, err := client.ServiceIntegrations.List(projectName, sourceServiceName)
 	if err != nil {
-		return diag.FromErr(fmt.Errorf("unable to list integrations for %s/%s: %s", projectName, sourceServiceName, err))
+		return diag.Errorf("unable to list integrations for %s/%s: %s", projectName, sourceServiceName, err)
 	}
 
 	for _, i := range integrations {

--- a/internal/service/static_ip/resource_static_ip.go
+++ b/internal/service/static_ip/resource_static_ip.go
@@ -88,13 +88,13 @@ func resourceStaticIPCreate(ctx context.Context, d *schema.ResourceData, m inter
 
 	r, err := client.StaticIPs.Create(project, aiven.CreateStaticIPRequest{CloudName: cloudName})
 	if err != nil {
-		return diag.FromErr(fmt.Errorf("unable to create static ip: %w", err))
+		return diag.Errorf("unable to create static ip: %w", err)
 	}
 
 	d.SetId(schemautil.BuildResourceID(project, r.StaticIPAddressID))
 
 	if err := resourceStaticIPWait(ctx, d, m); err != nil {
-		return diag.FromErr(fmt.Errorf("unable to wait for static ip to become active: %w", err))
+		return diag.Errorf("unable to wait for static ip to become active: %w", err)
 	}
 
 	return resourceStaticIPRead(ctx, d, m)

--- a/internal/service/static_ip/resource_static_ip.go
+++ b/internal/service/static_ip/resource_static_ip.go
@@ -88,13 +88,13 @@ func resourceStaticIPCreate(ctx context.Context, d *schema.ResourceData, m inter
 
 	r, err := client.StaticIPs.Create(project, aiven.CreateStaticIPRequest{CloudName: cloudName})
 	if err != nil {
-		return diag.Errorf("unable to create static ip: %w", err)
+		return diag.Errorf("unable to create static ip: %s", err)
 	}
 
 	d.SetId(schemautil.BuildResourceID(project, r.StaticIPAddressID))
 
 	if err := resourceStaticIPWait(ctx, d, m); err != nil {
-		return diag.Errorf("unable to wait for static ip to become active: %w", err)
+		return diag.Errorf("unable to wait for static ip to become active: %s", err)
 	}
 
 	return resourceStaticIPRead(ctx, d, m)

--- a/internal/service/vpc/resource_project_vpc_test.go
+++ b/internal/service/vpc/resource_project_vpc_test.go
@@ -176,11 +176,11 @@ data "aiven_project" "foo" {
 }
 
 resource "aiven_pg" "bar" {
-  project                 = data.aiven_project.foo.project
-  cloud_name              = "google-europe-west1"
-  plan                    = "startup-4"
-  service_name            = "test-acc-sr-%s"
-  project_vpc_id  		  = "wrong_vpc_id"
+  project        = data.aiven_project.foo.project
+  cloud_name     = "google-europe-west1"
+  plan           = "startup-4"
+  service_name   = "test-acc-sr-%s"
+  project_vpc_id = "wrong_vpc_id"
 }
 `, os.Getenv("AIVEN_PROJECT_NAME"), name)
 }


### PR DESCRIPTION
## About this change—what it does

When a user provides a wrong Project VPC ID for the service TF provider panic, this PR adds an error handling.

ci: adding `vpn` package to acceptance tests
```
make testacc  PKG=vpc                                            
TF_ACC=1 go test ./internal/service/vpc/... -v -count 1 -parallel 20   -timeout 180m
2022/07/27 09:37:31 [DEBUG] Creating an instance of TopicCache ...
=== RUN   Test_validateVPCID
=== RUN   Test_validateVPCID/basic
=== RUN   Test_validateVPCID/wrong_id
--- PASS: Test_validateVPCID (0.00s)
    --- PASS: Test_validateVPCID/basic (0.00s)
    --- PASS: Test_validateVPCID/wrong_id (0.00s)
=== RUN   TestAccAivenAWSPrivatelink_basic
    resource_aws_privatelink_test.go:20: AIVEN_AWS_PRIVATELINK_VPCID and AIVEN_AWS_PRIVATELINK_PRINCIPAL env variables are required to run this test
--- SKIP: TestAccAivenAWSPrivatelink_basic (0.00s)
=== RUN   TestAccAivenAWSVPCPeeringConnection_basic
    resource_aws_vpc_peering_connection_test.go:17: env variables AWS_REGION, AWS_VPC_ID and AWS_ACCOUNT_ID required to run this test
--- SKIP: TestAccAivenAWSVPCPeeringConnection_basic (0.00s)
=== RUN   TestAccAivenAzurePrivatelink_basic
    resource_azure_privatelink_test.go:19: AIVEN_AZURE_PRIVATELINK_VPCID and AIVEN_AZURE_PRIVATELINK_SUB_ID env variables are required to run this test
--- SKIP: TestAccAivenAzurePrivatelink_basic (0.00s)
=== RUN   TestAccAivenProjectVPC_basic
=== PAUSE TestAccAivenProjectVPC_basic
=== RUN   TestAccAivenTransitGatewayVPCAttachment_basic
    resource_transit_gateway_vpc_attachement_test.go:18: env variables AWS_REGION, AWS_TRANSIT_GATEWAY_ID and AWS_ACCOUNT_ID required to run this test
--- SKIP: TestAccAivenTransitGatewayVPCAttachment_basic (0.00s)
=== CONT  TestAccAivenProjectVPC_basic
--- PASS: TestAccAivenProjectVPC_basic (594.59s)
PASS
ok      github.com/aiven/terraform-provider-aiven/internal/service/vpc  594.605s
```