### PR TITLE
revert: fix: add commit message prefix to dependabot (#1077)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,8 +4,6 @@ updates:
     directory: /
     schedule:
       interval: daily
-    commit-message:
-      prefix: "chore:"
   - package-ecosystem: gomod
     directory: /
     schedule:
@@ -13,8 +11,6 @@ updates:
     ignore:
       - dependency-name: golang.org/x/tools
       - dependency-name: google.golang.org/grpc
-    commit-message:
-      prefix: "chore:"
   - package-ecosystem: gomod
     directory: /tools
     schedule:
@@ -22,5 +18,3 @@ updates:
     ignore:
       - dependency-name: golang.org/x/tools
       - dependency-name: google.golang.org/grpc
-    commit-message:
-      prefix: "chore:"


### PR DESCRIPTION
<!-- All contributors, please complete these sections, including maintainers. -->

## About this change—what it does

This reverts commit 60f44239b88079a8f7277a7e621b809ec67eb098.

<!-- Provide a small sentence that summarizes the change. -->

<!-- Provide the issue number below, if it exists. -->

## Why this way

<!-- Provide a small explanation on why this is the approach you took for solving this problem. -->
it was added erroneously
