### PR TITLE
feat(kafka_connector): make config non-sensitive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ nav_order: 1
 
 - Add `aiven_m3db` specific configuration options
 - Fix `aiven_kafka_topic`: add client-side validation for the `partitions` field
+- Make `config` field of `aiven_kafka_connector` resource non-sensitive
 
 ## [4.1.3] - 2023-03-22
 

--- a/docs/data-sources/kafka_connector.md
+++ b/docs/data-sources/kafka_connector.md
@@ -31,7 +31,7 @@ data "aiven_kafka_connector" "kafka-es-con1" {
 
 ### Read-Only
 
-- `config` (Map of String, Sensitive) The Kafka Connector configuration parameters.
+- `config` (Map of String) The Kafka Connector configuration parameters.
 - `id` (String) The ID of this resource.
 - `plugin_author` (String) The Kafka connector author.
 - `plugin_class` (String) The Kafka connector Java class.

--- a/docs/resources/kafka_connector.md
+++ b/docs/resources/kafka_connector.md
@@ -35,7 +35,7 @@ resource "aiven_kafka_connector" "kafka-os-con1" {
 
 ### Required
 
-- `config` (Map of String, Sensitive) The Kafka Connector configuration parameters.
+- `config` (Map of String) The Kafka Connector configuration parameters.
 - `connector_name` (String) The kafka connector name. This property cannot be changed, doing so forces recreation of the resource.
 - `project` (String) Identifies the project this resource belongs to. To set up proper dependencies please refer to this variable as a reference. This property cannot be changed, doing so forces recreation of the resource.
 - `service_name` (String) Specifies the name of the service that this resource belongs to. To set up proper dependencies please refer to this variable as a reference. This property cannot be changed, doing so forces recreation of the resource.

--- a/internal/sdkprovider/service/kafka/kafka_connector.go
+++ b/internal/sdkprovider/service/kafka/kafka_connector.go
@@ -26,9 +26,8 @@ var aivenKafkaConnectorSchema = map[string]*schema.Schema{
 		Description: userconfig.Desc("The kafka connector name.").ForceNew().Build(),
 	},
 	"config": {
-		Type:      schema.TypeMap,
-		Required:  true,
-		Sensitive: true,
+		Type:     schema.TypeMap,
+		Required: true,
 		Elem: &schema.Schema{
 			Type: schema.TypeString,
 		},


### PR DESCRIPTION
<!-- All contributors, please complete these sections, including maintainers. -->

## About this change—what it does

<!-- Provide a small sentence that summarizes the change. -->
makes `config` field of `aiven_kafka_connector` resource non-sensitive

<!-- Provide the issue number below, if it exists. -->
resolves #1099 

reverts #810 (introduced in #701)

## Why this way

<!-- Provide a small explanation on why this is the approach you took for solving this problem. -->
we cannot predict fields in the `config` field at all, so this has to remain a schemaless map on our side

users would still be able to mark specific fields sensitive if they wish to do so by using `sensitive()` HCL function, e.g.:

```hcl
  config = {
    "topics"                         = aiven_kafka_topic.topic-logs-app-1.topic_name
    "connector.class"                = "io.aiven.kafka.connect.opensearch.OpensearchSinkConnector"
    "type.name"                      = "os-connector"
    "name"                           = "kafka-os-con1"
    "connection.url"                 = "https://${aiven_opensearch.os-service1.service_host}:${aiven_opensearch.os-service1.service_port}"
    "connection.username"            = sensitive(aiven_opensearch.os-service1.service_username)
    "connection.password"            = sensitive(aiven_opensearch.os-service1.service_password)
    "key.converter"                  = "org.apache.kafka.connect.storage.StringConverter"
    "value.converter"                = "org.apache.kafka.connect.json.JsonConverter"
    "tasks.max"                      = 1
    "schema.ignore"                  = true
    "value.converter.schemas.enable" = false
  }
```
