### PR TITLE
chore(kafka): deprecate karapace option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ nav_order: 1
 - Fix Account SAML Field mapping set method
 - Adjust generated SQL for ClickHouse privilege grants
 - Fix `required` not generated for top level fields for user config options
+- Deprecate `karapace` option on `aiven_kafka` schema
 
 ## [4.2.1] - 2023-04-06
 

--- a/docs/resources/kafka.md
+++ b/docs/resources/kafka.md
@@ -56,7 +56,7 @@ resource "aiven_kafka" "kafka1" {
 - `disk_space` (String) Service disk space. Possible values depend on the service type, the cloud provider and the project. Therefore, reducing will result in the service rebalancing.
 - `kafka` (Block List, Max: 1) Kafka server provided values (see [below for nested schema](#nestedblock--kafka))
 - `kafka_user_config` (Block List, Max: 1) Kafka user configurable settings (see [below for nested schema](#nestedblock--kafka_user_config))
-- `karapace` (Boolean) Switch the service to use Karapace for schema registry and REST proxy
+- `karapace` (Boolean, Deprecated) Switch the service to use Karapace for schema registry and REST proxy
 - `maintenance_window_dow` (String) Day of week when maintenance operations should be performed. One monday, tuesday, wednesday, etc.
 - `maintenance_window_time` (String) Time of day when maintenance operations should be performed. UTC time in HH:mm:ss format.
 - `plan` (String) Defines what kind of computing resources are allocated for the service. It can be changed after creation, though there are some restrictions when going to a smaller plan such as the new plan must have sufficient amount of disk space to store all current data and switching to a plan with fewer nodes might not be supported. The basic plan names are `hobbyist`, `startup-x`, `business-x` and `premium-x` where `x` is (roughly) the amount of memory on each node (also other attributes like number of CPUs and amount of disk space varies but naming is based on memory). The available options can be seem from the [Aiven pricing page](https://aiven.io/pricing).

--- a/internal/sdkprovider/service/kafka/kafka.go
+++ b/internal/sdkprovider/service/kafka/kafka.go
@@ -5,6 +5,7 @@ import (
 	"strconv"
 
 	"github.com/aiven/aiven-go-client"
+
 	"github.com/aiven/terraform-provider-aiven/internal/schemautil"
 	"github.com/aiven/terraform-provider-aiven/internal/schemautil/userconfig/dist"
 	"github.com/aiven/terraform-provider-aiven/internal/schemautil/userconfig/stateupgrader"
@@ -21,6 +22,7 @@ func aivenKafkaSchema() map[string]*schema.Schema {
 		Optional:         true,
 		Description:      "Switch the service to use Karapace for schema registry and REST proxy",
 		DiffSuppressFunc: schemautil.EmptyObjectDiffSuppressFunc,
+		Deprecated:       "Usage of this field is discouraged.",
 	}
 	aivenKafkaSchema["default_acl"] = &schema.Schema{
 		Type:             schema.TypeBool,


### PR DESCRIPTION
## About this change—what it does

Deprecates `karapace` option on `kafka`.