### PR TITLE
chore(aiven_account_team_project): un-deprecate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ nav_order: 1
 - `aiven_kafka_topic` field `unclean_leader_election_enable` is deprecated
 - Fix CIDRs handled improperly in VPC resources
 - Deprecate `peer_region` field of `aiven_transit_gateway_vpc_attachment` resource
+- Un-deprecated `aiven_account_team_project`, it will be deprecated when there is an alternative
 
 ## [4.4.1] - 2023-06-01
 

--- a/internal/sdkprovider/service/account/account_team_project.go
+++ b/internal/sdkprovider/service/account/account_team_project.go
@@ -55,8 +55,7 @@ account team you are trying to link to this project.
 		},
 		Timeouts: schemautil.DefaultResourceTimeouts(),
 
-		Schema:             aivenAccountTeamProjectSchema,
-		DeprecationMessage: "This resource is deprecated and will be removed in the next major release.",
+		Schema: aivenAccountTeamProjectSchema,
 	}
 }
 


### PR DESCRIPTION
<!-- All contributors, please complete these sections, including maintainers. -->

## About this change—what it does

<!-- Provide a small sentence that summarizes the change. -->
un-deprecates `aiven_account_team_project`

<!-- Provide the issue number below, if it exists. -->

## Why this way

<!-- Provide a small explanation on why this is the approach you took for solving this problem. -->
we should deprecate it when there's an alternative
