### PR TITLE
feat(service): unify timeouts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ nav_order: 1
 
 ## [MAJOR.MINOR.PATCH] - YYYY-MM-DD
 
+- Unified timeout values across all resources
+- Added ability for more granular timeout configuration
+
 ## [3.12.1] - 2023-02-16
 
 - Fix `CreateOnlyDiffSuppressFunc`

--- a/docs/resources/account.md
+++ b/docs/resources/account.md
@@ -28,6 +28,7 @@ resource "aiven_account" "account1" {
 ### Optional
 
 - `primary_billing_group_id` (String) Billing group id
+- `timeouts` (Block, Optional) (see [below for nested schema](#nestedblock--timeouts))
 
 ### Read-Only
 
@@ -38,6 +39,16 @@ resource "aiven_account" "account1" {
 - `owner_team_id` (String) Owner team id
 - `tenant_id` (String) Tenant id
 - `update_time` (String) Time of last update
+
+<a id="nestedblock--timeouts"></a>
+### Nested Schema for `timeouts`
+
+Optional:
+
+- `create` (String)
+- `default` (String)
+- `delete` (String)
+- `update` (String)
 
 ## Import
 

--- a/docs/resources/account_authentication.md
+++ b/docs/resources/account_authentication.md
@@ -45,6 +45,7 @@ resource "aiven_account_authentication" "foo" {
 - `saml_idp_url` (String) SAML Idp URL
 - `saml_signature_algorithm` (String) Signature algorithm. This is an advanced option that typically does not need to be set.
 - `saml_variant` (String) SAML server variant
+- `timeouts` (Block, Optional) (see [below for nested schema](#nestedblock--timeouts))
 
 ### Read-Only
 
@@ -65,6 +66,17 @@ Optional:
 - `identity` (String) Field name for user's identity. This field must always exist in responses, and must be immutable and unique. Contents of this field are used to identify the user. Using user ID (such as unix user id) is highly recommended, as email address may change, requiring relinking user to Aiven user.
 - `last_name` (String) Field name for user's last name
 - `real_name` (String) Field name for user's full name. If specified, first_name and last_name mappings are ignored
+
+
+<a id="nestedblock--timeouts"></a>
+### Nested Schema for `timeouts`
+
+Optional:
+
+- `create` (String)
+- `default` (String)
+- `delete` (String)
+- `update` (String)
 
 ## Import
 

--- a/docs/resources/account_team.md
+++ b/docs/resources/account_team.md
@@ -27,12 +27,26 @@ resource "aiven_account_team" "account_team1" {
 - `account_id` (String) The unique account id
 - `name` (String) The account team name
 
+### Optional
+
+- `timeouts` (Block, Optional) (see [below for nested schema](#nestedblock--timeouts))
+
 ### Read-Only
 
 - `create_time` (String) Time of creation
 - `id` (String) The ID of this resource.
 - `team_id` (String) The auto-generated unique account team id
 - `update_time` (String) Time of last update
+
+<a id="nestedblock--timeouts"></a>
+### Nested Schema for `timeouts`
+
+Optional:
+
+- `create` (String)
+- `default` (String)
+- `delete` (String)
+- `update` (String)
 
 ## Import
 

--- a/docs/resources/account_team_member.md
+++ b/docs/resources/account_team_member.md
@@ -40,12 +40,26 @@ resource "aiven_account_team_member" "foo" {
 - `team_id` (String) An account team id This property cannot be changed, doing so forces recreation of the resource.
 - `user_email` (String) Is a user email address that first will be invited, and after accepting an invitation, he or she becomes a member of a team. This property cannot be changed, doing so forces recreation of the resource.
 
+### Optional
+
+- `timeouts` (Block, Optional) (see [below for nested schema](#nestedblock--timeouts))
+
 ### Read-Only
 
 - `accepted` (Boolean) is a boolean flag that determines whether an invitation was accepted or not by the user. `false` value means that the invitation was sent to the user but not yet accepted. `true` means that the user accepted the invitation and now a member of an account team.
 - `create_time` (String) Time of creation
 - `id` (String) The ID of this resource.
 - `invited_by_user_email` (String) The email address that invited this user.
+
+<a id="nestedblock--timeouts"></a>
+### Nested Schema for `timeouts`
+
+Optional:
+
+- `create` (String)
+- `default` (String)
+- `delete` (String)
+- `update` (String)
 
 ## Import
 

--- a/docs/resources/account_team_project.md
+++ b/docs/resources/account_team_project.md
@@ -45,10 +45,21 @@ resource "aiven_account_team_project" "account_team_project1" {
 
 - `project_name` (String) The name of an already existing project
 - `team_type` (String) The Account team project type The possible values are `admin`, `developer`, `operator` and `read_only`.
+- `timeouts` (Block, Optional) (see [below for nested schema](#nestedblock--timeouts))
 
 ### Read-Only
 
 - `id` (String) The ID of this resource.
+
+<a id="nestedblock--timeouts"></a>
+### Nested Schema for `timeouts`
+
+Optional:
+
+- `create` (String)
+- `default` (String)
+- `delete` (String)
+- `update` (String)
 
 ## Import
 

--- a/docs/resources/aws_privatelink.md
+++ b/docs/resources/aws_privatelink.md
@@ -48,6 +48,8 @@ resource "aiven_aws_privatelink" "foo" {
 Optional:
 
 - `create` (String)
+- `default` (String)
+- `delete` (String)
 - `update` (String)
 
 ## Import

--- a/docs/resources/aws_vpc_peering_connection.md
+++ b/docs/resources/aws_vpc_peering_connection.md
@@ -47,7 +47,9 @@ resource "aiven_aws_vpc_peering_connection" "foo" {
 Optional:
 
 - `create` (String)
+- `default` (String)
 - `delete` (String)
+- `update` (String)
 
 ## Import
 

--- a/docs/resources/azure_privatelink.md
+++ b/docs/resources/azure_privatelink.md
@@ -50,6 +50,7 @@ resource "aiven_azure_privatelink" "foo" {
 Optional:
 
 - `create` (String)
+- `default` (String)
 - `delete` (String)
 - `update` (String)
 

--- a/docs/resources/azure_privatelink_connection_approval.md
+++ b/docs/resources/azure_privatelink_connection_approval.md
@@ -94,6 +94,7 @@ resource "aiven_azure_privatelink_connection_approval" "approval" {
 Optional:
 
 - `create` (String)
+- `default` (String)
 - `delete` (String)
 - `update` (String)
 

--- a/docs/resources/azure_vpc_peering_connection.md
+++ b/docs/resources/azure_vpc_peering_connection.md
@@ -52,7 +52,9 @@ resource "aiven_azure_vpc_peering_connection" "foo" {
 Optional:
 
 - `create` (String)
+- `default` (String)
 - `delete` (String)
+- `update` (String)
 
 ## Import
 

--- a/docs/resources/billing_group.md
+++ b/docs/resources/billing_group.md
@@ -45,12 +45,23 @@ resource "aiven_project" "pr1" {
 - `copy_from_billing_group` (String) ID of the billing group to copy from
 - `country_code` (String) Country code
 - `state` (String) State
+- `timeouts` (Block, Optional) (see [below for nested schema](#nestedblock--timeouts))
 - `vat_id` (String) VAT id
 - `zip_code` (String) Zip Code
 
 ### Read-Only
 
 - `id` (String) The ID of this resource.
+
+<a id="nestedblock--timeouts"></a>
+### Nested Schema for `timeouts`
+
+Optional:
+
+- `create` (String)
+- `default` (String)
+- `delete` (String)
+- `update` (String)
 
 ## Import
 

--- a/docs/resources/cassandra.md
+++ b/docs/resources/cassandra.md
@@ -150,6 +150,7 @@ Required:
 Optional:
 
 - `create` (String)
+- `default` (String)
 - `delete` (String)
 - `update` (String)
 

--- a/docs/resources/cassandra_user.md
+++ b/docs/resources/cassandra_user.md
@@ -33,6 +33,7 @@ resource "aiven_cassandra_user" "foo" {
 ### Optional
 
 - `password` (String, Sensitive) The password of the Cassandra User.
+- `timeouts` (Block, Optional) (see [below for nested schema](#nestedblock--timeouts))
 
 ### Read-Only
 
@@ -40,5 +41,15 @@ resource "aiven_cassandra_user" "foo" {
 - `access_key` (String, Sensitive) Access certificate key for the user if applicable for the service in question
 - `id` (String) The ID of this resource.
 - `type` (String) Type of the user account. Tells whether the user is the primary account or a regular account.
+
+<a id="nestedblock--timeouts"></a>
+### Nested Schema for `timeouts`
+
+Optional:
+
+- `create` (String)
+- `default` (String)
+- `delete` (String)
+- `update` (String)
 
 

--- a/docs/resources/clickhouse.md
+++ b/docs/resources/clickhouse.md
@@ -109,6 +109,7 @@ Required:
 Optional:
 
 - `create` (String)
+- `default` (String)
 - `delete` (String)
 - `update` (String)
 

--- a/docs/resources/clickhouse_database.md
+++ b/docs/resources/clickhouse_database.md
@@ -43,7 +43,10 @@ resource "aiven_clickhouse_database" "clickhouse_db" {
 
 Optional:
 
+- `create` (String)
+- `default` (String)
 - `delete` (String)
+- `update` (String)
 
 ## Import
 

--- a/docs/resources/clickhouse_grant.md
+++ b/docs/resources/clickhouse_grant.md
@@ -87,6 +87,7 @@ resource "aiven_clickhouse_grant" "demo-user-grant" {
 - `privilege_grant` (Block Set) Configuration to grant a privilege. This property cannot be changed, doing so forces recreation of the resource. (see [below for nested schema](#nestedblock--privilege_grant))
 - `role` (String) The role to grant privileges or roles to. To set up proper dependencies please refer to this variable as a reference. This property cannot be changed, doing so forces recreation of the resource.
 - `role_grant` (Block Set) Configuration to grant a role. This property cannot be changed, doing so forces recreation of the resource. (see [below for nested schema](#nestedblock--role_grant))
+- `timeouts` (Block, Optional) (see [below for nested schema](#nestedblock--timeouts))
 - `user` (String) The user to grant privileges or roles to. To set up proper dependencies please refer to this variable as a reference. This property cannot be changed, doing so forces recreation of the resource.
 
 ### Read-Only
@@ -114,5 +115,16 @@ Optional:
 Optional:
 
 - `role` (String) The role that is to be granted. To set up proper dependencies please refer to this variable as a reference. This property cannot be changed, doing so forces recreation of the resource.
+
+
+<a id="nestedblock--timeouts"></a>
+### Nested Schema for `timeouts`
+
+Optional:
+
+- `create` (String)
+- `default` (String)
+- `delete` (String)
+- `update` (String)
 
 

--- a/docs/resources/clickhouse_role.md
+++ b/docs/resources/clickhouse_role.md
@@ -38,9 +38,23 @@ resource "aiven_clickhouse_role" "foo" {
 - `role` (String) The role that is to be created. This property cannot be changed, doing so forces recreation of the resource.
 - `service_name` (String) Specifies the name of the service that this resource belongs to. To set up proper dependencies please refer to this variable as a reference. This property cannot be changed, doing so forces recreation of the resource.
 
+### Optional
+
+- `timeouts` (Block, Optional) (see [below for nested schema](#nestedblock--timeouts))
+
 ### Read-Only
 
 - `id` (String) The ID of this resource.
+
+<a id="nestedblock--timeouts"></a>
+### Nested Schema for `timeouts`
+
+Optional:
+
+- `create` (String)
+- `default` (String)
+- `delete` (String)
+- `update` (String)
 
 ## Import
 

--- a/docs/resources/clickhouse_user.md
+++ b/docs/resources/clickhouse_user.md
@@ -29,12 +29,26 @@ resource "aiven_clickhouse_user" "ch-user" {
 - `service_name` (String) Specifies the name of the service that this resource belongs to. To set up proper dependencies please refer to this variable as a reference. This property cannot be changed, doing so forces recreation of the resource.
 - `username` (String) The actual name of the Clickhouse user. This property cannot be changed, doing so forces recreation of the resource.
 
+### Optional
+
+- `timeouts` (Block, Optional) (see [below for nested schema](#nestedblock--timeouts))
+
 ### Read-Only
 
 - `id` (String) The ID of this resource.
 - `password` (String, Sensitive) The password of the clickhouse user.
 - `required` (Boolean) Indicates if a clickhouse user is required
 - `uuid` (String) UUID of the clickhouse user.
+
+<a id="nestedblock--timeouts"></a>
+### Nested Schema for `timeouts`
+
+Optional:
+
+- `create` (String)
+- `default` (String)
+- `delete` (String)
+- `update` (String)
 
 ## Import
 

--- a/docs/resources/connection_pool.md
+++ b/docs/resources/connection_pool.md
@@ -38,12 +38,23 @@ resource "aiven_connection_pool" "mytestpool" {
 
 - `pool_mode` (String) The mode the pool operates in The possible values are `session`, `transaction` and `statement`. The default value is `transaction`.
 - `pool_size` (Number) The number of connections the pool may create towards the backend server. This does not affect the number of incoming connections, which is always a much larger number. The default value is `10`.
+- `timeouts` (Block, Optional) (see [below for nested schema](#nestedblock--timeouts))
 - `username` (String) The name of the service user used to connect to the database. To set up proper dependencies please refer to this variable as a reference.
 
 ### Read-Only
 
 - `connection_uri` (String, Sensitive) The URI for connecting to the pool
 - `id` (String) The ID of this resource.
+
+<a id="nestedblock--timeouts"></a>
+### Nested Schema for `timeouts`
+
+Optional:
+
+- `create` (String)
+- `default` (String)
+- `delete` (String)
+- `update` (String)
 
 ## Import
 

--- a/docs/resources/database.md
+++ b/docs/resources/database.md
@@ -45,7 +45,10 @@ resource "aiven_database" "mydatabase" {
 
 Optional:
 
+- `create` (String)
+- `default` (String)
 - `delete` (String)
+- `update` (String)
 
 ## Import
 

--- a/docs/resources/flink.md
+++ b/docs/resources/flink.md
@@ -138,6 +138,7 @@ Required:
 Optional:
 
 - `create` (String)
+- `default` (String)
 - `delete` (String)
 - `update` (String)
 

--- a/docs/resources/flink_application.md
+++ b/docs/resources/flink_application.md
@@ -29,6 +29,10 @@ resource "aiven_flink_application" "foo" {
 - `project` (String) Identifies the project this resource belongs to. To set up proper dependencies please refer to this variable as a reference. This property cannot be changed, doing so forces recreation of the resource.
 - `service_name` (String) Specifies the name of the service that this resource belongs to. To set up proper dependencies please refer to this variable as a reference. This property cannot be changed, doing so forces recreation of the resource.
 
+### Optional
+
+- `timeouts` (Block, Optional) (see [below for nested schema](#nestedblock--timeouts))
+
 ### Read-Only
 
 - `application_id` (String) Application ID
@@ -37,6 +41,16 @@ resource "aiven_flink_application" "foo" {
 - `id` (String) The ID of this resource.
 - `updated_at` (String) Application update time
 - `updated_by` (String) Application updater
+
+<a id="nestedblock--timeouts"></a>
+### Nested Schema for `timeouts`
+
+Optional:
+
+- `create` (String)
+- `default` (String)
+- `delete` (String)
+- `update` (String)
 
 ## Import
 

--- a/docs/resources/flink_application_version.md
+++ b/docs/resources/flink_application_version.md
@@ -65,6 +65,10 @@ resource "aiven_flink_application_version" "foo" {
 - `sources` (Block Set, Min: 1) Application sources (see [below for nested schema](#nestedblock--sources))
 - `statement` (String) Job SQL statement
 
+### Optional
+
+- `timeouts` (Block, Optional) (see [below for nested schema](#nestedblock--timeouts))
+
 ### Read-Only
 
 - `application_version_id` (String) Application version ID
@@ -95,6 +99,17 @@ Required:
 Optional:
 
 - `integration_id` (String) The integration ID
+
+
+<a id="nestedblock--timeouts"></a>
+### Nested Schema for `timeouts`
+
+Optional:
+
+- `create` (String)
+- `default` (String)
+- `delete` (String)
+- `update` (String)
 
 ## Import
 

--- a/docs/resources/flink_job.md
+++ b/docs/resources/flink_job.md
@@ -57,7 +57,9 @@ resource "aiven_flink_job" "job" {
 
 Optional:
 
+- `create` (String)
+- `default` (String)
 - `delete` (String)
-- `read` (String)
+- `update` (String)
 
 

--- a/docs/resources/flink_table.md
+++ b/docs/resources/flink_table.md
@@ -57,12 +57,24 @@ resource "aiven_flink_table" "table" {
 - `kafka_value_format` (String) Kafka Value Format The possible values are `avro`, `avro-confluent`, `debezium-avro-confluent`, `debezium-json` and `json`. This property cannot be changed, doing so forces recreation of the resource.
 - `like_options` (String) [LIKE](https://nightlies.apache.org/flink/flink-docs-master/docs/dev/table/sql/create/#like) statement for table creation. This property cannot be changed, doing so forces recreation of the resource.
 - `opensearch_index` (String) For an OpenSearch table, the OpenSearch index the table outputs to. This property cannot be changed, doing so forces recreation of the resource.
+- `timeouts` (Block, Optional) (see [below for nested schema](#nestedblock--timeouts))
 - `upsert_kafka` (Block Set, Max: 1) Kafka upsert connector configuration. (see [below for nested schema](#nestedblock--upsert_kafka))
 
 ### Read-Only
 
 - `id` (String) The ID of this resource.
 - `table_id` (String) The Table ID of the flink table in the flink service.
+
+<a id="nestedblock--timeouts"></a>
+### Nested Schema for `timeouts`
+
+Optional:
+
+- `create` (String)
+- `default` (String)
+- `delete` (String)
+- `update` (String)
+
 
 <a id="nestedblock--upsert_kafka"></a>
 ### Nested Schema for `upsert_kafka`

--- a/docs/resources/gcp_vpc_peering_connection.md
+++ b/docs/resources/gcp_vpc_peering_connection.md
@@ -46,7 +46,9 @@ resource "aiven_gcp_vpc_peering_connection" "foo" {
 Optional:
 
 - `create` (String)
+- `default` (String)
 - `delete` (String)
+- `update` (String)
 
 ## Import
 

--- a/docs/resources/grafana.md
+++ b/docs/resources/grafana.md
@@ -283,6 +283,7 @@ Required:
 Optional:
 
 - `create` (String)
+- `default` (String)
 - `delete` (String)
 - `update` (String)
 

--- a/docs/resources/influxdb.md
+++ b/docs/resources/influxdb.md
@@ -159,6 +159,7 @@ Required:
 Optional:
 
 - `create` (String)
+- `default` (String)
 - `delete` (String)
 - `update` (String)
 

--- a/docs/resources/influxdb_database.md
+++ b/docs/resources/influxdb_database.md
@@ -35,6 +35,9 @@ The InfluxDB Database resource allows the creation and management of Aiven Influ
 
 Optional:
 
+- `create` (String)
+- `default` (String)
 - `delete` (String)
+- `update` (String)
 
 

--- a/docs/resources/influxdb_user.md
+++ b/docs/resources/influxdb_user.md
@@ -33,6 +33,7 @@ resource "aiven_influxdb_user" "foo" {
 ### Optional
 
 - `password` (String, Sensitive) The password of the InfluxDB User.
+- `timeouts` (Block, Optional) (see [below for nested schema](#nestedblock--timeouts))
 
 ### Read-Only
 
@@ -40,5 +41,15 @@ resource "aiven_influxdb_user" "foo" {
 - `access_key` (String, Sensitive) Access certificate key for the user if applicable for the service in question
 - `id` (String) The ID of this resource.
 - `type` (String) Type of the user account. Tells whether the user is the primary account or a regular account.
+
+<a id="nestedblock--timeouts"></a>
+### Nested Schema for `timeouts`
+
+Optional:
+
+- `create` (String)
+- `default` (String)
+- `delete` (String)
+- `update` (String)
 
 

--- a/docs/resources/kafka.md
+++ b/docs/resources/kafka.md
@@ -281,6 +281,7 @@ Required:
 Optional:
 
 - `create` (String)
+- `default` (String)
 - `delete` (String)
 - `update` (String)
 

--- a/docs/resources/kafka_acl.md
+++ b/docs/resources/kafka_acl.md
@@ -36,10 +36,21 @@ resource "aiven_kafka_acl" "mytestacl" {
 ### Optional
 
 - `acl_id` (String) Kafka ACL ID
+- `timeouts` (Block, Optional) (see [below for nested schema](#nestedblock--timeouts))
 
 ### Read-Only
 
 - `id` (String) The ID of this resource.
+
+<a id="nestedblock--timeouts"></a>
+### Nested Schema for `timeouts`
+
+Optional:
+
+- `create` (String)
+- `default` (String)
+- `delete` (String)
+- `update` (String)
 
 ## Import
 

--- a/docs/resources/kafka_connect.md
+++ b/docs/resources/kafka_connect.md
@@ -169,6 +169,7 @@ Required:
 Optional:
 
 - `create` (String)
+- `default` (String)
 - `delete` (String)
 - `update` (String)
 

--- a/docs/resources/kafka_connector.md
+++ b/docs/resources/kafka_connector.md
@@ -60,7 +60,10 @@ resource "aiven_kafka_connector" "kafka-os-con1" {
 
 Optional:
 
-- `read` (String)
+- `create` (String)
+- `default` (String)
+- `delete` (String)
+- `update` (String)
 
 
 <a id="nestedatt--task"></a>

--- a/docs/resources/kafka_mirrormaker.md
+++ b/docs/resources/kafka_mirrormaker.md
@@ -134,6 +134,7 @@ Required:
 Optional:
 
 - `create` (String)
+- `default` (String)
 - `delete` (String)
 - `update` (String)
 

--- a/docs/resources/kafka_schema.md
+++ b/docs/resources/kafka_schema.md
@@ -51,11 +51,22 @@ resource "aiven_kafka_schema" "kafka-schema1" {
 
 - `compatibility_level` (String) Kafka Schemas compatibility level. The possible values are `BACKWARD`, `BACKWARD_TRANSITIVE`, `FORWARD`, `FORWARD_TRANSITIVE`, `FULL`, `FULL_TRANSITIVE` and `NONE`.
 - `schema_type` (String) Kafka Schema type JSON or AVRO
+- `timeouts` (Block, Optional) (see [below for nested schema](#nestedblock--timeouts))
 
 ### Read-Only
 
 - `id` (String) The ID of this resource.
 - `version` (Number) Kafka Schema configuration version.
+
+<a id="nestedblock--timeouts"></a>
+### Nested Schema for `timeouts`
+
+Optional:
+
+- `create` (String)
+- `default` (String)
+- `delete` (String)
+- `update` (String)
 
 ## Import
 

--- a/docs/resources/kafka_schema_configuration.md
+++ b/docs/resources/kafka_schema_configuration.md
@@ -31,10 +31,21 @@ resource "aiven_kafka_schema_configuration" "config" {
 ### Optional
 
 - `compatibility_level` (String) Kafka Schemas compatibility level. The possible values are `BACKWARD`, `BACKWARD_TRANSITIVE`, `FORWARD`, `FORWARD_TRANSITIVE`, `FULL`, `FULL_TRANSITIVE` and `NONE`.
+- `timeouts` (Block, Optional) (see [below for nested schema](#nestedblock--timeouts))
 
 ### Read-Only
 
 - `id` (String) The ID of this resource.
+
+<a id="nestedblock--timeouts"></a>
+### Nested Schema for `timeouts`
+
+Optional:
+
+- `create` (String)
+- `default` (String)
+- `delete` (String)
+- `update` (String)
 
 ## Import
 

--- a/docs/resources/kafka_schema_registry_acl.md
+++ b/docs/resources/kafka_schema_registry_acl.md
@@ -26,9 +26,20 @@ The Resource Kafka Schema Registry ACL resource allows the creation and manageme
 ### Optional
 
 - `acl_id` (String) Kafka Schema Registry ACL ID
+- `timeouts` (Block, Optional) (see [below for nested schema](#nestedblock--timeouts))
 
 ### Read-Only
 
 - `id` (String) The ID of this resource.
+
+<a id="nestedblock--timeouts"></a>
+### Nested Schema for `timeouts`
+
+Optional:
+
+- `create` (String)
+- `default` (String)
+- `delete` (String)
+- `update` (String)
 
 

--- a/docs/resources/kafka_topic.md
+++ b/docs/resources/kafka_topic.md
@@ -106,8 +106,9 @@ Optional:
 Optional:
 
 - `create` (String)
+- `default` (String)
 - `delete` (String)
-- `read` (String)
+- `update` (String)
 
 ## Import
 

--- a/docs/resources/kafka_user.md
+++ b/docs/resources/kafka_user.md
@@ -24,6 +24,7 @@ The Kafka User resource allows the creation and management of Aiven Kafka Users.
 ### Optional
 
 - `password` (String, Sensitive) The password of the Kafka User.
+- `timeouts` (Block, Optional) (see [below for nested schema](#nestedblock--timeouts))
 
 ### Read-Only
 
@@ -31,5 +32,15 @@ The Kafka User resource allows the creation and management of Aiven Kafka Users.
 - `access_key` (String, Sensitive) Access certificate key for the user
 - `id` (String) The ID of this resource.
 - `type` (String) Type of the user account. Tells whether the user is the primary account or a regular account.
+
+<a id="nestedblock--timeouts"></a>
+### Nested Schema for `timeouts`
+
+Optional:
+
+- `create` (String)
+- `default` (String)
+- `delete` (String)
+- `update` (String)
 
 

--- a/docs/resources/m3aggregator.md
+++ b/docs/resources/m3aggregator.md
@@ -114,6 +114,7 @@ Required:
 Optional:
 
 - `create` (String)
+- `default` (String)
 - `delete` (String)
 - `update` (String)
 

--- a/docs/resources/m3db.md
+++ b/docs/resources/m3db.md
@@ -230,6 +230,7 @@ Required:
 Optional:
 
 - `create` (String)
+- `default` (String)
 - `delete` (String)
 - `update` (String)
 

--- a/docs/resources/m3db_user.md
+++ b/docs/resources/m3db_user.md
@@ -33,10 +33,21 @@ resource "aiven_m3db_user" "foo" {
 ### Optional
 
 - `password` (String, Sensitive) The password of the M3DB User.
+- `timeouts` (Block, Optional) (see [below for nested schema](#nestedblock--timeouts))
 
 ### Read-Only
 
 - `id` (String) The ID of this resource.
 - `type` (String) Type of the user account. Tells whether the user is the primary account or a regular account.
+
+<a id="nestedblock--timeouts"></a>
+### Nested Schema for `timeouts`
+
+Optional:
+
+- `create` (String)
+- `default` (String)
+- `delete` (String)
+- `update` (String)
 
 

--- a/docs/resources/mirrormaker_replication_flow.md
+++ b/docs/resources/mirrormaker_replication_flow.md
@@ -50,12 +50,23 @@ resource "aiven_mirrormaker_replication_flow" "f1" {
 - `replication_policy_class` (String) Replication policy class. The possible values are `org.apache.kafka.connect.mirror.DefaultReplicationPolicy` and `org.apache.kafka.connect.mirror.IdentityReplicationPolicy`. The default value is `org.apache.kafka.connect.mirror.DefaultReplicationPolicy`.
 - `sync_group_offsets_enabled` (Boolean) Sync consumer group offsets. The default value is `false`.
 - `sync_group_offsets_interval_seconds` (Number) Frequency of consumer group offset sync. The default value is `1`.
+- `timeouts` (Block, Optional) (see [below for nested schema](#nestedblock--timeouts))
 - `topics` (List of String) List of topics and/or regular expressions to replicate
 - `topics_blacklist` (List of String) List of topics and/or regular expressions to not replicate.
 
 ### Read-Only
 
 - `id` (String) The ID of this resource.
+
+<a id="nestedblock--timeouts"></a>
+### Nested Schema for `timeouts`
+
+Optional:
+
+- `create` (String)
+- `default` (String)
+- `delete` (String)
+- `update` (String)
 
 ## Import
 

--- a/docs/resources/mysql.md
+++ b/docs/resources/mysql.md
@@ -217,6 +217,7 @@ Required:
 Optional:
 
 - `create` (String)
+- `default` (String)
 - `delete` (String)
 - `update` (String)
 

--- a/docs/resources/mysql_database.md
+++ b/docs/resources/mysql_database.md
@@ -43,7 +43,10 @@ resource "aiven_mysql_database" "mydatabase" {
 
 Optional:
 
+- `create` (String)
+- `default` (String)
 - `delete` (String)
+- `update` (String)
 
 ## Import
 

--- a/docs/resources/mysql_user.md
+++ b/docs/resources/mysql_user.md
@@ -34,6 +34,7 @@ resource "aiven_mysql_user" "foo" {
 
 - `authentication` (String) Authentication details. The possible values are `caching_sha2_password` and `mysql_native_password`.
 - `password` (String, Sensitive) The password of the MySQL User ( not applicable for all services ).
+- `timeouts` (Block, Optional) (see [below for nested schema](#nestedblock--timeouts))
 
 ### Read-Only
 
@@ -41,5 +42,15 @@ resource "aiven_mysql_user" "foo" {
 - `access_key` (String, Sensitive) Access certificate key for the user
 - `id` (String) The ID of this resource.
 - `type` (String) Type of the user account. Tells whether the user is the primary account or a regular account.
+
+<a id="nestedblock--timeouts"></a>
+### Nested Schema for `timeouts`
+
+Optional:
+
+- `create` (String)
+- `default` (String)
+- `delete` (String)
+- `update` (String)
 
 

--- a/docs/resources/opensearch.md
+++ b/docs/resources/opensearch.md
@@ -235,6 +235,7 @@ Required:
 Optional:
 
 - `create` (String)
+- `default` (String)
 - `delete` (String)
 - `update` (String)
 

--- a/docs/resources/opensearch_acl_config.md
+++ b/docs/resources/opensearch_acl_config.md
@@ -52,10 +52,21 @@ resource "aiven_opensearch_acl_config" "foo" {
 
 - `enabled` (Boolean) Enable Opensearch ACLs. When disabled authenticated service users have unrestricted access. The default value is `true`.
 - `extended_acl` (Boolean) Index rules can be applied in a limited fashion to the _mget, _msearch and _bulk APIs (and only those) by enabling the ExtendedAcl option for the service. When it is enabled, users can use these APIs as long as all operations only target indexes they have been granted access to. The default value is `true`.
+- `timeouts` (Block, Optional) (see [below for nested schema](#nestedblock--timeouts))
 
 ### Read-Only
 
 - `id` (String) The ID of this resource.
+
+<a id="nestedblock--timeouts"></a>
+### Nested Schema for `timeouts`
+
+Optional:
+
+- `create` (String)
+- `default` (String)
+- `delete` (String)
+- `update` (String)
 
 ## Import
 

--- a/docs/resources/opensearch_acl_rule.md
+++ b/docs/resources/opensearch_acl_rule.md
@@ -84,9 +84,23 @@ resource "aiven_opensearch_acl_rule" "os_acl_rule" {
 - `service_name` (String) Specifies the name of the service that this resource belongs to. To set up proper dependencies please refer to this variable as a reference. This property cannot be changed, doing so forces recreation of the resource.
 - `username` (String) The username for the ACL entry Maximum Length: `40`. To set up proper dependencies please refer to this variable as a reference. This property cannot be changed, doing so forces recreation of the resource.
 
+### Optional
+
+- `timeouts` (Block, Optional) (see [below for nested schema](#nestedblock--timeouts))
+
 ### Read-Only
 
 - `id` (String) The ID of this resource.
+
+<a id="nestedblock--timeouts"></a>
+### Nested Schema for `timeouts`
+
+Optional:
+
+- `create` (String)
+- `default` (String)
+- `delete` (String)
+- `update` (String)
 
 ## Import
 

--- a/docs/resources/opensearch_user.md
+++ b/docs/resources/opensearch_user.md
@@ -33,10 +33,21 @@ resource "aiven_opensearch_user" "foo" {
 ### Optional
 
 - `password` (String, Sensitive) The password of the Opensearch User.
+- `timeouts` (Block, Optional) (see [below for nested schema](#nestedblock--timeouts))
 
 ### Read-Only
 
 - `id` (String) The ID of this resource.
 - `type` (String) Type of the user account. Tells whether the user is the primary account or a regular account.
+
+<a id="nestedblock--timeouts"></a>
+### Nested Schema for `timeouts`
+
+Optional:
+
+- `create` (String)
+- `default` (String)
+- `delete` (String)
+- `update` (String)
 
 

--- a/docs/resources/pg_database.md
+++ b/docs/resources/pg_database.md
@@ -45,7 +45,10 @@ resource "aiven_pg_database" "mydatabase" {
 
 Optional:
 
+- `create` (String)
+- `default` (String)
 - `delete` (String)
+- `update` (String)
 
 ## Import
 

--- a/docs/resources/pg_user.md
+++ b/docs/resources/pg_user.md
@@ -34,6 +34,7 @@ resource "aiven_pg_user" "foo" {
 
 - `password` (String, Sensitive) The password of the PG User ( not applicable for all services ).
 - `pg_allow_replication` (Boolean) Defines whether replication is allowed. This property cannot be changed, doing so forces recreation of the resource.
+- `timeouts` (Block, Optional) (see [below for nested schema](#nestedblock--timeouts))
 
 ### Read-Only
 
@@ -41,6 +42,16 @@ resource "aiven_pg_user" "foo" {
 - `access_key` (String, Sensitive) Access certificate key for the user
 - `id` (String) The ID of this resource.
 - `type` (String) Type of the user account. Tells whether the user is the primary account or a regular account.
+
+<a id="nestedblock--timeouts"></a>
+### Nested Schema for `timeouts`
+
+Optional:
+
+- `create` (String)
+- `default` (String)
+- `delete` (String)
+- `update` (String)
 
 ## Import
 

--- a/docs/resources/project.md
+++ b/docs/resources/project.md
@@ -37,6 +37,7 @@ resource "aiven_project" "myproject" {
 - `default_cloud` (String) Defines the default cloud provider and region where services are hosted. This can be changed freely after the project is created. This will not affect existing services.
 - `tag` (Block Set) Tags are key-value pairs that allow you to categorize projects. (see [below for nested schema](#nestedblock--tag))
 - `technical_emails` (Set of String) Defines the email addresses that will receive alerts about upcoming maintenance updates or warnings about service instability. It is  good practice to keep this up-to-date to be aware of any potential issues with your project.
+- `timeouts` (Block, Optional) (see [below for nested schema](#nestedblock--timeouts))
 - `use_source_project_billing_group` (Boolean) Use the same billing group that is used in source project.
 
 ### Read-Only
@@ -53,6 +54,17 @@ Required:
 
 - `key` (String) Project tag key
 - `value` (String) Project tag value
+
+
+<a id="nestedblock--timeouts"></a>
+### Nested Schema for `timeouts`
+
+Optional:
+
+- `create` (String)
+- `default` (String)
+- `delete` (String)
+- `update` (String)
 
 ## Import
 

--- a/docs/resources/project_user.md
+++ b/docs/resources/project_user.md
@@ -29,10 +29,24 @@ resource "aiven_project_user" "mytestuser" {
 - `member_type` (String) Project membership type. The possible values are `admin`, `developer` and `operator`.
 - `project` (String) Identifies the project this resource belongs to. To set up proper dependencies please refer to this variable as a reference. This property cannot be changed, doing so forces recreation of the resource.
 
+### Optional
+
+- `timeouts` (Block, Optional) (see [below for nested schema](#nestedblock--timeouts))
+
 ### Read-Only
 
 - `accepted` (Boolean) Whether the user has accepted the request to join the project; adding user to a project sends an invitation to the target user and the actual membership is only created once the user accepts the invitation.
 - `id` (String) The ID of this resource.
+
+<a id="nestedblock--timeouts"></a>
+### Nested Schema for `timeouts`
+
+Optional:
+
+- `create` (String)
+- `default` (String)
+- `delete` (String)
+- `update` (String)
 
 ## Import
 

--- a/docs/resources/project_vpc.md
+++ b/docs/resources/project_vpc.md
@@ -48,7 +48,9 @@ resource "aiven_project_vpc" "myvpc" {
 Optional:
 
 - `create` (String)
+- `default` (String)
 - `delete` (String)
+- `update` (String)
 
 ## Import
 

--- a/docs/resources/redis.md
+++ b/docs/resources/redis.md
@@ -176,6 +176,7 @@ Required:
 Optional:
 
 - `create` (String)
+- `default` (String)
 - `delete` (String)
 - `update` (String)
 

--- a/docs/resources/redis_user.md
+++ b/docs/resources/redis_user.md
@@ -37,10 +37,21 @@ resource "aiven_redis_user" "foo" {
 - `redis_acl_channels` (List of String) Defines the permitted pub/sub channel patterns. This property cannot be changed, doing so forces recreation of the resource.
 - `redis_acl_commands` (List of String) Defines rules for individual commands. The field is required with`redis_acl_categories` and `redis_acl_keys`. This property cannot be changed, doing so forces recreation of the resource.
 - `redis_acl_keys` (List of String) Defines key access rules. The field is required with`redis_acl_categories` and `redis_acl_keys`. This property cannot be changed, doing so forces recreation of the resource.
+- `timeouts` (Block, Optional) (see [below for nested schema](#nestedblock--timeouts))
 
 ### Read-Only
 
 - `id` (String) The ID of this resource.
 - `type` (String) Type of the user account. Tells whether the user is the primary account or a regular account.
+
+<a id="nestedblock--timeouts"></a>
+### Nested Schema for `timeouts`
+
+Optional:
+
+- `create` (String)
+- `default` (String)
+- `delete` (String)
+- `update` (String)
 
 

--- a/docs/resources/service_integration.md
+++ b/docs/resources/service_integration.md
@@ -271,6 +271,9 @@ Optional:
 Optional:
 
 - `create` (String)
+- `default` (String)
+- `delete` (String)
+- `update` (String)
 ## Import
 Import is supported using the following syntax:
 ```shell

--- a/docs/resources/service_integration_endpoint.md
+++ b/docs/resources/service_integration_endpoint.md
@@ -35,6 +35,7 @@ The Service Integration Endpoint resource allows the creation and management of 
 - `prometheus_user_config` (Block List, Max: 1) Prometheus user configurable settings (see [below for nested schema](#nestedblock--prometheus_user_config))
 - `rsyslog_user_config` (Block List, Max: 1) Rsyslog user configurable settings (see [below for nested schema](#nestedblock--rsyslog_user_config))
 - `signalfx_user_config` (Block List, Max: 1) Signalfx user configurable settings (see [below for nested schema](#nestedblock--signalfx_user_config))
+- `timeouts` (Block, Optional) (see [below for nested schema](#nestedblock--timeouts))
 
 ### Read-Only
 
@@ -189,5 +190,16 @@ Optional:
 - `enabled_metrics` (List of String) list of metrics to send
 - `signalfx_api_key` (String, Sensitive) SignalFX API key
 - `signalfx_realm` (String) SignalFX realm
+
+
+<a id="nestedblock--timeouts"></a>
+### Nested Schema for `timeouts`
+
+Optional:
+
+- `create` (String)
+- `default` (String)
+- `delete` (String)
+- `update` (String)
 
 

--- a/docs/resources/service_user.md
+++ b/docs/resources/service_user.md
@@ -40,6 +40,7 @@ resource "aiven_service_user" "myserviceuser" {
 - `redis_acl_channels` (List of String) Redis specific field, defines the permitted pub/sub channel patterns. This property cannot be changed, doing so forces recreation of the resource.
 - `redis_acl_commands` (List of String) Redis specific field, defines rules for individual commands. The field is required with`redis_acl_categories` and `redis_acl_keys`. This property cannot be changed, doing so forces recreation of the resource.
 - `redis_acl_keys` (List of String) Redis specific field, defines key access rules. The field is required with`redis_acl_categories` and `redis_acl_keys`. This property cannot be changed, doing so forces recreation of the resource.
+- `timeouts` (Block, Optional) (see [below for nested schema](#nestedblock--timeouts))
 
 ### Read-Only
 
@@ -47,6 +48,16 @@ resource "aiven_service_user" "myserviceuser" {
 - `access_key` (String, Sensitive) Access certificate key for the user if applicable for the service in question
 - `id` (String) The ID of this resource.
 - `type` (String) Type of the user account. Tells wether the user is the primary account or a regular account.
+
+<a id="nestedblock--timeouts"></a>
+### Nested Schema for `timeouts`
+
+Optional:
+
+- `create` (String)
+- `default` (String)
+- `delete` (String)
+- `update` (String)
 
 ## Import
 

--- a/docs/resources/static_ip.md
+++ b/docs/resources/static_ip.md
@@ -20,6 +20,10 @@ The aiven_static_ip resource allows the creation and deletion of static ips. Ple
 - `cloud_name` (String) Specifies the cloud that the static ip belongs to. This property cannot be changed, doing so forces recreation of the resource.
 - `project` (String) Identifies the project this resource belongs to. To set up proper dependencies please refer to this variable as a reference. This property cannot be changed, doing so forces recreation of the resource.
 
+### Optional
+
+- `timeouts` (Block, Optional) (see [below for nested schema](#nestedblock--timeouts))
+
 ### Read-Only
 
 - `id` (String) The ID of this resource.
@@ -27,5 +31,15 @@ The aiven_static_ip resource allows the creation and deletion of static ips. Ple
 - `service_name` (String) The service name the static ip is associated with.
 - `state` (String) The state the static ip is in.
 - `static_ip_address_id` (String) The static ip id of the resource. Should be used as a reference elsewhere.
+
+<a id="nestedblock--timeouts"></a>
+### Nested Schema for `timeouts`
+
+Optional:
+
+- `create` (String)
+- `default` (String)
+- `delete` (String)
+- `update` (String)
 
 

--- a/docs/resources/transit_gateway_vpc_attachment.md
+++ b/docs/resources/transit_gateway_vpc_attachment.md
@@ -52,6 +52,9 @@ resource "aiven_transit_gateway_vpc_attachment" "attachment" {
 Optional:
 
 - `create` (String)
+- `default` (String)
+- `delete` (String)
+- `update` (String)
 
 ## Import
 

--- a/docs/resources/vpc_peering_connection.md
+++ b/docs/resources/vpc_peering_connection.md
@@ -80,7 +80,9 @@ resource "aiven_vpc_peering_connection" "mypeeringconnection" {
 Optional:
 
 - `create` (String)
+- `default` (String)
 - `delete` (String)
+- `update` (String)
 ## Import
 Import is supported using the following syntax:
 ```shell

--- a/internal/schemautil/service.go
+++ b/internal/schemautil/service.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/aiven/aiven-go-client"
 	"github.com/docker/go-units"
@@ -15,6 +16,18 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
+
+func DefaultResourceTimeouts() *schema.ResourceTimeout {
+	// DefaultTimeoutMinutes is the default timeout for service operations.
+	const DefaultTimeoutMinutes = 20
+
+	return &schema.ResourceTimeout{
+		Create:  schema.DefaultTimeout(DefaultTimeoutMinutes * time.Minute),
+		Update:  schema.DefaultTimeout(DefaultTimeoutMinutes * time.Minute),
+		Delete:  schema.DefaultTimeout(DefaultTimeoutMinutes * time.Minute),
+		Default: schema.DefaultTimeout(DefaultTimeoutMinutes * time.Minute),
+	}
+}
 
 const (
 	ServiceTypePG               = "pg"

--- a/internal/service/account/account.go
+++ b/internal/service/account/account.go
@@ -64,6 +64,7 @@ func ResourceAccount() *schema.Resource {
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},
+		Timeouts: schemautil.DefaultResourceTimeouts(),
 
 		Schema: aivenAccountSchema,
 	}

--- a/internal/service/account/account_authentication.go
+++ b/internal/service/account/account_authentication.go
@@ -150,6 +150,7 @@ func ResourceAccountAuthentication() *schema.Resource {
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},
+		Timeouts: schemautil.DefaultResourceTimeouts(),
 
 		Schema: aivenAccountAuthenticationSchema,
 	}

--- a/internal/service/account/account_team.go
+++ b/internal/service/account/account_team.go
@@ -48,6 +48,7 @@ func ResourceAccountTeam() *schema.Resource {
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},
+		Timeouts: schemautil.DefaultResourceTimeouts(),
 
 		Schema: aivenAccountTeamSchema,
 	}

--- a/internal/service/account/account_team_member.go
+++ b/internal/service/account/account_team_member.go
@@ -64,6 +64,7 @@ eliminate an account team member if one has accepted an invitation previously.
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},
+		Timeouts: schemautil.DefaultResourceTimeouts(),
 
 		Schema: aivenAccountTeamMemberSchema,
 	}

--- a/internal/service/account/account_team_project.go
+++ b/internal/service/account/account_team_project.go
@@ -51,6 +51,8 @@ account team you are trying to link to this project.
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},
+		Timeouts: schemautil.DefaultResourceTimeouts(),
+
 		Schema: aivenAccountTeamProjectSchema,
 	}
 }

--- a/internal/service/cassandra/cassandra.go
+++ b/internal/service/cassandra/cassandra.go
@@ -1,8 +1,6 @@
 package cassandra
 
 import (
-	"time"
-
 	"github.com/aiven/terraform-provider-aiven/internal/schemautil"
 	"github.com/aiven/terraform-provider-aiven/internal/schemautil/userconfig/dist"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"
@@ -58,11 +56,7 @@ func ResourceCassandra() *schema.Resource {
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},
-		Timeouts: &schema.ResourceTimeout{
-			Create: schema.DefaultTimeout(20 * time.Minute),
-			Update: schema.DefaultTimeout(20 * time.Minute),
-			Delete: schema.DefaultTimeout(20 * time.Minute),
-		},
+		Timeouts: schemautil.DefaultResourceTimeouts(),
 
 		Schema: cassandraSchema(),
 	}

--- a/internal/service/cassandra/cassandra_user.go
+++ b/internal/service/cassandra/cassandra_user.go
@@ -56,6 +56,7 @@ func ResourceCassandraUser() *schema.Resource {
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},
+		Timeouts: schemautil.DefaultResourceTimeouts(),
 
 		Schema: aivenCassandraUserSchema,
 	}

--- a/internal/service/clickhouse/clickhouse.go
+++ b/internal/service/clickhouse/clickhouse.go
@@ -1,8 +1,6 @@
 package clickhouse
 
 import (
-	"time"
-
 	"github.com/aiven/terraform-provider-aiven/internal/schemautil"
 	"github.com/aiven/terraform-provider-aiven/internal/schemautil/userconfig/dist"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"
@@ -77,11 +75,7 @@ func ResourceClickhouse() *schema.Resource {
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},
-		Timeouts: &schema.ResourceTimeout{
-			Create: schema.DefaultTimeout(20 * time.Minute),
-			Update: schema.DefaultTimeout(20 * time.Minute),
-			Delete: schema.DefaultTimeout(20 * time.Minute),
-		},
+		Timeouts: schemautil.DefaultResourceTimeouts(),
 
 		Schema: clickhouseSchema(),
 	}

--- a/internal/service/clickhouse/clickhouse_database.go
+++ b/internal/service/clickhouse/clickhouse_database.go
@@ -2,7 +2,6 @@ package clickhouse
 
 import (
 	"context"
-	"time"
 
 	"github.com/aiven/aiven-go-client"
 	"github.com/aiven/terraform-provider-aiven/internal/schemautil"
@@ -38,9 +37,7 @@ func ResourceClickhouseDatabase() *schema.Resource {
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},
-		Timeouts: &schema.ResourceTimeout{
-			Delete: schema.DefaultTimeout(2 * time.Minute),
-		},
+		Timeouts: schemautil.DefaultResourceTimeouts(),
 
 		Schema: aivenClickhouseDatabaseSchema,
 	}

--- a/internal/service/clickhouse/clickhouse_grant.go
+++ b/internal/service/clickhouse/clickhouse_grant.go
@@ -105,6 +105,7 @@ Notes:
 		ReadContext:        resourceClickhouseGrantRead,
 		DeleteContext:      resourceClickhouseGrantDelete,
 		Schema:             aivenClickhouseGrantSchema,
+		Timeouts:           schemautil.DefaultResourceTimeouts(),
 	}
 }
 

--- a/internal/service/clickhouse/clickhouse_role.go
+++ b/internal/service/clickhouse/clickhouse_role.go
@@ -32,6 +32,7 @@ func ResourceClickhouseRole() *schema.Resource {
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},
+		Timeouts: schemautil.DefaultResourceTimeouts(),
 
 		Schema: aivenClickhouseRoleSchema,
 	}

--- a/internal/service/clickhouse/clickhouse_user.go
+++ b/internal/service/clickhouse/clickhouse_user.go
@@ -49,6 +49,7 @@ func ResourceClickhouseUser() *schema.Resource {
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},
+		Timeouts: schemautil.DefaultResourceTimeouts(),
 
 		Schema: aivenClickhouseUserSchema,
 	}

--- a/internal/service/connectionpool/connection_pool.go
+++ b/internal/service/connectionpool/connection_pool.go
@@ -62,6 +62,7 @@ func ResourceConnectionPool() *schema.Resource {
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},
+		Timeouts: schemautil.DefaultResourceTimeouts(),
 
 		Schema: aivenConnectionPoolSchema,
 	}

--- a/internal/service/database/database.go
+++ b/internal/service/database/database.go
@@ -72,9 +72,7 @@ func ResourceDatabase() *schema.Resource {
 		Importer: &schema.ResourceImporter{
 			StateContext: resourceDatabaseState,
 		},
-		Timeouts: &schema.ResourceTimeout{
-			Delete: schema.DefaultTimeout(2 * time.Minute),
-		},
+		Timeouts: schemautil.DefaultResourceTimeouts(),
 
 		// TODO: add user config
 		Schema: aivenDatabaseSchema,

--- a/internal/service/flink/flink.go
+++ b/internal/service/flink/flink.go
@@ -1,8 +1,6 @@
 package flink
 
 import (
-	"time"
-
 	"github.com/aiven/terraform-provider-aiven/internal/schemautil"
 	"github.com/aiven/terraform-provider-aiven/internal/schemautil/userconfig/dist"
 
@@ -71,11 +69,7 @@ func ResourceFlink() *schema.Resource {
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},
-		Timeouts: &schema.ResourceTimeout{
-			Create: schema.DefaultTimeout(20 * time.Minute),
-			Update: schema.DefaultTimeout(20 * time.Minute),
-			Delete: schema.DefaultTimeout(20 * time.Minute),
-		},
+		Timeouts: schemautil.DefaultResourceTimeouts(),
 
 		Schema: aivenFlinkSchema(),
 	}

--- a/internal/service/flink/flink_application.go
+++ b/internal/service/flink/flink_application.go
@@ -64,7 +64,8 @@ func ResourceFlinkApplication() *schema.Resource {
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},
-		Schema: aivenFlinkApplicationSchema,
+		Timeouts: schemautil.DefaultResourceTimeouts(),
+		Schema:   aivenFlinkApplicationSchema,
 	}
 }
 

--- a/internal/service/flink/flink_application_version.go
+++ b/internal/service/flink/flink_application_version.go
@@ -103,7 +103,8 @@ func ResourceFlinkApplicationVersion() *schema.Resource {
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},
-		Schema: aivenFlinkApplicationVersionSchema,
+		Timeouts: schemautil.DefaultResourceTimeouts(),
+		Schema:   aivenFlinkApplicationVersionSchema,
 	}
 }
 

--- a/internal/service/flink/flink_job.go
+++ b/internal/service/flink/flink_job.go
@@ -52,14 +52,11 @@ var aivenFlinkJobSchema = map[string]*schema.Schema{
 
 func ResourceFlinkJob() *schema.Resource {
 	return &schema.Resource{
-		Description:   "The Flink Job resource allows the creation and management of Aiven Jobs.",
-		ReadContext:   resourceFlinkJobRead,
-		CreateContext: resourceFlinkJobCreate,
-		DeleteContext: resourceFlinkJobDelete,
-		Timeouts: &schema.ResourceTimeout{
-			Read:   schema.DefaultTimeout(1 * time.Minute),
-			Delete: schema.DefaultTimeout(1 * time.Minute),
-		},
+		Description:        "The Flink Job resource allows the creation and management of Aiven Jobs.",
+		ReadContext:        resourceFlinkJobRead,
+		CreateContext:      resourceFlinkJobCreate,
+		DeleteContext:      resourceFlinkJobDelete,
+		Timeouts:           schemautil.DefaultResourceTimeouts(),
 		Schema:             aivenFlinkJobSchema,
 		CustomizeDiff:      customdiff.If(schemautil.ResourceShouldExist, resourceFlinkJobCustomizeDiff),
 		DeprecationMessage: schemautil.DeprecationMessage,

--- a/internal/service/flink/flink_table.go
+++ b/internal/service/flink/flink_table.go
@@ -197,6 +197,7 @@ func ResourceFlinkTable() *schema.Resource {
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},
+		Timeouts:           schemautil.DefaultResourceTimeouts(),
 		Schema:             aivenFlinkTableSchema,
 		CustomizeDiff:      customdiff.If(schemautil.ResourceShouldExist, resourceFlinkTableCustomizeDiff),
 		DeprecationMessage: schemautil.DeprecationMessage,

--- a/internal/service/grafana/grafana.go
+++ b/internal/service/grafana/grafana.go
@@ -1,8 +1,6 @@
 package grafana
 
 import (
-	"time"
-
 	"github.com/aiven/terraform-provider-aiven/internal/schemautil"
 	"github.com/aiven/terraform-provider-aiven/internal/schemautil/userconfig/dist"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"
@@ -57,11 +55,7 @@ func ResourceGrafana() *schema.Resource {
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},
-		Timeouts: &schema.ResourceTimeout{
-			Create: schema.DefaultTimeout(20 * time.Minute),
-			Update: schema.DefaultTimeout(20 * time.Minute),
-			Delete: schema.DefaultTimeout(20 * time.Minute),
-		},
+		Timeouts: schemautil.DefaultResourceTimeouts(),
 
 		Schema: grafanaSchema(),
 	}

--- a/internal/service/influxdb/influxdb.go
+++ b/internal/service/influxdb/influxdb.go
@@ -1,8 +1,6 @@
 package influxdb
 
 import (
-	"time"
-
 	"github.com/aiven/terraform-provider-aiven/internal/schemautil"
 	"github.com/aiven/terraform-provider-aiven/internal/schemautil/userconfig/dist"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"
@@ -64,11 +62,7 @@ func ResourceInfluxDB() *schema.Resource {
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},
-		Timeouts: &schema.ResourceTimeout{
-			Create: schema.DefaultTimeout(20 * time.Minute),
-			Update: schema.DefaultTimeout(20 * time.Minute),
-			Delete: schema.DefaultTimeout(20 * time.Minute),
-		},
+		Timeouts: schemautil.DefaultResourceTimeouts(),
 
 		Schema: influxDBSchema(),
 	}

--- a/internal/service/influxdb/influxdb_database.go
+++ b/internal/service/influxdb/influxdb_database.go
@@ -2,7 +2,6 @@ package influxdb
 
 import (
 	"context"
-	"time"
 
 	"github.com/aiven/aiven-go-client"
 	"github.com/aiven/terraform-provider-aiven/internal/schemautil"
@@ -37,9 +36,7 @@ func ResourceInfluxDBDatabase() *schema.Resource {
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},
-		Timeouts: &schema.ResourceTimeout{
-			Delete: schema.DefaultTimeout(2 * time.Minute),
-		},
+		Timeouts: schemautil.DefaultResourceTimeouts(),
 
 		Schema: aivenInfluxDBDatabaseSchema,
 	}

--- a/internal/service/influxdb/influxdb_user.go
+++ b/internal/service/influxdb/influxdb_user.go
@@ -56,6 +56,7 @@ func ResourceInfluxDBUser() *schema.Resource {
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},
+		Timeouts: schemautil.DefaultResourceTimeouts(),
 
 		Schema: aivenInfluxDBUserSchema,
 	}

--- a/internal/service/kafka/kafka.go
+++ b/internal/service/kafka/kafka.go
@@ -3,7 +3,6 @@ package kafka
 import (
 	"context"
 	"strconv"
-	"time"
 
 	"github.com/aiven/aiven-go-client"
 	"github.com/aiven/terraform-provider-aiven/internal/schemautil"
@@ -91,11 +90,7 @@ func ResourceKafka() *schema.Resource {
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},
-		Timeouts: &schema.ResourceTimeout{
-			Create: schema.DefaultTimeout(20 * time.Minute),
-			Update: schema.DefaultTimeout(20 * time.Minute),
-			Delete: schema.DefaultTimeout(20 * time.Minute),
-		},
+		Timeouts: schemautil.DefaultResourceTimeouts(),
 
 		Schema: aivenKafkaSchema(),
 		CustomizeDiff: customdiff.Sequence(

--- a/internal/service/kafka/kafka_acl.go
+++ b/internal/service/kafka/kafka_acl.go
@@ -53,6 +53,7 @@ func ResourceKafkaACL() *schema.Resource {
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},
+		Timeouts: schemautil.DefaultResourceTimeouts(),
 
 		Schema: aivenKafkaACLSchema,
 	}

--- a/internal/service/kafka/kafka_connect.go
+++ b/internal/service/kafka/kafka_connect.go
@@ -1,8 +1,6 @@
 package kafka
 
 import (
-	"time"
-
 	"github.com/aiven/terraform-provider-aiven/internal/schemautil"
 	"github.com/aiven/terraform-provider-aiven/internal/schemautil/userconfig/dist"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"
@@ -54,11 +52,7 @@ func ResourceKafkaConnect() *schema.Resource {
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},
-		Timeouts: &schema.ResourceTimeout{
-			Create: schema.DefaultTimeout(20 * time.Minute),
-			Update: schema.DefaultTimeout(20 * time.Minute),
-			Delete: schema.DefaultTimeout(20 * time.Minute),
-		},
+		Timeouts: schemautil.DefaultResourceTimeouts(),
 
 		Schema: aivenKafkaConnectSchema(),
 	}

--- a/internal/service/kafka/kafka_connector.go
+++ b/internal/service/kafka/kafka_connector.go
@@ -94,9 +94,7 @@ func ResourceKafkaConnector() *schema.Resource {
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},
-		Timeouts: &schema.ResourceTimeout{
-			Read: schema.DefaultTimeout(2 * time.Minute),
-		},
+		Timeouts: schemautil.DefaultResourceTimeouts(),
 
 		Schema: aivenKafkaConnectorSchema,
 		CustomizeDiff: customdiff.IfValueChange("config",

--- a/internal/service/kafka/kafka_mirrormaker.go
+++ b/internal/service/kafka/kafka_mirrormaker.go
@@ -1,8 +1,6 @@
 package kafka
 
 import (
-	"time"
-
 	"github.com/aiven/terraform-provider-aiven/internal/schemautil"
 	"github.com/aiven/terraform-provider-aiven/internal/schemautil/userconfig/dist"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"
@@ -53,11 +51,7 @@ func ResourceKafkaMirrormaker() *schema.Resource {
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},
-		Timeouts: &schema.ResourceTimeout{
-			Create: schema.DefaultTimeout(20 * time.Minute),
-			Update: schema.DefaultTimeout(20 * time.Minute),
-			Delete: schema.DefaultTimeout(20 * time.Minute),
-		},
+		Timeouts: schemautil.DefaultResourceTimeouts(),
 
 		Schema: aivenKafkaMirrormakerSchema(),
 	}

--- a/internal/service/kafka/kafka_schema.go
+++ b/internal/service/kafka/kafka_schema.go
@@ -90,6 +90,7 @@ func ResourceKafkaSchema() *schema.Resource {
 			StateContext: schema.ImportStatePassthroughContext,
 		},
 		CustomizeDiff: resourceKafkaSchemaCustomizeDiff,
+		Timeouts:      schemautil.DefaultResourceTimeouts(),
 
 		Schema: aivenKafkaSchemaSchema,
 	}

--- a/internal/service/kafka/kafka_schema_configuration.go
+++ b/internal/service/kafka/kafka_schema_configuration.go
@@ -48,6 +48,7 @@ func ResourceKafkaSchemaConfiguration() *schema.Resource {
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},
+		Timeouts: schemautil.DefaultResourceTimeouts(),
 
 		Schema: aivenKafkaSchemaConfigurationSchema,
 	}

--- a/internal/service/kafka/kafka_schema_registry_acl.go
+++ b/internal/service/kafka/kafka_schema_registry_acl.go
@@ -54,6 +54,7 @@ func ResourceKafkaSchemaRegistryACL() *schema.Resource {
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},
+		Timeouts: schemautil.DefaultResourceTimeouts(),
 
 		Schema: aivenKafkaSchemaRegistryACLSchema,
 	}

--- a/internal/service/kafka/kafka_topic.go
+++ b/internal/service/kafka/kafka_topic.go
@@ -231,12 +231,8 @@ func ResourceKafkaTopic() *schema.Resource {
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},
-		Timeouts: &schema.ResourceTimeout{
-			Create: schema.DefaultTimeout(5 * time.Minute),
-			Read:   schema.DefaultTimeout(10 * time.Minute),
-			Delete: schema.DefaultTimeout(2 * time.Minute),
-		},
-		Schema: aivenKafkaTopicSchema,
+		Timeouts: schemautil.DefaultResourceTimeouts(),
+		Schema:   aivenKafkaTopicSchema,
 	}
 }
 

--- a/internal/service/kafka/kafka_user.go
+++ b/internal/service/kafka/kafka_user.go
@@ -55,6 +55,7 @@ func ResourceKafkaUser() *schema.Resource {
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},
+		Timeouts: schemautil.DefaultResourceTimeouts(),
 
 		Schema: aivenKafkaUserSchema,
 	}

--- a/internal/service/kafka/mirrormaker_replication_flow.go
+++ b/internal/service/kafka/mirrormaker_replication_flow.go
@@ -103,6 +103,7 @@ func ResourceMirrorMakerReplicationFlow() *schema.Resource {
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},
+		Timeouts: schemautil.DefaultResourceTimeouts(),
 
 		Schema: aivenMirrorMakerReplicationFlowSchema,
 	}

--- a/internal/service/m3db/m3aggregator.go
+++ b/internal/service/m3db/m3aggregator.go
@@ -1,8 +1,6 @@
 package m3db
 
 import (
-	"time"
-
 	"github.com/aiven/terraform-provider-aiven/internal/schemautil"
 	"github.com/aiven/terraform-provider-aiven/internal/schemautil/userconfig/dist"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"
@@ -53,11 +51,7 @@ func ResourceM3Aggregator() *schema.Resource {
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},
-		Timeouts: &schema.ResourceTimeout{
-			Create: schema.DefaultTimeout(20 * time.Minute),
-			Update: schema.DefaultTimeout(20 * time.Minute),
-			Delete: schema.DefaultTimeout(20 * time.Minute),
-		},
+		Timeouts: schemautil.DefaultResourceTimeouts(),
 
 		Schema: aivenM3AggregatorSchema(),
 	}

--- a/internal/service/m3db/m3db.go
+++ b/internal/service/m3db/m3db.go
@@ -1,8 +1,6 @@
 package m3db
 
 import (
-	"time"
-
 	"github.com/aiven/terraform-provider-aiven/internal/schemautil"
 	"github.com/aiven/terraform-provider-aiven/internal/schemautil/userconfig/dist"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"
@@ -57,11 +55,7 @@ func ResourceM3DB() *schema.Resource {
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},
-		Timeouts: &schema.ResourceTimeout{
-			Create: schema.DefaultTimeout(20 * time.Minute),
-			Update: schema.DefaultTimeout(20 * time.Minute),
-			Delete: schema.DefaultTimeout(20 * time.Minute),
-		},
+		Timeouts: schemautil.DefaultResourceTimeouts(),
 
 		Schema: aivenM3DBSchema(),
 	}

--- a/internal/service/m3db/m3db_user.go
+++ b/internal/service/m3db/m3db_user.go
@@ -44,6 +44,7 @@ func ResourceM3DBUser() *schema.Resource {
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},
+		Timeouts: schemautil.DefaultResourceTimeouts(),
 
 		Schema: aivenM3DBUserSchema,
 	}

--- a/internal/service/mysql/mysql.go
+++ b/internal/service/mysql/mysql.go
@@ -1,8 +1,6 @@
 package mysql
 
 import (
-	"time"
-
 	"github.com/aiven/terraform-provider-aiven/internal/schemautil"
 	"github.com/aiven/terraform-provider-aiven/internal/schemautil/userconfig/dist"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"
@@ -57,11 +55,7 @@ func ResourceMySQL() *schema.Resource {
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},
-		Timeouts: &schema.ResourceTimeout{
-			Create: schema.DefaultTimeout(20 * time.Minute),
-			Update: schema.DefaultTimeout(20 * time.Minute),
-			Delete: schema.DefaultTimeout(20 * time.Minute),
-		},
+		Timeouts: schemautil.DefaultResourceTimeouts(),
 
 		Schema: aivenMySQLSchema(),
 	}

--- a/internal/service/mysql/mysql_database.go
+++ b/internal/service/mysql/mysql_database.go
@@ -2,7 +2,6 @@ package mysql
 
 import (
 	"context"
-	"time"
 
 	"github.com/aiven/aiven-go-client"
 	"github.com/aiven/terraform-provider-aiven/internal/schemautil"
@@ -37,9 +36,7 @@ func ResourceMySQLDatabase() *schema.Resource {
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},
-		Timeouts: &schema.ResourceTimeout{
-			Delete: schema.DefaultTimeout(2 * time.Minute),
-		},
+		Timeouts: schemautil.DefaultResourceTimeouts(),
 
 		Schema: aivenMySQLDatabaseSchema,
 	}

--- a/internal/service/mysql/mysql_user.go
+++ b/internal/service/mysql/mysql_user.go
@@ -68,6 +68,7 @@ func ResourceMySQLUser() *schema.Resource {
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},
+		Timeouts: schemautil.DefaultResourceTimeouts(),
 
 		Schema: aivenMySQLUserSchema,
 	}

--- a/internal/service/opensearch/opensearch.go
+++ b/internal/service/opensearch/opensearch.go
@@ -1,8 +1,6 @@
 package opensearch
 
 import (
-	"time"
-
 	"github.com/aiven/terraform-provider-aiven/internal/schemautil"
 	"github.com/aiven/terraform-provider-aiven/internal/schemautil/userconfig/dist"
 
@@ -66,11 +64,7 @@ func ResourceOpensearch() *schema.Resource {
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},
-		Timeouts: &schema.ResourceTimeout{
-			Create: schema.DefaultTimeout(20 * time.Minute),
-			Update: schema.DefaultTimeout(20 * time.Minute),
-			Delete: schema.DefaultTimeout(20 * time.Minute),
-		},
+		Timeouts: schemautil.DefaultResourceTimeouts(),
 
 		Schema: opensearchSchema(),
 	}

--- a/internal/service/opensearch/opensearch_acl_config.go
+++ b/internal/service/opensearch/opensearch_acl_config.go
@@ -37,6 +37,7 @@ func ResourceOpensearchACLConfig() *schema.Resource {
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},
+		Timeouts: schemautil.DefaultResourceTimeouts(),
 
 		Schema: aivenOpensearchACLConfigSchema,
 	}

--- a/internal/service/opensearch/opensearch_acl_rule.go
+++ b/internal/service/opensearch/opensearch_acl_rule.go
@@ -45,6 +45,7 @@ func ResourceOpensearchACLRule() *schema.Resource {
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},
+		Timeouts: schemautil.DefaultResourceTimeouts(),
 
 		Schema: aivenOpensearchACLRuleSchema,
 	}

--- a/internal/service/opensearch/opensearch_user.go
+++ b/internal/service/opensearch/opensearch_user.go
@@ -44,6 +44,7 @@ func ResourceOpensearchUser() *schema.Resource {
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},
+		Timeouts: schemautil.DefaultResourceTimeouts(),
 
 		Schema: aivenOpensearchUserSchema,
 	}

--- a/internal/service/pg/pg.go
+++ b/internal/service/pg/pg.go
@@ -118,12 +118,7 @@ func ResourcePG() *schema.Resource {
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},
-		Timeouts: &schema.ResourceTimeout{
-			Create:  schema.DefaultTimeout(20 * time.Minute),
-			Update:  schema.DefaultTimeout(20 * time.Minute),
-			Delete:  schema.DefaultTimeout(20 * time.Minute),
-			Default: schema.DefaultTimeout(5 * time.Minute),
-		},
+		Timeouts: schemautil.DefaultResourceTimeouts(),
 
 		Schema: aivenPGSchema(),
 	}

--- a/internal/service/pg/pg_database.go
+++ b/internal/service/pg/pg_database.go
@@ -2,7 +2,6 @@ package pg
 
 import (
 	"context"
-	"time"
 
 	"github.com/aiven/aiven-go-client"
 	"github.com/aiven/terraform-provider-aiven/internal/schemautil"
@@ -64,9 +63,7 @@ func ResourcePGDatabase() *schema.Resource {
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},
-		Timeouts: &schema.ResourceTimeout{
-			Delete: schema.DefaultTimeout(2 * time.Minute),
-		},
+		Timeouts: schemautil.DefaultResourceTimeouts(),
 
 		Schema: aivenPGDatabaseSchema,
 	}

--- a/internal/service/pg/pg_user.go
+++ b/internal/service/pg/pg_user.go
@@ -69,6 +69,7 @@ func ResourcePGUser() *schema.Resource {
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},
+		Timeouts: schemautil.DefaultResourceTimeouts(),
 
 		Schema: aivenPGUserSchema,
 	}

--- a/internal/service/project/billing_group.go
+++ b/internal/service/project/billing_group.go
@@ -108,6 +108,7 @@ func ResourceBillingGroup() *schema.Resource {
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},
+		Timeouts: schemautil.DefaultResourceTimeouts(),
 
 		Schema: aivenBillingGroupSchema,
 	}

--- a/internal/service/project/project.go
+++ b/internal/service/project/project.go
@@ -115,6 +115,7 @@ func ResourceProject() *schema.Resource {
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},
+		Timeouts: schemautil.DefaultResourceTimeouts(),
 
 		Schema: aivenProjectSchema,
 		CustomizeDiff: customdiff.IfValueChange("tag",

--- a/internal/service/project/project_user.go
+++ b/internal/service/project/project_user.go
@@ -41,6 +41,7 @@ func ResourceProjectUser() *schema.Resource {
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},
+		Timeouts: schemautil.DefaultResourceTimeouts(),
 
 		Schema: aivenProjectUserSchema,
 	}

--- a/internal/service/redis/redis.go
+++ b/internal/service/redis/redis.go
@@ -1,8 +1,6 @@
 package redis
 
 import (
-	"time"
-
 	"github.com/aiven/terraform-provider-aiven/internal/schemautil"
 	"github.com/aiven/terraform-provider-aiven/internal/schemautil/userconfig/dist"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"
@@ -58,11 +56,7 @@ func ResourceRedis() *schema.Resource {
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},
-		Timeouts: &schema.ResourceTimeout{
-			Create: schema.DefaultTimeout(20 * time.Minute),
-			Update: schema.DefaultTimeout(20 * time.Minute),
-			Delete: schema.DefaultTimeout(20 * time.Minute),
-		},
+		Timeouts: schemautil.DefaultResourceTimeouts(),
 
 		Schema: redisSchema(),
 	}

--- a/internal/service/redis/redis_user.go
+++ b/internal/service/redis/redis_user.go
@@ -87,6 +87,7 @@ func ResourceRedisUser() *schema.Resource {
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},
+		Timeouts: schemautil.DefaultResourceTimeouts(),
 
 		Schema: aivenRedisUserSchema,
 	}

--- a/internal/service/serviceintegration/service_integration.go
+++ b/internal/service/serviceintegration/service_integration.go
@@ -89,9 +89,7 @@ func ResourceServiceIntegration() *schema.Resource {
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},
-		Timeouts: &schema.ResourceTimeout{
-			Create: schema.DefaultTimeout(10 * time.Minute),
-		},
+		Timeouts: schemautil.DefaultResourceTimeouts(),
 
 		Schema: aivenServiceIntegrationSchema,
 	}

--- a/internal/service/serviceintegration/service_integration_endpoint.go
+++ b/internal/service/serviceintegration/service_integration_endpoint.go
@@ -63,6 +63,7 @@ func ResourceServiceIntegrationEndpoint() *schema.Resource {
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},
+		Timeouts: schemautil.DefaultResourceTimeouts(),
 
 		Schema: aivenServiceIntegrationEndpointSchema,
 	}

--- a/internal/service/serviceuser/service_user.go
+++ b/internal/service/serviceuser/service_user.go
@@ -119,6 +119,7 @@ func ResourceServiceUser() *schema.Resource {
 		Importer: &schema.ResourceImporter{
 			StateContext: resourceServiceUserState,
 		},
+		Timeouts: schemautil.DefaultResourceTimeouts(),
 
 		Schema:             aivenServiceUserSchema,
 		DeprecationMessage: "Please use service-specific resources instead of this one, for example: aiven_kafka_user, aiven_pg_user etc.",

--- a/internal/service/staticip/static_ip.go
+++ b/internal/service/staticip/static_ip.go
@@ -52,7 +52,8 @@ func ResourceStaticIP() *schema.Resource {
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},
-		Schema: aivenStaticIPSchema,
+		Timeouts: schemautil.DefaultResourceTimeouts(),
+		Schema:   aivenStaticIPSchema,
 	}
 }
 

--- a/internal/service/vpc/aws_privatelink.go
+++ b/internal/service/vpc/aws_privatelink.go
@@ -44,10 +44,7 @@ func ResourceAWSPrivatelink() *schema.Resource {
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},
-		Timeouts: &schema.ResourceTimeout{
-			Create: schema.DefaultTimeout(20 * time.Minute),
-			Update: schema.DefaultTimeout(20 * time.Minute),
-		},
+		Timeouts: schemautil.DefaultResourceTimeouts(),
 
 		Schema: aivenAWSPrivatelinkSchema,
 	}

--- a/internal/service/vpc/aws_vpc_peering_connection.go
+++ b/internal/service/vpc/aws_vpc_peering_connection.go
@@ -67,10 +67,7 @@ func ResourceAWSVPCPeeringConnection() *schema.Resource {
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},
-		Timeouts: &schema.ResourceTimeout{
-			Create: schema.DefaultTimeout(2 * time.Minute),
-			Delete: schema.DefaultTimeout(2 * time.Minute),
-		},
+		Timeouts: schemautil.DefaultResourceTimeouts(),
 
 		Schema: aivenAWSVPCPeeringConnectionSchema,
 	}

--- a/internal/service/vpc/azure_privatelink.go
+++ b/internal/service/vpc/azure_privatelink.go
@@ -56,11 +56,7 @@ func ResourceAzurePrivatelink() *schema.Resource {
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},
-		Timeouts: &schema.ResourceTimeout{
-			Create: schema.DefaultTimeout(20 * time.Minute),
-			Update: schema.DefaultTimeout(20 * time.Minute),
-			Delete: schema.DefaultTimeout(20 * time.Minute),
-		},
+		Timeouts: schemautil.DefaultResourceTimeouts(),
 
 		Schema: aivenAzurePrivatelinkSchema,
 	}

--- a/internal/service/vpc/azure_privatelink_connection_approve.go
+++ b/internal/service/vpc/azure_privatelink_connection_approve.go
@@ -44,11 +44,7 @@ func ResourceAzurePrivatelinkConnectionApproval() *schema.Resource {
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},
-		Timeouts: &schema.ResourceTimeout{
-			Create: schema.DefaultTimeout(20 * time.Minute),
-			Update: schema.DefaultTimeout(20 * time.Minute),
-			Delete: schema.DefaultTimeout(20 * time.Minute),
-		},
+		Timeouts: schemautil.DefaultResourceTimeouts(),
 
 		Schema: aivenPrivatelinkConnectionApprovalSchema,
 	}

--- a/internal/service/vpc/azure_vpc_peering_connection.go
+++ b/internal/service/vpc/azure_vpc_peering_connection.go
@@ -76,10 +76,7 @@ func ResourceAzureVPCPeeringConnection() *schema.Resource {
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},
-		Timeouts: &schema.ResourceTimeout{
-			Create: schema.DefaultTimeout(20 * time.Minute),
-			Delete: schema.DefaultTimeout(20 * time.Minute),
-		},
+		Timeouts: schemautil.DefaultResourceTimeouts(),
 
 		Schema: aivenAzureVPCPeeringConnectionSchema,
 	}

--- a/internal/service/vpc/gcp_vpc_peering_connection.go
+++ b/internal/service/vpc/gcp_vpc_peering_connection.go
@@ -61,10 +61,7 @@ func ResourceGCPVPCPeeringConnection() *schema.Resource {
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},
-		Timeouts: &schema.ResourceTimeout{
-			Create: schema.DefaultTimeout(2 * time.Minute),
-			Delete: schema.DefaultTimeout(2 * time.Minute),
-		},
+		Timeouts: schemautil.DefaultResourceTimeouts(),
 
 		Schema: aivenGCPVPCPeeringConnectionSchema,
 	}

--- a/internal/service/vpc/project_vpc.go
+++ b/internal/service/vpc/project_vpc.go
@@ -44,10 +44,7 @@ func ResourceProjectVPC() *schema.Resource {
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},
-		Timeouts: &schema.ResourceTimeout{
-			Create: schema.DefaultTimeout(20 * time.Minute),
-			Delete: schema.DefaultTimeout(20 * time.Minute),
-		},
+		Timeouts: schemautil.DefaultResourceTimeouts(),
 
 		Schema: aivenProjectVPCSchema,
 	}

--- a/internal/service/vpc/transit_gateway_vpc_attachement.go
+++ b/internal/service/vpc/transit_gateway_vpc_attachement.go
@@ -2,7 +2,6 @@ package vpc
 
 import (
 	"context"
-	"time"
 
 	"github.com/aiven/aiven-go-client"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -72,9 +71,7 @@ func ResourceTransitGatewayVPCAttachment() *schema.Resource {
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},
-		Timeouts: &schema.ResourceTimeout{
-			Create: schema.DefaultTimeout(2 * time.Minute),
-		},
+		Timeouts: schemautil.DefaultResourceTimeouts(),
 
 		Schema: aivenTransitGatewayVPCAttachmentSchema,
 	}

--- a/internal/service/vpc/vpc_peering_connection.go
+++ b/internal/service/vpc/vpc_peering_connection.go
@@ -92,10 +92,7 @@ func ResourceVPCPeeringConnection() *schema.Resource {
 		Importer: &schema.ResourceImporter{
 			StateContext: resourceVPCPeeringConnectionImport,
 		},
-		Timeouts: &schema.ResourceTimeout{
-			Create: schema.DefaultTimeout(2 * time.Minute),
-			Delete: schema.DefaultTimeout(2 * time.Minute),
-		},
+		Timeouts: schemautil.DefaultResourceTimeouts(),
 
 		Schema:             aivenVPCPeeringConnectionSchema,
 		DeprecationMessage: "Please use a cloud specific VPC peering connection resource",


### PR DESCRIPTION
<!-- All contributors, please complete these sections, including maintainers. -->

## About this change—what it does

<!-- Provide a small sentence that summarizes the change. -->

this PR unifies the timeout values across all resources so that they are managed in a more obvious way, and uses a constant value so we are able to easily adjust it when/if needed

this PR also keeps an ability for users to manage the timeout values for their resources, and also adds `Default` timeout option to all the resources where it was missing, as well as all the other CRDU timeouts

<!-- Provide the issue number below, if it exists. -->

this PR is linked to and was discovered during #1054

## Why this way

<!-- Provide a small explanation on why this is the approach you took for solving this problem. -->
we want to allow our users to manage their timeouts, while both having a reasonable default timeout value, easily modifiable if needed, and unified across all the resources so they become functioning in a more obvious manner for the end users
