### PR TITLE
feat(schemautil): normalize ip_filter_object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ nav_order: 1
 ## [MAJOR.MINOR.PATCH] - YYYY-MM-DD
 
 - Fix races in tests
+- Add support for normalization of `ip_filter_object` user config options
 
 ## [3.10.0] - 2022-12-14
 - Add ClickHouse examples:

--- a/internal/schemautil/mutations_test.go
+++ b/internal/schemautil/mutations_test.go
@@ -1,0 +1,265 @@
+package schemautil
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+// TestCopySensitiveFields tests the copySensitiveFields function.
+func TestCopySensitiveFields(t *testing.T) {
+	type args struct {
+		old map[string]interface{}
+		new map[string]interface{}
+	}
+	tests := []struct {
+		name string
+		args args
+		want map[string]interface{}
+	}{
+		{
+			name: "empty",
+			args: args{
+				old: map[string]interface{}{},
+				new: map[string]interface{}{},
+			},
+			want: map[string]interface{}{},
+		},
+		{
+			name: "no sensitive fields",
+			args: args{
+				old: map[string]interface{}{
+					"foo": "bar",
+				},
+				new: map[string]interface{}{
+					"foo": "bar",
+				},
+			},
+			want: map[string]interface{}{
+				"foo": "bar",
+			},
+		},
+		{
+			name: "sensitive fields",
+			args: args{
+				old: map[string]interface{}{
+					"foo":            "bar",
+					"admin_username": "admin",
+					"admin_password": "password",
+				},
+				new: map[string]interface{}{
+					"foo": "bar",
+				},
+			},
+			want: map[string]interface{}{
+				"foo":            "bar",
+				"admin_username": "admin",
+				"admin_password": "password",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			copySensitiveFields(tt.args.old, tt.args.new)
+
+			if !cmp.Equal(tt.args.new, tt.want) {
+				t.Errorf(cmp.Diff(tt.want, tt.args.new))
+			}
+		})
+	}
+}
+
+// TestNormalizeIpFilter tests the normalizeIpFilter function.
+func TestNormalizeIpFilter(t *testing.T) {
+	type args struct {
+		old map[string]interface{}
+		new map[string]interface{}
+	}
+	tests := []struct {
+		name string
+		args args
+		want map[string]interface{}
+	}{
+		{
+			name: "empty",
+			args: args{
+				old: map[string]interface{}{},
+				new: map[string]interface{}{},
+			},
+			want: map[string]interface{}{},
+		},
+		{
+			name: "no ip filter",
+			args: args{
+				old: map[string]interface{}{
+					"foo": "bar",
+				},
+				new: map[string]interface{}{
+					"foo": "bar",
+				},
+			},
+			want: map[string]interface{}{
+				"foo": "bar",
+			},
+		},
+		{
+			name: "ip filter",
+			args: args{
+				old: map[string]interface{}{
+					"foo": "bar",
+					"ip_filter": []interface{}{
+						"1.3.3.8/32",
+						"1.3.3.7/32",
+					},
+				},
+				new: map[string]interface{}{
+					"foo": "bar",
+					"ip_filter": []interface{}{
+						"1.3.3.7/32",
+						"1.3.3.8/32",
+					},
+				},
+			},
+			want: map[string]interface{}{
+				"foo": "bar",
+				"ip_filter": []interface{}{
+					"1.3.3.8/32",
+					"1.3.3.7/32",
+				},
+			},
+		},
+		{
+			name: "ip filter with remote changes",
+			args: args{
+				old: map[string]interface{}{
+					"foo": "bar",
+					"ip_filter": []interface{}{
+						"1.3.3.8/32",
+						"1.3.3.7/32",
+					},
+				},
+				new: map[string]interface{}{
+					"foo": "bar",
+					"ip_filter": []interface{}{
+						"1.3.3.7/32",
+						"1.3.3.8/32",
+						"1.3.3.9/32",
+					},
+				},
+			},
+			want: map[string]interface{}{
+				"foo": "bar",
+				"ip_filter": []interface{}{
+					"1.3.3.8/32",
+					"1.3.3.7/32",
+					"1.3.3.9/32",
+				},
+			},
+		},
+		{
+			name: "ip filter object",
+			args: args{
+				old: map[string]interface{}{
+					"foo": "bar",
+					"ip_filter_object": []interface{}{
+						map[string]interface{}{
+							"network":     "1.3.3.8/32",
+							"description": "foo",
+						},
+						map[string]interface{}{
+							"network":     "1.3.3.7/32",
+							"description": "foo",
+						},
+					},
+				},
+				new: map[string]interface{}{
+					"foo": "bar",
+					"ip_filter_object": []interface{}{
+						map[string]interface{}{
+							"network":     "1.3.3.7/32",
+							"description": "foo",
+						},
+						map[string]interface{}{
+							"network":     "1.3.3.8/32",
+							"description": "foo",
+						},
+					},
+				},
+			},
+			want: map[string]interface{}{
+				"foo": "bar",
+				"ip_filter_object": []interface{}{
+					map[string]interface{}{
+						"network":     "1.3.3.8/32",
+						"description": "foo",
+					},
+					map[string]interface{}{
+						"network":     "1.3.3.7/32",
+						"description": "foo",
+					},
+				},
+			},
+		},
+		{
+			name: "ip filter object with remote changes",
+			args: args{
+				old: map[string]interface{}{
+					"foo": "bar",
+					"ip_filter_object": []interface{}{
+						map[string]interface{}{
+							"network":     "1.3.3.8/32",
+							"description": "foo",
+						},
+						map[string]interface{}{
+							"network":     "1.3.3.7/32",
+							"description": "foo",
+						},
+					},
+				},
+				new: map[string]interface{}{
+					"foo": "bar",
+					"ip_filter_object": []interface{}{
+						map[string]interface{}{
+							"network":     "1.3.3.7/32",
+							"description": "foo",
+						},
+						map[string]interface{}{
+							"network":     "1.3.3.8/32",
+							"description": "foo",
+						},
+						map[string]interface{}{
+							"network":     "1.3.3.9/32",
+							"description": "foo",
+						},
+					},
+				},
+			},
+			want: map[string]interface{}{
+				"foo": "bar",
+				"ip_filter_object": []interface{}{
+					map[string]interface{}{
+						"network":     "1.3.3.8/32",
+						"description": "foo",
+					},
+					map[string]interface{}{
+						"network":     "1.3.3.7/32",
+						"description": "foo",
+					},
+					map[string]interface{}{
+						"network":     "1.3.3.9/32",
+						"description": "foo",
+					},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			normalizeIpFilter(tt.args.old, tt.args.new)
+
+			if !cmp.Equal(tt.args.new, tt.want) {
+				t.Errorf(cmp.Diff(tt.want, tt.args.new))
+			}
+		})
+	}
+}

--- a/internal/schemautil/userconfig/apiconvert/toapi.go
+++ b/internal/schemautil/userconfig/apiconvert/toapi.go
@@ -169,6 +169,15 @@ func itemToAPI(
 	// We omit the value if has no changes in the Terraform user configuration.
 	o := !d.HasChange(fks)
 
+	// We need to make sure that if there were any changes to the parent object, we also send the value, even if it
+	// was not changed.
+	//
+	// We check that there are more than three elements in the fk slice, because we don't want to send the value if
+	// the parent object is the root object.
+	if o && len(fk) > 3 && d.HasChange(fks[:strings.LastIndex(fks, ".0")]) {
+		o = false
+	}
+
 	// TODO: Remove this statement and the branch below it when we use actual types in the schema.
 	if va, ok := v.(string); ok && va == "" {
 		return res, o, nil

--- a/internal/schemautil/userconfig/apiconvert/toapi_test.go
+++ b/internal/schemautil/userconfig/apiconvert/toapi_test.go
@@ -308,6 +308,7 @@ func TestToAPI(t *testing.T) {
 			want: map[string]any{
 				"namespaces": []interface{}{
 					map[string]any{
+						"name": "default",
 						"type": "unaggregated",
 					},
 				},
@@ -470,6 +471,10 @@ func TestToAPI(t *testing.T) {
 			},
 			want: map[string]any{
 				"ip_filter": []interface{}{
+					map[string]interface{}{
+						"description": "test",
+						"network":     "0.0.0.0/0",
+					},
 					map[string]interface{}{
 						"description": "",
 						"network":     "10.20.0.0/16",
@@ -678,7 +683,8 @@ func TestToAPI(t *testing.T) {
 						map[string]interface{}{
 							"namespaces": []interface{}{
 								map[string]interface{}{
-									"retention": "48h",
+									"resolution": "30s",
+									"retention":  "48h",
 								},
 							},
 						},


### PR DESCRIPTION
<!-- All contributors, please complete these sections, including maintainers. -->

## About this change—what it does

<!-- Provide a small sentence that summarizes the change. -->
this PR adds support for normalization of `ip_filter_object`

additionally, it introduces a small fix to the `apiconvert` package which is going to prevent the omit of nested items if the top item has been changed, e.g. if we modify only the `description` field of an `ip_filter_object`, the API expects us to send a full `ip_filter_object` array, instead of only modified items; this should as well be the case for other nested structures

<!-- Provide the issue number below, if it exists. -->
resolves #987

## Why this way

<!-- Provide a small explanation on why this is the approach you took for solving this problem. -->
currently, we didn't have a way to utilize the functionality that is provided via `ip_filter_object`

this PR makes `ip_filter_object` to function properly
