### PR TITLE
update disk space on refresh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ nav_order: 1
 ## [MAJOR.MINOR.PATCH] - YYYY-MM-DD
 
 - Add additional disk space support
+- Update disk space on refresh
 
 ## [3.5.1] - 2022-08-16
 

--- a/internal/schemautil/custom_diff.go
+++ b/internal/schemautil/custom_diff.go
@@ -66,12 +66,18 @@ func CustomizeDiffCheckDiskSpace(ctx context.Context, d *schema.ResourceDiff, m 
 	}
 
 	var requestedDiskSpaceMB int
-	ds, okDiskSpace := d.GetOk("disk_space")
-	if !okDiskSpace {
-		return nil
+
+	if ds, ok := d.GetOk("disk_space"); ok {
+		requestedDiskSpaceMB = ConvertToDiskSpaceMB(ds.(string))
+	} else {
+		if ads, ok := d.GetOk("additional_disk_space"); ok {
+			requestedDiskSpaceMB = servicePlanParams.DiskSizeMBDefault + ConvertToDiskSpaceMB(ads.(string))
+		}
 	}
 
-	requestedDiskSpaceMB = ConvertToDiskSpaceMB(ds.(string))
+	if requestedDiskSpaceMB == 0 {
+		return nil
+	}
 
 	if servicePlanParams.DiskSizeMBDefault != requestedDiskSpaceMB {
 		// first check if the plan allows dynamic disk sizing

--- a/internal/schemautil/service.go
+++ b/internal/schemautil/service.go
@@ -583,6 +583,17 @@ func copyServicePropertiesFromAPIResponseToTerraform(
 	if err := d.Set("maintenance_window_time", s.MaintenanceWindow.TimeOfDay); err != nil {
 		return err
 	}
+	if _, ok := d.GetOk("disk_space"); ok && s.DiskSpaceMB != 0 {
+		if err := d.Set("disk_space", HumanReadableByteSize(s.DiskSpaceMB*units.MiB)); err != nil {
+			return err
+		}
+	}
+	if _, ok := d.GetOk("additional_disk_space"); ok && s.DiskSpaceMB != 0 {
+		if err := d.Set("additional_disk_space", HumanReadableByteSize((s.DiskSpaceMB-servicePlanParams.DiskSizeMBDefault)*units.MiB)); err != nil {
+			return err
+		}
+	}
+
 	if err := d.Set("disk_space_used", HumanReadableByteSize(s.DiskSpaceMB*units.MiB)); err != nil {
 		return err
 	}


### PR DESCRIPTION
<!-- All contributors, please complete these sections, including maintainers. -->

## About this change—what it does

Disk space is not updated during the TF refresh/read, and it may cause some discrepancy between TF state and remove the Aiven state of the resource 