### PR TITLE
add aiven_azure_privatelink_connection_approval test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ nav_order: 1
 - Add OpenSearch external integration endpoint
 - Add `aiven_pg_user` import example to docs
 - Extend converter for the service user configuration options `ip_filter` object format
+- Fix `aiven_azure_privatelink_connection_approval` import
 
 ## [3.8.0] - 2022-09-30
 

--- a/docs/resources/azure_privatelink_connection_approval.md
+++ b/docs/resources/azure_privatelink_connection_approval.md
@@ -64,7 +64,7 @@ resource "azurerm_private_endpoint" "endpoint" {
 
 resource "aiven_azure_privatelink_connection_approval" "approval" {
   project             = var.aiven_project_id
-  service_name        = aiven_pg.default
+  service_name        = aiven_pg.default.service_name
   endpoint_ip_address = azurerm_private_endpoint.endpoint.private_service_connection[0].private_ip_address
 }
 ```

--- a/examples/resources/aiven_azure_privatelink_connection_approval/resource.tf
+++ b/examples/resources/aiven_azure_privatelink_connection_approval/resource.tf
@@ -49,6 +49,6 @@ resource "azurerm_private_endpoint" "endpoint" {
 
 resource "aiven_azure_privatelink_connection_approval" "approval" {
   project             = var.aiven_project_id
-  service_name        = aiven_pg.default
+  service_name        = aiven_pg.default.service_name
   endpoint_ip_address = azurerm_private_endpoint.endpoint.private_service_connection[0].private_ip_address
 }

--- a/go.mod
+++ b/go.mod
@@ -3,12 +3,12 @@ module github.com/aiven/terraform-provider-aiven
 go 1.18
 
 require (
-	github.com/aiven/aiven-go-client v1.7.1-0.20221102112614-02e040acfe91
+	github.com/aiven/aiven-go-client v1.7.1-0.20221108145444-aa8b10f12d8f
 	github.com/aiven/aiven-go-client/tools/exp v0.0.0-20221102122203-4f39deb34b6a
 	github.com/docker/go-units v0.5.0
 	github.com/gruntwork-io/terratest v0.40.22
 	github.com/hashicorp/go-cty v1.4.1-0.20200414143053-d3edf31b6320
-	github.com/hashicorp/terraform-plugin-sdk/v2 v2.24.0
+	github.com/hashicorp/terraform-plugin-sdk/v2 v2.22.0
 	github.com/kelseyhightower/envconfig v1.4.0
 	github.com/stretchr/testify v1.8.0
 	golang.org/x/exp v0.0.0-20220722155223-a9213eeb770e

--- a/go.sum
+++ b/go.sum
@@ -51,8 +51,8 @@ github.com/acomagu/bufpipe v1.0.3/go.mod h1:mxdxdup/WdsKVreO5GpW4+M/1CE2sMG4jeGJ
 github.com/agext/levenshtein v1.2.1/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=
 github.com/agext/levenshtein v1.2.3 h1:YB2fHEn0UJagG8T1rrWknE3ZQzWM06O8AMAatNn7lmo=
 github.com/agext/levenshtein v1.2.3/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=
-github.com/aiven/aiven-go-client v1.7.1-0.20221102112614-02e040acfe91 h1:UlAX7dFwb1OaHPnsg1L5noOLvrC6jJQXeqWplKTBtho=
-github.com/aiven/aiven-go-client v1.7.1-0.20221102112614-02e040acfe91/go.mod h1:TkcTcz6bA/SmGoLiDrsLZTdhEwVECN9DI0zT8FacbEs=
+github.com/aiven/aiven-go-client v1.7.1-0.20221108145444-aa8b10f12d8f h1:ft6kgjpV2ZvXjKe5zK5SJvgGFeGy3cFnnvTynBInHic=
+github.com/aiven/aiven-go-client v1.7.1-0.20221108145444-aa8b10f12d8f/go.mod h1:TkcTcz6bA/SmGoLiDrsLZTdhEwVECN9DI0zT8FacbEs=
 github.com/aiven/aiven-go-client/tools/exp v0.0.0-20221102122203-4f39deb34b6a h1:cG+TKgxX2azRUkOGgE+H0+gBEeKDgS1B3Ntr6baWZto=
 github.com/aiven/aiven-go-client/tools/exp v0.0.0-20221102122203-4f39deb34b6a/go.mod h1:PEjz1ETUA7nlqD9gpbLWDyAEwkYbAU1JvhhKXtUQjwM=
 github.com/anmitsu/go-shlex v0.0.0-20161002113705-648efa622239/go.mod h1:2FmKhYUyUczH0OGQWaF5ceTx0UBShxjsH6f8oGKYe2c=
@@ -245,8 +245,8 @@ github.com/hashicorp/terraform-plugin-go v0.14.0 h1:ttnSlS8bz3ZPYbMb84DpcPhY4F5D
 github.com/hashicorp/terraform-plugin-go v0.14.0/go.mod h1:2nNCBeRLaenyQEi78xrGrs9hMbulveqG/zDMQSvVJTE=
 github.com/hashicorp/terraform-plugin-log v0.7.0 h1:SDxJUyT8TwN4l5b5/VkiTIaQgY6R+Y2BQ0sRZftGKQs=
 github.com/hashicorp/terraform-plugin-log v0.7.0/go.mod h1:p4R1jWBXRTvL4odmEkFfDdhUjHf9zcs/BCoNHAc7IK4=
-github.com/hashicorp/terraform-plugin-sdk/v2 v2.24.0 h1:FtCLTiTcykdsURXPt/ku7fYXm3y19nbzbZcUxHx9RbI=
-github.com/hashicorp/terraform-plugin-sdk/v2 v2.24.0/go.mod h1:80wf5oad1tW+oLnbXS4UTYmDCrl7BuN1Q+IA91X1a4Y=
+github.com/hashicorp/terraform-plugin-sdk/v2 v2.22.0 h1:MzfNfrheTt24xbEbA4npUSbX3GYu4xjXS7czcpJFyQY=
+github.com/hashicorp/terraform-plugin-sdk/v2 v2.22.0/go.mod h1:q1XKSxXg9nDmhV0IvNZNZxe3gcTAHzMqrjs8wX1acng=
 github.com/hashicorp/terraform-registry-address v0.0.0-20220623143253-7d51757b572c h1:D8aRO6+mTqHfLsK/BC3j5OAoogv1WLRWzY1AaTo3rBg=
 github.com/hashicorp/terraform-registry-address v0.0.0-20220623143253-7d51757b572c/go.mod h1:Wn3Na71knbXc1G8Lh+yu/dQWWJeFQEpDeJMtWMtlmNI=
 github.com/hashicorp/terraform-svchost v0.0.0-20200729002733-f050f53b9734 h1:HKLsbzeOsfXmKNpr3GiT18XAblV0BjCbzL8KQAMZGa0=

--- a/internal/service/vpc/resource_azure_privatelink_connection_approve.go
+++ b/internal/service/vpc/resource_azure_privatelink_connection_approve.go
@@ -6,11 +6,11 @@ import (
 	"time"
 
 	"github.com/aiven/aiven-go-client"
-	"github.com/aiven/terraform-provider-aiven/internal/schemautil"
-
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/aiven/terraform-provider-aiven/internal/schemautil"
 )
 
 var aivenPrivatelinkConnectionApprovalSchema = map[string]*schema.Schema{
@@ -162,7 +162,7 @@ func resourcePrivatelinkConnectionApprovalRead(_ context.Context, d *schema.Reso
 		return diag.FromErr(err)
 	}
 
-	plConnectionID := d.Get("privatelink_connection_id").(string)
+	plConnectionID := schemautil.OptionalStringPointer(d, "privatelink_connection_id")
 	plConnection, err := client.AzurePrivatelink.ConnectionGet(project, service, plConnectionID)
 	if err != nil {
 		if aiven.IsNotFound(err) {

--- a/internal/service/vpc/resource_azure_privatelink_connection_approve_test.go
+++ b/internal/service/vpc/resource_azure_privatelink_connection_approve_test.go
@@ -1,0 +1,186 @@
+package vpc_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/kelseyhightower/envconfig"
+
+	acc "github.com/aiven/terraform-provider-aiven/internal/acctest"
+)
+
+// azurePLCASecrets AzurePrivateLinkConnectionApproval secrets
+type azurePLCASecrets struct {
+	Project        string `envconfig:"AIVEN_PROJECT_NAME" required:"true"`
+	ClientID       string `envconfig:"AZURE_CLIENT_ID" required:"true"`
+	ClientSecret   string `envconfig:"AZURE_CLIENT_SECRET" required:"true"`
+	TenantID       string `envconfig:"AZURE_TENANT_ID" required:"true"`
+	SubscriptionID string `envconfig:"AZURE_SUBSCRIPTION_ID" required:"true"`
+}
+
+func TestAccAivenAzurePrivateLinkConnectionApproval_basic(t *testing.T) {
+	var s azurePLCASecrets
+	err := envconfig.Process("", &s)
+	if err != nil {
+		t.Skipf("Not all values has been provided: %s", err)
+	}
+
+	prefix := "test-tf-acc-" + acctest.RandString(7)
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acc.TestAccPreCheck(t) },
+		ProviderFactories: acc.TestAccProviderFactories,
+		ExternalProviders: map[string]resource.ExternalProvider{
+			"azurerm": {
+				Source:            "hashicorp/azurerm",
+				VersionConstraint: "=3.30.0",
+			},
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAzurePrivateLinkConnectionApprovalResource(prefix, &s),
+				Check: resource.ComposeTestCheckFunc(
+					// Aiven resources
+					resource.TestCheckResourceAttr("aiven_project_vpc.project_vpc", "state", "ACTIVE"),
+					resource.TestCheckResourceAttr("aiven_pg.pg", "state", "RUNNING"),
+					resource.TestCheckResourceAttr("aiven_azure_privatelink.private_link", "state", "active"),
+					resource.TestCheckResourceAttr("aiven_azure_privatelink_connection_approval.approval", "state", "active"),
+					resource.TestCheckResourceAttrSet("aiven_azure_privatelink_connection_approval.approval", "endpoint_ip_address"),
+					resource.TestCheckResourceAttrSet("aiven_azure_privatelink_connection_approval.approval", "privatelink_connection_id"),
+
+					// Azure resources
+					resource.TestCheckResourceAttrSet("azurerm_resource_group.resource_group", "id"),
+					resource.TestCheckResourceAttrSet("azurerm_virtual_network.virtual_network", "id"),
+					resource.TestCheckResourceAttrSet("azurerm_subnet.subnet", "id"),
+					resource.TestCheckResourceAttrSet("azurerm_private_endpoint.private_endpoint", "id"),
+				),
+			},
+			importStateByName("aiven_project_vpc.project_vpc"),
+			importStateByName("aiven_pg.pg"),
+			importStateByName("aiven_azure_privatelink.private_link"),
+			importStateByName("aiven_azure_privatelink_connection_approval.approval"),
+			importStateByName("azurerm_resource_group.resource_group"),
+			importStateByName("azurerm_virtual_network.virtual_network"),
+			importStateByName("azurerm_subnet.subnet"),
+			importStateByName("azurerm_private_endpoint.private_endpoint"),
+		},
+	})
+}
+
+func testAccAzurePrivateLinkConnectionApprovalResource(prefix string, s *azurePLCASecrets) string {
+	return fmt.Sprintf(`
+data "aiven_project" "project" {
+  project = %[2]q
+}
+
+provider "azurerm" {
+  features {}
+  client_id       = %[3]q
+  client_secret   = %[4]q
+  tenant_id       = %[5]q
+  subscription_id = %[6]q
+}
+
+resource "aiven_project_vpc" "project_vpc" {
+  project      = data.aiven_project.project.project
+  cloud_name   = "azure-germany-north"
+  network_cidr = "192.168.1.0/24"
+
+  timeouts {
+    create = "15m"
+  }
+}
+
+resource "aiven_static_ip" "static_ips" {
+  count      = 2
+  project    = aiven_project_vpc.project_vpc.project
+  cloud_name = aiven_project_vpc.project_vpc.cloud_name
+}
+
+resource "aiven_pg" "pg" {
+  service_name   = "%[1]s-pg"
+  project        = data.aiven_project.project.project
+  project_vpc_id = aiven_project_vpc.project_vpc.id
+  cloud_name     = aiven_project_vpc.project_vpc.cloud_name
+  plan           = "startup-4"
+  static_ips     = [for sip in aiven_static_ip.static_ips : sip.static_ip_address_id]
+
+  pg_user_config {
+    static_ips = true
+
+    privatelink_access {
+      pg        = true
+      pgbouncer = true
+    }
+  }
+}
+
+resource "aiven_azure_privatelink" "private_link" {
+  project      = data.aiven_project.project.project
+  service_name = aiven_pg.pg.service_name
+
+  user_subscription_ids = [
+    %[6]q,
+  ]
+}
+
+resource "azurerm_resource_group" "resource_group" {
+  location = "germanynorth"
+  name     = "%[1]s-private-link"
+}
+
+resource "azurerm_virtual_network" "virtual_network" {
+  name                = "%[1]s-virtual-network"
+  address_space       = ["10.0.0.0/16"]
+  location            = azurerm_resource_group.resource_group.location
+  resource_group_name = azurerm_resource_group.resource_group.name
+}
+
+resource "azurerm_subnet" "subnet" {
+  name                 = "%[1]s-subnet"
+  resource_group_name  = azurerm_resource_group.resource_group.name
+  virtual_network_name = azurerm_virtual_network.virtual_network.name
+  address_prefixes     = ["10.0.2.0/24"]
+}
+
+resource "azurerm_private_endpoint" "private_endpoint" {
+  name                = "%[1]s-private-endpoint"
+  location            = azurerm_resource_group.resource_group.location
+  resource_group_name = azurerm_resource_group.resource_group.name
+  subnet_id           = azurerm_subnet.subnet.id
+
+  private_service_connection {
+    name                           = aiven_pg.pg.service_name
+    request_message                = aiven_pg.pg.service_name
+    private_connection_resource_id = aiven_azure_privatelink.private_link.azure_service_id
+    is_manual_connection           = true
+  }
+
+  depends_on = [
+    aiven_azure_privatelink.private_link,
+  ]
+}
+
+resource "aiven_azure_privatelink_connection_approval" "approval" {
+  project             = data.aiven_project.project.project
+  service_name        = aiven_pg.pg.service_name
+  endpoint_ip_address = azurerm_private_endpoint.private_endpoint.private_service_connection[0].private_ip_address
+}`, prefix, s.Project, s.ClientID, s.ClientSecret, s.TenantID, s.SubscriptionID)
+}
+
+func importStateByName(name string) resource.TestStep {
+	return resource.TestStep{
+		ResourceName: name,
+		ImportState:  true,
+		ImportStateIdFunc: func(s *terraform.State) (string, error) {
+			root := s.RootModule()
+			rs, ok := root.Resources[name]
+			if !ok {
+				return "", fmt.Errorf(`resource %q not found in the state`, name)
+			}
+			return rs.Primary.ID, nil
+		},
+	}
+}


### PR DESCRIPTION
## About this change—what it does

- adds aiven_azure_privatelink_connection_approval test
- fixes add aiven_azure_privatelink_connection_approval docs
- downgrades terraform-plugin-sdk to run multiple providers in [tests](https://github.com/hashicorp/terraform-plugin-sdk/issues/1064)