### PR TITLE
Add three ClickHouse examples (standalone service, Postgres & Kafka integrations)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ nav_order: 1
 # Changelog
 
 ## [MAJOR.MINOR.PATCH] - YYYY-MM-DD
+- Add ClickHouse examples:
+  - Standalone service
 
 ## [3.9.0] - 2022-12-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ nav_order: 1
 - Add ClickHouse examples:
   - Standalone service
   - Integration with Kafka source
+  - Integration with PostgreSQL source
 
 ## [3.9.0] - 2022-12-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ nav_order: 1
 ## [MAJOR.MINOR.PATCH] - YYYY-MM-DD
 - Add ClickHouse examples:
   - Standalone service
+  - Integration with Kafka source
 
 ## [3.9.0] - 2022-12-01
 

--- a/docs/guides/examples.md
+++ b/docs/guides/examples.md
@@ -11,6 +11,7 @@ Other examples can be found in the [examples](https://github.com/aiven/terraform
 - [Elasticsearch deployment and configuration](https://github.com/aiven/terraform-provider-aiven/tree/master/examples/elasticsearch)
 - [Standalone Kafka connect deployment with custom config](https://github.com/aiven/terraform-provider-aiven/tree/master/examples/kafka_connect)
 - [Deploying a ClickHouse service](https://github.com/aiven/terraform-provider-aiven/tree/master/examples/clickhouse)
+- [Deploying ClickHouse with a Kafka source integration](https://github.com/aiven/terraform-provider-aiven/tree/master/examples/clickhouse_integrations/kafka_source)
 - [Deploying Kafka with a Prometheus Service Integration](https://github.com/aiven/terraform-provider-aiven/tree/master/examples/kafka_prometheus)
 - [Deploying Kafka and Elasticsearch with a Kafka Connect Elasticsearch Sink connector](https://github.com/aiven/terraform-provider-aiven/tree/master/examples/kafka_connectors/es_sink)
 - [Deploying Kafka and Elasticsearch with a Kafka Connect Mongo Sink connector](https://github.com/aiven/terraform-provider-aiven/tree/master/examples/kafka_connectors/mongo_sink)

--- a/docs/guides/examples.md
+++ b/docs/guides/examples.md
@@ -12,6 +12,7 @@ Other examples can be found in the [examples](https://github.com/aiven/terraform
 - [Standalone Kafka connect deployment with custom config](https://github.com/aiven/terraform-provider-aiven/tree/master/examples/kafka_connect)
 - [Deploying a ClickHouse service](https://github.com/aiven/terraform-provider-aiven/tree/master/examples/clickhouse)
 - [Deploying ClickHouse with a Kafka source integration](https://github.com/aiven/terraform-provider-aiven/tree/master/examples/clickhouse_integrations/kafka_source)
+- [Deploying ClickHouse with a PostgreSQL source integration](https://github.com/aiven/terraform-provider-aiven/tree/master/examples/clickhouse_integrations/postgres_source)
 - [Deploying Kafka with a Prometheus Service Integration](https://github.com/aiven/terraform-provider-aiven/tree/master/examples/kafka_prometheus)
 - [Deploying Kafka and Elasticsearch with a Kafka Connect Elasticsearch Sink connector](https://github.com/aiven/terraform-provider-aiven/tree/master/examples/kafka_connectors/es_sink)
 - [Deploying Kafka and Elasticsearch with a Kafka Connect Mongo Sink connector](https://github.com/aiven/terraform-provider-aiven/tree/master/examples/kafka_connectors/mongo_sink)

--- a/docs/guides/examples.md
+++ b/docs/guides/examples.md
@@ -10,6 +10,7 @@ Other examples can be found in the [examples](https://github.com/aiven/terraform
 - [Account, projects, teams, and member management](https://github.com/aiven/terraform-provider-aiven/tree/master/examples/account)
 - [Elasticsearch deployment and configuration](https://github.com/aiven/terraform-provider-aiven/tree/master/examples/elasticsearch)
 - [Standalone Kafka connect deployment with custom config](https://github.com/aiven/terraform-provider-aiven/tree/master/examples/kafka_connect)
+- [Deploying a ClickHouse service](https://github.com/aiven/terraform-provider-aiven/tree/master/examples/clickhouse)
 - [Deploying Kafka with a Prometheus Service Integration](https://github.com/aiven/terraform-provider-aiven/tree/master/examples/kafka_prometheus)
 - [Deploying Kafka and Elasticsearch with a Kafka Connect Elasticsearch Sink connector](https://github.com/aiven/terraform-provider-aiven/tree/master/examples/kafka_connectors/es_sink)
 - [Deploying Kafka and Elasticsearch with a Kafka Connect Mongo Sink connector](https://github.com/aiven/terraform-provider-aiven/tree/master/examples/kafka_connectors/mongo_sink)

--- a/examples/clickhouse/main.tf
+++ b/examples/clickhouse/main.tf
@@ -1,0 +1,20 @@
+// Initialize the provider
+// The only configuration option needed is the API token
+
+terraform {
+  required_providers {
+    aiven = {
+      source  = "aiven/aiven"
+      version = ">=3.8"
+    }
+  }
+}
+
+provider "aiven" {
+  api_token = var.aiven_api_token
+}
+
+variable "aiven_api_token" {
+  description = "Aiven console API token"
+  type        = string
+}

--- a/examples/clickhouse/services.tf
+++ b/examples/clickhouse/services.tf
@@ -1,0 +1,102 @@
+resource "aiven_project" "clickhouse_dev" {
+  project = "clickhouse-dev"
+}
+
+// ClickHouse service in the same region
+resource "aiven_clickhouse" "dev" {
+  project                 = aiven_project.clickhouse_dev.project
+  cloud_name              = "google-europe-west1"
+  plan                    = "hobbyist"
+  service_name            = "clickhouse-gcp-eu"
+  maintenance_window_dow  = "monday"
+  maintenance_window_time = "10:00:00"
+}
+
+// Sample ClickHouse database that can be used to write the raw data
+resource "aiven_clickhouse_database" "iot_analytics" {
+  project      = aiven_project.clickhouse_dev.project
+  service_name = aiven_clickhouse.dev.service_name
+  name         = "iot_analytics"
+}
+
+// ETL user with write permissions to the IoT measurements DB
+resource "aiven_clickhouse_user" "etl" {
+  project      = aiven_project.clickhouse_dev.project
+  service_name = aiven_clickhouse.dev.service_name
+  username     = "etl"
+}
+
+// Writer role that will be granted insert privilege to the measurements DB
+resource "aiven_clickhouse_role" "writer" {
+  project      = aiven_project.clickhouse_dev.project
+  service_name = aiven_clickhouse.dev.service_name
+  role         = "writer"
+}
+
+// Writer role's privileges
+resource "aiven_clickhouse_grant" "writer_role" {
+  project      = aiven_clickhouse.dev.project
+  service_name = aiven_clickhouse.dev.service_name
+  role         = aiven_clickhouse_role.writer.role
+
+  privilege_grant {
+    privilege = "INSERT"
+    database  = aiven_clickhouse_database.iot_analytics.name
+    table     = "*"
+  }
+
+  privilege_grant {
+    privilege = "SELECT"
+    database  = aiven_clickhouse_database.iot_analytics.name
+    table     = "*"
+  }
+}
+
+// Grant the writer role to the ETL user
+resource "aiven_clickhouse_grant" "etl_user" {
+  project      = aiven_clickhouse.dev.project
+  service_name = aiven_clickhouse.dev.service_name
+  user         = aiven_clickhouse_user.etl.username
+
+  role_grant {
+    role = aiven_clickhouse_role.writer.role
+  }
+}
+
+// Analyst user with read-only access to the IoT measurements DB
+resource "aiven_clickhouse_user" "analyst" {
+  project      = aiven_project.clickhouse_dev.project
+  service_name = aiven_clickhouse.dev.service_name
+  username     = "analyst"
+}
+
+// Reader role that will be granted insert privilege to the measurements DB
+resource "aiven_clickhouse_role" "reader" {
+  project      = aiven_project.clickhouse_dev.project
+  service_name = aiven_clickhouse.dev.service_name
+  role         = "reader"
+}
+
+// Reader role's privileges
+resource "aiven_clickhouse_grant" "reader_role" {
+  project      = aiven_clickhouse.dev.project
+  service_name = aiven_clickhouse.dev.service_name
+  role         = aiven_clickhouse_role.reader.role
+
+  privilege_grant {
+    privilege = "SELECT"
+    database  = aiven_clickhouse_database.iot_analytics.name
+    table     = "*"
+  }
+}
+
+// Grant the reader role to the Analyst user
+resource "aiven_clickhouse_grant" "analyst_user" {
+  project      = aiven_clickhouse.dev.project
+  service_name = aiven_clickhouse.dev.service_name
+  user         = aiven_clickhouse_user.analyst.username
+
+  role_grant {
+    role = aiven_clickhouse_role.reader.role
+  }
+}

--- a/examples/clickhouse_integrations/kafka_source/Readme.rst
+++ b/examples/clickhouse_integrations/kafka_source/Readme.rst
@@ -1,0 +1,25 @@
+ClickHouse integration with a Kafka source
+==========================================
+
+The goal of the example is to show how to integrate ClickHouse with Kafka topic sources.
+
+Imagine you're ingesting messages from edges IoT devices with measurements of the following form:
+
+.. code-block:: javascript
+
+  {
+    "sensor_id": 10000001,
+    "ts": "2022-12-01T10:08:24.446369",
+    "key": "pressure_pa",
+    "value": 101.325
+  }
+
+
+``kafka.tf`` creates a Kafka service and the associated `edge-measurements` topic.
+ACLs are not glossed over to focus the example on the integration.
+
+``clickhouse.tf`` creates a ClickHouse service and the Kafka service integration, using the JSON schema presented above.
+The result will be a ``service_kafka-gcp-eu`` database containing the ingested messages.
+
+``clickhouse.tf`` also create an ``iot_analytics`` database for downstream transformation and aggregation of the raw data,
+as well as analyst and writer roles with different sets of privileges over this database.

--- a/examples/clickhouse_integrations/kafka_source/access.tf
+++ b/examples/clickhouse_integrations/kafka_source/access.tf
@@ -1,0 +1,81 @@
+// ETL user with write permissions to the IoT measurements DB
+resource "aiven_clickhouse_user" "etl" {
+  project      = aiven_project.clickhouse_kafka_source.project
+  service_name = aiven_clickhouse.clickhouse.service_name
+  username     = "etl"
+}
+
+// Writer role that will be granted insert privilege to the measurements DB
+resource "aiven_clickhouse_role" "writer" {
+  project      = aiven_project.clickhouse_kafka_source.project
+  service_name = aiven_clickhouse.clickhouse.service_name
+  role         = "writer"
+}
+
+// Writer role's privileges
+resource "aiven_clickhouse_grant" "writer_role" {
+  project      = aiven_clickhouse.clickhouse.project
+  service_name = aiven_clickhouse.clickhouse.service_name
+  role         = aiven_clickhouse_role.writer.role
+
+  privilege_grant {
+    privilege = "INSERT"
+    database  = aiven_clickhouse_database.iot_analytics.name
+    table     = "*"
+  }
+
+  privilege_grant {
+    privilege = "SELECT"
+    database  = aiven_clickhouse_database.iot_analytics.name
+    table     = "*"
+  }
+}
+
+// Grant the writer role to the ETL user
+resource "aiven_clickhouse_grant" "etl_user" {
+  project      = aiven_clickhouse.clickhouse.project
+  service_name = aiven_clickhouse.clickhouse.service_name
+  user         = aiven_clickhouse_user.etl.username
+
+  role_grant {
+    role = aiven_clickhouse_role.writer.role
+  }
+}
+
+// Analyst user with read-only access to the IoT measurements DB
+resource "aiven_clickhouse_user" "analyst" {
+  project      = aiven_project.clickhouse_kafka_source.project
+  service_name = aiven_clickhouse.clickhouse.service_name
+  username     = "analyst"
+}
+
+// Reader role that will be granted insert privilege to the measurements DB
+resource "aiven_clickhouse_role" "reader" {
+  project      = aiven_project.clickhouse_kafka_source.project
+  service_name = aiven_clickhouse.clickhouse.service_name
+  role         = "reader"
+}
+
+// Reader role's privileges
+resource "aiven_clickhouse_grant" "reader_role" {
+  project      = aiven_clickhouse.clickhouse.project
+  service_name = aiven_clickhouse.clickhouse.service_name
+  role         = aiven_clickhouse_role.reader.role
+
+  privilege_grant {
+    privilege = "SELECT"
+    database  = aiven_clickhouse_database.iot_analytics.name
+    table     = "*"
+  }
+}
+
+// Grant the reader role to the Analyst user
+resource "aiven_clickhouse_grant" "analyst_user" {
+  project      = aiven_clickhouse.clickhouse.project
+  service_name = aiven_clickhouse.clickhouse.service_name
+  user         = aiven_clickhouse_user.analyst.username
+
+  role_grant {
+    role = aiven_clickhouse_role.reader.role
+  }
+}

--- a/examples/clickhouse_integrations/kafka_source/clickhouse.tf
+++ b/examples/clickhouse_integrations/kafka_source/clickhouse.tf
@@ -1,0 +1,53 @@
+// ClickHouse service in the same region
+resource "aiven_clickhouse" "clickhouse" {
+  project                 = aiven_project.clickhouse_kafka_source.project
+  cloud_name              = "google-europe-west1"
+  plan                    = "startup-beta-16"
+  service_name            = "clickhouse-gcp-eu"
+  maintenance_window_dow  = "monday"
+  maintenance_window_time = "10:00:00"
+}
+
+// ClickHouse service integration with a Kafka source topic containing
+// edge measurements in JSON format.
+// This will create a `service_kafka-gcp-eu` database with a
+// `edge_measurements_raw` using the Kafka ClickHouse Engine.
+resource "aiven_service_integration" "clickhouse_kafka_source" {
+  project                  = aiven_project.clickhouse_kafka_source.project
+  integration_type         = "clickhouse_kafka"
+  source_service_name      = aiven_kafka.kafka.service_name
+  destination_service_name = aiven_clickhouse.clickhouse.service_name
+  clickhouse_kafka_user_config {
+    tables {
+      name        = "edge_measurements_raw"
+      group_name  = "clickhouse-ingestion"
+      data_format = "JSONEachRow"
+      columns {
+        name = "sensor_id"
+        type = "UInt64"
+      }
+      columns {
+        name = "ts"
+        type = "DateTime64(6)"
+      }
+      columns {
+        name = "key"
+        type = "LowCardinality(String)"
+      }
+      columns {
+        name = "value"
+        type = "Float64"
+      }
+      topics {
+        name = aiven_kafka_topic.edge_measurements.topic_name
+      }
+    }
+  }
+}
+
+// ClickHouse database that can be used to run analytics over the ingested data
+resource "aiven_clickhouse_database" "iot_analytics" {
+  project      = aiven_project.clickhouse_kafka_source.project
+  service_name = aiven_clickhouse.clickhouse.service_name
+  name         = "iot_analytics"
+}

--- a/examples/clickhouse_integrations/kafka_source/kafka.tf
+++ b/examples/clickhouse_integrations/kafka_source/kafka.tf
@@ -1,0 +1,36 @@
+// Kafka service on GCP eu-west
+resource "aiven_kafka" "kafka" {
+  project                 = aiven_project.clickhouse_kafka_source.project
+  cloud_name              = "google-europe-west1"
+  plan                    = "business-4"
+  service_name            = "kafka-gcp-eu"
+  maintenance_window_dow  = "monday"
+  maintenance_window_time = "10:00:00"
+
+  // Enable kafka REST to view and send messages from the Console
+  kafka_user_config {
+    kafka_rest = true
+
+    public_access {
+      kafka_rest = true
+    }
+  }
+}
+
+// Kafka topic used to ingest edge measurements from the IoT devices fleet
+resource "aiven_kafka_topic" "edge_measurements" {
+  project                = aiven_project.clickhouse_kafka_source.project
+  service_name           = aiven_kafka.kafka.service_name
+  topic_name             = "edge-measurements"
+  partitions             = 50
+  replication            = 3
+  termination_protection = false
+
+  config {
+    flush_ms                       = 10
+    unclean_leader_election_enable = true
+    cleanup_policy                 = "delete"
+    retention_bytes                = "134217728" // 10 GiB
+    retention_ms                   = "604800000" // 1 week
+  }
+}

--- a/examples/clickhouse_integrations/kafka_source/project.tf
+++ b/examples/clickhouse_integrations/kafka_source/project.tf
@@ -1,0 +1,4 @@
+// Sample project name
+resource "aiven_project" "clickhouse_kafka_source" {
+  project = "clickhouse-kafka-source"
+}

--- a/examples/clickhouse_integrations/kafka_source/provider.tf
+++ b/examples/clickhouse_integrations/kafka_source/provider.tf
@@ -1,0 +1,15 @@
+// Initialize the provider
+// The only configuration option needed is the API token
+
+terraform {
+  required_providers {
+    aiven = {
+      source  = "aiven/aiven"
+      version = ">=3.9"
+    }
+  }
+}
+
+provider "aiven" {
+  api_token = var.aiven_api_token
+}

--- a/examples/clickhouse_integrations/kafka_source/variables.tf
+++ b/examples/clickhouse_integrations/kafka_source/variables.tf
@@ -1,0 +1,4 @@
+variable "aiven_api_token" {
+  description = "Aiven console API token"
+  type        = string
+}

--- a/examples/clickhouse_integrations/postgres_source/Readme.rst
+++ b/examples/clickhouse_integrations/postgres_source/Readme.rst
@@ -1,0 +1,22 @@
+ClickHouse integration with a PostgreSQL source
+===============================================
+
+The goal of the example is to show how to exposed PostgreSQL databases in ClickHouse.
+
+Imagine you're tackling an inventory analytics use case and your PostgreSQL service has three databases you'd like to access in ClickHouse:
+
+- ``suppliers_dims``: a suppliers database with dimension tables used for joins and reporting
+- ``inventory_facts``: an inventory database with aggregated fact tables used enrich reports
+- ``order_events``: an order events database with event sourced tables used to compute near-real-time stats
+
+``postgres.tf`` creates a PostgreSQL service and the associated databases.
+ACLs are glossed over to keep the focus on the service integration component.
+
+``clickhouse.tf`` creates a ClickHouse service and the PostgreSQL service integration for the three databases above.
+
+As a result, once the services are running, the three following databases will be accessible in ClickHouse:
+
+- ``service_postgres-gcp-us_suppliers_dims_public``
+- ``service_postgres-gcp-us_inventory_facts_public``
+- ``service_postgres-gcp-us_order_events_public``
+

--- a/examples/clickhouse_integrations/postgres_source/clickhouse.tf
+++ b/examples/clickhouse_integrations/postgres_source/clickhouse.tf
@@ -1,0 +1,33 @@
+// ClickHouse service based in the same region
+resource "aiven_clickhouse" "clickhouse" {
+  project                 = aiven_project.clickhouse_postgres_source.project
+  service_name            = "clickhouse-gcp-us"
+  cloud_name              = "google-us-east4"
+  plan                    = "startup-beta-16"
+  maintenance_window_dow  = "monday"
+  maintenance_window_time = "10:00:00"
+
+}
+
+// ClickHouse service integration for the PostgreSQL service as source
+// exposing three databases in the public schema
+resource "aiven_service_integration" "clickhouse_postgres_source" {
+  project                  = aiven_project.clickhouse_postgres_source.project
+  integration_type         = "clickhouse_postgresql"
+  source_service_name      = aiven_pg.postgres.service_name
+  destination_service_name = aiven_clickhouse.clickhouse.service_name
+  clickhouse_postgresql_user_config {
+    databases {
+      database = aiven_pg_database.suppliers_dims.database_name
+      schema = "public"
+    }
+    databases {
+      database = aiven_pg_database.inventory_facts.database_name
+      schema = "public"
+    }
+    databases {
+      database = aiven_pg_database.order_events.database_name
+      schema = "public"
+    }
+  }
+}

--- a/examples/clickhouse_integrations/postgres_source/postgres.tf
+++ b/examples/clickhouse_integrations/postgres_source/postgres.tf
@@ -1,0 +1,27 @@
+// Postgres service based in GCP US East
+resource "aiven_pg" "postgres" {
+  project                 = aiven_project.clickhouse_postgres_source.project
+  service_name            = "postgres-gcp-us"
+  cloud_name              = "google-us-east4"
+  plan                    = "business-8" // Primary + read replica
+  maintenance_window_dow  = "monday"
+  maintenance_window_time = "10:00:00"
+}
+
+resource "aiven_pg_database" "suppliers_dims" {
+  project       = aiven_project.clickhouse_postgres_source.project
+  service_name  = aiven_pg.postgres.service_name
+  database_name = "suppliers_dims"
+}
+
+resource "aiven_pg_database" "inventory_facts" {
+  project       = aiven_project.clickhouse_postgres_source.project
+  service_name  = aiven_pg.postgres.service_name
+  database_name = "inventory_facts"
+}
+
+resource "aiven_pg_database" "order_events" {
+  project       = aiven_project.clickhouse_postgres_source.project
+  service_name  = aiven_pg.postgres.service_name
+  database_name = "order_events"
+}

--- a/examples/clickhouse_integrations/postgres_source/project.tf
+++ b/examples/clickhouse_integrations/postgres_source/project.tf
@@ -1,0 +1,4 @@
+// Sample project name
+resource "aiven_project" "clickhouse_postgres_source" {
+  project = "clickhouse-postgres-source"
+}

--- a/examples/clickhouse_integrations/postgres_source/provider.tf
+++ b/examples/clickhouse_integrations/postgres_source/provider.tf
@@ -1,0 +1,16 @@
+// Initialize the provider
+// The only configuration option needed is the API token
+
+terraform {
+  required_providers {
+    aiven = {
+      source  = "aiven/aiven"
+      version = ">=3.9"
+    }
+  }
+}
+
+
+provider "aiven" {
+  api_token = var.aiven_api_token
+}

--- a/examples/clickhouse_integrations/postgres_source/variables.tf
+++ b/examples/clickhouse_integrations/postgres_source/variables.tf
@@ -1,0 +1,4 @@
+variable "aiven_api_token" {
+  description = "Aiven console API token"
+  type        = string
+}

--- a/templates/guides/examples.md
+++ b/templates/guides/examples.md
@@ -11,6 +11,7 @@ Other examples can be found in the [examples](https://github.com/aiven/terraform
 - [Elasticsearch deployment and configuration](https://github.com/aiven/terraform-provider-aiven/tree/master/examples/elasticsearch)
 - [Standalone Kafka connect deployment with custom config](https://github.com/aiven/terraform-provider-aiven/tree/master/examples/kafka_connect)
 - [Deploying a ClickHouse service](https://github.com/aiven/terraform-provider-aiven/tree/master/examples/clickhouse)
+- [Deploying ClickHouse with a Kafka source integration](https://github.com/aiven/terraform-provider-aiven/tree/master/examples/clickhouse_integrations/kafka_source)
 - [Deploying Kafka with a Prometheus Service Integration](https://github.com/aiven/terraform-provider-aiven/tree/master/examples/kafka_prometheus)
 - [Deploying Kafka and Elasticsearch with a Kafka Connect Elasticsearch Sink connector](https://github.com/aiven/terraform-provider-aiven/tree/master/examples/kafka_connectors/es_sink)
 - [Deploying Kafka and Elasticsearch with a Kafka Connect Mongo Sink connector](https://github.com/aiven/terraform-provider-aiven/tree/master/examples/kafka_connectors/mongo_sink)

--- a/templates/guides/examples.md
+++ b/templates/guides/examples.md
@@ -12,6 +12,7 @@ Other examples can be found in the [examples](https://github.com/aiven/terraform
 - [Standalone Kafka connect deployment with custom config](https://github.com/aiven/terraform-provider-aiven/tree/master/examples/kafka_connect)
 - [Deploying a ClickHouse service](https://github.com/aiven/terraform-provider-aiven/tree/master/examples/clickhouse)
 - [Deploying ClickHouse with a Kafka source integration](https://github.com/aiven/terraform-provider-aiven/tree/master/examples/clickhouse_integrations/kafka_source)
+- [Deploying ClickHouse with a PostgreSQL source integration](https://github.com/aiven/terraform-provider-aiven/tree/master/examples/clickhouse_integrations/postgres_source)
 - [Deploying Kafka with a Prometheus Service Integration](https://github.com/aiven/terraform-provider-aiven/tree/master/examples/kafka_prometheus)
 - [Deploying Kafka and Elasticsearch with a Kafka Connect Elasticsearch Sink connector](https://github.com/aiven/terraform-provider-aiven/tree/master/examples/kafka_connectors/es_sink)
 - [Deploying Kafka and Elasticsearch with a Kafka Connect Mongo Sink connector](https://github.com/aiven/terraform-provider-aiven/tree/master/examples/kafka_connectors/mongo_sink)

--- a/templates/guides/examples.md
+++ b/templates/guides/examples.md
@@ -10,6 +10,7 @@ Other examples can be found in the [examples](https://github.com/aiven/terraform
 - [Account, projects, teams, and member management](https://github.com/aiven/terraform-provider-aiven/tree/master/examples/account)
 - [Elasticsearch deployment and configuration](https://github.com/aiven/terraform-provider-aiven/tree/master/examples/elasticsearch)
 - [Standalone Kafka connect deployment with custom config](https://github.com/aiven/terraform-provider-aiven/tree/master/examples/kafka_connect)
+- [Deploying a ClickHouse service](https://github.com/aiven/terraform-provider-aiven/tree/master/examples/clickhouse)
 - [Deploying Kafka with a Prometheus Service Integration](https://github.com/aiven/terraform-provider-aiven/tree/master/examples/kafka_prometheus)
 - [Deploying Kafka and Elasticsearch with a Kafka Connect Elasticsearch Sink connector](https://github.com/aiven/terraform-provider-aiven/tree/master/examples/kafka_connectors/es_sink)
 - [Deploying Kafka and Elasticsearch with a Kafka Connect Mongo Sink connector](https://github.com/aiven/terraform-provider-aiven/tree/master/examples/kafka_connectors/mongo_sink)


### PR DESCRIPTION
## About this change

This PR adds three ClickHouse examples: 
- a standalone service example showcasing privilege grants, and 
- two service integration examples for Kafka and PostgreSQL sources respectively

## Why this way

The standalone ClickHouse service example is on the toplevel examples dir to stay consistent with other services' examples.

The service integrations examples are grouped in a `clickhouse_integrations` directory: there may be more sources and sinks in the future. The two examples are split into two sub-directories for clarity and because users may want to tweak and test them separately as a first step.

The examples are not very worked in terms of access controls from the PostgreSQL and Kafka side of things because the goal is to highlight the integrations more than the other aspects of the provider's usage.

*Note*: The examples' ClickHouse plans will have to be updated when the service leaves Beta.