### PR TITLE
Added missing OpenSearch external integration endpoint schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ nav_order: 1
 - Fix `GetServiceUserValidateFunc`
 - Fix provider panics on `terraform import` with invalid vpc peering id
 - Fix Azure vpc peering connection import
+- Add OpenSearch external integration endpoint
 
 ## [3.8.0] - 2022-09-30
 

--- a/docs/data-sources/service_integration_endpoint.md
+++ b/docs/data-sources/service_integration_endpoint.md
@@ -37,6 +37,7 @@ data "aiven_service_integration_endpoint" "myendpoint" {
 - `external_elasticsearch_logs_user_config` (List of Object) external elasticsearch specific user configurable settings (see [below for nested schema](#nestedatt--external_elasticsearch_logs_user_config))
 - `external_google_cloud_logging_user_config` (List of Object) external Google Cloud Logginig specific user configurable settings (see [below for nested schema](#nestedatt--external_google_cloud_logging_user_config))
 - `external_kafka_user_config` (List of Object) external Kafka specific user configurable settings (see [below for nested schema](#nestedatt--external_kafka_user_config))
+- `external_opensearch_logs_user_config` (List of Object) external opensearch specific user configurable settings (see [below for nested schema](#nestedatt--external_opensearch_logs_user_config))
 - `external_schema_registry_user_config` (List of Object) External schema registry specific user configurable settings (see [below for nested schema](#nestedatt--external_schema_registry_user_config))
 - `id` (String) The ID of this resource.
 - `jolokia_user_config` (List of Object) Jolokia specific user configurable settings (see [below for nested schema](#nestedatt--jolokia_user_config))
@@ -125,6 +126,18 @@ Read-Only:
 - `ssl_client_cert` (String)
 - `ssl_client_key` (String)
 - `ssl_endpoint_identification_algorithm` (String)
+
+
+<a id="nestedatt--external_opensearch_logs_user_config"></a>
+### Nested Schema for `external_opensearch_logs_user_config`
+
+Read-Only:
+
+- `ca` (String)
+- `index_days_max` (String)
+- `index_prefix` (String)
+- `timeout` (String)
+- `url` (String)
 
 
 <a id="nestedatt--external_schema_registry_user_config"></a>

--- a/docs/resources/service_integration_endpoint.md
+++ b/docs/resources/service_integration_endpoint.md
@@ -29,6 +29,7 @@ The Service Integration Endpoint resource allows the creation and management of 
 - `external_elasticsearch_logs_user_config` (Block List, Max: 1) external elasticsearch specific user configurable settings (see [below for nested schema](#nestedblock--external_elasticsearch_logs_user_config))
 - `external_google_cloud_logging_user_config` (Block List, Max: 1) external Google Cloud Logginig specific user configurable settings (see [below for nested schema](#nestedblock--external_google_cloud_logging_user_config))
 - `external_kafka_user_config` (Block List, Max: 1) external Kafka specific user configurable settings (see [below for nested schema](#nestedblock--external_kafka_user_config))
+- `external_opensearch_logs_user_config` (Block List, Max: 1) external opensearch specific user configurable settings (see [below for nested schema](#nestedblock--external_opensearch_logs_user_config))
 - `external_schema_registry_user_config` (Block List, Max: 1) External schema registry specific user configurable settings (see [below for nested schema](#nestedblock--external_schema_registry_user_config))
 - `jolokia_user_config` (Block List, Max: 1) Jolokia specific user configurable settings (see [below for nested schema](#nestedblock--jolokia_user_config))
 - `prometheus_user_config` (Block List, Max: 1) Prometheus specific user configurable settings (see [below for nested schema](#nestedblock--prometheus_user_config))
@@ -121,6 +122,18 @@ Optional:
 - `ssl_client_cert` (String) PEM-encoded client certificate
 - `ssl_client_key` (String) PEM-encoded client key
 - `ssl_endpoint_identification_algorithm` (String) The endpoint identification algorithm to validate server hostname using server certificate.
+
+
+<a id="nestedblock--external_opensearch_logs_user_config"></a>
+### Nested Schema for `external_opensearch_logs_user_config`
+
+Optional:
+
+- `ca` (String) PEM encoded CA certificate
+- `index_days_max` (String) Maximum number of days of logs to keep
+- `index_prefix` (String) OpenSearch index prefix
+- `timeout` (String) OpenSearch request timeout limit
+- `url` (String) OpenSearch connection URL
 
 
 <a id="nestedblock--external_schema_registry_user_config"></a>

--- a/internal/service/service_integration/resource_service_integration_endpoint.go
+++ b/internal/service/service_integration/resource_service_integration_endpoint.go
@@ -77,6 +77,17 @@ var aivenServiceIntegrationEndpointSchema = map[string]*schema.Schema{
 		Optional: true,
 		Type:     schema.TypeList,
 	},
+	"external_opensearch_logs_user_config": {
+		Description: "external opensearch specific user configurable settings",
+		Elem: &schema.Resource{
+			Schema: schemautil.GenerateTerraformUserConfigSchema(
+				templates.GetUserConfigSchema("endpoint")["external_opensearch_logs"].(map[string]interface{}),
+			),
+		},
+		MaxItems: 1,
+		Optional: true,
+		Type:     schema.TypeList,
+	},
 	"external_aws_cloudwatch_logs_user_config": {
 		Description: "external AWS CloudWatch Logs specific user configurable settings",
 		Elem: &schema.Resource{


### PR DESCRIPTION
## About this change—what it does
Adds the OpenSearch schema for external integration endpoints which is currently missing and a customer would like to use
