### PR TITLE
improve team member deletion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ nav_order: 1
 
 - Fix races in tests
 - Add support for normalization of `ip_filter_object` user config options
+- Improve team member deletion
 
 ## [3.10.0] - 2022-12-14
 - Add ClickHouse examples:

--- a/internal/service/account/resource_account_team_member_test.go
+++ b/internal/service/account/resource_account_team_member_test.go
@@ -6,11 +6,12 @@ import (
 	"testing"
 
 	"github.com/aiven/aiven-go-client"
-	acc "github.com/aiven/terraform-provider-aiven/internal/acctest"
-	"github.com/aiven/terraform-provider-aiven/internal/schemautil"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	acc "github.com/aiven/terraform-provider-aiven/internal/acctest"
+	"github.com/aiven/terraform-provider-aiven/internal/schemautil"
 )
 
 func TestAccAivenAccountTeamMember_basic(t *testing.T) {


### PR DESCRIPTION
## About this change—what it does

If user's email not on the members list terraform won't warn.
With this fix it will return an error.