### PR TITLE
feat: drop signalfx from supported integration types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ nav_order: 1
 ## [MAJOR.MINOR.PATCH] - YYYY-MM-DD
 
 - Added docs and validation for `aiven_service_integration_endpoint`
+- Dropped `signalfx` from supported integration types
 
 ## [4.2.1] - 2023-04-06
 

--- a/docs/data-sources/service_integration_endpoint.md
+++ b/docs/data-sources/service_integration_endpoint.md
@@ -31,7 +31,7 @@ data "aiven_service_integration_endpoint" "myendpoint" {
 
 - `datadog_user_config` (List of Object) Datadog user configurable settings (see [below for nested schema](#nestedatt--datadog_user_config))
 - `endpoint_config` (Map of String) Integration endpoint specific backend configuration
-- `endpoint_type` (String) Type of the service integration endpoint. Possible values: `datadog`, `prometheus`, `rsyslog`, `external_elasticsearch_logs`, `external_opensearch_logs`, `external_aws_cloudwatch_logs`, `external_google_cloud_logging`, `external_kafka`, `jolokia`, `signalfx`, `external_schema_registry`, `external_aws_cloudwatch_metrics`
+- `endpoint_type` (String) Type of the service integration endpoint. Possible values: `datadog`, `prometheus`, `rsyslog`, `external_elasticsearch_logs`, `external_opensearch_logs`, `external_aws_cloudwatch_logs`, `external_google_cloud_logging`, `external_kafka`, `jolokia`, `external_schema_registry`, `external_aws_cloudwatch_metrics`
 - `external_aws_cloudwatch_logs_user_config` (List of Object) ExternalAwsCloudwatchLogs user configurable settings (see [below for nested schema](#nestedatt--external_aws_cloudwatch_logs_user_config))
 - `external_aws_cloudwatch_metrics_user_config` (List of Object) ExternalAwsCloudwatchMetrics user configurable settings (see [below for nested schema](#nestedatt--external_aws_cloudwatch_metrics_user_config))
 - `external_elasticsearch_logs_user_config` (List of Object) ExternalElasticsearchLogs user configurable settings (see [below for nested schema](#nestedatt--external_elasticsearch_logs_user_config))
@@ -43,7 +43,6 @@ data "aiven_service_integration_endpoint" "myendpoint" {
 - `jolokia_user_config` (List of Object) Jolokia user configurable settings (see [below for nested schema](#nestedatt--jolokia_user_config))
 - `prometheus_user_config` (List of Object) Prometheus user configurable settings (see [below for nested schema](#nestedatt--prometheus_user_config))
 - `rsyslog_user_config` (List of Object) Rsyslog user configurable settings (see [below for nested schema](#nestedatt--rsyslog_user_config))
-- `signalfx_user_config` (List of Object) Signalfx user configurable settings (see [below for nested schema](#nestedatt--signalfx_user_config))
 
 <a id="nestedatt--datadog_user_config"></a>
 ### Nested Schema for `datadog_user_config`
@@ -183,15 +182,5 @@ Read-Only:
 - `sd` (String)
 - `server` (String)
 - `tls` (Boolean)
-
-
-<a id="nestedatt--signalfx_user_config"></a>
-### Nested Schema for `signalfx_user_config`
-
-Read-Only:
-
-- `enabled_metrics` (List of String)
-- `signalfx_api_key` (String)
-- `signalfx_realm` (String)
 
 

--- a/docs/resources/service_integration_endpoint.md
+++ b/docs/resources/service_integration_endpoint.md
@@ -18,7 +18,7 @@ The Service Integration Endpoint resource allows the creation and management of 
 ### Required
 
 - `endpoint_name` (String) Name of the service integration endpoint
-- `endpoint_type` (String) Type of the service integration endpoint. Possible values: `datadog`, `prometheus`, `rsyslog`, `external_elasticsearch_logs`, `external_opensearch_logs`, `external_aws_cloudwatch_logs`, `external_google_cloud_logging`, `external_kafka`, `jolokia`, `signalfx`, `external_schema_registry`, `external_aws_cloudwatch_metrics`
+- `endpoint_type` (String) Type of the service integration endpoint. Possible values: `datadog`, `prometheus`, `rsyslog`, `external_elasticsearch_logs`, `external_opensearch_logs`, `external_aws_cloudwatch_logs`, `external_google_cloud_logging`, `external_kafka`, `jolokia`, `external_schema_registry`, `external_aws_cloudwatch_metrics`
 - `project` (String) Project the service integration endpoint belongs to
 
 ### Optional
@@ -34,7 +34,6 @@ The Service Integration Endpoint resource allows the creation and management of 
 - `jolokia_user_config` (Block List, Max: 1) Jolokia user configurable settings (see [below for nested schema](#nestedblock--jolokia_user_config))
 - `prometheus_user_config` (Block List, Max: 1) Prometheus user configurable settings (see [below for nested schema](#nestedblock--prometheus_user_config))
 - `rsyslog_user_config` (Block List, Max: 1) Rsyslog user configurable settings (see [below for nested schema](#nestedblock--rsyslog_user_config))
-- `signalfx_user_config` (Block List, Max: 1) Signalfx user configurable settings (see [below for nested schema](#nestedblock--signalfx_user_config))
 - `timeouts` (Block, Optional) (see [below for nested schema](#nestedblock--timeouts))
 
 ### Read-Only
@@ -183,16 +182,6 @@ Optional:
 - `sd` (String) Structured data block for log message.
 - `server` (String) rsyslog server IP address or hostname.
 - `tls` (Boolean) Require TLS. The default value is `true`.
-
-
-<a id="nestedblock--signalfx_user_config"></a>
-### Nested Schema for `signalfx_user_config`
-
-Optional:
-
-- `enabled_metrics` (List of String) list of metrics to send.
-- `signalfx_api_key` (String, Sensitive) SignalFX API key.
-- `signalfx_realm` (String) SignalFX realm. The default value is `us0`.
 
 
 <a id="nestedblock--timeouts"></a>

--- a/internal/schemautil/userconfig/stateupgrader/v0/serviceintegration/service_integration_endpoint.go
+++ b/internal/schemautil/userconfig/stateupgrader/v0/serviceintegration/service_integration_endpoint.go
@@ -43,7 +43,6 @@ var aivenServiceIntegrationEndpointSchema = map[string]*schema.Schema{
 	"external_google_cloud_logging_user_config":   dist.IntegrationEndpointTypeExternalGoogleCloudLogging(),
 	"external_kafka_user_config":                  dist.IntegrationEndpointTypeExternalKafka(),
 	"jolokia_user_config":                         dist.IntegrationEndpointTypeJolokia(),
-	"signalfx_user_config":                        dist.IntegrationEndpointTypeSignalfx(),
 	"external_schema_registry_user_config":        dist.IntegrationEndpointTypeExternalSchemaRegistry(),
 	"external_aws_cloudwatch_metrics_user_config": dist.IntegrationEndpointTypeExternalAwsCloudwatchMetrics(),
 }

--- a/internal/sdkprovider/service/serviceintegration/service_integration_endpoint.go
+++ b/internal/sdkprovider/service/serviceintegration/service_integration_endpoint.go
@@ -26,7 +26,6 @@ var integrationEndpointTypes = []string{
 	"external_google_cloud_logging",
 	"external_kafka",
 	"jolokia",
-	"signalfx",
 	"external_schema_registry",
 	"external_aws_cloudwatch_metrics",
 }
@@ -67,7 +66,6 @@ var aivenServiceIntegrationEndpointSchema = map[string]*schema.Schema{
 	"external_google_cloud_logging_user_config":   dist.IntegrationEndpointTypeExternalGoogleCloudLogging(),
 	"external_kafka_user_config":                  dist.IntegrationEndpointTypeExternalKafka(),
 	"jolokia_user_config":                         dist.IntegrationEndpointTypeJolokia(),
-	"signalfx_user_config":                        dist.IntegrationEndpointTypeSignalfx(),
 	"external_schema_registry_user_config":        dist.IntegrationEndpointTypeExternalSchemaRegistry(),
 	"external_aws_cloudwatch_metrics_user_config": dist.IntegrationEndpointTypeExternalAwsCloudwatchMetrics(),
 }


### PR DESCRIPTION
<!-- All contributors, please complete these sections, including maintainers. -->

## About this change—what it does

<!-- Provide a small sentence that summarizes the change. -->
drops `signalfx` from supported integration types

<!-- Provide the issue number below, if it exists. -->

## Why this way

<!-- Provide a small explanation on why this is the approach you took for solving this problem. -->
this is no longer supported in the backend, relevant changes were merged in the upstream library https://github.com/aiven/go-api-schemas/commit/b72e6a79b0ebefe1d726a0923b04174bace827c0

since this no longer works, we have no other option but to drop this from our Terraform provider as well
