### PR TITLE
fix(schemautil): CreateOnlyDiffSuppressFunc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ nav_order: 1
 
 ## [MAJOR.MINOR.PATCH] - YYYY-MM-DD
 
+- Fix `CreateOnlyDiffSuppressFunc`
+
 ## [3.12.0] - 2023-02-10
 
 - Fix user config serialization with null values only

--- a/internal/schemautil/schemautil.go
+++ b/internal/schemautil/schemautil.go
@@ -121,7 +121,7 @@ func ParseOptionalStringToBool(val interface{}) *bool {
 }
 
 func CreateOnlyDiffSuppressFunc(_, _, _ string, d *schema.ResourceData) bool {
-	return !d.IsNewResource()
+	return len(d.Id()) > 0
 }
 
 // EmptyObjectDiffSuppressFunc suppresses a diff for service user configuration options when


### PR DESCRIPTION
<!-- All contributors, please complete these sections, including maintainers. -->

## About this change—what it does

<!-- Provide a small sentence that summarizes the change. -->
it appears that when Terraform calls for `DiffSuppressFunc`, it has not yet reached enough context with the internal [`Apply`](https://github.com/hashicorp/terraform-plugin-sdk/blob/main/helper/schema/resource.go#L762) method of `*schema.Resource`

it makes it that https://github.com/hashicorp/terraform-plugin-sdk/blob/main/helper/schema/resource.go#L835 hasn't been executed yet, and when calling for `d.IsNewResource()` within `DiffSuppressFunc` context, it always results in `false`

<!-- Provide the issue number below, if it exists. -->

## Why this way

<!-- Provide a small explanation on why this is the approach you took for solving this problem. -->
we want to have `CreateOnlyDiffSuppressFunc` working :)
