### PR TITLE
add kafka_authentication_method support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ nav_order: 1
   - Integration with PostgreSQL source
 - Fix vpc peering id parser
 - Add `offset_syncs_topic_location` support for `aiven_mirrormaker_replication_flow` resource 
+- Add `kafka_authentication_method` output support in `aiven.kafka.components[]`
 
 ## [3.9.0] - 2022-12-01
 

--- a/internal/schemautil/service.go
+++ b/internal/schemautil/service.go
@@ -693,11 +693,12 @@ func FlattenServiceComponents(r *aiven.Service) []map[string]interface{} {
 
 	for _, c := range r.Components {
 		component := map[string]interface{}{
-			"component": c.Component,
-			"host":      c.Host,
-			"port":      c.Port,
-			"route":     c.Route,
-			"usage":     c.Usage,
+			"component":                   c.Component,
+			"host":                        c.Host,
+			"port":                        c.Port,
+			"route":                       c.Route,
+			"usage":                       c.Usage,
+			"kafka_authentication_method": c.KafkaAuthenticationMethod,
 		}
 		components = append(components, component)
 	}


### PR DESCRIPTION
## About this change—what it does
Would it be possible to add `kafka_authentication_method` attribute to the list of components from the output of an Aiven service  ? 

We would like to be able to differentiate components between "sasl" and "certificate" and as of today, this value (`aiven.kafka.components[].kafka_authentication_method`) is always an empty string. 

## Why this way

The [Aiven API](https://api.aiven.io/doc/#tag/Service/operation/ServiceGet) returns this attribute (it's not required though) and it seems to be supported by the [Aiven Go Client](https://github.com/aiven/aiven-go-client/blob/master/service.go#L84) 
