### PR TITLE
fix(apiconvert): ToAPI for objects and arrays

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ nav_order: 1
 
 ## [MAJOR.MINOR.PATCH] - YYYY-MM-DD
 
+- Fix for "to API" converter for objects and arrays
+
 ## [4.1.1] - 2023-03-15
 
 - Fix `aiven_kafka_topic` create. Now conflicts if topic exists

--- a/internal/schemautil/userconfig/apiconvert/toapi_test.go
+++ b/internal/schemautil/userconfig/apiconvert/toapi_test.go
@@ -507,6 +507,10 @@ func TestToAPI(t *testing.T) {
 										"description": "",
 										"network":     "10.20.0.0/16",
 									},
+									map[string]interface{}{
+										"description": "foo",
+										"network":     "1.3.3.7/32",
+									},
 								},
 							},
 						},
@@ -516,12 +520,16 @@ func TestToAPI(t *testing.T) {
 						"m3db_user_config.0.ip_filter_object.0":             {},
 						"m3db_user_config.0.ip_filter_object.0.description": {},
 						"m3db_user_config.0.ip_filter_object.0.network":     {},
+						"m3db_user_config.0.ip_filter_object.1":             {},
+						"m3db_user_config.0.ip_filter_object.1.description": {},
+						"m3db_user_config.0.ip_filter_object.1.network":     {},
 					},
 					map[string]struct{}{
 						"m3db_user_config.0.ip_filter_object":               {},
 						"m3db_user_config.0.ip_filter_object.1":             {},
 						"m3db_user_config.0.ip_filter_object.1.description": {},
 						"m3db_user_config.0.ip_filter_object.1.network":     {},
+						"m3db_user_config.0.ip_filter_object.2":             {},
 					},
 					false,
 				),
@@ -535,6 +543,10 @@ func TestToAPI(t *testing.T) {
 					map[string]interface{}{
 						"description": "",
 						"network":     "10.20.0.0/16",
+					},
+					map[string]interface{}{
+						"description": "foo",
+						"network":     "1.3.3.7/32",
 					},
 				},
 			},


### PR DESCRIPTION
<!-- All contributors, please complete these sections, including maintainers. -->

## About this change—what it does

<!-- Provide a small sentence that summarizes the change. -->
fixes `ToAPI` for objects and arrays

<!-- Provide the issue number below, if it exists. -->
resolves #1088

## Why this way

<!-- Provide a small explanation on why this is the approach you took for solving this problem. -->
to make it work :)
