### PR TITLE
sweep test-tf prefix too

### DIFF
--- a/internal/sweep/sweep.go
+++ b/internal/sweep/sweep.go
@@ -52,7 +52,7 @@ func SweepServices(region, t string) error {
 			continue
 		}
 
-		if !hasPrefixAny(s.Name, "test-acc", "test-examples", "k8s-") {
+		if !hasPrefixAny(s.Name, "test-tf", "test-acc", "test-examples", "k8s-") {
 			continue
 		}
 


### PR DESCRIPTION
## About this change—what it does

Sweeps services with `test-tf` prefix