### PR TITLE
remove retention_hours from the kafka topic resource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ nav_order: 1
 ## [MAJOR.MINOR.PATCH] - YYYY-MM-DD
 
 - Add additional disk space support
+- Remove the `retention_hours` logic from the `aiven_kafka_topic` resource
 
 ## [3.5.1] - 2022-08-16
 

--- a/internal/service/kafka/resource_kafka_topic.go
+++ b/internal/service/kafka/resource_kafka_topic.go
@@ -360,19 +360,6 @@ func resourceKafkaTopicRead(ctx context.Context, d *schema.ResourceData, m inter
 		return diag.FromErr(err)
 	}
 
-	if _, ok := d.GetOk("retention_hours"); ok {
-		// it could be -1, which means infinite retention
-		if topic.Config.RetentionMs.Value != -1 {
-			if err := d.Set("retention_hours", topic.Config.RetentionMs.Value/(1000*60*60)); err != nil {
-				return diag.FromErr(err)
-			}
-		} else {
-			if err := d.Set("retention_hours", topic.Config.RetentionMs.Value); err != nil {
-				return diag.FromErr(err)
-			}
-		}
-	}
-
 	if err := d.Set("termination_protection", d.Get("termination_protection")); err != nil {
 		return diag.FromErr(err)
 	}

--- a/internal/service/kafka/resource_kafka_topic_test.go
+++ b/internal/service/kafka/resource_kafka_topic_test.go
@@ -83,7 +83,6 @@ func TestAccAivenKafkaTopic_termination_protection(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "partitions", "3"),
 					resource.TestCheckResourceAttr(resourceName, "replication", "2"),
 					resource.TestCheckResourceAttr(resourceName, "termination_protection", "true"),
-					resource.TestCheckNoResourceAttr(resourceName, "retention_hours"),
 				),
 			},
 		},


### PR DESCRIPTION
## About this change—what it does

retention_hours field is deprecated in v2 and gone from the resource in v3, and the code that sets this value can be deleted.
