### PR TITLE
rename examples-tests job

### DIFF
--- a/.github/workflows/examples-tests.yml
+++ b/.github/workflows/examples-tests.yml
@@ -12,7 +12,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  acceptance_tests:
+  examples_tests:
     runs-on: ubuntu-latest
     steps:
       - uses: softprops/turnstyle@v1


### PR DESCRIPTION
## About this change—what it does

Copy/pasted job name, should be renamed.