### PR TITLE
fix: improve static IP error handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ nav_order: 1
 
 ## [MAJOR.MINOR.PATCH] - YYYY-MM-DD
 
+- Improve static IP error handling end messaging 
+
 ## [3.7.0] - 2022-09-30
 
 - Update to the official name Aiven Provider for Terraform

--- a/internal/service/static_ip/resource_static_ip.go
+++ b/internal/service/static_ip/resource_static_ip.go
@@ -66,8 +66,10 @@ func resourceStaticIPRead(_ context.Context, d *schema.ResourceData, m interface
 
 	r, err := client.StaticIPs.List(project)
 	if err != nil {
-		return diag.Errorf("error getting a list of static IPs for a project: %s",
-			schemautil.ResourceReadHandleNotFound(err, d))
+		if schemautil.ResourceReadHandleNotFound(err, d) == nil {
+			return nil
+		}
+		return diag.Errorf("error getting a list of static IPs for a project: %s", err)
 	}
 	for _, sip := range r.StaticIPs {
 		if sip.StaticIPAddressID == staticIPAddressId {
@@ -78,6 +80,8 @@ func resourceStaticIPRead(_ context.Context, d *schema.ResourceData, m interface
 			return nil
 		}
 	}
+
+	d.SetId("")
 
 	return nil
 }


### PR DESCRIPTION
<!-- All contributors, please complete these sections, including maintainers. -->

## About this change—what it does

Improve static IP error handling to fix failing acc tests: 
```
2022/10/06 11:39:32 [DEBUG] Creating an instance of kafkaTopicCache ...
=== RUN   TestAccAivenResourceStaticIp
=== PAUSE TestAccAivenResourceStaticIp
=== RUN   TestAccAivenResourceStaticIpNonExistentIdentifier
=== PAUSE TestAccAivenResourceStaticIpNonExistentIdentifier
=== CONT  TestAccAivenResourceStaticIp
=== CONT  TestAccAivenResourceStaticIpNonExistentIdentifier
--- PASS: TestAccAivenResourceStaticIpNonExistentIdentifier (9.16s)
--- PASS: TestAccAivenResourceStaticIp (15.42s)
PASS
```