### PR TITLE
add gcp vpc self link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ nav_order: 1
 - Add extra timeout for `kafka_connect` service integration create
 - Support `clickhouse_kafka` integration type in `aiven_service_integration` 
 - Fix `aiven_transit_gateway_vpc_attachment` fails to parse ID
+- Add `self_link` field to `aiven_gcp_vpc_peering_connection` resource
 
 ## [3.8.1] - 2022-11-10
 

--- a/docs/data-sources/gcp_vpc_peering_connection.md
+++ b/docs/data-sources/gcp_vpc_peering_connection.md
@@ -32,6 +32,7 @@ data "aiven_gcp_vpc_peering_connection" "foo" {
 ### Read-Only
 
 - `id` (String) The ID of this resource.
+- `self_link` (String) Computed GCP network peering link
 - `state` (String) State of the peering connection
 - `state_info` (Map of String) State-specific help or error information
 

--- a/docs/resources/gcp_vpc_peering_connection.md
+++ b/docs/resources/gcp_vpc_peering_connection.md
@@ -36,6 +36,7 @@ resource "aiven_gcp_vpc_peering_connection" "foo" {
 ### Read-Only
 
 - `id` (String) The ID of this resource.
+- `self_link` (String) Computed GCP network peering link
 - `state` (String) State of the peering connection
 - `state_info` (Map of String) State-specific help or error information
 

--- a/internal/service/vpc/resource_gcp_vpc_peering_connection.go
+++ b/internal/service/vpc/resource_gcp_vpc_peering_connection.go
@@ -13,6 +13,8 @@ import (
 	"github.com/aiven/terraform-provider-aiven/internal/schemautil"
 )
 
+const _gcpAPI = "https://www.googleapis.com/compute/v1"
+
 var aivenGCPVPCPeeringConnectionSchema = map[string]*schema.Schema{
 	"vpc_id": {
 		ForceNew:     true,
@@ -250,19 +252,22 @@ func copyGCPVPCPeeringConnectionPropertiesFromAPIResponseToTerraform(
 	var toProjectId string
 	var toVPCNetwork string
 
-	if peeringConnection.StateInfo != nil && len(*peeringConnection.StateInfo) > 0 {
-		if v, ok := (*peeringConnection.StateInfo)["to_project_id"]; ok {
-			toProjectId = v.(string)
-		}
-		if v, ok := (*peeringConnection.StateInfo)["to_vpc_network"]; ok {
-			toVPCNetwork = v.(string)
-		}
+	if peeringConnection.StateInfo != nil {
+		si := *peeringConnection.StateInfo
+		if len(si) > 0 {
+			if v, ok := si["to_project_id"]; ok {
+				toProjectId = v.(string)
+			}
+			if v, ok := si["to_vpc_network"]; ok {
+				toVPCNetwork = v.(string)
+			}
 
-		if toProjectId != "" && toVPCNetwork != "" {
-			if err := d.Set("self_link",
-				fmt.Sprintf("https://www.googleapis.com/compute/v1/projects/%s/global/networks/%s",
-					toProjectId, toVPCNetwork)); err != nil {
-				return diag.FromErr(err)
+			if toProjectId != "" && toVPCNetwork != "" {
+				if err := d.Set("self_link",
+					fmt.Sprintf(_gcpAPI+"/projects/%s/global/networks/%s",
+						toProjectId, toVPCNetwork)); err != nil {
+					return diag.FromErr(err)
+				}
 			}
 		}
 	}

--- a/internal/service/vpc/resource_gcp_vpc_peering_connection_test.go
+++ b/internal/service/vpc/resource_gcp_vpc_peering_connection_test.go
@@ -1,0 +1,204 @@
+package vpc_test
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/aiven/aiven-go-client"
+	acc "github.com/aiven/terraform-provider-aiven/internal/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/kelseyhightower/envconfig"
+)
+
+type gcpSecrets struct {
+	AivenProject string `envconfig:"AIVEN_PROJECT_NAME" required:"true"`
+	GCPProjectID string `envconfig:"GCP_PROJECT_ID" required:"true"`
+	GCPRegion    string `envconfig:"GCP_REGION" required:"true"`
+}
+
+func TestAccAivenGCPPeeringConnection_basic(t *testing.T) {
+	var s gcpSecrets
+
+	err := envconfig.Process("", &s)
+	if err != nil {
+		t.Skipf("Not all values have been provided to establish a GCP VPC peering connection: %s", err)
+	}
+
+	importResourceName := "aiven_gcp_vpc_peering_connection.foo"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { acc.TestAccPreCheck(t) },
+		ProviderFactories: acc.TestAccProviderFactories,
+		ExternalProviders: map[string]resource.ExternalProvider{
+			"google": {
+				Source:            "hashicorp/google",
+				VersionConstraint: ">=4.0.0,<5.0.0",
+			},
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: testAccGCPVPCPeeringConnection(&s),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(importResourceName, "state"),
+					resource.TestCheckResourceAttrSet(importResourceName, "self_link"),
+					resource.TestCheckResourceAttr("google_compute_network_peering.foo", "state", "ACTIVE"),
+					resource.TestCheckResourceAttr("data.aiven_gcp_vpc_peering_connection.bar", "state", "PENDING_PEER"),
+					resource.TestCheckResourceAttrSet("data.aiven_gcp_vpc_peering_connection.bar", "self_link"),
+				),
+			},
+			{
+				Config: testAccGCPVPCPeeringConnection(&s),
+				Check: func(state *terraform.State) error {
+					c := acc.TestAccProvider.Meta().(*aiven.Client)
+					p := s.AivenProject
+
+				QueryVpc:
+					vpcs, err := c.VPCs.List(p)
+					if err != nil {
+						return err
+					}
+
+					var v *aiven.VPC
+					for _, vpc := range vpcs {
+						if vpc.CloudName == fmt.Sprintf("google-%s", s.GCPRegion) {
+							v = vpc
+						}
+					}
+
+					if v == nil {
+						return errors.New("error getting GCP peering connection, project VPC is empty")
+					}
+
+					cons, err := c.VPCPeeringConnections.List(p, v.ProjectVPCID)
+					if err != nil {
+						return fmt.Errorf("error getting list of peering connections: %w", err)
+					}
+
+					if len(cons) == 0 {
+						return fmt.Errorf("error getting GCP peering connection, list of peering connections is empty for Project VPC ID (%s)", v.ProjectVPCID)
+					}
+
+					for _, pvpc := range cons {
+						if pvpc.State != "ACTIVE" {
+							t.Logf("GCP VPC peering connection in VPC (%s) is in state %s, waiting for it to be ACTIVE...", v.ProjectVPCID, pvpc.State)
+							time.Sleep(10 * time.Second)
+							goto QueryVpc
+						}
+					}
+
+					t.Logf("Hooray! GCP VPC peering connection is ACTIVE!")
+
+					return nil
+				},
+			},
+			{
+				ResourceName: importResourceName,
+				ImportState:  true,
+				Config:       testAccGCPVPCPeeringConnection(&s),
+				ImportStateIdFunc: func(s *terraform.State) (string, error) {
+					rs, ok := s.RootModule().Resources[importResourceName]
+					if !ok {
+						return "", fmt.Errorf("expected resource '%s' to be present in the state", importResourceName)
+					}
+					if _, ok := rs.Primary.Attributes["vpc_id"]; !ok {
+						return "", fmt.Errorf("expected resource '%s' to have 'vpc_id' attribute", importResourceName)
+					}
+					if _, ok := rs.Primary.Attributes["gcp_project_id"]; !ok {
+						return "", fmt.Errorf("expected resource '%s' to have 'gcp_project_id' attribute", importResourceName)
+					}
+					if _, ok := rs.Primary.Attributes["peer_vpc"]; !ok {
+						return "", fmt.Errorf("expected resource '%s' to have 'peer_vpc' attribute", importResourceName)
+					}
+					return rs.Primary.ID, nil
+				},
+				ImportStateCheck: func(s []*terraform.InstanceState) error {
+					if len(s) != 1 {
+						for k, i := range s {
+							t.Logf("GCP VPC imported (%d): %#+v", k, i.Attributes)
+						}
+						return fmt.Errorf("expected only one instance to be imported, instead %d were imported", len(s))
+					}
+
+					attributes := s[0].Attributes
+					vpcId, ok := attributes["vpc_id"]
+					if !ok {
+						return errors.New("expected 'vpc_id' field to be set")
+					}
+
+					gcpProjectID, ok := attributes["gcp_project_id"]
+					if !ok {
+						return errors.New("expected 'gcp_project_id' field to be set")
+					}
+
+					peerVPC, ok := attributes["peer_vpc"]
+					if !ok {
+						return errors.New("expected 'gcp_project_id' field to be set")
+					}
+
+					expectedId := fmt.Sprintf("%s/%s/%s", vpcId, gcpProjectID, peerVPC)
+					if !strings.EqualFold(s[0].ID, expectedId) {
+						return fmt.Errorf("expected ID to match '%s', but got: %s", expectedId, s[0].ID)
+					}
+
+					if _, ok := attributes["self_link"]; !ok {
+						return errors.New("expected 'self_link' field to be set")
+					}
+
+					if s, ok := attributes["state"]; !ok || s != "ACTIVE" {
+						return fmt.Errorf("expected 'state' field to be set and equal to `ACTIVE`, got `%s`", s)
+					}
+
+					return nil
+				},
+			},
+		},
+	})
+}
+
+func testAccGCPVPCPeeringConnection(s *gcpSecrets) string {
+	return fmt.Sprintf(`
+data "aiven_project" "project" {
+  project = "%[1]s"
+}
+
+provider "google" {
+  project = "%[2]s"
+  region  = "%[3]s"
+}
+
+resource "aiven_project_vpc" "project_vpc" {
+  project      = data.aiven_project.project.project
+  cloud_name   = "google-%[3]s"
+  network_cidr = "10.0.0.0/24"
+}
+
+resource "aiven_gcp_vpc_peering_connection" "foo" {
+  vpc_id         = aiven_project_vpc.project_vpc.id
+  gcp_project_id = "%[2]s"
+  peer_vpc       = "default"
+}
+
+data "google_compute_network" "foo" {
+  project = "%[2]s"
+  name    = "default"
+}
+
+resource "google_compute_network_peering" "foo" {
+  name         = "acc-test-vpc-peering"
+  network      = data.google_compute_network.foo.id
+  peer_network = aiven_gcp_vpc_peering_connection.foo.self_link
+}
+
+data "aiven_gcp_vpc_peering_connection" "bar" {
+  vpc_id         = aiven_gcp_vpc_peering_connection.foo.vpc_id
+  gcp_project_id = aiven_gcp_vpc_peering_connection.foo.gcp_project_id
+  peer_vpc       = aiven_gcp_vpc_peering_connection.foo.peer_vpc
+
+  depends_on = [google_compute_network_peering.foo]
+}
+`, s.AivenProject, s.GCPProjectID, s.GCPRegion)
+}


### PR DESCRIPTION
<!-- All contributors, please complete these sections, including maintainers. -->

## About this change—what it does

- add `self_link` computed field field, to support this: 
```hcl
resource "google_compute_network_peering" "foo" {
  name         = "acc-test-vpc-peering"
  network      = data.google_compute_network.foo.id
  peer_network = aiven_gcp_vpc_peering_connection.foo.self_link
}
```
- GCP VPC peering e2e tests (including import and data-source validation) 
```shell
TF_ACC=1 CGO_ENABLED=0 go test ./internal/service/vpc/... \
-v -count 1 -parallel 10  -run=TestAccAivenGCPPeeringConnection_basic -timeout 180m
2022/11/30 10:56:01 [DEBUG] Creating an instance of kafkaTopicCache ...
=== RUN   TestAccAivenGCPPeeringConnection_basic
    resource_gcp_vpc_peering_connection_test.go:86: GCP VPC peering connection in VPC (7d072ab3-0256-4693-81fe-d39a33758ef3) is in state PENDING_PEER, waiting for it to be ACTIVE...
    resource_gcp_vpc_peering_connection_test.go:86: GCP VPC peering connection in VPC (7d072ab3-0256-4693-81fe-d39a33758ef3) is in state PENDING_PEER, waiting for it to be ACTIVE...
    resource_gcp_vpc_peering_connection_test.go:86: GCP VPC peering connection in VPC (7d072ab3-0256-4693-81fe-d39a33758ef3) is in state PENDING_PEER, waiting for it to be ACTIVE...
    resource_gcp_vpc_peering_connection_test.go:86: GCP VPC peering connection in VPC (7d072ab3-0256-4693-81fe-d39a33758ef3) is in state PENDING_PEER, waiting for it to be ACTIVE...
    resource_gcp_vpc_peering_connection_test.go:86: GCP VPC peering connection in VPC (7d072ab3-0256-4693-81fe-d39a33758ef3) is in state PENDING_PEER, waiting for it to be ACTIVE...
    resource_gcp_vpc_peering_connection_test.go:86: GCP VPC peering connection in VPC (7d072ab3-0256-4693-81fe-d39a33758ef3) is in state PENDING_PEER, waiting for it to be ACTIVE...
    resource_gcp_vpc_peering_connection_test.go:86: GCP VPC peering connection in VPC (7d072ab3-0256-4693-81fe-d39a33758ef3) is in state PENDING_PEER, waiting for it to be ACTIVE...
    resource_gcp_vpc_peering_connection_test.go:86: GCP VPC peering connection in VPC (7d072ab3-0256-4693-81fe-d39a33758ef3) is in state PENDING_PEER, waiting for it to be ACTIVE...
    resource_gcp_vpc_peering_connection_test.go:86: GCP VPC peering connection in VPC (7d072ab3-0256-4693-81fe-d39a33758ef3) is in state PENDING_PEER, waiting for it to be ACTIVE...
    resource_gcp_vpc_peering_connection_test.go:86: GCP VPC peering connection in VPC (7d072ab3-0256-4693-81fe-d39a33758ef3) is in state PENDING_PEER, waiting for it to be ACTIVE...
    resource_gcp_vpc_peering_connection_test.go:86: GCP VPC peering connection in VPC (7d072ab3-0256-4693-81fe-d39a33758ef3) is in state PENDING_PEER, waiting for it to be ACTIVE...
    resource_gcp_vpc_peering_connection_test.go:86: GCP VPC peering connection in VPC (7d072ab3-0256-4693-81fe-d39a33758ef3) is in state PENDING_PEER, waiting for it to be ACTIVE...
    resource_gcp_vpc_peering_connection_test.go:86: GCP VPC peering connection in VPC (7d072ab3-0256-4693-81fe-d39a33758ef3) is in state PENDING_PEER, waiting for it to be ACTIVE...
    resource_gcp_vpc_peering_connection_test.go:86: GCP VPC peering connection in VPC (7d072ab3-0256-4693-81fe-d39a33758ef3) is in state PENDING_PEER, waiting for it to be ACTIVE...
    resource_gcp_vpc_peering_connection_test.go:86: GCP VPC peering connection in VPC (7d072ab3-0256-4693-81fe-d39a33758ef3) is in state PENDING_PEER, waiting for it to be ACTIVE...
    resource_gcp_vpc_peering_connection_test.go:86: GCP VPC peering connection in VPC (7d072ab3-0256-4693-81fe-d39a33758ef3) is in state PENDING_PEER, waiting for it to be ACTIVE...
    resource_gcp_vpc_peering_connection_test.go:86: GCP VPC peering connection in VPC (7d072ab3-0256-4693-81fe-d39a33758ef3) is in state PENDING_PEER, waiting for it to be ACTIVE...
    resource_gcp_vpc_peering_connection_test.go:92: Hooray! GCP VPC peering connection is ACTIVE!
--- PASS: TestAccAivenGCPPeeringConnection_basic (425.93s)
PASS
ok      github.com/aiven/terraform-provider-aiven/internal/service/vpc  425.944s

```

Related to #921 