### PR TITLE
fix(schemautil): maintenance_window_dow=never resource update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ nav_order: 1
 ## [MAJOR.MINOR.PATCH] - YYYY-MM-DD
 
 - Fix `CreateOnlyDiffSuppressFunc`
+- Fix `maintenance_window_dow` set `never` blocks resource update
 
 ## [3.12.0] - 2023-02-10
 

--- a/internal/schemautil/helpers.go
+++ b/internal/schemautil/helpers.go
@@ -61,6 +61,11 @@ func GetProjectVPCIdPointer(d ResourceStateOrResourceDiff) (*string, error) {
 
 func GetMaintenanceWindow(d ResourceStateOrResourceDiff) *aiven.MaintenanceWindow {
 	dow := d.Get("maintenance_window_dow").(string)
+	if dow == "never" {
+		// `never` is not available in the API, but can be set on the backend
+		// Sending this back to the backend will fail the validation
+		return nil
+	}
 	t := d.Get("maintenance_window_time").(string)
 	if len(dow) > 0 && len(t) > 0 {
 		return &aiven.MaintenanceWindow{DayOfWeek: dow, TimeOfDay: t}

--- a/internal/schemautil/service.go
+++ b/internal/schemautil/service.go
@@ -71,6 +71,10 @@ func ServiceCommonSchema() map[string]*schema.Schema {
 			DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
 				return new == ""
 			},
+			// There is also `never` value, which can't be set, but can be received from the backend.
+			// Sending `never` is suppressed in GetMaintenanceWindow function,
+			// but then we need to not let to set `never` manually
+			ValidateDiagFunc: ValidateEnum("monday", "tuesday", "wednesday", "thursday", "friday", "saturday", "sunday"),
 		},
 		"maintenance_window_time": {
 			Type:        schema.TypeString,


### PR DESCRIPTION
## About this change—what it does

When `maintenance_window_dow` set to `never` on the backend terraform send it back on updates. And that fails with the validation, because `never` is not available through the API.