### PR TITLE
fix: Update data aiven_project_vpc example

### DIFF
--- a/examples/data-sources/aiven_project_vpc/data-source.tf
+++ b/examples/data-sources/aiven_project_vpc/data-source.tf
@@ -7,5 +7,5 @@ data "aiven_project_vpc" "myvpc" {
 data "aiven_project_vpc" "myvpc" {
   project    = aiven_project.myproject.project
   cloud_name = "google-europe-west1"
-  id         = aiven_project_vpc.vpc.id
+  vpc_id     = aiven_project_vpc.vpc.id
 }


### PR DESCRIPTION
## About this change—what it does

The `id` field is actually `vpc_id` in this example, and should get updated.

## Why this way

It's a typo fix.
