### PR TITLE
fix(docs): remove optional mark from kafka's computed fields

### DIFF
--- a/docs/resources/kafka.md
+++ b/docs/resources/kafka.md
@@ -54,7 +54,6 @@ resource "aiven_kafka" "kafka1" {
 - `cloud_name` (String) Defines where the cloud provider and region where the service is hosted in. This can be changed freely after service is created. Changing the value will trigger a potentially lengthy migration process for the service. Format is cloud provider name (`aws`, `azure`, `do` `google`, `upcloud`, etc.), dash, and the cloud provider specific region name. These are documented on each Cloud provider's own support articles, like [here for Google](https://cloud.google.com/compute/docs/regions-zones/) and [here for AWS](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Concepts.RegionsAndAvailabilityZones.html).
 - `default_acl` (Boolean) Create default wildcard Kafka ACL
 - `disk_space` (String) Service disk space. Possible values depend on the service type, the cloud provider and the project. Therefore, reducing will result in the service rebalancing.
-- `kafka` (Block List, Max: 1) Kafka server provided values (see [below for nested schema](#nestedblock--kafka))
 - `kafka_user_config` (Block List, Max: 1) Kafka user configurable settings (see [below for nested schema](#nestedblock--kafka_user_config))
 - `karapace` (Boolean, Deprecated) Switch the service to use Karapace for schema registry and REST proxy
 - `maintenance_window_dow` (String) Day of week when maintenance operations should be performed. One monday, tuesday, wednesday, etc.
@@ -75,6 +74,7 @@ resource "aiven_kafka" "kafka1" {
 - `disk_space_step` (String) The default disk space step of the service, possible values depend on the service type, the cloud provider and the project. `disk_space` needs to increment from `disk_space_default` by increments of this size.
 - `disk_space_used` (String) Disk space that service is currently using
 - `id` (String) The ID of this resource.
+- `kafka` (List of Object) Kafka server provided values (see [below for nested schema](#nestedatt--kafka))
 - `service_host` (String) The hostname of the service.
 - `service_password` (String, Sensitive) Password used for connecting to the service, if applicable
 - `service_port` (Number) The port of the service
@@ -82,18 +82,6 @@ resource "aiven_kafka" "kafka1" {
 - `service_uri` (String, Sensitive) URI for connecting to the service. Service specific info is under "kafka", "pg", etc.
 - `service_username` (String) Username used for connecting to the service, if applicable
 - `state` (String) Service state. One of `POWEROFF`, `REBALANCING`, `REBUILDING` or `RUNNING`
-
-<a id="nestedblock--kafka"></a>
-### Nested Schema for `kafka`
-
-Optional:
-
-- `access_cert` (String, Sensitive) The Kafka client certificate
-- `access_key` (String, Sensitive) The Kafka client certificate key
-- `connect_uri` (String, Sensitive) The Kafka Connect URI, if any
-- `rest_uri` (String, Sensitive) The Kafka REST URI, if any
-- `schema_registry_uri` (String, Sensitive) The Schema Registry URI, if any
-
 
 <a id="nestedblock--kafka_user_config"></a>
 ### Nested Schema for `kafka_user_config`
@@ -312,6 +300,18 @@ Read-Only:
 - `route` (String)
 - `ssl` (Boolean)
 - `usage` (String)
+
+
+<a id="nestedatt--kafka"></a>
+### Nested Schema for `kafka`
+
+Read-Only:
+
+- `access_cert` (String)
+- `access_key` (String)
+- `connect_uri` (String)
+- `rest_uri` (String)
+- `schema_registry_uri` (String)
 
 ## Import
 

--- a/internal/sdkprovider/service/kafka/kafka.go
+++ b/internal/sdkprovider/service/kafka/kafka.go
@@ -34,45 +34,38 @@ func aivenKafkaSchema() map[string]*schema.Schema {
 	}
 	aivenKafkaSchema[schemautil.ServiceTypeKafka] = &schema.Schema{
 		Type:        schema.TypeList,
-		MaxItems:    1,
 		Computed:    true,
 		Description: "Kafka server provided values",
-		Optional:    true,
 		Elem: &schema.Resource{
 			Schema: map[string]*schema.Schema{
 				"access_cert": {
 					Type:        schema.TypeString,
 					Computed:    true,
 					Description: "The Kafka client certificate",
-					Optional:    true,
 					Sensitive:   true,
 				},
 				"access_key": {
 					Type:        schema.TypeString,
 					Computed:    true,
 					Description: "The Kafka client certificate key",
-					Optional:    true,
 					Sensitive:   true,
 				},
 				"connect_uri": {
 					Type:        schema.TypeString,
 					Computed:    true,
 					Description: "The Kafka Connect URI, if any",
-					Optional:    true,
 					Sensitive:   true,
 				},
 				"rest_uri": {
 					Type:        schema.TypeString,
 					Computed:    true,
 					Description: "The Kafka REST URI, if any",
-					Optional:    true,
 					Sensitive:   true,
 				},
 				"schema_registry_uri": {
 					Type:        schema.TypeString,
 					Computed:    true,
 					Description: "The Schema Registry URI, if any",
-					Optional:    true,
 					Sensitive:   true,
 				},
 			},


### PR DESCRIPTION
## About this change—what it does

Fixes documentation for kafka.