### PR TITLE
fix(flink): incorrect state name spelling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ nav_order: 1
 
 ## [MAJOR.MINOR.PATCH] - YYYY-MM-DD
 - Fix user config serialization with null values only
+- Fix incorrect state name spelling in Flink resource
 
 ## [3.11.0] - 2023-01-09
 - Fix races in tests

--- a/internal/service/flink/flink_job.go
+++ b/internal/service/flink/flink_job.go
@@ -129,7 +129,7 @@ func resourceFlinkJobCreate(ctx context.Context, d *schema.ResourceData, m inter
 	conf := &resource.StateChangeConf{
 		Pending: []string{
 			"CANCELED",
-			"CANCELING",
+			"CANCELLING",
 			"CREATED",
 			"DEPLOYING",
 			"FAILED",
@@ -182,7 +182,7 @@ func resourceFlinkJobDelete(ctx context.Context, d *schema.ResourceData, m inter
 
 	conf := &resource.StateChangeConf{
 		Pending: []string{
-			"CANCELING",
+			"CANCELLING",
 			"CREATED",
 			"DEPLOYING",
 			"INITIALIZING",


### PR DESCRIPTION
<!-- All contributors, please complete these sections, including maintainers. -->

## About this change—what it does

<!-- Provide a small sentence that summarizes the change. -->
fixes incorrect state name spelling in Flink resource

<!-- Provide the issue number below, if it exists. -->

## Why this way

<!-- Provide a small explanation on why this is the approach you took for solving this problem. -->
it panics otherwise
