### PR TITLE
Update official provider name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ nav_order: 1
 
 # Changelog
 
-## [X.X.X] - not yet released
+## [MAJOR.MINOR.PATCH] - YYYY-MM-DD
 
 - Update to the official name Aiven Provider for Terraform
 - Replaced older links from help.aiven.io to docs.aiven.io

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ nav_order: 1
 
 # Changelog
 
-## [MAJOR.MINOR.PATCH] - YYYY-MM-DD
+## [3.6.0] - 2022-08-31
 
 - Add additional disk space support
 - Update disk space on refresh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ nav_order: 1
 
 # Changelog
 
+## [X.X.X] - not yet released
+
+- Update to the official name Aiven Provider for Terraform
+- Replaced older links from help.aiven.io to docs.aiven.io
+
 ## [3.6.0] - 2022-08-31
 
 - Add additional disk space support

--- a/docs/guides/install-terraform-v012.md
+++ b/docs/guides/install-terraform-v012.md
@@ -5,9 +5,9 @@ page_title: "Using Terraform v0.12"
 # Using Terraform v0.12
 _If you can please upgrade your Terraform client to version 0.13 or above, in this case, there is no need to install the provider manually._
 
-Download the latest Aiven provider for your platform from the [release page](https://github.com/aiven/terraform-provider-aiven/releases).
+Download the latest Aiven Provider for Terraform for your platform from the [release page](https://github.com/aiven/terraform-provider-aiven/releases).
 
-Third-party provider plugins — locally installed providers, not on the registry — need to be assigned a source and placed in the appropriate subdirectory for Terraform to find and use them. Create the appropriate subdirectory within the user plugins directory for the Aiven provider and move the downloaded binary there.
+Third-party provider plugins — locally installed providers, not on the registry — need to be assigned a source and placed in the appropriate subdirectory for Terraform to find and use them. Create the appropriate subdirectory within the user plugins directory for the Aiven Provider for Terraform and move the downloaded binary there.
 
 ```bash
 export AIVEN_PROVIDER_VERSION=2.X.X
@@ -35,4 +35,4 @@ provider "aiven" {
 }
 ```
 
-Then, initialize your Terraform workspace by running `terraform init`. If your Aiven provider is located in the correct directory, it should successfully initialize.
+Then, initialize your Terraform workspace by running `terraform init`. If your Aiven Provider for Terraform is located in the correct directory, it should successfully initialize.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,8 +1,8 @@
-# Aiven Terraform Provider
-The Terraform provider for [Aiven.io](https://aiven.io/), an open source data platform as a service. 
+# Aiven Provider for Terraform
+The Terraform provider for [Aiven](https://aiven.io/), an open source data platform as a service. 
 
 ## Authentication token
-[Signup at Aiven](https://console.aiven.io/signup?utm_source=terraformregistry&utm_medium=organic&utm_campaign=terraform&utm_content=signup) and see the [official instructions](https://help.aiven.io/en/articles/2059201-authentication-tokens) to create an API Authentication Token.
+[Signup at Aiven](https://console.aiven.io/signup?utm_source=terraformregistry&utm_medium=organic&utm_campaign=terraform&utm_content=signup) and see the [official instructions](https://docs.aiven.io/docs/platform/howto/create_authentication_token.html) to create an API Authentication Token.
 
 ## Example usage
 _Only available for Terraform v0.13 and above. For older versions, see [here](guides/install-terraform-v012.md)._

--- a/examples/account/README.md
+++ b/examples/account/README.md
@@ -1,6 +1,6 @@
 # Aiven Project, Account, and Teams Example
 
-Please also read through our [help article](https://help.aiven.io/en/articles/3504926-account-management-in-console) that talks about setting up projects, accounts, and teams through the Aiven Console.
+Please also read through the [official docs](https://docs.aiven.io/docs/platform/concepts/projects_accounts_access.html) that talk about projects, accounts, and managing access permissions.
 
 ## Overview
 
@@ -20,7 +20,7 @@ More information about [Aiven user roles](https://help.aiven.io/en/articles/9237
 
 ## Setup
 
-### Install Aiven Terraform Provider
+### Install Aiven Provider for Terraform
 
 See [Installation Instructions](https://github.com/aiven/terraform-provider-aiven#installation).
 

--- a/examples/kafka_mirrormaker_bidirectional/README.md
+++ b/examples/kafka_mirrormaker_bidirectional/README.md
@@ -10,11 +10,11 @@ following table for roles and privileges:
 
 ## Setup
 
-### Install Aiven Terraform Provider
+### Install Aiven Provider for Terraform
 
 Update the `aiven` provider version in `main.tf`, e.g. `2.x.x => 2.1.0`.
 
-The Aiven Terraform provider is offered on the [Hashicorp Terraform Registry](https://registry.terraform.io/providers/aiven/aiven/latest).
+The Aiven Provider for Terraform is offered on the [Hashicorp Terraform Registry](https://registry.terraform.io/providers/aiven/aiven/latest).
 
 ### Variables
 

--- a/examples/kafka_mirrormaker_global/README.md
+++ b/examples/kafka_mirrormaker_global/README.md
@@ -9,11 +9,11 @@ This setup includes a circular replication flow between three global regions.
 
 ## Setup
 
-### Install Aiven Terraform Provider
+### Install Aiven Provider for Terraform
 
 Update the `aiven` provider version in `main.tf`, e.g. `2.x.x => 2.1.0`.
 
-The Aiven Terraform provider is offered on the [Hashicorp Terraform Registry](https://registry.terraform.io/providers/aiven/aiven/latest).
+The Aiven Provider for Terraform is offered on the [Hashicorp Terraform Registry](https://registry.terraform.io/providers/aiven/aiven/latest).
 
 ### Variables
 

--- a/templates/guides/install-terraform-v012.md
+++ b/templates/guides/install-terraform-v012.md
@@ -5,9 +5,9 @@ page_title: "Using Terraform v0.12"
 # Using Terraform v0.12
 _If you can please upgrade your Terraform client to version 0.13 or above, in this case, there is no need to install the provider manually._
 
-Download the latest Aiven provider for your platform from the [release page](https://github.com/aiven/terraform-provider-aiven/releases).
+Download the latest Aiven Provider for Terraform for your platform from the [release page](https://github.com/aiven/terraform-provider-aiven/releases).
 
-Third-party provider plugins — locally installed providers, not on the registry — need to be assigned a source and placed in the appropriate subdirectory for Terraform to find and use them. Create the appropriate subdirectory within the user plugins directory for the Aiven provider and move the downloaded binary there.
+Third-party provider plugins — locally installed providers, not on the registry — need to be assigned a source and placed in the appropriate subdirectory for Terraform to find and use them. Create the appropriate subdirectory within the user plugins directory for the Aiven Provider for Terraform and move the downloaded binary there.
 
 ```bash
 export AIVEN_PROVIDER_VERSION=2.X.X
@@ -35,4 +35,4 @@ provider "aiven" {
 }
 ```
 
-Then, initialize your Terraform workspace by running `terraform init`. If your Aiven provider is located in the correct directory, it should successfully initialize.
+Then, initialize your Terraform workspace by running `terraform init`. If your Aiven Provider for Terraform is located in the correct directory, it should successfully initialize.

--- a/templates/index.md
+++ b/templates/index.md
@@ -1,8 +1,8 @@
-# Aiven Terraform Provider
-The Terraform provider for [Aiven.io](https://aiven.io/), an open source data platform as a service. 
+# Aiven Provider for Terraform
+The Terraform provider for [Aiven](https://aiven.io/), an open source data platform as a service. 
 
 ## Authentication token
-[Signup at Aiven](https://console.aiven.io/signup?utm_source=terraformregistry&utm_medium=organic&utm_campaign=terraform&utm_content=signup) and see the [official instructions](https://help.aiven.io/en/articles/2059201-authentication-tokens) to create an API Authentication Token.
+[Signup at Aiven](https://console.aiven.io/signup?utm_source=terraformregistry&utm_medium=organic&utm_campaign=terraform&utm_content=signup) and see the [official instructions](https://docs.aiven.io/docs/platform/howto/create_authentication_token.html) to create an API Authentication Token.
 
 ## Example usage
 _Only available for Terraform v0.13 and above. For older versions, see [here](guides/install-terraform-v012.md)._


### PR DESCRIPTION
<!-- All contributors, please complete these sections, including maintainers. -->

## About this change—what it does

The public Terraform Registry docs included some instances of "Aiven Terraform Provider" whereas the official name of the product is "Aiven Provider for Terraform".

This PR updates those texts as well as some outdated docs link for creating authentication tokens.

## Why this way

This is the only way to make a docs change.

## Note to the reviewer

I didn't make any change to `docs/` directory since I believe that the docs are auto-generated from the template. Please review if I made changes to the correct place/directory. 
