### PR TITLE
capitalize variables in sample project

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ nav_order: 1
 - Add `make` targets `build` and `build-dev`
 - Add sweeper for account authentication
 - Make use of `BUILD_DEV_DIR` in `Makefile`
+- Capitalize variables in sample project
 
 ## [3.4.0] - 2022-07-26
 

--- a/sample_project/sample.tf
+++ b/sample_project/sample.tf
@@ -1,8 +1,8 @@
-variable "aiven_api_token" {
+variable "AIVEN_API_TOKEN" {
   type = string
 }
 
-variable "aiven_project_name" {
+variable "AIVEN_PROJECT_NAME" {
   type = string
 }
 
@@ -16,11 +16,11 @@ terraform {
 }
 
 provider "aiven" {
-  api_token = var.aiven_api_token
+  api_token = var.AIVEN_API_TOKEN
 }
 
 data "aiven_project" "sample" {
-  project = var.aiven_project_name
+  project = var.AIVEN_PROJECT_NAME
 }
 
 # Kafka service

--- a/sample_project/terraform.tfvars
+++ b/sample_project/terraform.tfvars
@@ -1,2 +1,2 @@
-aiven_api_token    = ""
-aiven_project_name = ""
+AIVEN_API_TOKEN    = ""
+AIVEN_PROJECT_NAME = ""


### PR DESCRIPTION
<!-- All contributors, please complete these sections, including maintainers. -->

## About this change—what it does

<!-- Provide a small sentence that summarizes the change. -->
capitalizes variables in sample project

<!-- Provide the issue number below, if it exists. -->

## Why this way

<!-- Provide a small explanation on why this is the approach you took for solving this problem. -->
if you want to override those variables via environment variables, you have to use the following syntax:

```bash
export TF_VAR_<name>=<value>
```

and having them uncapitalized makes it end up looking:

```bash
export TF_VAR_aiven_api_token=<value>
export TF_VAR_aiven_project_name=<value>
```
