### PR TITLE
docs: update available clickhouse integrations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ nav_order: 1
 - Add a converter for the service user configuration options `ip_filter` object format
 - Fix the Kafka service `default_acl` criteria for the deletion of default ACLs
 - Don't send empty `additional_backup_regions` to the API
+- Update available ClickHouse service integrations
 
 ## [3.7.0] - 2022-09-30
 

--- a/docs/resources/clickhouse.md
+++ b/docs/resources/clickhouse.md
@@ -80,7 +80,7 @@ Optional:
 
 Required:
 
-- `integration_type` (String) Type of the service integration. The only supported value at the moment is `read_replica`
+- `integration_type` (String) Type of the service integration. The only supported values at the moment are `clickhouse_kafka` and `clickhouse_postgresql`.
 - `source_service_name` (String) Name of the source service
 
 

--- a/internal/service/clickhouse/resource_clickhouse.go
+++ b/internal/service/clickhouse/resource_clickhouse.go
@@ -19,6 +19,25 @@ func clickhouseSchema() map[string]*schema.Schema {
 		},
 	}
 	s[schemautil.ServiceTypeClickhouse+"_user_config"] = schemautil.GenerateServiceUserConfigurationSchema(schemautil.ServiceTypeClickhouse)
+	s["service_integrations"] = &schema.Schema{
+		Type:        schema.TypeList,
+		Optional:    true,
+		Description: "Service integrations to specify when creating a service. Not applied after initial service creation",
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				"source_service_name": {
+					Type:        schema.TypeString,
+					Required:    true,
+					Description: "Name of the source service",
+				},
+				"integration_type": {
+					Type:        schema.TypeString,
+					Required:    true,
+					Description: "Type of the service integration. The only supported values at the moment are `clickhouse_kafka` and `clickhouse_postgresql`.",
+				},
+			},
+		},
+	}
 
 	return s
 }


### PR DESCRIPTION
<!-- All contributors, please complete these sections, including maintainers. -->

## About this change—what it does

Changes the wording in the clickhouse resource documentation to reflect the currently available service integrations.

<!-- Provide a small sentence that summarizes the change. -->

<!-- Provide the issue number below, if it exists. -->

## Why this way

<!-- Provide a small explanation on why this is the approach you took for solving this problem. -->

It's a simple doc wording change.