### PR TITLE
feat(userconfig): add ip_filter, namespaces string alias fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ nav_order: 1
 - Add `aiven_m3db` specific configuration options
 - Fix `aiven_kafka_topic`: add client-side validation for the `partitions` field
 - Make `config` field of `aiven_kafka_connector` resource non-sensitive
+- Add string-suffixed alias fields for `ip_filter` and `namespaces` user config options
 
 ## [4.1.3] - 2023-03-22
 

--- a/docs/data-sources/cassandra.md
+++ b/docs/data-sources/cassandra.md
@@ -73,6 +73,7 @@ Read-Only:
 - `cassandra_version` (String)
 - `ip_filter` (List of String)
 - `ip_filter_object` (List of Object) (see [below for nested schema](#nestedobjatt--cassandra_user_config--ip_filter_object))
+- `ip_filter_string` (List of String)
 - `migrate_sstableloader` (Boolean)
 - `private_access` (List of Object) (see [below for nested schema](#nestedobjatt--cassandra_user_config--private_access))
 - `project_to_fork_from` (String)

--- a/docs/data-sources/clickhouse.md
+++ b/docs/data-sources/clickhouse.md
@@ -71,6 +71,7 @@ Read-Only:
 - `additional_backup_regions` (List of String)
 - `ip_filter` (List of String)
 - `ip_filter_object` (List of Object) (see [below for nested schema](#nestedobjatt--clickhouse_user_config--ip_filter_object))
+- `ip_filter_string` (List of String)
 - `project_to_fork_from` (String)
 - `service_to_fork_from` (String)
 

--- a/docs/data-sources/flink.md
+++ b/docs/data-sources/flink.md
@@ -86,6 +86,7 @@ Read-Only:
 - `flink_version` (String)
 - `ip_filter` (List of String)
 - `ip_filter_object` (List of Object) (see [below for nested schema](#nestedobjatt--flink_user_config--ip_filter_object))
+- `ip_filter_string` (List of String)
 - `number_of_task_slots` (Number)
 - `privatelink_access` (List of Object) (see [below for nested schema](#nestedobjatt--flink_user_config--privatelink_access))
 

--- a/docs/data-sources/grafana.md
+++ b/docs/data-sources/grafana.md
@@ -108,6 +108,7 @@ Read-Only:
 - `google_analytics_ua_id` (String)
 - `ip_filter` (List of String)
 - `ip_filter_object` (List of Object) (see [below for nested schema](#nestedobjatt--grafana_user_config--ip_filter_object))
+- `ip_filter_string` (List of String)
 - `metrics_enabled` (Boolean)
 - `private_access` (List of Object) (see [below for nested schema](#nestedobjatt--grafana_user_config--private_access))
 - `privatelink_access` (List of Object) (see [below for nested schema](#nestedobjatt--grafana_user_config--privatelink_access))

--- a/docs/data-sources/influxdb.md
+++ b/docs/data-sources/influxdb.md
@@ -88,6 +88,7 @@ Read-Only:
 - `influxdb` (List of Object) (see [below for nested schema](#nestedobjatt--influxdb_user_config--influxdb))
 - `ip_filter` (List of String)
 - `ip_filter_object` (List of Object) (see [below for nested schema](#nestedobjatt--influxdb_user_config--ip_filter_object))
+- `ip_filter_string` (List of String)
 - `private_access` (List of Object) (see [below for nested schema](#nestedobjatt--influxdb_user_config--private_access))
 - `privatelink_access` (List of Object) (see [below for nested schema](#nestedobjatt--influxdb_user_config--privatelink_access))
 - `project_to_fork_from` (String)

--- a/docs/data-sources/kafka.md
+++ b/docs/data-sources/kafka.md
@@ -93,6 +93,7 @@ Read-Only:
 - `custom_domain` (String)
 - `ip_filter` (List of String)
 - `ip_filter_object` (List of Object) (see [below for nested schema](#nestedobjatt--kafka_user_config--ip_filter_object))
+- `ip_filter_string` (List of String)
 - `kafka` (List of Object) (see [below for nested schema](#nestedobjatt--kafka_user_config--kafka))
 - `kafka_authentication_methods` (List of Object) (see [below for nested schema](#nestedobjatt--kafka_user_config--kafka_authentication_methods))
 - `kafka_connect` (Boolean)

--- a/docs/data-sources/kafka_connect.md
+++ b/docs/data-sources/kafka_connect.md
@@ -85,6 +85,7 @@ Read-Only:
 - `additional_backup_regions` (List of String)
 - `ip_filter` (List of String)
 - `ip_filter_object` (List of Object) (see [below for nested schema](#nestedobjatt--kafka_connect_user_config--ip_filter_object))
+- `ip_filter_string` (List of String)
 - `kafka_connect` (List of Object) (see [below for nested schema](#nestedobjatt--kafka_connect_user_config--kafka_connect))
 - `private_access` (List of Object) (see [below for nested schema](#nestedobjatt--kafka_connect_user_config--private_access))
 - `privatelink_access` (List of Object) (see [below for nested schema](#nestedobjatt--kafka_connect_user_config--privatelink_access))

--- a/docs/data-sources/kafka_mirrormaker.md
+++ b/docs/data-sources/kafka_mirrormaker.md
@@ -85,6 +85,7 @@ Read-Only:
 - `additional_backup_regions` (List of String)
 - `ip_filter` (List of String)
 - `ip_filter_object` (List of Object) (see [below for nested schema](#nestedobjatt--kafka_mirrormaker_user_config--ip_filter_object))
+- `ip_filter_string` (List of String)
 - `kafka_mirrormaker` (List of Object) (see [below for nested schema](#nestedobjatt--kafka_mirrormaker_user_config--kafka_mirrormaker))
 - `static_ips` (Boolean)
 

--- a/docs/data-sources/m3aggregator.md
+++ b/docs/data-sources/m3aggregator.md
@@ -85,6 +85,7 @@ Read-Only:
 - `custom_domain` (String)
 - `ip_filter` (List of String)
 - `ip_filter_object` (List of Object) (see [below for nested schema](#nestedobjatt--m3aggregator_user_config--ip_filter_object))
+- `ip_filter_string` (List of String)
 - `m3_version` (String)
 - `m3aggregator_version` (String)
 - `static_ips` (Boolean)

--- a/docs/data-sources/m3db.md
+++ b/docs/data-sources/m3db.md
@@ -86,6 +86,7 @@ Read-Only:
 - `custom_domain` (String)
 - `ip_filter` (List of String)
 - `ip_filter_object` (List of Object) (see [below for nested schema](#nestedobjatt--m3db_user_config--ip_filter_object))
+- `ip_filter_string` (List of String)
 - `limits` (List of Object) (see [below for nested schema](#nestedobjatt--m3db_user_config--limits))
 - `m3` (List of Object) (see [below for nested schema](#nestedobjatt--m3db_user_config--m3))
 - `m3_version` (String)
@@ -205,6 +206,7 @@ Read-Only:
 - `name` (String)
 - `namespaces` (List of String)
 - `namespaces_object` (List of Object) (see [below for nested schema](#nestedobjatt--m3db_user_config--rules--mapping--namespaces_object))
+- `namespaces_string` (List of String)
 - `tags` (List of Object) (see [below for nested schema](#nestedobjatt--m3db_user_config--rules--mapping--tags))
 
 <a id="nestedobjatt--m3db_user_config--rules--mapping--namespaces_object"></a>

--- a/docs/data-sources/mysql.md
+++ b/docs/data-sources/mysql.md
@@ -90,6 +90,7 @@ Read-Only:
 - `binlog_retention_period` (Number)
 - `ip_filter` (List of String)
 - `ip_filter_object` (List of Object) (see [below for nested schema](#nestedobjatt--mysql_user_config--ip_filter_object))
+- `ip_filter_string` (List of String)
 - `migration` (List of Object) (see [below for nested schema](#nestedobjatt--mysql_user_config--migration))
 - `mysql` (List of Object) (see [below for nested schema](#nestedobjatt--mysql_user_config--mysql))
 - `mysql_version` (String)

--- a/docs/data-sources/opensearch.md
+++ b/docs/data-sources/opensearch.md
@@ -90,6 +90,7 @@ Read-Only:
 - `index_template` (List of Object) (see [below for nested schema](#nestedobjatt--opensearch_user_config--index_template))
 - `ip_filter` (List of String)
 - `ip_filter_object` (List of Object) (see [below for nested schema](#nestedobjatt--opensearch_user_config--ip_filter_object))
+- `ip_filter_string` (List of String)
 - `keep_index_refresh_interval` (Boolean)
 - `max_index_count` (Number)
 - `opensearch` (List of Object) (see [below for nested schema](#nestedobjatt--opensearch_user_config--opensearch))

--- a/docs/data-sources/pg.md
+++ b/docs/data-sources/pg.md
@@ -99,6 +99,7 @@ Read-Only:
 - `enable_ipv6` (Boolean)
 - `ip_filter` (List of String)
 - `ip_filter_object` (List of Object) (see [below for nested schema](#nestedobjatt--pg_user_config--ip_filter_object))
+- `ip_filter_string` (List of String)
 - `migration` (List of Object) (see [below for nested schema](#nestedobjatt--pg_user_config--migration))
 - `pg` (List of Object) (see [below for nested schema](#nestedobjatt--pg_user_config--pg))
 - `pg_read_replica` (Boolean)

--- a/docs/data-sources/redis.md
+++ b/docs/data-sources/redis.md
@@ -85,6 +85,7 @@ Read-Only:
 - `additional_backup_regions` (List of String)
 - `ip_filter` (List of String)
 - `ip_filter_object` (List of Object) (see [below for nested schema](#nestedobjatt--redis_user_config--ip_filter_object))
+- `ip_filter_string` (List of String)
 - `migration` (List of Object) (see [below for nested schema](#nestedobjatt--redis_user_config--migration))
 - `private_access` (List of Object) (see [below for nested schema](#nestedobjatt--redis_user_config--private_access))
 - `privatelink_access` (List of Object) (see [below for nested schema](#nestedobjatt--redis_user_config--privatelink_access))

--- a/docs/resources/cassandra.md
+++ b/docs/resources/cassandra.md
@@ -82,6 +82,7 @@ Optional:
 - `cassandra_version` (String) Cassandra major version.
 - `ip_filter` (List of String, Deprecated) Allow incoming connections from CIDR address block, e.g. '10.20.0.0/16'.
 - `ip_filter_object` (Block List, Max: 1024) Allow incoming connections from CIDR address block, e.g. '10.20.0.0/16'. (see [below for nested schema](#nestedblock--cassandra_user_config--ip_filter_object))
+- `ip_filter_string` (List of String) Allow incoming connections from CIDR address block, e.g. '10.20.0.0/16'.
 - `migrate_sstableloader` (Boolean) Sets the service into migration mode enabling the sstableloader utility to be used to upload Cassandra data files. Available only on service create.
 - `private_access` (Block List, Max: 1) Allow access to selected service ports from private networks. (see [below for nested schema](#nestedblock--cassandra_user_config--private_access))
 - `project_to_fork_from` (String) Name of another project to fork a service from. This has effect only when a new service is being created.

--- a/docs/resources/clickhouse.md
+++ b/docs/resources/clickhouse.md
@@ -72,6 +72,7 @@ Optional:
 - `additional_backup_regions` (List of String) Additional Cloud Regions for Backup Replication.
 - `ip_filter` (List of String, Deprecated) Allow incoming connections from CIDR address block, e.g. '10.20.0.0/16'.
 - `ip_filter_object` (Block List, Max: 1024) Allow incoming connections from CIDR address block, e.g. '10.20.0.0/16'. (see [below for nested schema](#nestedblock--clickhouse_user_config--ip_filter_object))
+- `ip_filter_string` (List of String) Allow incoming connections from CIDR address block, e.g. '10.20.0.0/16'.
 - `project_to_fork_from` (String) Name of another project to fork a service from. This has effect only when a new service is being created.
 - `service_to_fork_from` (String) Name of another service to fork from. This has effect only when a new service is being created.
 

--- a/docs/resources/flink.md
+++ b/docs/resources/flink.md
@@ -84,6 +84,7 @@ Optional:
 - `flink_version` (String) Flink major version.
 - `ip_filter` (List of String, Deprecated) Allow incoming connections from CIDR address block, e.g. '10.20.0.0/16'.
 - `ip_filter_object` (Block List, Max: 1024) Allow incoming connections from CIDR address block, e.g. '10.20.0.0/16'. (see [below for nested schema](#nestedblock--flink_user_config--ip_filter_object))
+- `ip_filter_string` (List of String) Allow incoming connections from CIDR address block, e.g. '10.20.0.0/16'.
 - `number_of_task_slots` (Number) Task slots per node. For a 3 node plan, total number of task slots is 3x this value.
 - `privatelink_access` (Block List, Max: 1) Allow access to selected service components through Privatelink. (see [below for nested schema](#nestedblock--flink_user_config--privatelink_access))
 

--- a/docs/resources/grafana.md
+++ b/docs/resources/grafana.md
@@ -103,6 +103,7 @@ Optional:
 - `google_analytics_ua_id` (String) Google Analytics ID.
 - `ip_filter` (List of String, Deprecated) Allow incoming connections from CIDR address block, e.g. '10.20.0.0/16'.
 - `ip_filter_object` (Block List, Max: 1024) Allow incoming connections from CIDR address block, e.g. '10.20.0.0/16'. (see [below for nested schema](#nestedblock--grafana_user_config--ip_filter_object))
+- `ip_filter_string` (List of String) Allow incoming connections from CIDR address block, e.g. '10.20.0.0/16'.
 - `metrics_enabled` (Boolean) Enable Grafana /metrics endpoint.
 - `private_access` (Block List, Max: 1) Allow access to selected service ports from private networks. (see [below for nested schema](#nestedblock--grafana_user_config--private_access))
 - `privatelink_access` (Block List, Max: 1) Allow access to selected service components through Privatelink. (see [below for nested schema](#nestedblock--grafana_user_config--privatelink_access))

--- a/docs/resources/influxdb.md
+++ b/docs/resources/influxdb.md
@@ -80,6 +80,7 @@ Optional:
 - `influxdb` (Block List, Max: 1) influxdb.conf configuration values. (see [below for nested schema](#nestedblock--influxdb_user_config--influxdb))
 - `ip_filter` (List of String, Deprecated) Allow incoming connections from CIDR address block, e.g. '10.20.0.0/16'.
 - `ip_filter_object` (Block List, Max: 1024) Allow incoming connections from CIDR address block, e.g. '10.20.0.0/16'. (see [below for nested schema](#nestedblock--influxdb_user_config--ip_filter_object))
+- `ip_filter_string` (List of String) Allow incoming connections from CIDR address block, e.g. '10.20.0.0/16'.
 - `private_access` (Block List, Max: 1) Allow access to selected service ports from private networks. (see [below for nested schema](#nestedblock--influxdb_user_config--private_access))
 - `privatelink_access` (Block List, Max: 1) Allow access to selected service components through Privatelink. (see [below for nested schema](#nestedblock--influxdb_user_config--privatelink_access))
 - `project_to_fork_from` (String) Name of another project to fork a service from. This has effect only when a new service is being created.

--- a/docs/resources/kafka.md
+++ b/docs/resources/kafka.md
@@ -104,6 +104,7 @@ Optional:
 - `custom_domain` (String) Serve the web frontend using a custom CNAME pointing to the Aiven DNS name.
 - `ip_filter` (List of String, Deprecated) Allow incoming connections from CIDR address block, e.g. '10.20.0.0/16'.
 - `ip_filter_object` (Block List, Max: 1024) Allow incoming connections from CIDR address block, e.g. '10.20.0.0/16'. (see [below for nested schema](#nestedblock--kafka_user_config--ip_filter_object))
+- `ip_filter_string` (List of String) Allow incoming connections from CIDR address block, e.g. '10.20.0.0/16'.
 - `kafka` (Block List, Max: 1) Kafka broker configuration values. (see [below for nested schema](#nestedblock--kafka_user_config--kafka))
 - `kafka_authentication_methods` (Block List, Max: 1) Kafka authentication methods. (see [below for nested schema](#nestedblock--kafka_user_config--kafka_authentication_methods))
 - `kafka_connect` (Boolean) Enable Kafka Connect service. The default value is `false`.

--- a/docs/resources/kafka_connect.md
+++ b/docs/resources/kafka_connect.md
@@ -82,6 +82,7 @@ Optional:
 - `additional_backup_regions` (List of String) Additional Cloud Regions for Backup Replication.
 - `ip_filter` (List of String, Deprecated) Allow incoming connections from CIDR address block, e.g. '10.20.0.0/16'.
 - `ip_filter_object` (Block List, Max: 1024) Allow incoming connections from CIDR address block, e.g. '10.20.0.0/16'. (see [below for nested schema](#nestedblock--kafka_connect_user_config--ip_filter_object))
+- `ip_filter_string` (List of String) Allow incoming connections from CIDR address block, e.g. '10.20.0.0/16'.
 - `kafka_connect` (Block List, Max: 1) Kafka Connect configuration values. (see [below for nested schema](#nestedblock--kafka_connect_user_config--kafka_connect))
 - `private_access` (Block List, Max: 1) Allow access to selected service ports from private networks. (see [below for nested schema](#nestedblock--kafka_connect_user_config--private_access))
 - `privatelink_access` (Block List, Max: 1) Allow access to selected service components through Privatelink. (see [below for nested schema](#nestedblock--kafka_connect_user_config--privatelink_access))

--- a/docs/resources/kafka_mirrormaker.md
+++ b/docs/resources/kafka_mirrormaker.md
@@ -80,6 +80,7 @@ Optional:
 - `additional_backup_regions` (List of String) Additional Cloud Regions for Backup Replication.
 - `ip_filter` (List of String, Deprecated) Allow incoming connections from CIDR address block, e.g. '10.20.0.0/16'.
 - `ip_filter_object` (Block List, Max: 1024) Allow incoming connections from CIDR address block, e.g. '10.20.0.0/16'. (see [below for nested schema](#nestedblock--kafka_mirrormaker_user_config--ip_filter_object))
+- `ip_filter_string` (List of String) Allow incoming connections from CIDR address block, e.g. '10.20.0.0/16'.
 - `kafka_mirrormaker` (Block List, Max: 1) Kafka MirrorMaker configuration values. (see [below for nested schema](#nestedblock--kafka_mirrormaker_user_config--kafka_mirrormaker))
 - `static_ips` (Boolean) Use static public IP addresses.
 

--- a/docs/resources/m3aggregator.md
+++ b/docs/resources/m3aggregator.md
@@ -76,6 +76,7 @@ Optional:
 - `custom_domain` (String) Serve the web frontend using a custom CNAME pointing to the Aiven DNS name.
 - `ip_filter` (List of String, Deprecated) Allow incoming connections from CIDR address block, e.g. '10.20.0.0/16'.
 - `ip_filter_object` (Block List, Max: 1024) Allow incoming connections from CIDR address block, e.g. '10.20.0.0/16'. (see [below for nested schema](#nestedblock--m3aggregator_user_config--ip_filter_object))
+- `ip_filter_string` (List of String) Allow incoming connections from CIDR address block, e.g. '10.20.0.0/16'.
 - `m3_version` (String, Deprecated) M3 major version (deprecated, use m3aggregator_version).
 - `m3aggregator_version` (String) M3 major version (the minimum compatible version).
 - `static_ips` (Boolean) Use static public IP addresses.

--- a/docs/resources/m3db.md
+++ b/docs/resources/m3db.md
@@ -82,12 +82,13 @@ Optional:
 - `custom_domain` (String) Serve the web frontend using a custom CNAME pointing to the Aiven DNS name.
 - `ip_filter` (List of String, Deprecated) Allow incoming connections from CIDR address block, e.g. '10.20.0.0/16'.
 - `ip_filter_object` (Block List, Max: 1024) Allow incoming connections from CIDR address block, e.g. '10.20.0.0/16'. (see [below for nested schema](#nestedblock--m3db_user_config--ip_filter_object))
+- `ip_filter_string` (List of String) Allow incoming connections from CIDR address block, e.g. '10.20.0.0/16'.
 - `limits` (Block List, Max: 1) M3 limits. (see [below for nested schema](#nestedblock--m3db_user_config--limits))
 - `m3` (Block List, Max: 1) M3 specific configuration options. (see [below for nested schema](#nestedblock--m3db_user_config--m3))
 - `m3_version` (String, Deprecated) M3 major version (deprecated, use m3db_version).
 - `m3coordinator_enable_graphite_carbon_ingest` (Boolean) Enables access to Graphite Carbon plaintext metrics ingestion. It can be enabled only for services inside VPCs. The metrics are written to aggregated namespaces only.
 - `m3db_version` (String) M3 major version (the minimum compatible version).
-- `namespaces` (Block List, Max: 2147483647, Deprecated) List of M3 namespaces. (see [below for nested schema](#nestedblock--m3db_user_config--namespaces))
+- `namespaces` (Block List, Max: 2147483647) List of M3 namespaces. (see [below for nested schema](#nestedblock--m3db_user_config--namespaces))
 - `private_access` (Block List, Max: 1) Allow access to selected service ports from private networks. (see [below for nested schema](#nestedblock--m3db_user_config--private_access))
 - `project_to_fork_from` (String) Name of another project to fork a service from. This has effect only when a new service is being created.
 - `public_access` (Block List, Max: 1) Allow access to selected service ports from the public Internet. (see [below for nested schema](#nestedblock--m3db_user_config--public_access))
@@ -210,6 +211,7 @@ Optional:
 - `name` (String) The (optional) name of the rule.
 - `namespaces` (List of String, Deprecated) This rule will be used to store the metrics in the given namespace(s). If a namespace is target of rules, the global default aggregation will be automatically disabled. Note that specifying filters that match no namespaces whatsoever will be returned as an error. Filter the namespace by glob (=wildcards).
 - `namespaces_object` (Block List, Max: 10) This rule will be used to store the metrics in the given namespace(s). If a namespace is target of rules, the global default aggregation will be automatically disabled. Note that specifying filters that match no namespaces whatsoever will be returned as an error. Filter the namespace by exact match of retention period and resolution. (see [below for nested schema](#nestedblock--m3db_user_config--rules--mapping--namespaces_object))
+- `namespaces_string` (List of String) This rule will be used to store the metrics in the given namespace(s). If a namespace is target of rules, the global default aggregation will be automatically disabled. Note that specifying filters that match no namespaces whatsoever will be returned as an error. Filter the namespace by glob (=wildcards).
 - `tags` (Block List, Max: 10) List of tags to be appended to matching metrics. (see [below for nested schema](#nestedblock--m3db_user_config--rules--mapping--tags))
 
 <a id="nestedblock--m3db_user_config--rules--mapping--namespaces_object"></a>

--- a/docs/resources/mysql.md
+++ b/docs/resources/mysql.md
@@ -90,6 +90,7 @@ Optional:
 - `binlog_retention_period` (Number) The minimum amount of time in seconds to keep binlog entries before deletion. This may be extended for services that require binlog entries for longer than the default for example if using the MySQL Debezium Kafka connector.
 - `ip_filter` (List of String, Deprecated) Allow incoming connections from CIDR address block, e.g. '10.20.0.0/16'.
 - `ip_filter_object` (Block List, Max: 1024) Allow incoming connections from CIDR address block, e.g. '10.20.0.0/16'. (see [below for nested schema](#nestedblock--mysql_user_config--ip_filter_object))
+- `ip_filter_string` (List of String) Allow incoming connections from CIDR address block, e.g. '10.20.0.0/16'.
 - `migration` (Block List, Max: 1) Migrate data from existing server. (see [below for nested schema](#nestedblock--mysql_user_config--migration))
 - `mysql` (Block List, Max: 1) mysql.conf configuration values. (see [below for nested schema](#nestedblock--mysql_user_config--mysql))
 - `mysql_version` (String) MySQL major version.

--- a/docs/resources/opensearch.md
+++ b/docs/resources/opensearch.md
@@ -90,6 +90,7 @@ Optional:
 - `index_template` (Block List, Max: 1) Template settings for all new indexes. (see [below for nested schema](#nestedblock--opensearch_user_config--index_template))
 - `ip_filter` (List of String, Deprecated) Allow incoming connections from CIDR address block, e.g. '10.20.0.0/16'.
 - `ip_filter_object` (Block List, Max: 1024) Allow incoming connections from CIDR address block, e.g. '10.20.0.0/16'. (see [below for nested schema](#nestedblock--opensearch_user_config--ip_filter_object))
+- `ip_filter_string` (List of String) Allow incoming connections from CIDR address block, e.g. '10.20.0.0/16'.
 - `keep_index_refresh_interval` (Boolean) Aiven automation resets index.refresh_interval to default value for every index to be sure that indices are always visible to search. If it doesn't fit your case, you can disable this by setting up this flag to true.
 - `max_index_count` (Number, Deprecated) Use index_patterns instead. The default value is `0`.
 - `opensearch` (Block List, Max: 1) OpenSearch settings. (see [below for nested schema](#nestedblock--opensearch_user_config--opensearch))

--- a/docs/resources/pg.md
+++ b/docs/resources/pg.md
@@ -123,6 +123,7 @@ Optional:
 - `enable_ipv6` (Boolean) Register AAAA DNS records for the service, and allow IPv6 packets to service ports.
 - `ip_filter` (List of String, Deprecated) Allow incoming connections from CIDR address block, e.g. '10.20.0.0/16'.
 - `ip_filter_object` (Block List, Max: 1024) Allow incoming connections from CIDR address block, e.g. '10.20.0.0/16'. (see [below for nested schema](#nestedblock--pg_user_config--ip_filter_object))
+- `ip_filter_string` (List of String) Allow incoming connections from CIDR address block, e.g. '10.20.0.0/16'.
 - `migration` (Block List, Max: 1) Migrate data from existing server. (see [below for nested schema](#nestedblock--pg_user_config--migration))
 - `pg` (Block List, Max: 1) postgresql.conf configuration values. (see [below for nested schema](#nestedblock--pg_user_config--pg))
 - `pg_read_replica` (Boolean, Deprecated) Use read_replica service integration instead.

--- a/docs/resources/redis.md
+++ b/docs/resources/redis.md
@@ -80,6 +80,7 @@ Optional:
 - `additional_backup_regions` (List of String) Additional Cloud Regions for Backup Replication.
 - `ip_filter` (List of String, Deprecated) Allow incoming connections from CIDR address block, e.g. '10.20.0.0/16'.
 - `ip_filter_object` (Block List, Max: 1024) Allow incoming connections from CIDR address block, e.g. '10.20.0.0/16'. (see [below for nested schema](#nestedblock--redis_user_config--ip_filter_object))
+- `ip_filter_string` (List of String) Allow incoming connections from CIDR address block, e.g. '10.20.0.0/16'.
 - `migration` (Block List, Max: 1) Migrate data from existing server. (see [below for nested schema](#nestedblock--redis_user_config--migration))
 - `private_access` (Block List, Max: 1) Allow access to selected service ports from private networks. (see [below for nested schema](#nestedblock--redis_user_config--private_access))
 - `privatelink_access` (Block List, Max: 1) Allow access to selected service components through Privatelink. (see [below for nested schema](#nestedblock--redis_user_config--privatelink_access))

--- a/internal/schemautil/mutations.go
+++ b/internal/schemautil/mutations.go
@@ -27,17 +27,25 @@ func normalizeIPFilter(old, new map[string]interface{}) {
 	if oldIPFilters == nil || newIPFilters == nil {
 		var ok bool
 
-		oldIPFilters, ok = old["ip_filter_object"].([]interface{})
-		if !ok {
-			return
-		}
+		oldIPFilters, _ = old["ip_filter_string"].([]interface{})
 
-		newIPFilters, ok = new["ip_filter_object"].([]interface{})
-		if !ok {
-			return
-		}
+		newIPFilters, ok = new["ip_filter_string"].([]interface{})
 
-		fieldToWrite = "ip_filter_object"
+		fieldToWrite = "ip_filter_string"
+
+		if !ok {
+			oldIPFilters, ok = old["ip_filter_object"].([]interface{})
+			if !ok {
+				return
+			}
+
+			newIPFilters, ok = new["ip_filter_object"].([]interface{})
+			if !ok {
+				return
+			}
+
+			fieldToWrite = "ip_filter_object"
+		}
 	}
 
 	var normalizedIPFilters []interface{}
@@ -55,7 +63,7 @@ func normalizeIPFilter(old, new map[string]interface{}) {
 			var comparableN interface{}
 
 			// If we're dealing with a string format, we need to compare the values directly.
-			if fieldToWrite == "ip_filter" {
+			if fieldToWrite == "ip_filter" || fieldToWrite == "ip_filter_string" {
 				comparableO = o
 
 				comparableN = n
@@ -91,7 +99,7 @@ func normalizeIPFilter(old, new map[string]interface{}) {
 
 			var comparableN interface{}
 
-			if fieldToWrite == "ip_filter" {
+			if fieldToWrite == "ip_filter" || fieldToWrite == "ip_filter_string" {
 				comparableO = o
 
 				comparableN = n
@@ -114,4 +122,30 @@ func normalizeIPFilter(old, new map[string]interface{}) {
 	}
 
 	new[fieldToWrite] = append(normalizedIPFilters, nonexistentIPFilters...)
+}
+
+// stringSuffixForIPFilters adds a _string suffix to the IP filters.
+func stringSuffixForIPFilters(new map[string]interface{}) {
+	ipFilters := new["ip_filter"].([]interface{})
+
+	if ipFilters == nil {
+		return
+	}
+
+	new["ip_filter_string"] = ipFilters
+
+	new["ip_filter"] = nil
+}
+
+// stringSuffixForNamespaces adds a _string suffix to the namespaces.
+func stringSuffixForNamespaces(new map[string]interface{}) {
+	namespaces := new["namespaces"].([]interface{})
+
+	if namespaces == nil {
+		return
+	}
+
+	new["namespace_string"] = namespaces
+
+	new["namespaces"] = nil
 }

--- a/internal/schemautil/service.go
+++ b/internal/schemautil/service.go
@@ -674,6 +674,15 @@ func copyServicePropertiesFromAPIResponseToTerraform(
 		// TODO: Remove when the remote schema in Aiven begins to contain information about sensitive fields.
 		copySensitiveFields(oldUserConfigFirst, newUserConfigFirst)
 
+		// TODO: Remove when we no longer need to support the deprecated `ip_filter` field.
+		if _, exists := d.GetOk(serviceType + "_user_config.0.ip_filter_string"); exists {
+			stringSuffixForIPFilters(newUserConfigFirst)
+		}
+
+		if _, exists := d.GetOk(serviceType + "_user_config.0.rules.0.mapping.0.namespaces_string"); exists {
+			stringSuffixForNamespaces(newUserConfigFirst)
+		}
+
 		normalizeIPFilter(oldUserConfigFirst, newUserConfigFirst)
 	}
 

--- a/internal/schemautil/userconfig/dist/service_types.go
+++ b/internal/schemautil/userconfig/dist/service_types.go
@@ -63,7 +63,7 @@ func ServiceTypeCassandra() *schema.Schema {
 			Type:        schema.TypeString,
 		},
 		"ip_filter": {
-			Deprecated:       "This will be removed in v5.0.0 and replaced with ip_filter_string instead.",
+			Deprecated:       "This will be removed in v5.0.0 and replaced with ip_filter_string instead. When switching to ip_filter_string, please apply the changes twice due to technical limitations.",
 			Description:      "Allow incoming connections from CIDR address block, e.g. '10.20.0.0/16'.",
 			DiffSuppressFunc: schemautil.IPFilterArrayDiffSuppressFunc,
 			Elem: &schema.Schema{
@@ -88,6 +88,17 @@ func ServiceTypeCassandra() *schema.Schema {
 					Type:        schema.TypeString,
 				},
 			}},
+			MaxItems: 1024,
+			Optional: true,
+			Type:     schema.TypeList,
+		},
+		"ip_filter_string": {
+			Description:      "Allow incoming connections from CIDR address block, e.g. '10.20.0.0/16'.",
+			DiffSuppressFunc: schemautil.IPFilterArrayDiffSuppressFunc,
+			Elem: &schema.Schema{
+				DiffSuppressFunc: schemautil.IPFilterValueDiffSuppressFunc,
+				Type:             schema.TypeString,
+			},
 			MaxItems: 1024,
 			Optional: true,
 			Type:     schema.TypeList,
@@ -174,7 +185,7 @@ func ServiceTypeClickhouse() *schema.Schema {
 			Type:        schema.TypeList,
 		},
 		"ip_filter": {
-			Deprecated:       "This will be removed in v5.0.0 and replaced with ip_filter_string instead.",
+			Deprecated:       "This will be removed in v5.0.0 and replaced with ip_filter_string instead. When switching to ip_filter_string, please apply the changes twice due to technical limitations.",
 			Description:      "Allow incoming connections from CIDR address block, e.g. '10.20.0.0/16'.",
 			DiffSuppressFunc: schemautil.IPFilterArrayDiffSuppressFunc,
 			Elem: &schema.Schema{
@@ -199,6 +210,17 @@ func ServiceTypeClickhouse() *schema.Schema {
 					Type:        schema.TypeString,
 				},
 			}},
+			MaxItems: 1024,
+			Optional: true,
+			Type:     schema.TypeList,
+		},
+		"ip_filter_string": {
+			Description:      "Allow incoming connections from CIDR address block, e.g. '10.20.0.0/16'.",
+			DiffSuppressFunc: schemautil.IPFilterArrayDiffSuppressFunc,
+			Elem: &schema.Schema{
+				DiffSuppressFunc: schemautil.IPFilterValueDiffSuppressFunc,
+				Type:             schema.TypeString,
+			},
 			MaxItems: 1024,
 			Optional: true,
 			Type:     schema.TypeList,
@@ -644,7 +666,7 @@ func ServiceTypeElasticsearch() *schema.Schema {
 			Type:     schema.TypeList,
 		},
 		"ip_filter": {
-			Deprecated:       "This will be removed in v5.0.0 and replaced with ip_filter_string instead.",
+			Deprecated:       "This will be removed in v5.0.0 and replaced with ip_filter_string instead. When switching to ip_filter_string, please apply the changes twice due to technical limitations.",
 			Description:      "Allow incoming connections from CIDR address block, e.g. '10.20.0.0/16'.",
 			DiffSuppressFunc: schemautil.IPFilterArrayDiffSuppressFunc,
 			Elem: &schema.Schema{
@@ -669,6 +691,17 @@ func ServiceTypeElasticsearch() *schema.Schema {
 					Type:        schema.TypeString,
 				},
 			}},
+			MaxItems: 1024,
+			Optional: true,
+			Type:     schema.TypeList,
+		},
+		"ip_filter_string": {
+			Description:      "Allow incoming connections from CIDR address block, e.g. '10.20.0.0/16'.",
+			DiffSuppressFunc: schemautil.IPFilterArrayDiffSuppressFunc,
+			Elem: &schema.Schema{
+				DiffSuppressFunc: schemautil.IPFilterValueDiffSuppressFunc,
+				Type:             schema.TypeString,
+			},
 			MaxItems: 1024,
 			Optional: true,
 			Type:     schema.TypeList,
@@ -899,7 +932,7 @@ func ServiceTypeFlink() *schema.Schema {
 			Type:        schema.TypeString,
 		},
 		"ip_filter": {
-			Deprecated:       "This will be removed in v5.0.0 and replaced with ip_filter_string instead.",
+			Deprecated:       "This will be removed in v5.0.0 and replaced with ip_filter_string instead. When switching to ip_filter_string, please apply the changes twice due to technical limitations.",
 			Description:      "Allow incoming connections from CIDR address block, e.g. '10.20.0.0/16'.",
 			DiffSuppressFunc: schemautil.IPFilterArrayDiffSuppressFunc,
 			Elem: &schema.Schema{
@@ -924,6 +957,17 @@ func ServiceTypeFlink() *schema.Schema {
 					Type:        schema.TypeString,
 				},
 			}},
+			MaxItems: 1024,
+			Optional: true,
+			Type:     schema.TypeList,
+		},
+		"ip_filter_string": {
+			Description:      "Allow incoming connections from CIDR address block, e.g. '10.20.0.0/16'.",
+			DiffSuppressFunc: schemautil.IPFilterArrayDiffSuppressFunc,
+			Elem: &schema.Schema{
+				DiffSuppressFunc: schemautil.IPFilterValueDiffSuppressFunc,
+				Type:             schema.TypeString,
+			},
 			MaxItems: 1024,
 			Optional: true,
 			Type:     schema.TypeList,
@@ -1622,7 +1666,7 @@ func ServiceTypeGrafana() *schema.Schema {
 			Type:        schema.TypeString,
 		},
 		"ip_filter": {
-			Deprecated:       "This will be removed in v5.0.0 and replaced with ip_filter_string instead.",
+			Deprecated:       "This will be removed in v5.0.0 and replaced with ip_filter_string instead. When switching to ip_filter_string, please apply the changes twice due to technical limitations.",
 			Description:      "Allow incoming connections from CIDR address block, e.g. '10.20.0.0/16'.",
 			DiffSuppressFunc: schemautil.IPFilterArrayDiffSuppressFunc,
 			Elem: &schema.Schema{
@@ -1647,6 +1691,17 @@ func ServiceTypeGrafana() *schema.Schema {
 					Type:        schema.TypeString,
 				},
 			}},
+			MaxItems: 1024,
+			Optional: true,
+			Type:     schema.TypeList,
+		},
+		"ip_filter_string": {
+			Description:      "Allow incoming connections from CIDR address block, e.g. '10.20.0.0/16'.",
+			DiffSuppressFunc: schemautil.IPFilterArrayDiffSuppressFunc,
+			Elem: &schema.Schema{
+				DiffSuppressFunc: schemautil.IPFilterValueDiffSuppressFunc,
+				Type:             schema.TypeString,
+			},
 			MaxItems: 1024,
 			Optional: true,
 			Type:     schema.TypeList,
@@ -1931,7 +1986,7 @@ func ServiceTypeInfluxdb() *schema.Schema {
 			Type:     schema.TypeList,
 		},
 		"ip_filter": {
-			Deprecated:       "This will be removed in v5.0.0 and replaced with ip_filter_string instead.",
+			Deprecated:       "This will be removed in v5.0.0 and replaced with ip_filter_string instead. When switching to ip_filter_string, please apply the changes twice due to technical limitations.",
 			Description:      "Allow incoming connections from CIDR address block, e.g. '10.20.0.0/16'.",
 			DiffSuppressFunc: schemautil.IPFilterArrayDiffSuppressFunc,
 			Elem: &schema.Schema{
@@ -1956,6 +2011,17 @@ func ServiceTypeInfluxdb() *schema.Schema {
 					Type:        schema.TypeString,
 				},
 			}},
+			MaxItems: 1024,
+			Optional: true,
+			Type:     schema.TypeList,
+		},
+		"ip_filter_string": {
+			Description:      "Allow incoming connections from CIDR address block, e.g. '10.20.0.0/16'.",
+			DiffSuppressFunc: schemautil.IPFilterArrayDiffSuppressFunc,
+			Elem: &schema.Schema{
+				DiffSuppressFunc: schemautil.IPFilterValueDiffSuppressFunc,
+				Type:             schema.TypeString,
+			},
 			MaxItems: 1024,
 			Optional: true,
 			Type:     schema.TypeList,
@@ -2058,7 +2124,7 @@ func ServiceTypeKafka() *schema.Schema {
 			Type:        schema.TypeString,
 		},
 		"ip_filter": {
-			Deprecated:       "This will be removed in v5.0.0 and replaced with ip_filter_string instead.",
+			Deprecated:       "This will be removed in v5.0.0 and replaced with ip_filter_string instead. When switching to ip_filter_string, please apply the changes twice due to technical limitations.",
 			Description:      "Allow incoming connections from CIDR address block, e.g. '10.20.0.0/16'.",
 			DiffSuppressFunc: schemautil.IPFilterArrayDiffSuppressFunc,
 			Elem: &schema.Schema{
@@ -2083,6 +2149,17 @@ func ServiceTypeKafka() *schema.Schema {
 					Type:        schema.TypeString,
 				},
 			}},
+			MaxItems: 1024,
+			Optional: true,
+			Type:     schema.TypeList,
+		},
+		"ip_filter_string": {
+			Description:      "Allow incoming connections from CIDR address block, e.g. '10.20.0.0/16'.",
+			DiffSuppressFunc: schemautil.IPFilterArrayDiffSuppressFunc,
+			Elem: &schema.Schema{
+				DiffSuppressFunc: schemautil.IPFilterValueDiffSuppressFunc,
+				Type:             schema.TypeString,
+			},
 			MaxItems: 1024,
 			Optional: true,
 			Type:     schema.TypeList,
@@ -3049,7 +3126,7 @@ func ServiceTypeKafkaConnect() *schema.Schema {
 			Type:        schema.TypeList,
 		},
 		"ip_filter": {
-			Deprecated:       "This will be removed in v5.0.0 and replaced with ip_filter_string instead.",
+			Deprecated:       "This will be removed in v5.0.0 and replaced with ip_filter_string instead. When switching to ip_filter_string, please apply the changes twice due to technical limitations.",
 			Description:      "Allow incoming connections from CIDR address block, e.g. '10.20.0.0/16'.",
 			DiffSuppressFunc: schemautil.IPFilterArrayDiffSuppressFunc,
 			Elem: &schema.Schema{
@@ -3074,6 +3151,17 @@ func ServiceTypeKafkaConnect() *schema.Schema {
 					Type:        schema.TypeString,
 				},
 			}},
+			MaxItems: 1024,
+			Optional: true,
+			Type:     schema.TypeList,
+		},
+		"ip_filter_string": {
+			Description:      "Allow incoming connections from CIDR address block, e.g. '10.20.0.0/16'.",
+			DiffSuppressFunc: schemautil.IPFilterArrayDiffSuppressFunc,
+			Elem: &schema.Schema{
+				DiffSuppressFunc: schemautil.IPFilterValueDiffSuppressFunc,
+				Type:             schema.TypeString,
+			},
 			MaxItems: 1024,
 			Optional: true,
 			Type:     schema.TypeList,
@@ -3366,7 +3454,7 @@ func ServiceTypeKafkaMirrormaker() *schema.Schema {
 			Type:        schema.TypeList,
 		},
 		"ip_filter": {
-			Deprecated:       "This will be removed in v5.0.0 and replaced with ip_filter_string instead.",
+			Deprecated:       "This will be removed in v5.0.0 and replaced with ip_filter_string instead. When switching to ip_filter_string, please apply the changes twice due to technical limitations.",
 			Description:      "Allow incoming connections from CIDR address block, e.g. '10.20.0.0/16'.",
 			DiffSuppressFunc: schemautil.IPFilterArrayDiffSuppressFunc,
 			Elem: &schema.Schema{
@@ -3391,6 +3479,17 @@ func ServiceTypeKafkaMirrormaker() *schema.Schema {
 					Type:        schema.TypeString,
 				},
 			}},
+			MaxItems: 1024,
+			Optional: true,
+			Type:     schema.TypeList,
+		},
+		"ip_filter_string": {
+			Description:      "Allow incoming connections from CIDR address block, e.g. '10.20.0.0/16'.",
+			DiffSuppressFunc: schemautil.IPFilterArrayDiffSuppressFunc,
+			Elem: &schema.Schema{
+				DiffSuppressFunc: schemautil.IPFilterValueDiffSuppressFunc,
+				Type:             schema.TypeString,
+			},
 			MaxItems: 1024,
 			Optional: true,
 			Type:     schema.TypeList,
@@ -3533,7 +3632,7 @@ func ServiceTypeM3aggregator() *schema.Schema {
 			Type:        schema.TypeString,
 		},
 		"ip_filter": {
-			Deprecated:       "This will be removed in v5.0.0 and replaced with ip_filter_string instead.",
+			Deprecated:       "This will be removed in v5.0.0 and replaced with ip_filter_string instead. When switching to ip_filter_string, please apply the changes twice due to technical limitations.",
 			Description:      "Allow incoming connections from CIDR address block, e.g. '10.20.0.0/16'.",
 			DiffSuppressFunc: schemautil.IPFilterArrayDiffSuppressFunc,
 			Elem: &schema.Schema{
@@ -3558,6 +3657,17 @@ func ServiceTypeM3aggregator() *schema.Schema {
 					Type:        schema.TypeString,
 				},
 			}},
+			MaxItems: 1024,
+			Optional: true,
+			Type:     schema.TypeList,
+		},
+		"ip_filter_string": {
+			Description:      "Allow incoming connections from CIDR address block, e.g. '10.20.0.0/16'.",
+			DiffSuppressFunc: schemautil.IPFilterArrayDiffSuppressFunc,
+			Elem: &schema.Schema{
+				DiffSuppressFunc: schemautil.IPFilterValueDiffSuppressFunc,
+				Type:             schema.TypeString,
+			},
 			MaxItems: 1024,
 			Optional: true,
 			Type:     schema.TypeList,
@@ -3606,7 +3716,7 @@ func ServiceTypeM3db() *schema.Schema {
 			Type:        schema.TypeString,
 		},
 		"ip_filter": {
-			Deprecated:       "This will be removed in v5.0.0 and replaced with ip_filter_string instead.",
+			Deprecated:       "This will be removed in v5.0.0 and replaced with ip_filter_string instead. When switching to ip_filter_string, please apply the changes twice due to technical limitations.",
 			Description:      "Allow incoming connections from CIDR address block, e.g. '10.20.0.0/16'.",
 			DiffSuppressFunc: schemautil.IPFilterArrayDiffSuppressFunc,
 			Elem: &schema.Schema{
@@ -3631,6 +3741,17 @@ func ServiceTypeM3db() *schema.Schema {
 					Type:        schema.TypeString,
 				},
 			}},
+			MaxItems: 1024,
+			Optional: true,
+			Type:     schema.TypeList,
+		},
+		"ip_filter_string": {
+			Description:      "Allow incoming connections from CIDR address block, e.g. '10.20.0.0/16'.",
+			DiffSuppressFunc: schemautil.IPFilterArrayDiffSuppressFunc,
+			Elem: &schema.Schema{
+				DiffSuppressFunc: schemautil.IPFilterValueDiffSuppressFunc,
+				Type:             schema.TypeString,
+			},
 			MaxItems: 1024,
 			Optional: true,
 			Type:     schema.TypeList,
@@ -3788,7 +3909,6 @@ func ServiceTypeM3db() *schema.Schema {
 			Type:        schema.TypeString,
 		},
 		"namespaces": {
-			Deprecated:  "This will be removed in v5.0.0 and replaced with namespaces_string instead.",
 			Description: "List of M3 namespaces.",
 			Elem: &schema.Resource{Schema: map[string]*schema.Schema{
 				"name": {
@@ -4027,7 +4147,7 @@ func ServiceTypeM3db() *schema.Schema {
 						Type:        schema.TypeString,
 					},
 					"namespaces": {
-						Deprecated:  "This will be removed in v5.0.0 and replaced with namespaces_string instead.",
+						Deprecated:  "This will be removed in v5.0.0 and replaced with namespaces_string instead. When switching to namespaces_string, please apply the changes twice due to technical limitations.",
 						Description: "This rule will be used to store the metrics in the given namespace(s). If a namespace is target of rules, the global default aggregation will be automatically disabled. Note that specifying filters that match no namespaces whatsoever will be returned as an error. Filter the namespace by glob (=wildcards).",
 						Elem:        &schema.Schema{Type: schema.TypeString},
 						MaxItems:    10,
@@ -4051,6 +4171,13 @@ func ServiceTypeM3db() *schema.Schema {
 						MaxItems: 10,
 						Optional: true,
 						Type:     schema.TypeList,
+					},
+					"namespaces_string": {
+						Description: "This rule will be used to store the metrics in the given namespace(s). If a namespace is target of rules, the global default aggregation will be automatically disabled. Note that specifying filters that match no namespaces whatsoever will be returned as an error. Filter the namespace by glob (=wildcards).",
+						Elem:        &schema.Schema{Type: schema.TypeString},
+						MaxItems:    10,
+						Optional:    true,
+						Type:        schema.TypeList,
 					},
 					"tags": {
 						Description: "List of tags to be appended to matching metrics.",
@@ -4101,7 +4228,7 @@ func ServiceTypeM3db() *schema.Schema {
 						Type:        schema.TypeString,
 					},
 					"namespaces": {
-						Deprecated:  "This will be removed in v5.0.0 and replaced with namespaces_string instead.",
+						Deprecated:  "This will be removed in v5.0.0 and replaced with namespaces_string instead. When switching to namespaces_string, please apply the changes twice due to technical limitations.",
 						Description: "This rule will be used to store the metrics in the given namespace(s). If a namespace is target of rules, the global default aggregation will be automatically disabled. Note that specifying filters that match no namespaces whatsoever will be returned as an error. Filter the namespace by glob (=wildcards).",
 						Elem:        &schema.Schema{Type: schema.TypeString},
 						MaxItems:    10,
@@ -4125,6 +4252,13 @@ func ServiceTypeM3db() *schema.Schema {
 						MaxItems: 10,
 						Optional: true,
 						Type:     schema.TypeList,
+					},
+					"namespaces_string": {
+						Description: "This rule will be used to store the metrics in the given namespace(s). If a namespace is target of rules, the global default aggregation will be automatically disabled. Note that specifying filters that match no namespaces whatsoever will be returned as an error. Filter the namespace by glob (=wildcards).",
+						Elem:        &schema.Schema{Type: schema.TypeString},
+						MaxItems:    10,
+						Optional:    true,
+						Type:        schema.TypeList,
 					},
 					"tags": {
 						Description: "List of tags to be appended to matching metrics.",
@@ -4215,7 +4349,7 @@ func ServiceTypeMysql() *schema.Schema {
 			Type:        schema.TypeInt,
 		},
 		"ip_filter": {
-			Deprecated:       "This will be removed in v5.0.0 and replaced with ip_filter_string instead.",
+			Deprecated:       "This will be removed in v5.0.0 and replaced with ip_filter_string instead. When switching to ip_filter_string, please apply the changes twice due to technical limitations.",
 			Description:      "Allow incoming connections from CIDR address block, e.g. '10.20.0.0/16'.",
 			DiffSuppressFunc: schemautil.IPFilterArrayDiffSuppressFunc,
 			Elem: &schema.Schema{
@@ -4240,6 +4374,17 @@ func ServiceTypeMysql() *schema.Schema {
 					Type:        schema.TypeString,
 				},
 			}},
+			MaxItems: 1024,
+			Optional: true,
+			Type:     schema.TypeList,
+		},
+		"ip_filter_string": {
+			Description:      "Allow incoming connections from CIDR address block, e.g. '10.20.0.0/16'.",
+			DiffSuppressFunc: schemautil.IPFilterArrayDiffSuppressFunc,
+			Elem: &schema.Schema{
+				DiffSuppressFunc: schemautil.IPFilterValueDiffSuppressFunc,
+				Type:             schema.TypeString,
+			},
 			MaxItems: 1024,
 			Optional: true,
 			Type:     schema.TypeList,
@@ -4894,7 +5039,7 @@ func ServiceTypeOpensearch() *schema.Schema {
 			Type:     schema.TypeList,
 		},
 		"ip_filter": {
-			Deprecated:       "This will be removed in v5.0.0 and replaced with ip_filter_string instead.",
+			Deprecated:       "This will be removed in v5.0.0 and replaced with ip_filter_string instead. When switching to ip_filter_string, please apply the changes twice due to technical limitations.",
 			Description:      "Allow incoming connections from CIDR address block, e.g. '10.20.0.0/16'.",
 			DiffSuppressFunc: schemautil.IPFilterArrayDiffSuppressFunc,
 			Elem: &schema.Schema{
@@ -4919,6 +5064,17 @@ func ServiceTypeOpensearch() *schema.Schema {
 					Type:        schema.TypeString,
 				},
 			}},
+			MaxItems: 1024,
+			Optional: true,
+			Type:     schema.TypeList,
+		},
+		"ip_filter_string": {
+			Description:      "Allow incoming connections from CIDR address block, e.g. '10.20.0.0/16'.",
+			DiffSuppressFunc: schemautil.IPFilterArrayDiffSuppressFunc,
+			Elem: &schema.Schema{
+				DiffSuppressFunc: schemautil.IPFilterValueDiffSuppressFunc,
+				Type:             schema.TypeString,
+			},
 			MaxItems: 1024,
 			Optional: true,
 			Type:     schema.TypeList,
@@ -5505,7 +5661,7 @@ func ServiceTypePg() *schema.Schema {
 			Type:        schema.TypeBool,
 		},
 		"ip_filter": {
-			Deprecated:       "This will be removed in v5.0.0 and replaced with ip_filter_string instead.",
+			Deprecated:       "This will be removed in v5.0.0 and replaced with ip_filter_string instead. When switching to ip_filter_string, please apply the changes twice due to technical limitations.",
 			Description:      "Allow incoming connections from CIDR address block, e.g. '10.20.0.0/16'.",
 			DiffSuppressFunc: schemautil.IPFilterArrayDiffSuppressFunc,
 			Elem: &schema.Schema{
@@ -5530,6 +5686,17 @@ func ServiceTypePg() *schema.Schema {
 					Type:        schema.TypeString,
 				},
 			}},
+			MaxItems: 1024,
+			Optional: true,
+			Type:     schema.TypeList,
+		},
+		"ip_filter_string": {
+			Description:      "Allow incoming connections from CIDR address block, e.g. '10.20.0.0/16'.",
+			DiffSuppressFunc: schemautil.IPFilterArrayDiffSuppressFunc,
+			Elem: &schema.Schema{
+				DiffSuppressFunc: schemautil.IPFilterValueDiffSuppressFunc,
+				Type:             schema.TypeString,
+			},
 			MaxItems: 1024,
 			Optional: true,
 			Type:     schema.TypeList,
@@ -6476,7 +6643,7 @@ func ServiceTypeRedis() *schema.Schema {
 			Type:        schema.TypeList,
 		},
 		"ip_filter": {
-			Deprecated:       "This will be removed in v5.0.0 and replaced with ip_filter_string instead.",
+			Deprecated:       "This will be removed in v5.0.0 and replaced with ip_filter_string instead. When switching to ip_filter_string, please apply the changes twice due to technical limitations.",
 			Description:      "Allow incoming connections from CIDR address block, e.g. '10.20.0.0/16'.",
 			DiffSuppressFunc: schemautil.IPFilterArrayDiffSuppressFunc,
 			Elem: &schema.Schema{
@@ -6501,6 +6668,17 @@ func ServiceTypeRedis() *schema.Schema {
 					Type:        schema.TypeString,
 				},
 			}},
+			MaxItems: 1024,
+			Optional: true,
+			Type:     schema.TypeList,
+		},
+		"ip_filter_string": {
+			Description:      "Allow incoming connections from CIDR address block, e.g. '10.20.0.0/16'.",
+			DiffSuppressFunc: schemautil.IPFilterArrayDiffSuppressFunc,
+			Elem: &schema.Schema{
+				DiffSuppressFunc: schemautil.IPFilterValueDiffSuppressFunc,
+				Type:             schema.TypeString,
+			},
 			MaxItems: 1024,
 			Optional: true,
 			Type:     schema.TypeList,

--- a/internal/schemautil/userconfig/handle.go
+++ b/internal/schemautil/userconfig/handle.go
@@ -212,14 +212,27 @@ func handleArrayProperty(
 			s[jen.Id("MaxItems")] = jen.Lit(mi)
 		}
 
+		os := jen.Dict{}
+		for k, v := range s {
+			os[k] = v
+		}
+
 		// TODO: Remove with the next major version.
-		if an == "ip_filter" || an == "namespaces" {
+		if an == "ip_filter" || (iof && an == "namespaces") {
 			s[jen.Id("Deprecated")] = jen.Lit(
-				fmt.Sprintf("This will be removed in v5.0.0 and replaced with %s_string instead.", an),
+				fmt.Sprintf(
+					"This will be removed in v5.0.0 and replaced with %s_string instead. "+
+						"When switching to %s_string, please apply the changes twice due to technical limitations.",
+					an, an,
+				),
 			)
 		}
 
 		r[an] = jen.Values(s)
+
+		if an == "ip_filter" || (iof && an == "namespaces") {
+			r[fmt.Sprintf("%s_string", an)] = jen.Values(os)
+		}
 	}
 
 	return r, nil


### PR DESCRIPTION
<!-- All contributors, please complete these sections, including maintainers. -->

## About this change—what it does

<!-- Provide a small sentence that summarizes the change. -->
adds `ip_filter` and `namespaces` string-suffixed alias fields

<!-- Provide the issue number below, if it exists. -->

## Why this way

<!-- Provide a small explanation on why this is the approach you took for solving this problem. -->
to provide an alternative before deprecation is in effect
