### PR TITLE
Fixes rendering of import examples

### DIFF
--- a/docs/resources/service_integration.md
+++ b/docs/resources/service_integration.md
@@ -180,4 +180,6 @@ Optional:
 - `create` (String)
 ## Import
 Import is supported using the following syntax:
-{{codefile "shell" "examples/resources/aiven_service_integration/import.sh"}}
+```shell
+terraform import aiven_service_integration.myintegration project/integration_id
+```

--- a/docs/resources/vpc_peering_connection.md
+++ b/docs/resources/vpc_peering_connection.md
@@ -83,4 +83,6 @@ Optional:
 - `delete` (String)
 ## Import
 Import is supported using the following syntax:
-{{codefile "shell" "examples/resources/aiven_vpc_peering_connection/import.sh"}}
+```shell
+terraform import aiven_vpc_peering_connection.mypeeringconnection project/vpc_id/peer_cloud_account/peer_vpc/peer_region
+```

--- a/templates/resources/service_integration.md.tmpl
+++ b/templates/resources/service_integration.md.tmpl
@@ -22,5 +22,5 @@ Elasticsearch, etc.
 {{ if .HasImport -}}
 ## Import
 Import is supported using the following syntax:
-{{ printf "{{codefile \"shell\" %q}}" .ImportFile }}
+{{ codefile "shell" .ImportFile }}
 {{- end }}

--- a/templates/resources/vpc_peering_connection.md.tmpl
+++ b/templates/resources/vpc_peering_connection.md.tmpl
@@ -45,5 +45,5 @@ there. `state_info` field contains more details about the particular issue.
 {{ if .HasImport -}}
 ## Import
 Import is supported using the following syntax:
-{{ printf "{{codefile \"shell\" %q}}" .ImportFile }}
+{{ codefile "shell" .ImportFile }}
 {{- end }}


### PR DESCRIPTION
<!-- All contributors, please complete these sections, including maintainers. -->

## About this change—what it does

<!-- Provide a small sentence that summarizes the change. -->

In the cases where the resource documentation has been overridden the code for importing the example import statement was incorrect leading to the terraform registry documentation stating the following;

> Import is supported using the following syntax: {{codefile "shell" "examples/resources/aiven_service_integration/import.sh"}}

With this change the import statement is rendered correctly in the documentation.

<!-- Provide the issue number below, if it exists. -->


## Why this way

There is no other way to achieve correctly rendered documentation.

<!-- Provide a small explanation on why this is the approach you took for solving this problem. -->
