### PR TITLE
refactor(schemautil): global default timeout minutes

### DIFF
--- a/internal/schemautil/service.go
+++ b/internal/schemautil/service.go
@@ -17,16 +17,17 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
-func DefaultResourceTimeouts() *schema.ResourceTimeout {
-	// DefaultTimeoutMinutes is the default timeout for service operations.
-	const DefaultTimeoutMinutes = 20
+// DefaultTimeout is the default timeout for service operations. This is not a const because it can be changed during
+// compile time with -ldflags "-X github.com/aiven/terraform-provider-aiven/internal/schemautil.DefaultTimeout=30".
+var DefaultTimeout time.Duration = 20
 
+func DefaultResourceTimeouts() *schema.ResourceTimeout {
 	return &schema.ResourceTimeout{
-		Create:  schema.DefaultTimeout(DefaultTimeoutMinutes * time.Minute),
-		Update:  schema.DefaultTimeout(DefaultTimeoutMinutes * time.Minute),
-		Delete:  schema.DefaultTimeout(DefaultTimeoutMinutes * time.Minute),
-		Default: schema.DefaultTimeout(DefaultTimeoutMinutes * time.Minute),
-		Read:    schema.DefaultTimeout(DefaultTimeoutMinutes * time.Minute),
+		Create:  schema.DefaultTimeout(DefaultTimeout * time.Minute),
+		Update:  schema.DefaultTimeout(DefaultTimeout * time.Minute),
+		Delete:  schema.DefaultTimeout(DefaultTimeout * time.Minute),
+		Default: schema.DefaultTimeout(DefaultTimeout * time.Minute),
+		Read:    schema.DefaultTimeout(DefaultTimeout * time.Minute),
 	}
 }
 


### PR DESCRIPTION
<!-- All contributors, please complete these sections, including maintainers. -->

## About this change—what it does

<!-- Provide a small sentence that summarizes the change. -->
makes it possible to change the default timeout of the provider's resources on compile time via `-ldflags "-X github.com/aiven/terraform-provider-aiven/internal/schemautil.DefaultTimeoutMinutes=30"`

<!-- Provide the issue number below, if it exists. -->
resolves #1054 

## Why this way

<!-- Provide a small explanation on why this is the approach you took for solving this problem. -->
to allow to change timeouts values outside of Terraform protocol during compile time
