### PR TITLE
fix kafka user config with null values only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ nav_order: 1
 # Changelog
 
 ## [MAJOR.MINOR.PATCH] - YYYY-MM-DD
+- Fix user config serialization with null values only
 
 ## [3.11.0] - 2023-01-09
 - Fix races in tests

--- a/internal/schemautil/userconfig/apiconvert/toapi.go
+++ b/internal/schemautil/userconfig/apiconvert/toapi.go
@@ -127,6 +127,12 @@ func objectItemToAPI(
 
 	fv := v[0]
 
+	// Object with only "null" fields becomes nil
+	// Which can't be cast into a map
+	if fv == nil {
+		return res, true, nil
+	}
+
 	fva, ok := fv.(map[string]interface{})
 	if !ok {
 		return nil, false, fmt.Errorf("%s: not a map", fks)

--- a/internal/service/cassandra/cassandra_test.go
+++ b/internal/service/cassandra/cassandra_test.go
@@ -6,11 +6,11 @@ import (
 	"regexp"
 	"testing"
 
-	acc "github.com/aiven/terraform-provider-aiven/internal/acctest"
-
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	acc "github.com/aiven/terraform-provider-aiven/internal/acctest"
 )
 
 func TestAccAiven_cassandra(t *testing.T) {


### PR DESCRIPTION
## About this change—what it does

Fixes service's user config "to api" serialisation. If object has null fields only it's not send nor casted to object.

Resolves #1033  