### PR TITLE
fix `aiven_transit_gateway_vpc_attachment` fails to parse ID

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,8 @@ nav_order: 1
 
 - Revert `datasource_project_vpc` `cloud_name` and `project` deprecations
 - Add extra timeout for `kafka_connect` service integration create
-- Support `clickhouse_kafka` integration type in `aiven_service_integration`
+- Support `clickhouse_kafka` integration type in `aiven_service_integration` 
+- Fix `aiven_transit_gateway_vpc_attachment` fails to parse ID
 
 ## [3.8.1] - 2022-11-10
 

--- a/internal/service/vpc/resource_azure_privatelink_connection_approve_test.go
+++ b/internal/service/vpc/resource_azure_privatelink_connection_approve_test.go
@@ -12,7 +12,6 @@ import (
 	acc "github.com/aiven/terraform-provider-aiven/internal/acctest"
 )
 
-// azureSecrets AzurePrivateLinkConnectionApproval secrets
 type azureSecrets struct {
 	Project        string `envconfig:"AIVEN_PROJECT_NAME" required:"true"`
 	AivenAppID     string `envconfig:"AIVEN_AZURE_APP_ID" required:"true"`

--- a/internal/service/vpc/resource_transit_gateway_vpc_attachement.go
+++ b/internal/service/vpc/resource_transit_gateway_vpc_attachement.go
@@ -83,12 +83,12 @@ func ResourceTransitGatewayVPCAttachment() *schema.Resource {
 func resourceTransitGatewayVPCAttachmentUpdate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	client := m.(*aiven.Client)
 
-	cidrs := schemautil.FlattenToString(d.Get("user_peer_network_cidrs").([]interface{}))
-	p, err := parsePeerVPCID(d.Id())
+	p, err := parsePeerVPCIDWithRegion(d.Id())
 	if err != nil {
 		return diag.Errorf("error parsing peering VPC ID: %s", err)
 	}
 
+	cidrs := schemautil.FlattenToString(d.Get("user_peer_network_cidrs").([]interface{}))
 	peeringConnection, err := client.VPCPeeringConnections.Get(p.projectName, p.vpcID, p.peerCloudAccount, p.peerVPC)
 	if err != nil {
 		return diag.Errorf("cannot get transit gateway vpc attachment by id %s: %s", d.Id(), err)


### PR DESCRIPTION
## About this change—what it does

- Fix `aiven_transit_gateway_vpc_attachment` fails to parse ID, add test
- Add `aiven_aws_vpc_peering_connection` tests

Resolves: #967.
