### PR TITLE
refactor: use default validation.StringInSlice

### DIFF
--- a/internal/schemautil/common.go
+++ b/internal/schemautil/common.go
@@ -3,13 +3,9 @@ package schemautil
 import (
 	"fmt"
 	"regexp"
-	"strings"
 
-	"github.com/hashicorp/go-cty/cty"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"golang.org/x/exp/slices"
 
 	"github.com/aiven/terraform-provider-aiven/internal/schemautil/userconfig"
 )
@@ -75,20 +71,6 @@ func GetTagsFromSchema(d *schema.ResourceData) map[string]string {
 	}
 
 	return tags
-}
-
-func ValidateEnum[T string | int](enum ...T) schema.SchemaValidateDiagFunc {
-	return func(i interface{}, path cty.Path) diag.Diagnostics {
-		value := i.(T)
-		if !slices.Contains(enum, value) {
-			allowed := make([]string, 0, len(enum))
-			for _, s := range enum {
-				allowed = append(allowed, fmt.Sprintf("%q", s))
-			}
-			return diag.Errorf("%q is not one of: %s", value, strings.Join(allowed, ", "))
-		}
-		return nil
-	}
 }
 
 // PointerValueOrDefault returns pointer's value or default

--- a/internal/schemautil/service.go
+++ b/internal/schemautil/service.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/aiven/aiven-go-client"
 	"github.com/docker/go-units"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 
 	"github.com/aiven/terraform-provider-aiven/internal/schemautil/userconfig"
 	"github.com/aiven/terraform-provider-aiven/internal/schemautil/userconfig/apiconvert"
@@ -89,7 +90,7 @@ func ServiceCommonSchema() map[string]*schema.Schema {
 			// There is also `never` value, which can't be set, but can be received from the backend.
 			// Sending `never` is suppressed in GetMaintenanceWindow function,
 			// but then we need to not let to set `never` manually
-			ValidateDiagFunc: ValidateEnum("monday", "tuesday", "wednesday", "thursday", "friday", "saturday", "sunday"),
+			ValidateFunc: validation.StringInSlice([]string{"monday", "tuesday", "wednesday", "thursday", "friday", "saturday", "sunday"}, false),
 		},
 		"maintenance_window_time": {
 			Type:        schema.TypeString,

--- a/internal/sdkprovider/service/kafka/mirrormaker_replication_flow.go
+++ b/internal/sdkprovider/service/kafka/mirrormaker_replication_flow.go
@@ -4,12 +4,12 @@ import (
 	"context"
 
 	"github.com/aiven/aiven-go-client"
-	"github.com/aiven/terraform-provider-aiven/internal/schemautil/userconfig"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 
 	"github.com/aiven/terraform-provider-aiven/internal/schemautil"
+	"github.com/aiven/terraform-provider-aiven/internal/schemautil/userconfig"
 )
 
 var (
@@ -87,10 +87,10 @@ var aivenMirrorMakerReplicationFlowSchema = map[string]*schema.Schema{
 		Description: userconfig.Desc("Emit heartbeats enabled.").DefaultValue(false).Build(),
 	},
 	"offset_syncs_topic_location": {
-		Type:             schema.TypeString,
-		Optional:         true,
-		Description:      "Offset syncs topic location.",
-		ValidateDiagFunc: schemautil.ValidateEnum("source", "target"),
+		Type:         schema.TypeString,
+		Optional:     true,
+		Description:  "Offset syncs topic location.",
+		ValidateFunc: validation.StringInSlice([]string{"source", "target"}, false),
 	},
 }
 

--- a/internal/sdkprovider/service/kafka/mirrormaker_replication_flow_test.go
+++ b/internal/sdkprovider/service/kafka/mirrormaker_replication_flow_test.go
@@ -7,11 +7,11 @@ import (
 	"testing"
 
 	"github.com/aiven/aiven-go-client"
-	acc "github.com/aiven/terraform-provider-aiven/internal/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 
+	acc "github.com/aiven/terraform-provider-aiven/internal/acctest"
 	"github.com/aiven/terraform-provider-aiven/internal/schemautil"
 )
 
@@ -256,7 +256,7 @@ resource "aiven_mirrormaker_replication_flow" "foo" {
 		Steps: []resource.TestStep{
 			{
 				Config:      config,
-				ExpectError: regexp.MustCompile(`"lol_offset" is not one of: "source", "target"`),
+				ExpectError: regexp.MustCompile(`expected offset_syncs_topic_location to be one of \[source target], got lol_offset`),
 			},
 		},
 	})

--- a/internal/sdkprovider/service/serviceintegration/service_integration.go
+++ b/internal/sdkprovider/service/serviceintegration/service_integration.go
@@ -74,11 +74,11 @@ var aivenServiceIntegrationSchema = map[string]*schema.Schema{
 		Type:        schema.TypeString,
 	},
 	"integration_type": {
-		Description:      "Type of the service integration. Possible values: " + schemautil.JoinQuoted(integrationTypes, ", ", "`"),
-		ForceNew:         true,
-		Required:         true,
-		Type:             schema.TypeString,
-		ValidateDiagFunc: schemautil.ValidateEnum(integrationTypes...),
+		Description:  "Type of the service integration. Possible values: " + schemautil.JoinQuoted(integrationTypes, ", ", "`"),
+		ForceNew:     true,
+		Required:     true,
+		Type:         schema.TypeString,
+		ValidateFunc: validation.StringInSlice(integrationTypes, false),
 	},
 	"project": {
 		Description: "Project the integration belongs to",

--- a/internal/sdkprovider/service/serviceintegration/service_integration_endpoint.go
+++ b/internal/sdkprovider/service/serviceintegration/service_integration_endpoint.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/aiven/aiven-go-client"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 
 	"github.com/aiven/terraform-provider-aiven/internal/schemautil"
 	"github.com/aiven/terraform-provider-aiven/internal/schemautil/userconfig"
@@ -46,10 +47,10 @@ var aivenServiceIntegrationEndpointSchema = map[string]*schema.Schema{
 	"endpoint_type": {
 		Description: "Type of the service integration endpoint. Possible values: " +
 			schemautil.JoinQuoted(integrationEndpointTypes, ", ", "`"),
-		ForceNew:         true,
-		Required:         true,
-		Type:             schema.TypeString,
-		ValidateDiagFunc: schemautil.ValidateEnum(integrationEndpointTypes...),
+		ForceNew:     true,
+		Required:     true,
+		Type:         schema.TypeString,
+		ValidateFunc: validation.StringInSlice(integrationEndpointTypes, false),
 	},
 	"endpoint_config": {
 		Description: "Integration endpoint specific backend configuration",


### PR DESCRIPTION
## About this change—what it does

Replaces custom enum validator with builtin one.