### PR TITLE
refactor(typeupgrader): move switch to convert fn

### DIFF
--- a/internal/schemautil/userconfig/stateupgrader/typeupgrader/typeupgrader.go
+++ b/internal/schemautil/userconfig/stateupgrader/typeupgrader/typeupgrader.go
@@ -1,6 +1,7 @@
 package typeupgrader
 
 import (
+	"fmt"
 	"strconv"
 )
 
@@ -12,25 +13,9 @@ func Map(m map[string]interface{}, rules map[string]string) (err error) {
 			continue
 		}
 
-		switch t {
-		case "bool":
-			if va == "" {
-				va = "false"
-			}
-
-			m[k], err = strconv.ParseBool(va)
-			if err != nil {
-				return err
-			}
-		case "int":
-			if va == "" {
-				va = "0"
-			}
-
-			m[k], err = strconv.Atoi(va)
-			if err != nil {
-				return err
-			}
+		m[k], err = convert(va, t)
+		if err != nil {
+			return err
 		}
 	}
 
@@ -45,18 +30,31 @@ func Slice(s []interface{}, t string) (err error) {
 			continue
 		}
 
-		switch t {
-		case "int":
-			if va == "" {
-				va = "0"
-			}
-
-			s[i], err = strconv.Atoi(va)
-			if err != nil {
-				return err
-			}
+		s[i], err = convert(va, t)
+		if err != nil {
+			return err
 		}
 	}
 
 	return nil
+}
+
+// convert converts a value to the specified type.
+func convert(v string, t string) (res interface{}, err error) {
+	switch t {
+	case "bool":
+		if v == "" {
+			v = "false"
+		}
+
+		return strconv.ParseBool(v)
+	case "int":
+		if v == "" {
+			v = "0"
+		}
+
+		return strconv.Atoi(v)
+	default:
+		return nil, fmt.Errorf("unsupported type %q", t)
+	}
 }

--- a/internal/schemautil/userconfig/stateupgrader/typeupgrader/typeupgrader_test.go
+++ b/internal/schemautil/userconfig/stateupgrader/typeupgrader/typeupgrader_test.go
@@ -125,6 +125,20 @@ func TestMap(t *testing.T) {
 			},
 			wantErr: true,
 		},
+		{
+			name: "unknown type",
+			args: args{
+				m: map[string]interface{}{
+					"bool": "true",
+					"int":  "1",
+				},
+				rules: map[string]string{
+					"bool": "bool",
+					"int":  "foo",
+				},
+			},
+			wantErr: true,
+		},
 	}
 
 	for _, tt := range tests {
@@ -169,6 +183,14 @@ func TestSlice(t *testing.T) {
 			args: args{
 				s: []interface{}{"1", "foo", "3", "7"},
 				t: "int",
+			},
+			wantErr: true,
+		},
+		{
+			name: "unknown type",
+			args: args{
+				s: []interface{}{"1", "foo", "3", "7"},
+				t: "foo",
 			},
 			wantErr: true,
 		},


### PR DESCRIPTION
<!-- All contributors, please complete these sections, including maintainers. -->

## About this change—what it does

<!-- Provide a small sentence that summarizes the change. -->
moves `switch` to `convert` fn

<!-- Provide the issue number below, if it exists. -->

## Why this way

<!-- Provide a small explanation on why this is the approach you took for solving this problem. -->
deduplicates code and reduces complexity
