### PR TITLE
chore: mark flink job and table resources as deprecated

### DIFF
--- a/internal/schemautil/common.go
+++ b/internal/schemautil/common.go
@@ -12,6 +12,8 @@ import (
 	"golang.org/x/exp/slices"
 )
 
+const DeprecationMessage = "This resource is deprecated and will be removed in the next major release."
+
 //goland:noinspection GoDeprecation
 func GetACLUserValidateFunc() schema.SchemaValidateFunc { //nolint:staticcheck
 	return validation.StringMatch(

--- a/internal/service/flink/flink_job.go
+++ b/internal/service/flink/flink_job.go
@@ -60,8 +60,9 @@ func ResourceFlinkJob() *schema.Resource {
 			Read:   schema.DefaultTimeout(1 * time.Minute),
 			Delete: schema.DefaultTimeout(1 * time.Minute),
 		},
-		Schema:        aivenFlinkJobSchema,
-		CustomizeDiff: customdiff.If(schemautil.ResourceShouldExist, resourceFlinkJobCustomizeDiff),
+		Schema:             aivenFlinkJobSchema,
+		CustomizeDiff:      customdiff.If(schemautil.ResourceShouldExist, resourceFlinkJobCustomizeDiff),
+		DeprecationMessage: schemautil.DeprecationMessage,
 	}
 }
 

--- a/internal/service/flink/flink_table.go
+++ b/internal/service/flink/flink_table.go
@@ -197,8 +197,9 @@ func ResourceFlinkTable() *schema.Resource {
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},
-		Schema:        aivenFlinkTableSchema,
-		CustomizeDiff: customdiff.If(schemautil.ResourceShouldExist, resourceFlinkTableCustomizeDiff),
+		Schema:             aivenFlinkTableSchema,
+		CustomizeDiff:      customdiff.If(schemautil.ResourceShouldExist, resourceFlinkTableCustomizeDiff),
+		DeprecationMessage: schemautil.DeprecationMessage,
 	}
 }
 


### PR DESCRIPTION
<!-- All contributors, please complete these sections, including maintainers. -->

## About this change—what it does

Mark `aiven_flink_table` and `aiven_flink_job` resources as deprecated. 