### PR TITLE
fix(ip_filter): misconversion when using frontend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,9 @@ nav_order: 1
   - Standalone service
   - Integration with Kafka source
   - Integration with PostgreSQL source
-- Fix vpc peering id parser
+- Fix VPC peering ID parser
 - Add `offset_syncs_topic_location` support for `aiven_mirrormaker_replication_flow` resource 
+- Fix changes being incorrectly picked up by the `ip_filter` field after changing it in frontend
 
 ## [3.9.0] - 2022-12-01
 

--- a/internal/schemautil/userconfig/apiconvert/fromapi.go
+++ b/internal/schemautil/userconfig/apiconvert/fromapi.go
@@ -221,6 +221,49 @@ func propsFromAPI(n string, r map[string]interface{}, p map[string]interface{}) 
 			vrs = []map[string]interface{}{p}
 		}
 
+		// TODO: Remove when this is fixed in front end.
+		if vrs != nil && k == "ip_filter_object" {
+			vrsa, ok := vrs.([]interface{})
+			if !ok {
+				return nil, fmt.Errorf("%s...%s: ip_filter_object value is not []interface{}", n, k)
+			}
+
+			var cif []interface{}
+
+			nde := false
+
+			for _, v := range vrsa {
+				va, ok := v.(map[string]interface{})
+				if !ok {
+					return nil, fmt.Errorf(
+						"%s...%s: ip_filter_object value is not []map[string]interface{}", n, k,
+					)
+				}
+
+				vda, ok := va["description"].(string)
+				if !ok {
+					return nil, fmt.Errorf("%s...%s: description value is not a string", n, k)
+				}
+
+				if vda != "" {
+					nde = true
+				}
+
+				vna, ok := va["network"].(string)
+				if !ok {
+					return nil, fmt.Errorf("%s...%s: network value is not a string", n, k)
+				}
+
+				cif = append(cif, vna)
+			}
+
+			if !nde {
+				k = "ip_filter"
+
+				vrs = cif
+			}
+		}
+
 		res[userconfig.EncodeKey(k)] = vrs
 	}
 


### PR DESCRIPTION
<!-- All contributors, please complete these sections, including maintainers. -->

## About this change—what it does

<!-- Provide a small sentence that summarizes the change. -->
Fix changes being incorrectly picked up by the `ip_filter` field after changing it in frontend

<!-- Provide the issue number below, if it exists. -->
resolves #987 

## Why this way

<!-- Provide a small explanation on why this is the approach you took for solving this problem. -->
currently, the backend logic for the `ip_filter` field is mutable with schema changes from other API clients, e.g. the frontend client

this has to be addressed both in frontend and backend, for now we will introduce this small fix on our side
