### PR TITLE
fix(docs): index.md provider version

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -12,7 +12,7 @@ terraform {
   required_providers {
     aiven = {
       source = "aiven/aiven"
-      version = ">= 2.0.0, < 3.0.0"
+      version = ">= 3.0.0, < 4.0.0"
     }
   }
 }

--- a/templates/index.md
+++ b/templates/index.md
@@ -12,7 +12,7 @@ terraform {
   required_providers {
     aiven = {
       source = "aiven/aiven"
-      version = ">= 2.0.0, < 3.0.0"
+      version = ">= 3.0.0, < 4.0.0"
     }
   }
 }


### PR DESCRIPTION
<!-- All contributors, please complete these sections, including maintainers. -->

## About this change—what it does

<!-- Provide a small sentence that summarizes the change. -->

Change the example provider configuration to use at least version 3.10.0. 

<!-- Provide the issue number below, if it exists. -->
Resolves: no issue

## Why this way

<!-- Provide a small explanation on why this is the approach you took for solving this problem. -->
By using the example provider configuration users may accidentally use old version of the provider on their projects.