### PR TITLE
fix(kafka_topic): 404 error handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ nav_order: 1
   - `owner_team_id`
   - `is_account_owner`
 - Deprecated `aiven_account_team_project` resource
+- Improve Kafka Topic 404 error handling
 
 ## [4.3.0] - 2023-05-10
 

--- a/internal/sdkprovider/service/kafka/kafka_topic.go
+++ b/internal/sdkprovider/service/kafka/kafka_topic.go
@@ -223,7 +223,7 @@ var aivenKafkaTopicSchema = map[string]*schema.Schema{
 }
 
 func ResourceKafkaTopic() *schema.Resource {
-	_ = newTopicCache()
+	initTopicCache()
 
 	return &schema.Resource{
 		Description:   "The Kafka Topic resource allows the creation and management of Aiven Kafka Topics.",

--- a/internal/sdkprovider/service/kafka/kafka_topic_cache_test.go
+++ b/internal/sdkprovider/service/kafka/kafka_topic_cache_test.go
@@ -11,7 +11,7 @@ func setupTopicCacheTestCase(t *testing.T) func(t *testing.T) {
 	t.Log("setup Kafka Topic Cache test case")
 
 	if getTopicCache() == nil {
-		_ = newTopicCache()
+		initTopicCache()
 	}
 
 	return func(t *testing.T) {
@@ -35,6 +35,8 @@ func TestGetTopicCache(t *testing.T) {
 			&kafkaTopicCache{
 				internal: make(map[string]map[string]aiven.KafkaTopic),
 				inQueue:  make(map[string][]string),
+				missing:  make(map[string][]string),
+				v1list:   make(map[string][]string),
 			},
 		},
 	}

--- a/internal/sdkprovider/service/kafka/kafka_topic_wait.go
+++ b/internal/sdkprovider/service/kafka/kafka_topic_wait.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/aiven/aiven-go-client"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"golang.org/x/exp/slices"
 	"golang.org/x/sync/semaphore"
 )
 
@@ -38,8 +39,24 @@ func newKafkaTopicAvailabilityWaiter(client *aiven.Client, project, serviceName,
 func (w *kafkaTopicAvailabilityWaiter) RefreshFunc() resource.StateRefreshFunc {
 	return func() (interface{}, string, error) {
 		cache := getTopicCache()
-		topic, ok := cache.LoadByTopicName(w.Project, w.ServiceName, w.TopicName)
 
+		// Caching a list of all topics for a service from v1 GET endpoint.
+		// Aiven has a request-per-minute limit; therefore, to minimize
+		// the request count, we query the V1 list endpoint.
+		if len(cache.GetV1List(w.Project, w.ServiceName)) == 0 {
+			list, err := w.Client.KafkaTopics.List(w.Project, w.ServiceName)
+			if err != nil {
+				return nil, "CONFIGURING", fmt.Errorf("error calling v1 list for %s/%s: %w", w.Project, w.ServiceName, err)
+			}
+			cache.SetV1List(w.Project, w.ServiceName, list)
+		}
+
+		// Checking if the topic is in the missing list. If so, trowing 404 error
+		if slices.Contains(cache.GetMissing(w.Project, w.ServiceName), w.TopicName) {
+			return nil, "CONFIGURING", aiven.Error{Status: 404, Message: fmt.Sprintf("Topic %s is not found", w.TopicName)}
+		}
+
+		topic, ok := cache.LoadByTopicName(w.Project, w.ServiceName, w.TopicName)
 		if !ok {
 			err := w.refresh()
 
@@ -73,7 +90,6 @@ func (w *kafkaTopicAvailabilityWaiter) RefreshFunc() resource.StateRefreshFunc {
 func (w *kafkaTopicAvailabilityWaiter) refresh() error {
 	if !kafkaTopicAvailabilitySem.TryAcquire(1) {
 		log.Printf("[TRACE] Kafka Topic Availability cache refresh already in progress ...")
-		getTopicCache().AddToQueue(w.Project, w.ServiceName, w.TopicName)
 		return nil
 	}
 	defer kafkaTopicAvailabilitySem.Release(1)
@@ -96,6 +112,18 @@ func (w *kafkaTopicAvailabilityWaiter) refresh() error {
 		log.Printf("[DEBUG] Kafka Topic queue: %+v", queue)
 		v2Topics, err := w.Client.KafkaTopics.V2List(w.Project, w.ServiceName, queue)
 		if err != nil {
+			// V2 Kafka Topic endpoint retrieves 404 when one or more topics in the batch
+			// do not exist but does not say which ones are missing. Therefore, we need to
+			// identify the none existing topics.
+			if aiven.IsNotFound(err) {
+				// If topic is missing in V1 list then it does not exist, flagging it as missing
+				for _, t := range queue {
+					if !slices.Contains(c.GetV1List(w.Project, w.ServiceName), t) {
+						c.DeleteFromQueueAndMarkMissing(w.Project, w.ServiceName, t)
+					}
+				}
+				return nil
+			}
 			return err
 		}
 


### PR DESCRIPTION
<!-- All contributors, please complete these sections, including maintainers. -->

## About this change—what it does

We query Kafka Topics in batches with up to 100 topics simultaneously using the v2 list endpoint. If we add a topic name that does not exist to the query batch, API retrieves a 404 response. Furthermore, it retrieves a 404 even in case all topics in the batch do exist except one.

This API behavior causes problems when Terraform clients accidentally delete one or more topics outside of Terraform and then try to refresh a state. In this case, an nonexistent topic in the state will trigger a 404 response from the API.

In case we get 404 from the v2 list endpoint we will query v1 list (that has all topics for a services but topics data is not fully present in the response) and use to to determine which of the Kafka Topics do not exist and propagate 404 further for these topics only.