### PR TITLE
add mysql example test

### DIFF
--- a/.github/workflows/examples-tests.yml
+++ b/.github/workflows/examples-tests.yml
@@ -3,6 +3,7 @@ name: Examples Tests
 on:
   schedule:
     - cron: "0 13 * * *"
+  workflow_dispatch:
 
 permissions:
   contents: read

--- a/examples/kafka_connect/provider.tf
+++ b/examples/kafka_connect/provider.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aiven = {
       source  = "aiven/aiven"
-      version = ">=3.0.0"
+      version = ">=3.0.0, <4.0.0"
     }
   }
 }

--- a/examples/kafka_connectors/os_sink/provider.tf
+++ b/examples/kafka_connectors/os_sink/provider.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aiven = {
       source  = "aiven/aiven"
-      version = ">=3.0.0"
+      version = ">=3.0.0, <4.0.0"
     }
   }
 }

--- a/examples/kafka_connectors/os_sink/services.tf
+++ b/examples/kafka_connectors/os_sink/services.tf
@@ -27,7 +27,7 @@ resource "aiven_kafka_topic" "kafka-topic" {
 }
 
 resource "aiven_opensearch" "os" {
-  project                 = aiven_kafka.kafka.project
+  project                 = var.avn_project
   service_name            = var.os_name
   cloud_name              = "google-europe-west1"
   plan                    = "startup-4"

--- a/examples/kafka_prometheus/provider.tf
+++ b/examples/kafka_prometheus/provider.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aiven = {
       source  = "aiven/aiven"
-      version = ">=3.0.0"
+      version = ">=3.0.0, <4.0.0"
     }
   }
 }

--- a/examples/mysql/provider.tf
+++ b/examples/mysql/provider.tf
@@ -2,10 +2,12 @@ terraform {
   required_providers {
     aiven = {
       source  = "aiven/aiven"
-      version = ">= 2.0.0, < 3.0.0"
+      version = ">=3.0.0, <4.0.0"
     }
   }
 }
+
+# Initialize provider. No other config options than api_token
 provider "aiven" {
-  api_token = var.aiven_api_token
+  api_token = var.avn_token
 }

--- a/examples/mysql/service.tf
+++ b/examples/mysql/service.tf
@@ -1,15 +1,14 @@
-#Mysql database creation
 resource "aiven_mysql" "mysql" {
-  project                 = var.aiven_project_id
+  project                 = var.avn_project
   cloud_name              = "google-europe-west1"
   plan                    = "business-4"
-  service_name            = "mysql"
+  service_name            = var.mysql_name
   maintenance_window_dow  = "monday"
   maintenance_window_time = "10:00:00"
 
   mysql_user_config {
-    admin_password = "aiven"
-    admin_username = "aiven@123"
+    admin_username = var.mysql_username
+    admin_password = var.mysql_password
     mysql_version  = 8
 
     public_access {

--- a/examples/mysql/variables.tf
+++ b/examples/mysql/variables.tf
@@ -1,2 +1,5 @@
-variable "aiven_api_token" {}
-variable "aiven_project_id" {}
+variable "avn_token" {}
+variable "avn_project" {}
+variable "mysql_name" {}
+variable "mysql_username" {}
+variable "mysql_password" {}

--- a/examples/postgres/provider.tf
+++ b/examples/postgres/provider.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aiven = {
       source  = "aiven/aiven"
-      version = ">=3.0.0"
+      version = ">=3.0.0, <4.0.0"
     }
   }
 }

--- a/examples_tests/base_test.go
+++ b/examples_tests/base_test.go
@@ -1,0 +1,22 @@
+package examples
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestExamplesRandPrefix(t *testing.T) {
+	withPrefix := examplesRandPrefix()
+	kafkaName := withPrefix("kafka")
+
+	// Starts with prefix, ends with "-kafka", has valid length
+	assert.True(t, strings.HasPrefix(kafkaName, exampleTestsPrefix))
+	assert.True(t, strings.HasSuffix(kafkaName, "-kafka"))
+	assert.Equal(t, len(exampleTestsPrefix+"0000000-kafka"), len(kafkaName))
+
+	// Equal seed for a new name
+	mysqlName := withPrefix("mysql")
+	assert.True(t, strings.HasPrefix(kafkaName, mysqlName[:len(mysqlName)-len("mysql")]))
+}

--- a/examples_tests/kafka_connect_test.go
+++ b/examples_tests/kafka_connect_test.go
@@ -21,8 +21,9 @@ func (s *KafkaConnectTestSuite) TestKafkaConnect() {
 	s.T().Parallel()
 
 	// Given
-	kafkaServiceName := randName("test-examples-kafka-%s")
-	kafkaConnectName := randName("test-examples-kafka-connect-%s")
+	withPrefix := examplesRandPrefix()
+	kafkaServiceName := withPrefix("kafka")
+	kafkaConnectName := withPrefix("kafka-connect")
 	opts := s.withDefaults(&terraform.Options{
 		TerraformDir: "../examples/kafka_connect",
 		Vars: map[string]interface{}{

--- a/examples_tests/kafka_connector_test.go
+++ b/examples_tests/kafka_connector_test.go
@@ -21,10 +21,11 @@ func (s *KafkaConnectorTestSuite) TestKafkaConnectorOS() {
 	s.T().Parallel()
 
 	// Given
-	kafkaServiceName := randName("test-examples-kafka-%s")
-	kafkaConnectorName := randName("test-examples-kafka-connector-%s")
-	kafkaTopicName := randName("test-examples-kafka-topic-%s")
-	osServiceName := randName("test-examples-os-%s")
+	withPrefix := examplesRandPrefix()
+	kafkaServiceName := withPrefix("kafka")
+	kafkaConnectorName := withPrefix("kafka-connector")
+	kafkaTopicName := withPrefix("kafka-topic")
+	osServiceName := withPrefix("os")
 	opts := s.withDefaults(&terraform.Options{
 		TerraformDir: "../examples/kafka_connectors/os_sink",
 		Vars: map[string]interface{}{
@@ -47,10 +48,6 @@ func (s *KafkaConnectorTestSuite) TestKafkaConnectorOS() {
 	s.Equal("kafka", kafkaService.Type)
 	s.Equal("business-4", kafkaService.Plan)
 	s.Equal("google-europe-west1", kafkaService.CloudName)
-
-	kafkaTopic, err := s.client.KafkaTopics.Get(s.config.Project, kafkaServiceName, kafkaTopicName)
-	s.NoError(err)
-	s.Equal(kafkaTopic.TopicName, kafkaTopicName)
 
 	kafkaConnector, err := s.client.KafkaConnectors.GetByName(s.config.Project, kafkaServiceName, kafkaConnectorName)
 	s.NoError(err)

--- a/examples_tests/kafka_prometheus_test.go
+++ b/examples_tests/kafka_prometheus_test.go
@@ -22,8 +22,9 @@ func (s *KafkaPrometheusTestSuite) TestKafkaPrometheus() {
 	s.T().Parallel()
 
 	// Given
-	kafkaServiceName := randName("test-examples-kafka-%s")
-	prometheusEndpointName := randName("test-prometheus-endpoint-%s")
+	withPrefix := examplesRandPrefix()
+	kafkaServiceName := withPrefix("kafka")
+	prometheusEndpointName := withPrefix("prom-endpoint")
 	opts := s.withDefaults(&terraform.Options{
 		TerraformDir: "../examples/kafka_prometheus",
 		Vars: map[string]interface{}{
@@ -31,8 +32,8 @@ func (s *KafkaPrometheusTestSuite) TestKafkaPrometheus() {
 			"avn_project":              s.config.Project,
 			"kafka_name":               kafkaServiceName,
 			"prometheus_endpoint_name": prometheusEndpointName,
-			"prometheus_username":      randName("username%s"),
-			"prometheus_password":      randName("password%s"),
+			"prometheus_username":      "username" + uniqueID(),
+			"prometheus_password":      "password" + uniqueID(),
 		},
 	})
 

--- a/examples_tests/mysql_test.go
+++ b/examples_tests/mysql_test.go
@@ -1,0 +1,49 @@
+//go:build all || examples
+
+package examples
+
+import (
+	"testing"
+
+	"github.com/gruntwork-io/terratest/modules/terraform"
+	"github.com/stretchr/testify/suite"
+)
+
+type MysqlTestSuite struct {
+	BaseTestSuite
+}
+
+func TestMysqlTestSuite(t *testing.T) {
+	suite.Run(t, new(MysqlTestSuite))
+}
+
+func (s *MysqlTestSuite) TestMysql() {
+	s.T().Parallel()
+
+	// Given
+	withPrefix := examplesRandPrefix()
+	mysqlName := withPrefix("mysql")
+	opts := s.withDefaults(&terraform.Options{
+		TerraformDir: "../examples/mysql",
+		Vars: map[string]interface{}{
+			"avn_token":      s.config.Token,
+			"avn_project":    s.config.Project,
+			"mysql_name":     mysqlName,
+			"mysql_username": "username" + uniqueID(),
+			"mysql_password": "password" + uniqueID(),
+		},
+	})
+
+	// When
+	defer terraform.Destroy(s.T(), opts)
+	terraform.Apply(s.T(), opts)
+
+	// Then
+	mysql, err := s.client.Services.Get(s.config.Project, mysqlName)
+	s.NoError(err)
+	s.Equal("mysql", mysql.Type)
+	s.Equal("business-4", mysql.Plan)
+	s.Equal("google-europe-west1", mysql.CloudName)
+	s.Equal("monday", mysql.MaintenanceWindow.DayOfWeek)
+	s.Equal("10:00:00", mysql.MaintenanceWindow.TimeOfDay)
+}

--- a/examples_tests/postgres_test.go
+++ b/examples_tests/postgres_test.go
@@ -21,10 +21,10 @@ func (s *PostgresTestSuite) TestPostgres() {
 	s.T().Parallel()
 
 	// Given
-	genName := randNameGen("test-examples-postgres-%s")
-	pgNameEU := genName()
-	pgNameUS := genName()
-	pgNameAS := genName()
+	withPrefix := examplesRandPrefix()
+	pgNameEU := withPrefix("pg-eu")
+	pgNameUS := withPrefix("pg-us")
+	pgNameAS := withPrefix("pg-as")
 	opts := s.withDefaults(&terraform.Options{
 		TerraformDir: "../examples/postgres",
 		Vars: map[string]interface{}{

--- a/sample_project/sample.tf
+++ b/sample_project/sample.tf
@@ -10,7 +10,7 @@ terraform {
   required_providers {
     aiven = {
       source  = "aiven/aiven"
-      version = ">=3.0.0"
+      version = ">=3.0.0, <4.0.0"
     }
   }
 }


### PR DESCRIPTION
## About this change—what it does

- Adds mysql example test.
- Adds prefixed random name generator which shares same seed for each service within a test. That makes easier to track belonging resources. Prefix is hardcoded for the sweep command.
- Adds `workflow_dispatch` to the examples tests job to trigger it on demand.
- Limits required provider version for existing example tests