### PR TITLE
fix: add commit message prefix to dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,8 @@ updates:
     directory: /
     schedule:
       interval: daily
+    commit-message:
+      prefix: "chore:"
   - package-ecosystem: gomod
     directory: /
     schedule:
@@ -11,6 +13,8 @@ updates:
     ignore:
       - dependency-name: golang.org/x/tools
       - dependency-name: google.golang.org/grpc
+    commit-message:
+      prefix: "chore:"
   - package-ecosystem: gomod
     directory: /tools
     schedule:
@@ -18,3 +22,5 @@ updates:
     ignore:
       - dependency-name: golang.org/x/tools
       - dependency-name: google.golang.org/grpc
+    commit-message:
+      prefix: "chore:"


### PR DESCRIPTION
This will make it compliant with commit message linters 