### PR TITLE
revert datasource_project_vpc project and cloud_name deprecation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ nav_order: 1
 
 # Changelog
 
+## [MAJOR.MINOR.PATCH] - YYYY-MM-DD
+
+- Revert `datasource_project_vpc` `cloud_name` and `project` deprecations
+
 ## [3.8.1] - 2022-11-10
 
 - Fix `GetServiceUserValidateFunc`

--- a/docs/data-sources/project_vpc.md
+++ b/docs/data-sources/project_vpc.md
@@ -19,10 +19,8 @@ data "aiven_project_vpc" "myvpc" {
 }
 
 # Or
-data "aiven_project_vpc" "myvpc" {
-  project    = aiven_project.myproject.project
-  cloud_name = "google-europe-west1"
-  id         = aiven_project_vpc.vpc.id
+data "aiven_project_vpc" "myvpc_id" {
+  vpc_id = aiven_project_vpc.vpc.id
 }
 ```
 
@@ -31,8 +29,8 @@ data "aiven_project_vpc" "myvpc" {
 
 ### Optional
 
-- `cloud_name` (String, Deprecated) Defines where the cloud provider and region where the service is hosted in. See the Service resource for additional information.
-- `project` (String, Deprecated) Identifies the project this resource belongs to.
+- `cloud_name` (String) Defines where the cloud provider and region where the service is hosted in. See the Service resource for additional information.
+- `project` (String) Identifies the project this resource belongs to.
 - `vpc_id` (String) ID of the VPC. This can be used to filter out the specific VPC if there are more than one datasource returned.
 
 ### Read-Only

--- a/examples/data-sources/aiven_project_vpc/data-source.tf
+++ b/examples/data-sources/aiven_project_vpc/data-source.tf
@@ -4,8 +4,6 @@ data "aiven_project_vpc" "myvpc" {
 }
 
 # Or
-data "aiven_project_vpc" "myvpc" {
-  project    = aiven_project.myproject.project
-  cloud_name = "google-europe-west1"
-  id         = aiven_project_vpc.vpc.id
+data "aiven_project_vpc" "myvpc_id" {
+  vpc_id = aiven_project_vpc.vpc.id
 }

--- a/internal/service/vpc/datasource_project_vpc_test.go
+++ b/internal/service/vpc/datasource_project_vpc_test.go
@@ -1,0 +1,106 @@
+package vpc
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/aiven/aiven-go-client"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetVPC(t *testing.T) {
+	differentCloudName := []*aiven.VPC{
+		{ProjectVPCID: "foo", CloudName: "aws"},
+		{ProjectVPCID: "bar", CloudName: "azure"},
+	}
+
+	duplicateCloudName := []*aiven.VPC{
+		{ProjectVPCID: "foo", CloudName: "azure"},
+		{ProjectVPCID: "bar", CloudName: "azure"},
+	}
+
+	cases := []struct {
+		name           string
+		inputVPCList   []*aiven.VPC
+		inputVPCID     string
+		inputCloudName string
+		expectVPC      *aiven.VPC
+		expectErr      error
+	}{
+		{
+			name:           `same cloudName, gets by vpcID "foo"`,
+			inputVPCList:   duplicateCloudName,
+			inputVPCID:     "foo",
+			inputCloudName: "",
+			expectVPC:      &aiven.VPC{ProjectVPCID: "foo", CloudName: "azure"},
+			expectErr:      nil,
+		},
+		{
+			name:           `same cloudName, gets by vpcID "bar"`,
+			inputVPCList:   duplicateCloudName,
+			inputVPCID:     "bar",
+			inputCloudName: "",
+			expectVPC:      &aiven.VPC{ProjectVPCID: "bar", CloudName: "azure"},
+			expectErr:      nil,
+		},
+		{
+			name:           `different cloudName, gets by cloudName "azure"`,
+			inputVPCList:   differentCloudName,
+			inputVPCID:     "",
+			inputCloudName: "azure",
+			expectVPC:      &aiven.VPC{ProjectVPCID: "bar", CloudName: "azure"},
+			expectErr:      nil,
+		},
+		{
+			name:           `same cloudName, gets err`,
+			inputVPCList:   duplicateCloudName,
+			inputVPCID:     "",
+			inputCloudName: "azure",
+			expectVPC:      nil,
+			expectErr:      fmt.Errorf(`multiple project VPC with cloud_name "azure", use vpc_id instead`),
+		},
+		{
+			name:           `invalid input XNOR`,
+			inputVPCList:   duplicateCloudName,
+			inputVPCID:     "foo",
+			inputCloudName: "azure",
+			expectVPC:      nil,
+			expectErr:      fmt.Errorf(`provide exactly one: vpc_id or cloud_name`),
+		},
+		{
+			name:           `invalid input XNOR, both empty`,
+			inputVPCList:   duplicateCloudName,
+			inputVPCID:     "",
+			inputCloudName: "",
+			expectVPC:      nil,
+			expectErr:      fmt.Errorf(`provide exactly one: vpc_id or cloud_name`),
+		},
+		{
+			name:           `nothing found for cloudName "lol"`,
+			inputVPCList:   differentCloudName,
+			inputVPCID:     "",
+			inputCloudName: "lol",
+			expectVPC:      nil,
+			expectErr:      fmt.Errorf(`not found project VPC with cloud_name "lol"`),
+		},
+		{
+			name:           `nothing found for empty slice"`,
+			inputVPCList:   nil,
+			inputVPCID:     "",
+			inputCloudName: "lol",
+			expectVPC:      nil,
+			expectErr:      fmt.Errorf(`not found project VPC with cloud_name "lol"`),
+		},
+	}
+
+	for _, o := range cases {
+		t.Run(o.name, func(t *testing.T) {
+			vpc, err := getVPC(o.inputVPCList, o.inputVPCID, o.inputCloudName)
+			require.Equal(t, err, o.expectErr)
+			require.Equal(t, vpc, o.expectVPC)
+
+			// Never returns both nil, also xnor
+			require.NotEqual(t, err == nil, vpc == nil)
+		})
+	}
+}


### PR DESCRIPTION
## About this change—what it does

Reverts `project` and `cloud_name` deprecation for `datasource_project_vpc`.