### PR TITLE
chore(kafka_topic): deprecating unclean_leader_election_enable config option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ nav_order: 1
 ## [MAJOR.MINOR.PATCH] - YYYY-MM-DD
 
 - Fix not being able to be set `ip_filter` and similar array fields in user config options to an empty array
+- `aiven_kafka_topic` field `unclean_leader_election_enable` is deprecated
 
 ## [4.4.1] - 2023-06-01
 

--- a/docs/resources/kafka_topic.md
+++ b/docs/resources/kafka_topic.md
@@ -23,7 +23,6 @@ resource "aiven_kafka_topic" "mytesttopic" {
 
   config {
     flush_ms                       = 10
-    unclean_leader_election_enable = true
     cleanup_policy                 = "compact,delete"
   }
 
@@ -85,7 +84,7 @@ Optional:
 - `segment_index_bytes` (String) segment.index.bytes value
 - `segment_jitter_ms` (String) segment.jitter.ms value
 - `segment_ms` (String) segment.ms value
-- `unclean_leader_election_enable` (Boolean) unclean.leader.election.enable value
+- `unclean_leader_election_enable` (Boolean, Deprecated) unclean.leader.election.enable value; This field is deprecated and no longer functional.
 
 
 <a id="nestedblock--tag"></a>

--- a/examples/clickhouse_integrations/kafka_source/kafka.tf
+++ b/examples/clickhouse_integrations/kafka_source/kafka.tf
@@ -28,7 +28,6 @@ resource "aiven_kafka_topic" "edge_measurements" {
 
   config {
     flush_ms                       = 10
-    unclean_leader_election_enable = true
     cleanup_policy                 = "delete"
     retention_bytes                = "134217728" // 10 GiB
     retention_ms                   = "604800000" // 1 week

--- a/examples/resources/aiven_kafka_topic/resource.tf
+++ b/examples/resources/aiven_kafka_topic/resource.tf
@@ -8,7 +8,6 @@ resource "aiven_kafka_topic" "mytesttopic" {
 
   config {
     flush_ms                       = 10
-    unclean_leader_election_enable = true
     cleanup_policy                 = "compact,delete"
   }
 

--- a/internal/schemautil/userconfig/stateupgrader/v0/kafka/kafka_topic.go
+++ b/internal/schemautil/userconfig/stateupgrader/v0/kafka/kafka_topic.go
@@ -206,9 +206,10 @@ var aivenKafkaTopicSchema = map[string]*schema.Schema{
 				},
 				"unclean_leader_election_enable": {
 					Type:             schema.TypeString,
-					Description:      "unclean.leader.election.enable value",
+					Description:      "unclean.leader.election.enable value; This field is deprecated and no longer functional.",
 					Optional:         true,
 					DiffSuppressFunc: schemautil.EmptyObjectDiffSuppressFunc,
+					Deprecated:       "This field is deprecated and no longer functional.",
 				},
 			},
 		},
@@ -250,11 +251,9 @@ func ResourceKafkaTopicStateUpgrade(
 	}
 
 	err := typeupgrader.Map(config, map[string]string{
-		"message_downconversion_enable":  "bool",
-		"min_cleanable_dirty_ratio":      "float",
-		"preallocate":                    "bool",
-		"unclean_leader_election_enable": "bool",
-	})
+		"message_downconversion_enable": "bool",
+		"min_cleanable_dirty_ratio":     "float",
+		"preallocate":                   "bool"})
 	if err != nil {
 		return rawState, err
 	}

--- a/internal/sdkprovider/service/kafka/kafka_topic.go
+++ b/internal/sdkprovider/service/kafka/kafka_topic.go
@@ -213,9 +213,10 @@ var aivenKafkaTopicSchema = map[string]*schema.Schema{
 				},
 				"unclean_leader_election_enable": {
 					Type:             schema.TypeBool,
-					Description:      "unclean.leader.election.enable value",
+					Description:      "unclean.leader.election.enable value; This field is deprecated and no longer functional.",
 					Optional:         true,
 					DiffSuppressFunc: schemautil.EmptyObjectDiffSuppressFunc,
+					Deprecated:       "This field is deprecated and no longer functional.",
 				},
 			},
 		},
@@ -534,7 +535,6 @@ func flattenKafkaTopicConfig(t *aiven.KafkaTopic) []map[string]interface{} {
 			"segment_index_bytes":                 schemautil.ToOptionalString(t.Config.SegmentIndexBytes.Value),
 			"segment_jitter_ms":                   schemautil.ToOptionalString(t.Config.SegmentJitterMs.Value),
 			"segment_ms":                          schemautil.ToOptionalString(t.Config.SegmentMs.Value),
-			"unclean_leader_election_enable":      t.Config.UncleanLeaderElectionEnable.Value,
 		},
 	}
 }

--- a/internal/sdkprovider/service/kafka/kafka_topic_test.go
+++ b/internal/sdkprovider/service/kafka/kafka_topic_test.go
@@ -155,11 +155,10 @@ resource "aiven_kafka_topic" "foo" {
   replication  = 2
 
   config {
-    flush_ms                       = 10
-    unclean_leader_election_enable = true
-    cleanup_policy                 = "compact"
-    min_cleanable_dirty_ratio      = 0.01
-    delete_retention_ms            = 50000
+    flush_ms                  = 10
+    cleanup_policy            = "compact"
+    min_cleanable_dirty_ratio = 0.01
+    delete_retention_ms       = 50000
   }
 }
 


### PR DESCRIPTION
<!-- All contributors, please complete these sections, including maintainers. -->

## About this change—what it does

Deprecating `aiven_kafka_topic.unclean_leader_election_enable`