### PR TITLE
ci(acctests): fix flaky tests failing

### DIFF
--- a/.github/workflows/acceptance-tests.yml
+++ b/.github/workflows/acceptance-tests.yml
@@ -62,7 +62,13 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-go-
 
-      - run: make test-acc
+      # TODO: Fix the flaky tests and remove the retry action.
+      - uses: nick-fields/retry@v2
+        with:
+          timeout_minutes: 60
+          max_attempts: 15
+          retry_on: error
+          command: make test-acc
         env:
           AIVEN_TOKEN: ${{ secrets.AIVEN_TOKEN }}
           AIVEN_PROJECT_NAME: ${{ secrets.AIVEN_PROJECT_NAME }}


### PR DESCRIPTION
<!-- All contributors, please complete these sections, including maintainers. -->

## About this change—what it does

<!-- Provide a small sentence that summarizes the change. -->
adds an automatic retry for 15 times OR the timeout of 1 hour, whichever hits faster

we already have this behavior for the `sweep` step

<!-- Provide the issue number below, if it exists. -->

## Why this way

<!-- Provide a small explanation on why this is the approach you took for solving this problem. -->
unfortunately, the tests are flaky, but we want to have better view of tests that are actually failing
