### PR TITLE
prevent changelog enforcement for PRs from dependabot[bot]

### DIFF
--- a/.github/workflows/changelog-enforcer.yml
+++ b/.github/workflows/changelog-enforcer.yml
@@ -5,6 +5,10 @@ on:
     branches:
       - main
       - v*
+  push:
+    branches:
+      - main
+      - release-*
 
 permissions:
   contents: read
@@ -12,5 +16,6 @@ permissions:
 jobs:
   changelog-enforcer:
     runs-on: ubuntu-latest
+    if: github.actor != 'dependabot[bot]'
     steps:
       - uses: dangoslen/changelog-enforcer@v3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ nav_order: 1
 - Fix Changelog Enforcer GitHub Actions workflow
 - Make `Makefile` variables env changeable
 - Add `dependabot.yml`
-- Bump `github.com/golangci/golangci-lint` from 1.46.2 to 1.47.2 in `/tools`
+- Prevent Changelog Enforcer GitHub Actions workflow from triggering for PRs from `dependabot[bot]`
 
 ## [3.4.0] - 2022-07-26
 


### PR DESCRIPTION
<!-- All contributors, please complete these sections, including maintainers. -->

## About this change—what it does

<!-- Provide a small sentence that summarizes the change. -->
prevents changelog enforcement for PRs from dependabot[bot]

<!-- Provide the issue number below, if it exists. -->

## Why this way

<!-- Provide a small explanation on why this is the approach you took for solving this problem. -->
we don't want to have changelog entries for dependency bumps
