### PR TITLE
fix: adjust generated SQL for ClickHouse privilege grants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ nav_order: 1
 - Dropped `signalfx` from supported integration types
 - Fix MySQL user creation authentication field 
 - Fix Account SAML Field mapping set method
+- Adjust generated SQL for ClickHouse privilege grants
 
 ## [4.2.1] - 2023-04-06
 

--- a/docs/resources/clickhouse_grant.md
+++ b/docs/resources/clickhouse_grant.md
@@ -47,13 +47,12 @@ resource "aiven_clickhouse_grant" "demo-role-grant" {
   privilege_grant {
     privilege = "INSERT"
     database  = aiven_clickhouse_database.demodb.name
-    table     = "*"
+    table     = "demo-table"
   }
 
   privilege_grant {
     privilege = "SELECT"
     database  = aiven_clickhouse_database.demodb.name
-    table     = "*"
   }
 }
 

--- a/examples/resources/aiven_clickhouse_grant/resource.tf
+++ b/examples/resources/aiven_clickhouse_grant/resource.tf
@@ -25,13 +25,12 @@ resource "aiven_clickhouse_grant" "demo-role-grant" {
   privilege_grant {
     privilege = "INSERT"
     database  = aiven_clickhouse_database.demodb.name
-    table     = "*"
+    table     = "demo-table"
   }
 
   privilege_grant {
     privilege = "SELECT"
     database  = aiven_clickhouse_database.demodb.name
-    table     = "*"
   }
 }
 

--- a/internal/sdkprovider/service/clickhouse/grant.go
+++ b/internal/sdkprovider/service/clickhouse/grant.go
@@ -145,12 +145,14 @@ func createPrivilegeGrantStatement(grant PrivilegeGrant) string {
 
 	if len(grant.Table) > 0 {
 		b.WriteString(fmt.Sprintf(".%s", escape(grant.Table)))
+	} else {
+		b.WriteString(".*")
 	}
 
 	b.WriteString(fmt.Sprintf(" TO %s", escape(userOrRole(grant.Grantee))))
 
 	if grant.WithGrant {
-		b.WriteString(" WITH GRANT")
+		b.WriteString(" WITH GRANT OPTION")
 	}
 
 	return b.String()
@@ -171,6 +173,8 @@ func revokePrivilegeGrantStatement(grant PrivilegeGrant) string {
 
 	if len(grant.Table) > 0 {
 		b.WriteString(fmt.Sprintf(".%s", escape(grant.Table)))
+	} else {
+		b.WriteString(".*")
 	}
 
 	b.WriteString(fmt.Sprintf(" FROM %s", escape(userOrRole(grant.Grantee))))


### PR DESCRIPTION
## About this change—what it does

1. Fix `" WITH GRANT"` that should be `" WITH GRANT OPTION"`.

2. When a table is unspecified, write `.*` instead of nothing.
    A query like `GRANT SELECT ON foo TO bar` grants `SELECT` on the table `foo` of the current database of the connection.
    Instead we want to generate `GRANT SELECT ON foo.* TO bar` to grant `SELECT` on all tables of the `foo` database.

3. Adjust the documentation to not suggest using `"*"` as the table name.
    A `"*"` table name does not grant privilege on all tables, it grants privilege on the table named `*`.
    To grant privilege on all tables, the table name should be completely omitted.

Reference: https://clickhouse.com/docs/en/sql-reference/statements/grant#granting-privilege-syntax
