### PR TITLE
fix vpc peering connection `terraform import`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ nav_order: 1
 
 # Changelog
 
+## [MAJOR.MINOR.PATCH] - YYYY-MM-DD
+
+- Fix provider panics on `terraform import` with invalid vpc peering id
+
 ## [3.8.0] - 2022-09-30
 
 - Fix `aiven_gcp_vpc_peering_connection` creation


### PR DESCRIPTION
## About this change—what it does

VPC peering connection id parser doesn't validate user input and panics.

## Why this way

New parser:
- validates user input has valid size
- won't panic because of validation
