### PR TITLE
fix concurrent map writes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ nav_order: 1
 
 ## [MAJOR.MINOR.PATCH] - YYYY-MM-DD
 
+- Fix races in tests
+
 ## [3.10.0] - 2022-12-14
 - Add ClickHouse examples:
   - Standalone service


### PR DESCRIPTION
## About this change—what it does

Fixes races in tests because of concurrent map writes to `cachedRepresentationMaps`.