### PR TITLE
update Changelog Enforcer workflow

### DIFF
--- a/.github/workflows/changelog-enforcer.yml
+++ b/.github/workflows/changelog-enforcer.yml
@@ -5,6 +5,12 @@ on:
     branches:
       - main
       - v*
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - labeled
+      - unlabeled
   push:
     branches:
       - main
@@ -16,6 +22,9 @@ permissions:
 jobs:
   changelog-enforcer:
     runs-on: ubuntu-latest
-    if: github.actor != 'dependabot[bot]' && !contains(github.event.pull_request.labels.*.name, 'no changelog')
+    if: github.actor != 'dependabot[bot]'
     steps:
       - uses: dangoslen/changelog-enforcer@v3
+        with:
+          skipLabels: no changelog
+          versionPattern: '^## \[(\d*\.\d*\.\d*-?\w*|MAJOR.MINOR.PATCH)\]'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ nav_order: 1
 - Add `dependabot.yml`
 - Prevent Changelog Enforcer GitHub Actions workflow from triggering for PRs from `dependabot[bot]`
 - Add `no changelog` label check in `changelog-enforcer.yml`
+- Update Changelog Enforcer workflow
 
 ## [3.4.0] - 2022-07-26
 


### PR DESCRIPTION
delete me

<!-- All contributors, please complete these sections, including maintainers. -->

## About this change—what it does

<!-- Provide a small sentence that summarizes the change. -->
updates Changelog Enforcer workflow

<!-- Provide the issue number below, if it exists. -->

## Why this way

<!-- Provide a small explanation on why this is the approach you took for solving this problem. -->
it has built-in functionality for labels that skip changelog enforcement
also we use a different version pattern in changelog, which is different from what [KeepAChangelog](https://keepachangelog.com) offers
