### PR TITLE
small .golangci.yml fix

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,24 +1,12 @@
-issues:
-  exclude-rules:
-    # Exclude issues bypassing staticcheck.conf
-    - linters:
-        - staticcheck
-      text: "SA1019:"
-
-    - linters:
-        - unparam
-      text: "always receives"
-
-  max-per-linter: 0
-  max-same-issues: 0
-
 linters:
   disable-all: true
   enable:
     - deadcode
     - errcheck
     - gofmt
+    - goimports
     - gosimple
+    - govet
     - ineffassign
     - makezero
     - misspell
@@ -29,12 +17,9 @@ linters:
     - unconvert
     - unused
     - varcheck
-    - vet
-    - goimports
 
-linters-settings:
-  errcheck:
-    ignore: github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema:ForceNew|Set,fmt:.*,io:Close
+issues:
+  exclude-use-default: false
 
 run:
-  timeout: 10m
+  go: '1.17' # See https://github.com/golangci/golangci-lint/issues/2649.

--- a/internal/schemautil/common.go
+++ b/internal/schemautil/common.go
@@ -10,14 +10,14 @@ import (
 )
 
 //goland:noinspection GoDeprecation
-func GetACLUserValidateFunc() schema.SchemaValidateFunc {
+func GetACLUserValidateFunc() schema.SchemaValidateFunc { //nolint:staticcheck
 	return validation.StringMatch(
 		regexp.MustCompile(`^[-._*?A-Za-z0-9]+$`),
 		"Must consist of alpha-numeric characters, underscores, dashes, dots and glob characters '*' and '?'")
 }
 
 //goland:noinspection GoDeprecation
-func GetServiceUserValidateFunc() schema.SchemaValidateFunc {
+func GetServiceUserValidateFunc() schema.SchemaValidateFunc { //nolint:staticcheck
 	return validation.StringMatch(
 		regexp.MustCompile(`^(\*$|[a-zA-Z0-9-_?][a-zA-Z0-9-_?*]+)$`),
 		"username should be alphanumeric, may not start with dash or dot, max 64 characters")


### PR DESCRIPTION
<!-- All contributors, please complete these sections, including maintainers. -->

## About this change—what it does

<!-- Provide a small sentence that summarizes the change. -->
- dropped unused exclusion rules
- rearranged linters alphabetically
- drop timeout setting, the linter never takes more than several seconds to run—default is 30 minutes
- set linters to believe that we use Go 1.17, see https://github.com/golangci/golangci-lint/issues/2649
- replace `vet` with `govet`

there's going to be a bunch of clean up PRs, I will add a changelog entry for it with the last PR

<!-- Provide the issue number below, if it exists. -->

## Why this way

<!-- Provide a small explanation on why this is the approach you took for solving this problem. -->
to improve `.golangci.yml`
