### PR TITLE
codeowners: add mhoffm-aiven

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,2 @@
 * @aiven/team-dark-matter
+* @mhoffm-aiven


### PR DESCRIPTION
I used to be able to approve PRs and in some situations am still required to.