### PR TITLE
update Flink version to 1.15

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ nav_order: 1
 
 # Changelog
 
+## [MAJOR.MINOR.PATCH] - YYYY-MM-DD
+
+- Change Flink version to 1.15
+
 ## [3.6.0] - 2022-08-31
 
 - Add additional disk space support

--- a/docs/resources/flink.md
+++ b/docs/resources/flink.md
@@ -22,7 +22,7 @@ resource "aiven_flink" "flink" {
   maintenance_window_time = "10:00:00"
 
   flink_user_config {
-    flink_version = 1.13
+    flink_version = 1.15
   }
 }
 ```

--- a/examples/resources/aiven_flink/resource.tf
+++ b/examples/resources/aiven_flink/resource.tf
@@ -7,6 +7,6 @@ resource "aiven_flink" "flink" {
   maintenance_window_time = "10:00:00"
 
   flink_user_config {
-    flink_version = 1.13
+    flink_version = 1.15
   }
 }

--- a/internal/schemautil/templates/service_user_config_schema.go
+++ b/internal/schemautil/templates/service_user_config_schema.go
@@ -746,7 +746,7 @@ var (
       },
       "flink_version": {
         "enum": [
-          "1.13"
+          "1.15"
         ],
         "title": "Flink major version",
         "type": [

--- a/internal/schemautil/templates/service_user_config_schema.json
+++ b/internal/schemautil/templates/service_user_config_schema.json
@@ -736,7 +736,7 @@
       },
       "flink_version": {
         "enum": [
-          "1.13"
+          "1.15"
         ],
         "title": "Flink major version",
         "type": [


### PR DESCRIPTION
## About this change—what it does

The Flink version in Aiven for be updated to 1.15. The support for 1.13 will be removed. 

Change all references to Flink 1.15.