### PR TITLE
ci(lint): drop forced Go version in golangci-lint

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -17,8 +17,6 @@ linters:
     - unused
     - stylecheck
 
-
-
 issues:
   exclude:
     # TODO: We can have a whitelist for revive's var-naming rule.
@@ -26,6 +24,3 @@ issues:
 
     # TODO: We probably should add comments to all exported functions and methods.
     - 'exported: .*'
-
-run:
-  go: '1.17' # See https://github.com/golangci/golangci-lint/issues/2649.


### PR DESCRIPTION
<!-- All contributors, please complete these sections, including maintainers. -->

## About this change—what it does

<!-- Provide a small sentence that summarizes the change. -->
drops forced Go version in `golangci-lint`

<!-- Provide the issue number below, if it exists. -->

## Why this way

<!-- Provide a small explanation on why this is the approach you took for solving this problem. -->
https://github.com/golangci/golangci-lint/issues/2649 was resolved
