### PR TITLE
support "clickhouse_kafka" integration type in "aiven_service_integration"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ nav_order: 1
 
 - Revert `datasource_project_vpc` `cloud_name` and `project` deprecations
 - Add extra timeout for `kafka_connect` service integration create
+- Support `clickhouse_kafka` integration type in `aiven_service_integration` 
 
 ## [3.8.1] - 2022-11-10
 

--- a/docs/data-sources/service_integration.md
+++ b/docs/data-sources/service_integration.md
@@ -30,6 +30,7 @@ data "aiven_service_integration" "myintegration" {
 
 ### Read-Only
 
+- `clickhouse_kafka_user_config` (List of Object) ClickhouseKafka user configurable settings (see [below for nested schema](#nestedatt--clickhouse_kafka_user_config))
 - `datadog_user_config` (List of Object) Datadog user configurable settings (see [below for nested schema](#nestedatt--datadog_user_config))
 - `destination_endpoint_id` (String) Destination endpoint for the integration (if any)
 - `id` (String) The ID of this resource.
@@ -41,6 +42,43 @@ data "aiven_service_integration" "myintegration" {
 - `metrics_user_config` (List of Object) Metrics user configurable settings (see [below for nested schema](#nestedatt--metrics_user_config))
 - `mirrormaker_user_config` (List of Object) Mirrormaker user configurable settings (see [below for nested schema](#nestedatt--mirrormaker_user_config))
 - `source_endpoint_id` (String) Source endpoint for the integration (if any)
+
+<a id="nestedatt--clickhouse_kafka_user_config"></a>
+### Nested Schema for `clickhouse_kafka_user_config`
+
+Read-Only:
+
+- `tables` (List of Object) (see [below for nested schema](#nestedobjatt--clickhouse_kafka_user_config--tables))
+
+<a id="nestedobjatt--clickhouse_kafka_user_config--tables"></a>
+### Nested Schema for `clickhouse_kafka_user_config.tables`
+
+Read-Only:
+
+- `columns` (List of Object) (see [below for nested schema](#nestedobjatt--clickhouse_kafka_user_config--tables--columns))
+- `data_format` (String)
+- `group_name` (String)
+- `name` (String)
+- `topics` (List of Object) (see [below for nested schema](#nestedobjatt--clickhouse_kafka_user_config--tables--topics))
+
+<a id="nestedobjatt--clickhouse_kafka_user_config--tables--columns"></a>
+### Nested Schema for `clickhouse_kafka_user_config.tables.columns`
+
+Read-Only:
+
+- `name` (String)
+- `type` (String)
+
+
+<a id="nestedobjatt--clickhouse_kafka_user_config--tables--topics"></a>
+### Nested Schema for `clickhouse_kafka_user_config.tables.topics`
+
+Read-Only:
+
+- `name` (String)
+
+
+
 
 <a id="nestedatt--datadog_user_config"></a>
 ### Nested Schema for `datadog_user_config`

--- a/docs/resources/service_integration.md
+++ b/docs/resources/service_integration.md
@@ -33,6 +33,7 @@ resource "aiven_service_integration" "my_integration_metrics" {
 
 ### Optional
 
+- `clickhouse_kafka_user_config` (Block List, Max: 1) ClickhouseKafka user configurable settings (see [below for nested schema](#nestedblock--clickhouse_kafka_user_config))
 - `datadog_user_config` (Block List, Max: 1) Datadog user configurable settings (see [below for nested schema](#nestedblock--datadog_user_config))
 - `destination_endpoint_id` (String) Destination endpoint for the integration (if any)
 - `destination_service_name` (String) Destination service for the integration (if any)
@@ -50,6 +51,43 @@ resource "aiven_service_integration" "my_integration_metrics" {
 
 - `id` (String) The ID of this resource.
 - `integration_id` (String) Service Integration Id at aiven
+
+<a id="nestedblock--clickhouse_kafka_user_config"></a>
+### Nested Schema for `clickhouse_kafka_user_config`
+
+Optional:
+
+- `tables` (Block List, Max: 100) Tables to create (see [below for nested schema](#nestedblock--clickhouse_kafka_user_config--tables))
+
+<a id="nestedblock--clickhouse_kafka_user_config--tables"></a>
+### Nested Schema for `clickhouse_kafka_user_config.tables`
+
+Optional:
+
+- `columns` (Block List, Max: 100) Table columns (see [below for nested schema](#nestedblock--clickhouse_kafka_user_config--tables--columns))
+- `data_format` (String) Message data format
+- `group_name` (String) Kafka consumers group
+- `name` (String) Name of the table
+- `topics` (Block List, Max: 100) Kafka topics (see [below for nested schema](#nestedblock--clickhouse_kafka_user_config--tables--topics))
+
+<a id="nestedblock--clickhouse_kafka_user_config--tables--columns"></a>
+### Nested Schema for `clickhouse_kafka_user_config.tables.columns`
+
+Optional:
+
+- `name` (String) Column name
+- `type` (String) Column type
+
+
+<a id="nestedblock--clickhouse_kafka_user_config--tables--topics"></a>
+### Nested Schema for `clickhouse_kafka_user_config.tables.topics`
+
+Optional:
+
+- `name` (String) Name of the topic
+
+
+
 
 <a id="nestedblock--datadog_user_config"></a>
 ### Nested Schema for `datadog_user_config`

--- a/internal/service/service_integration/resource_service_integration.go
+++ b/internal/service/service_integration/resource_service_integration.go
@@ -74,6 +74,7 @@ var aivenServiceIntegrationSchema = map[string]*schema.Schema{
 	"kafka_logs_user_config":        dist.IntegrationTypeKafkaLogs(),
 	"metrics_user_config":           dist.IntegrationTypeMetrics(),
 	"datadog_user_config":           dist.IntegrationTypeDatadog(),
+	"clickhouse_kafka_user_config":  dist.IntegrationTypeClickhouseKafka(),
 }
 
 func ResourceServiceIntegration() *schema.Resource {


### PR DESCRIPTION
## About this change—what it does

Adds `clickhouse_kafka_user_config` to the service integration type schema 
to support `clickhouse_kafka` integration type

Resolves: #968.
