### PR TITLE
fix(apiconvert): double apply necessity on migration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ nav_order: 1
 - Fix `aiven_kafka_topic`: add client-side validation for the `partitions` field
 - Make `config` field of `aiven_kafka_connector` resource non-sensitive
 - Add string-suffixed alias fields for `ip_filter` and `namespaces` user config options
+- Fix double apply necessity when migrating from `ip_filter` to `ip_filter_object` and similar fields
 
 ## [4.1.3] - 2023-03-22
 

--- a/internal/schemautil/userconfig/apiconvert/toapi_test.go
+++ b/internal/schemautil/userconfig/apiconvert/toapi_test.go
@@ -3,8 +3,9 @@ package apiconvert
 import (
 	"testing"
 
-	"github.com/aiven/terraform-provider-aiven/internal/schemautil/userconfig"
 	"github.com/google/go-cmp/cmp"
+
+	"github.com/aiven/terraform-provider-aiven/internal/schemautil/userconfig"
 )
 
 // testResourceData is a resourceDatable compatible struct for testing.
@@ -583,6 +584,73 @@ func TestToAPI(t *testing.T) {
 			want: map[string]any{},
 		},
 		{
+			name: "migration from strings to objects in many to one array",
+			args: args{
+				st: userconfig.ServiceTypes,
+				n:  "m3db",
+				d: newTestResourceData(
+					map[string]interface{}{
+						"m3db_user_config": []interface{}{
+							map[string]interface{}{
+								"ip_filter": []interface{}{},
+								"ip_filter_object": []interface{}{
+									map[string]interface{}{
+										"description": "test",
+										"network":     "0.0.0.0/0",
+									},
+									map[string]interface{}{
+										"description": "",
+										"network":     "10.20.0.0/16",
+									},
+									map[string]interface{}{
+										"description": "foo",
+										"network":     "1.3.3.7/32",
+									},
+								},
+							},
+						},
+					},
+					map[string]struct{}{
+						"m3db_user_config":                                  {},
+						"m3db_user_config.0.ip_filter.0":                    {},
+						"m3db_user_config.0.ip_filter.1":                    {},
+						"m3db_user_config.0.ip_filter.2":                    {},
+						"m3db_user_config.0.ip_filter_object.0":             {},
+						"m3db_user_config.0.ip_filter_object.0.description": {},
+						"m3db_user_config.0.ip_filter_object.0.network":     {},
+						"m3db_user_config.0.ip_filter_object.1":             {},
+						"m3db_user_config.0.ip_filter_object.1.description": {},
+						"m3db_user_config.0.ip_filter_object.1.network":     {},
+					},
+					map[string]struct{}{
+						"m3db_user_config.0.ip_filter":                      {},
+						"m3db_user_config.0.ip_filter_object":               {},
+						"m3db_user_config.0.ip_filter_object.1":             {},
+						"m3db_user_config.0.ip_filter_object.1.description": {},
+						"m3db_user_config.0.ip_filter_object.1.network":     {},
+						"m3db_user_config.0.ip_filter_object.2":             {},
+					},
+					false,
+				),
+			},
+			want: map[string]any{
+				"ip_filter": []interface{}{
+					map[string]interface{}{
+						"description": "test",
+						"network":     "0.0.0.0/0",
+					},
+					map[string]interface{}{
+						"description": "",
+						"network":     "10.20.0.0/16",
+					},
+					map[string]interface{}{
+						"description": "foo",
+						"network":     "1.3.3.7/32",
+					},
+				},
+			},
+		},
+		{
 			name: "strings in many to one array via one_of",
 			args: args{
 				st: userconfig.ServiceTypes,
@@ -811,6 +879,67 @@ func TestToAPI(t *testing.T) {
 				),
 			},
 			want: map[string]any{},
+		},
+		{
+			name: "migration from strings to objects in many to one array via one_of",
+			args: args{
+				st: userconfig.ServiceTypes,
+				n:  "m3db",
+				d: newTestResourceData(
+					map[string]interface{}{
+						"m3db_user_config": []interface{}{
+							map[string]interface{}{
+								"rules": []interface{}{
+									map[string]interface{}{
+										"mapping": []interface{}{
+											map[string]interface{}{
+												"namespaces": []interface{}{},
+												"namespaces_object": []interface{}{
+													map[string]interface{}{
+														"resolution": "30s",
+														"retention":  "48h",
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+					map[string]struct{}{
+						"m3db_user_config": {},
+						"m3db_user_config.0.rules.0.mapping.0.namespaces.0":                   {},
+						"m3db_user_config.0.rules.0.mapping.0.namespaces_object.0.resolution": {},
+						"m3db_user_config.0.rules.0.mapping.0.namespaces_object.0.retention":  {},
+					},
+					map[string]struct{}{
+						"m3db_user_config.0.rules":                                            {},
+						"m3db_user_config.0.rules.0":                                          {},
+						"m3db_user_config.0.rules.0.mapping":                                  {},
+						"m3db_user_config.0.rules.0.mapping.0":                                {},
+						"m3db_user_config.0.rules.0.mapping.0.namespaces_object":              {},
+						"m3db_user_config.0.rules.0.mapping.0.namespaces_object.0":            {},
+						"m3db_user_config.0.rules.0.mapping.0.namespaces_object.0.resolution": {},
+						"m3db_user_config.0.rules.0.mapping.0.namespaces_object.0.retention":  {},
+					},
+					false,
+				),
+			},
+			want: map[string]any{
+				"rules": map[string]interface{}{
+					"mapping": []interface{}{
+						map[string]interface{}{
+							"namespaces": []interface{}{
+								map[string]interface{}{
+									"resolution": "30s",
+									"retention":  "48h",
+								},
+							},
+						},
+					},
+				},
+			},
 		},
 	}
 

--- a/internal/schemautil/userconfig/dist/service_types.go
+++ b/internal/schemautil/userconfig/dist/service_types.go
@@ -63,7 +63,7 @@ func ServiceTypeCassandra() *schema.Schema {
 			Type:        schema.TypeString,
 		},
 		"ip_filter": {
-			Deprecated:       "This will be removed in v5.0.0 and replaced with ip_filter_string instead. When switching to ip_filter_string, please apply the changes twice due to technical limitations.",
+			Deprecated:       "This will be removed in v5.0.0 and replaced with ip_filter_string instead.",
 			Description:      "Allow incoming connections from CIDR address block, e.g. '10.20.0.0/16'.",
 			DiffSuppressFunc: schemautil.IPFilterArrayDiffSuppressFunc,
 			Elem: &schema.Schema{
@@ -185,7 +185,7 @@ func ServiceTypeClickhouse() *schema.Schema {
 			Type:        schema.TypeList,
 		},
 		"ip_filter": {
-			Deprecated:       "This will be removed in v5.0.0 and replaced with ip_filter_string instead. When switching to ip_filter_string, please apply the changes twice due to technical limitations.",
+			Deprecated:       "This will be removed in v5.0.0 and replaced with ip_filter_string instead.",
 			Description:      "Allow incoming connections from CIDR address block, e.g. '10.20.0.0/16'.",
 			DiffSuppressFunc: schemautil.IPFilterArrayDiffSuppressFunc,
 			Elem: &schema.Schema{
@@ -666,7 +666,7 @@ func ServiceTypeElasticsearch() *schema.Schema {
 			Type:     schema.TypeList,
 		},
 		"ip_filter": {
-			Deprecated:       "This will be removed in v5.0.0 and replaced with ip_filter_string instead. When switching to ip_filter_string, please apply the changes twice due to technical limitations.",
+			Deprecated:       "This will be removed in v5.0.0 and replaced with ip_filter_string instead.",
 			Description:      "Allow incoming connections from CIDR address block, e.g. '10.20.0.0/16'.",
 			DiffSuppressFunc: schemautil.IPFilterArrayDiffSuppressFunc,
 			Elem: &schema.Schema{
@@ -932,7 +932,7 @@ func ServiceTypeFlink() *schema.Schema {
 			Type:        schema.TypeString,
 		},
 		"ip_filter": {
-			Deprecated:       "This will be removed in v5.0.0 and replaced with ip_filter_string instead. When switching to ip_filter_string, please apply the changes twice due to technical limitations.",
+			Deprecated:       "This will be removed in v5.0.0 and replaced with ip_filter_string instead.",
 			Description:      "Allow incoming connections from CIDR address block, e.g. '10.20.0.0/16'.",
 			DiffSuppressFunc: schemautil.IPFilterArrayDiffSuppressFunc,
 			Elem: &schema.Schema{
@@ -1666,7 +1666,7 @@ func ServiceTypeGrafana() *schema.Schema {
 			Type:        schema.TypeString,
 		},
 		"ip_filter": {
-			Deprecated:       "This will be removed in v5.0.0 and replaced with ip_filter_string instead. When switching to ip_filter_string, please apply the changes twice due to technical limitations.",
+			Deprecated:       "This will be removed in v5.0.0 and replaced with ip_filter_string instead.",
 			Description:      "Allow incoming connections from CIDR address block, e.g. '10.20.0.0/16'.",
 			DiffSuppressFunc: schemautil.IPFilterArrayDiffSuppressFunc,
 			Elem: &schema.Schema{
@@ -1986,7 +1986,7 @@ func ServiceTypeInfluxdb() *schema.Schema {
 			Type:     schema.TypeList,
 		},
 		"ip_filter": {
-			Deprecated:       "This will be removed in v5.0.0 and replaced with ip_filter_string instead. When switching to ip_filter_string, please apply the changes twice due to technical limitations.",
+			Deprecated:       "This will be removed in v5.0.0 and replaced with ip_filter_string instead.",
 			Description:      "Allow incoming connections from CIDR address block, e.g. '10.20.0.0/16'.",
 			DiffSuppressFunc: schemautil.IPFilterArrayDiffSuppressFunc,
 			Elem: &schema.Schema{
@@ -2124,7 +2124,7 @@ func ServiceTypeKafka() *schema.Schema {
 			Type:        schema.TypeString,
 		},
 		"ip_filter": {
-			Deprecated:       "This will be removed in v5.0.0 and replaced with ip_filter_string instead. When switching to ip_filter_string, please apply the changes twice due to technical limitations.",
+			Deprecated:       "This will be removed in v5.0.0 and replaced with ip_filter_string instead.",
 			Description:      "Allow incoming connections from CIDR address block, e.g. '10.20.0.0/16'.",
 			DiffSuppressFunc: schemautil.IPFilterArrayDiffSuppressFunc,
 			Elem: &schema.Schema{
@@ -3126,7 +3126,7 @@ func ServiceTypeKafkaConnect() *schema.Schema {
 			Type:        schema.TypeList,
 		},
 		"ip_filter": {
-			Deprecated:       "This will be removed in v5.0.0 and replaced with ip_filter_string instead. When switching to ip_filter_string, please apply the changes twice due to technical limitations.",
+			Deprecated:       "This will be removed in v5.0.0 and replaced with ip_filter_string instead.",
 			Description:      "Allow incoming connections from CIDR address block, e.g. '10.20.0.0/16'.",
 			DiffSuppressFunc: schemautil.IPFilterArrayDiffSuppressFunc,
 			Elem: &schema.Schema{
@@ -3454,7 +3454,7 @@ func ServiceTypeKafkaMirrormaker() *schema.Schema {
 			Type:        schema.TypeList,
 		},
 		"ip_filter": {
-			Deprecated:       "This will be removed in v5.0.0 and replaced with ip_filter_string instead. When switching to ip_filter_string, please apply the changes twice due to technical limitations.",
+			Deprecated:       "This will be removed in v5.0.0 and replaced with ip_filter_string instead.",
 			Description:      "Allow incoming connections from CIDR address block, e.g. '10.20.0.0/16'.",
 			DiffSuppressFunc: schemautil.IPFilterArrayDiffSuppressFunc,
 			Elem: &schema.Schema{
@@ -3632,7 +3632,7 @@ func ServiceTypeM3aggregator() *schema.Schema {
 			Type:        schema.TypeString,
 		},
 		"ip_filter": {
-			Deprecated:       "This will be removed in v5.0.0 and replaced with ip_filter_string instead. When switching to ip_filter_string, please apply the changes twice due to technical limitations.",
+			Deprecated:       "This will be removed in v5.0.0 and replaced with ip_filter_string instead.",
 			Description:      "Allow incoming connections from CIDR address block, e.g. '10.20.0.0/16'.",
 			DiffSuppressFunc: schemautil.IPFilterArrayDiffSuppressFunc,
 			Elem: &schema.Schema{
@@ -3716,7 +3716,7 @@ func ServiceTypeM3db() *schema.Schema {
 			Type:        schema.TypeString,
 		},
 		"ip_filter": {
-			Deprecated:       "This will be removed in v5.0.0 and replaced with ip_filter_string instead. When switching to ip_filter_string, please apply the changes twice due to technical limitations.",
+			Deprecated:       "This will be removed in v5.0.0 and replaced with ip_filter_string instead.",
 			Description:      "Allow incoming connections from CIDR address block, e.g. '10.20.0.0/16'.",
 			DiffSuppressFunc: schemautil.IPFilterArrayDiffSuppressFunc,
 			Elem: &schema.Schema{
@@ -4147,7 +4147,7 @@ func ServiceTypeM3db() *schema.Schema {
 						Type:        schema.TypeString,
 					},
 					"namespaces": {
-						Deprecated:  "This will be removed in v5.0.0 and replaced with namespaces_string instead. When switching to namespaces_string, please apply the changes twice due to technical limitations.",
+						Deprecated:  "This will be removed in v5.0.0 and replaced with namespaces_string instead.",
 						Description: "This rule will be used to store the metrics in the given namespace(s). If a namespace is target of rules, the global default aggregation will be automatically disabled. Note that specifying filters that match no namespaces whatsoever will be returned as an error. Filter the namespace by glob (=wildcards).",
 						Elem:        &schema.Schema{Type: schema.TypeString},
 						MaxItems:    10,
@@ -4228,7 +4228,7 @@ func ServiceTypeM3db() *schema.Schema {
 						Type:        schema.TypeString,
 					},
 					"namespaces": {
-						Deprecated:  "This will be removed in v5.0.0 and replaced with namespaces_string instead. When switching to namespaces_string, please apply the changes twice due to technical limitations.",
+						Deprecated:  "This will be removed in v5.0.0 and replaced with namespaces_string instead.",
 						Description: "This rule will be used to store the metrics in the given namespace(s). If a namespace is target of rules, the global default aggregation will be automatically disabled. Note that specifying filters that match no namespaces whatsoever will be returned as an error. Filter the namespace by glob (=wildcards).",
 						Elem:        &schema.Schema{Type: schema.TypeString},
 						MaxItems:    10,
@@ -4349,7 +4349,7 @@ func ServiceTypeMysql() *schema.Schema {
 			Type:        schema.TypeInt,
 		},
 		"ip_filter": {
-			Deprecated:       "This will be removed in v5.0.0 and replaced with ip_filter_string instead. When switching to ip_filter_string, please apply the changes twice due to technical limitations.",
+			Deprecated:       "This will be removed in v5.0.0 and replaced with ip_filter_string instead.",
 			Description:      "Allow incoming connections from CIDR address block, e.g. '10.20.0.0/16'.",
 			DiffSuppressFunc: schemautil.IPFilterArrayDiffSuppressFunc,
 			Elem: &schema.Schema{
@@ -5039,7 +5039,7 @@ func ServiceTypeOpensearch() *schema.Schema {
 			Type:     schema.TypeList,
 		},
 		"ip_filter": {
-			Deprecated:       "This will be removed in v5.0.0 and replaced with ip_filter_string instead. When switching to ip_filter_string, please apply the changes twice due to technical limitations.",
+			Deprecated:       "This will be removed in v5.0.0 and replaced with ip_filter_string instead.",
 			Description:      "Allow incoming connections from CIDR address block, e.g. '10.20.0.0/16'.",
 			DiffSuppressFunc: schemautil.IPFilterArrayDiffSuppressFunc,
 			Elem: &schema.Schema{
@@ -5661,7 +5661,7 @@ func ServiceTypePg() *schema.Schema {
 			Type:        schema.TypeBool,
 		},
 		"ip_filter": {
-			Deprecated:       "This will be removed in v5.0.0 and replaced with ip_filter_string instead. When switching to ip_filter_string, please apply the changes twice due to technical limitations.",
+			Deprecated:       "This will be removed in v5.0.0 and replaced with ip_filter_string instead.",
 			Description:      "Allow incoming connections from CIDR address block, e.g. '10.20.0.0/16'.",
 			DiffSuppressFunc: schemautil.IPFilterArrayDiffSuppressFunc,
 			Elem: &schema.Schema{
@@ -6643,7 +6643,7 @@ func ServiceTypeRedis() *schema.Schema {
 			Type:        schema.TypeList,
 		},
 		"ip_filter": {
-			Deprecated:       "This will be removed in v5.0.0 and replaced with ip_filter_string instead. When switching to ip_filter_string, please apply the changes twice due to technical limitations.",
+			Deprecated:       "This will be removed in v5.0.0 and replaced with ip_filter_string instead.",
 			Description:      "Allow incoming connections from CIDR address block, e.g. '10.20.0.0/16'.",
 			DiffSuppressFunc: schemautil.IPFilterArrayDiffSuppressFunc,
 			Elem: &schema.Schema{

--- a/internal/schemautil/userconfig/handle.go
+++ b/internal/schemautil/userconfig/handle.go
@@ -220,11 +220,7 @@ func handleArrayProperty(
 		// TODO: Remove with the next major version.
 		if an == "ip_filter" || (iof && an == "namespaces") {
 			s[jen.Id("Deprecated")] = jen.Lit(
-				fmt.Sprintf(
-					"This will be removed in v5.0.0 and replaced with %s_string instead. "+
-						"When switching to %s_string, please apply the changes twice due to technical limitations.",
-					an, an,
-				),
+				fmt.Sprintf("This will be removed in v5.0.0 and replaced with %s_string instead.", an),
 			)
 		}
 


### PR DESCRIPTION
<!-- All contributors, please complete these sections, including maintainers. -->

## About this change—what it does

<!-- Provide a small sentence that summarizes the change. -->
fixes double apply necessity on migration from typeless keys to typed keys

<!-- Provide the issue number below, if it exists. -->
resolves #1073 

## Why this way

<!-- Provide a small explanation on why this is the approach you took for solving this problem. -->
to eliminate the bug
