### PR TITLE
disable Changelog Enforcer for push

### DIFF
--- a/.github/workflows/changelog-enforcer.yml
+++ b/.github/workflows/changelog-enforcer.yml
@@ -11,10 +11,6 @@ on:
       - reopened
       - labeled
       - unlabeled
-  push:
-    branches:
-      - main
-      - release-*
 
 permissions:
   contents: read


### PR DESCRIPTION
delete me

<!-- All contributors, please complete these sections, including maintainers. -->

## About this change—what it does

<!-- Provide a small sentence that summarizes the change. -->
disables Changelog Enforcer for push

<!-- Provide the issue number below, if it exists. -->

## Why this way

<!-- Provide a small explanation on why this is the approach you took for solving this problem. -->
```log
Warning: ChangeLog enforcer only runs for pull_request and pull_request_target event types
```
