### PR TITLE
fix service project vpc custom diff

### DIFF
--- a/internal/schemautil/helpers.go
+++ b/internal/schemautil/helpers.go
@@ -43,6 +43,10 @@ func GetAPIServiceIntegrations(d ResourceStateOrResourceDiff) []aiven.NewService
 
 func GetProjectVPCIdPointer(d ResourceStateOrResourceDiff) (*string, error) {
 	vpcID := d.Get("project_vpc_id").(string)
+	if len(vpcID) == 0 {
+		return nil, nil
+	}
+
 	var vpcIDPointer *string
 
 	parts := strings.SplitN(vpcID, "/", 2)


### PR DESCRIPTION
fix service project vpc custom diff

## Why this way
do not error when id is empty or not set by a user



