### PR TITLE
fix version ldflag

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -5,7 +5,7 @@ builds:
     flags:
       - -trimpath
     ldflags:
-      - '-s -w -X github.com/aiven/terraform-provider-aiven/aiven.providerVersion={{.Version}}'
+      - '-s -w -X github.com/aiven/terraform-provider-aiven/internal/provider.version={{.Version}}'
     goos:
       - freebsd
       - windows

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ nav_order: 1
 
 - Add custom diff for all types of VPC peering connections that check if a VPC connection already exists before creation
 - Add error handling for service `project_vpc_id` field
+- Fix version `ldflag`
 
 ## [3.4.0] - 2022-07-26
 

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -32,7 +32,7 @@ import (
 )
 
 var (
-	providerVersion = "dev"
+	version = "dev"
 )
 
 // Provider returns a terraform.ResourceProvider.
@@ -246,7 +246,7 @@ func Provider() *schema.Provider {
 
 		client, err := aiven.NewTokenClient(
 			d.Get("api_token").(string),
-			fmt.Sprintf("terraform-provider-aiven/%s/%s", terraformVersion, providerVersion))
+			fmt.Sprintf("terraform-provider-aiven/%s/%s", terraformVersion, version))
 		if err != nil {
 			return nil, diag.FromErr(err)
 		}


### PR DESCRIPTION
<!-- All contributors, please complete these sections, including maintainers. -->

## About this change—what it does

<!-- Provide a small sentence that summarizes the change. -->
fixes version ldflag

<!-- Provide the issue number below, if it exists. -->
introduced in #798

## Why this way

<!-- Provide a small explanation on why this is the approach you took for solving this problem. -->
currently, our `User-Agent` string contains misleading `dev` version, and this is not correct