### PR TITLE
fix: flatten ip_filter in case it contains objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ nav_order: 1
 - Fix project create/update with `add_account_owners_admin_access` field
 - Add OpenSearch external integration endpoint
 - Add `aiven_pg_user` import example to docs
+- Extend converter for the service user configuration options `ip_filter` object format
 
 ## [3.8.0] - 2022-09-30
 

--- a/internal/schemautil/ipfilter.go
+++ b/internal/schemautil/ipfilter.go
@@ -9,6 +9,8 @@ import (
 // the same order as defined in the TF manifest.
 func NormalizeIpFilter(tfUserConfig interface{}, userConfig []map[string]interface{}) []map[string]interface{} {
 	tfInt, ok := tfUserConfig.([]interface{})
+	userConfig[0]["ip_filter"] = toStringSlice(userConfig[0]["ip_filter"].([]interface{}))
+
 	if !ok || len(tfInt) == 0 {
 		return userConfig
 	}


### PR DESCRIPTION
## About this change—what it does

Flatten `ip_filter` from object to []string, this is an extension of this https://github.com/aiven/terraform-provider-aiven/pull/932 patch happens to be not converting `ip_filter` in case a user created a service and added IP Filters using Aiven Console and then uses data-source or imports such resource to Terraform.

Resolves: #909.
