### PR TITLE
fix(kafkatopic): conflict on create existing topic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ nav_order: 1
 
 ## [MAJOR.MINOR.PATCH] - YYYY-MM-DD
 
+- Fix `aiven_kafka_topic` create. Now conflicts if topic exists
+
 ## [4.1.0] - 2023-03-07
 
 - Fix `add_account_owners_admin_access` type issue

--- a/internal/sdkprovider/service/kafka/kafka_topic_test.go
+++ b/internal/sdkprovider/service/kafka/kafka_topic_test.go
@@ -10,15 +10,15 @@ import (
 	"time"
 
 	"github.com/aiven/aiven-go-client"
-	acc "github.com/aiven/terraform-provider-aiven/internal/acctest"
-	"github.com/aiven/terraform-provider-aiven/internal/sdkprovider/service/kafka"
 	"github.com/avast/retry-go"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/stretchr/testify/assert"
 
+	acc "github.com/aiven/terraform-provider-aiven/internal/acctest"
 	"github.com/aiven/terraform-provider-aiven/internal/schemautil"
+	"github.com/aiven/terraform-provider-aiven/internal/sdkprovider/service/kafka"
 )
 
 func TestAccAivenKafkaTopic_basic(t *testing.T) {
@@ -490,4 +490,56 @@ resource "aiven_kafka_topic" "topic" {
 }
 `, prefix, project)
 	return result
+}
+
+func TestAccAivenKafkaTopic_conflicts_if_exists(t *testing.T) {
+	project := os.Getenv("AIVEN_PROJECT_NAME")
+	prefix := "test-tf-acc-" + acctest.RandString(7)
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acc.TestAccPreCheck(t) },
+		ProviderFactories: acc.TestAccProviderFactories,
+		CheckDestroy:      testAccCheckAivenKafkaTopicResourceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccAivenKafkaTopicConflictsIfExists(prefix, project),
+				ExpectError: regexp.MustCompile(`Topic conflict already exists"`),
+			},
+		},
+	})
+}
+
+func testAccAivenKafkaTopicConflictsIfExists(prefix, project string) string {
+	return fmt.Sprintf(`data "aiven_project" "project" {
+  project = %[2]q
+}
+
+resource "aiven_kafka" "kafka" {
+  project                 = data.aiven_project.project.project
+  cloud_name              = "google-europe-west1"
+  plan                    = "startup-2"
+  service_name            = "%[1]s-kafka"
+  maintenance_window_dow  = "monday"
+  maintenance_window_time = "10:00:00"
+}
+
+resource "aiven_kafka_topic" "topic" {
+  project      = aiven_kafka.kafka.project
+  service_name = aiven_kafka.kafka.service_name
+  topic_name   = "conflict"
+  partitions   = 5
+  replication  = 3
+}
+
+resource "aiven_kafka_topic" "topic_conflict" {
+  project      = aiven_kafka.kafka.project
+  service_name = aiven_kafka.kafka.service_name
+  topic_name   = "conflict"
+  partitions   = 5
+  replication  = 3
+
+  depends_on = [
+    aiven_kafka_topic.topic
+  ]
+}
+`, prefix, project)
 }


### PR DESCRIPTION
## About this change—what it does

Because of retries, kafka topic creation process may get already existing topic.