### PR TITLE
expose ssl field in service components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ nav_order: 1
   - Integration with PostgreSQL source
 - Fix vpc peering id parser
 - Add `offset_syncs_topic_location` support for `aiven_mirrormaker_replication_flow` resource 
-- Add `kafka_authentication_method` output support in `aiven.kafka.components[]`
+- Add `ssl` and `kafka_authentication_method` output support in service components
 
 ## [3.9.0] - 2022-12-01
 

--- a/internal/schemautil/common.go
+++ b/internal/schemautil/common.go
@@ -198,3 +198,11 @@ func ValidateEnum[T string | int](enum ...T) schema.SchemaValidateDiagFunc {
 		return nil
 	}
 }
+
+// PointerValueOrDefault returns pointer's value or default
+func PointerValueOrDefault[T comparable](v *T, d T) T {
+	if v == nil {
+		return d
+	}
+	return *v
+}

--- a/internal/schemautil/schemautil_test.go
+++ b/internal/schemautil/schemautil_test.go
@@ -4,6 +4,8 @@ import (
 	"errors"
 	"reflect"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func Test_validateDurationString(t *testing.T) {
@@ -91,4 +93,11 @@ func Test_splitResourceID(t *testing.T) {
 			}
 		})
 	}
+}
+
+func Test_PointerValueOrDefault(t *testing.T) {
+	var foo *string
+	bar := "bar"
+	assert.Equal(t, PointerValueOrDefault(foo, "default"), "default")
+	assert.Equal(t, PointerValueOrDefault(&bar, "default"), "bar")
 }

--- a/internal/schemautil/service.go
+++ b/internal/schemautil/service.go
@@ -7,9 +7,10 @@ import (
 	"strings"
 
 	"github.com/aiven/aiven-go-client"
+	"github.com/docker/go-units"
+
 	"github.com/aiven/terraform-provider-aiven/internal/schemautil/userconfig"
 	"github.com/aiven/terraform-provider-aiven/internal/schemautil/userconfig/apiconvert"
-	"github.com/docker/go-units"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -699,6 +700,9 @@ func FlattenServiceComponents(r *aiven.Service) []map[string]interface{} {
 			"route":                       c.Route,
 			"usage":                       c.Usage,
 			"kafka_authentication_method": c.KafkaAuthenticationMethod,
+			// By default, endpoints are always encrypted and
+			// this property is only included for service components that may disable encryption.
+			"ssl": PointerValueOrDefault(c.Ssl, true),
 		}
 		components = append(components, component)
 	}

--- a/internal/service/kafka/resource_kafka_test.go
+++ b/internal/service/kafka/resource_kafka_test.go
@@ -7,12 +7,11 @@ import (
 	"testing"
 
 	"github.com/aiven/aiven-go-client"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 
 	acc "github.com/aiven/terraform-provider-aiven/internal/acctest"
-
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 
 func TestAccAiven_kafka(t *testing.T) {
@@ -68,6 +67,9 @@ func TestAccAiven_kafka(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "state", "RUNNING"),
 					resource.TestCheckResourceAttr(resourceName, "termination_protection", "false"),
 					resource.TestCheckResourceAttr(resourceName, "default_acl", "false"),
+					resource.TestCheckResourceAttr(resourceName, "components.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "components.0.ssl", "true"),
+					resource.TestCheckResourceAttr(resourceName, "components.0.kafka_authentication_method", "certificate"),
 					resource.TestCheckResourceAttrSet(resourceName, "service_username"),
 					resource.TestCheckResourceAttrSet(resourceName, "service_password"),
 					resource.TestCheckResourceAttrSet(resourceName, "service_host"),


### PR DESCRIPTION
## About this change—what it does

- Exposes `ssl` field in service components.
- Adds test for `kafka_authentication_method` field

Resolves #992.