### PR TITLE
fix vpc peering id parser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ nav_order: 1
   - Standalone service
   - Integration with Kafka source
   - Integration with PostgreSQL source
+- Fix vpc peering id parser
 
 ## [3.9.0] - 2022-12-01
 

--- a/internal/service/vpc/resource_aws_vpc_peering_connection.go
+++ b/internal/service/vpc/resource_aws_vpc_peering_connection.go
@@ -168,7 +168,7 @@ func resourceAWSVPCPeeringConnectionCreate(ctx context.Context, d *schema.Resour
 func resourceAWSVPCPeeringConnectionRead(_ context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	client := m.(*aiven.Client)
 
-	p, err := parsePeerVPCIDWithRegion(d.Id())
+	p, err := parsePeerVPCID(d.Id())
 	if err != nil {
 		return diag.Errorf("error parsing AWS peering VPC ID: %s", err)
 	}
@@ -185,7 +185,7 @@ func resourceAWSVPCPeeringConnectionRead(_ context.Context, d *schema.ResourceDa
 func resourceAWSVPCPeeringConnectionDelete(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	client := m.(*aiven.Client)
 
-	p, err := parsePeerVPCIDWithRegion(d.Id())
+	p, err := parsePeerVPCID(d.Id())
 	if err != nil {
 		return diag.Errorf("error parsing AWS peering VPC ID: %s", err)
 	}

--- a/internal/service/vpc/resource_transit_gateway_vpc_attachement.go
+++ b/internal/service/vpc/resource_transit_gateway_vpc_attachement.go
@@ -83,7 +83,7 @@ func ResourceTransitGatewayVPCAttachment() *schema.Resource {
 func resourceTransitGatewayVPCAttachmentUpdate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	client := m.(*aiven.Client)
 
-	p, err := parsePeerVPCIDWithRegion(d.Id())
+	p, err := parsePeerVPCID(d.Id())
 	if err != nil {
 		return diag.Errorf("error parsing peering VPC ID: %s", err)
 	}

--- a/internal/service/vpc/resource_vpc_peering_connection_test.go
+++ b/internal/service/vpc/resource_vpc_peering_connection_test.go
@@ -2,8 +2,11 @@ package vpc
 
 import (
 	"errors"
+	"fmt"
 	"reflect"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func Test_validateVPCID(t *testing.T) {
@@ -39,6 +42,77 @@ func Test_validateVPCID(t *testing.T) {
 			if !reflect.DeepEqual(gotErrors, tt.wantErrors) {
 				t.Errorf("validateVPCID() gotErrors = %v, want %v", gotErrors, tt.wantErrors)
 			}
+		})
+	}
+}
+
+func Test_parsePeerVPCID(t *testing.T) {
+	region := "peerRegion"
+	cases := []struct {
+		name     string
+		source   string
+		expected *peeringVPCID
+		err      error
+	}{
+		{
+			name:     "empty string",
+			source:   "",
+			expected: nil,
+			err:      fmt.Errorf("expected unix path-like string with 4-5 chunks, got 1"),
+		},
+		{
+			name:     "too many chunks",
+			source:   "projectName/vpcID/peerCloudAccount/peerVPC/peerRegion/foo/bar/baz/egg",
+			expected: nil,
+			err:      fmt.Errorf("expected unix path-like string with 4-5 chunks, got 9"),
+		},
+		{
+			name:   "full 5 chunks",
+			source: "projectName/vpcID/peerCloudAccount/peerVPC/peerRegion",
+			expected: &peeringVPCID{
+				projectName:      "projectName",
+				vpcID:            "vpcID",
+				peerCloudAccount: "peerCloudAccount",
+				peerVPC:          "peerVPC",
+				peerRegion:       &region,
+			},
+		},
+		{
+			name:   "only 4 chunks",
+			source: "projectName/vpcID/peerCloudAccount/peerVPC",
+			expected: &peeringVPCID{
+				projectName:      "projectName",
+				vpcID:            "vpcID",
+				peerCloudAccount: "peerCloudAccount",
+				peerVPC:          "peerVPC",
+				peerRegion:       nil,
+			},
+		},
+		{
+			name:     "only 3 chunks",
+			source:   "projectName/vpcID/peerCloudAccount",
+			expected: nil,
+			err:      fmt.Errorf("expected unix path-like string with 4-5 chunks, got 3"),
+		},
+		{
+			name:     "only 2 chunks",
+			source:   "projectName/vpcID",
+			expected: nil,
+			err:      fmt.Errorf("expected unix path-like string with 4-5 chunks, got 2"),
+		},
+		{
+			name:     "only 1 chunk",
+			source:   "projectName",
+			expected: nil,
+			err:      fmt.Errorf("expected unix path-like string with 4-5 chunks, got 1"),
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			actual, err := parsePeerVPCID(c.source)
+			assert.Equal(t, c.err, err)
+			assert.Equal(t, c.expected, actual)
 		})
 	}
 }


### PR DESCRIPTION
## About this change—what it does

VPC peering CRUD functions accept IDs both 4 and 5 chunks length,
so parser must expect different sizes.  
Resolves: #988.