### PR TITLE
fix: update the Kafka service default_acl criteria for the deletion o…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ nav_order: 1
 - Return mirrormaker user config option
 - Update user config options
 - Add a converter for the service user configuration options `ip_filter` object format
+- Fix the Kafka service `default_acl` criteria for the deletion of default ACLs
+
 
 ## [3.7.0] - 2022-09-30
 


### PR DESCRIPTION

<!-- All contributors, please complete these sections, including maintainers. -->

## About this change—what it does

Update the Kafka service `default_acl` criteria for the deletion of default ACLs
