### PR TITLE
chore: use client's retries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ nav_order: 1
 
 - Add Organization User Groups support
 - Fixed incorrect `account_id` behavior in mixed constraint setup in `aiven_project` resource
+- Remove custom retries, use client builtin ones
 
 ## [4.8.0] - 2023-07-19
 

--- a/go.mod
+++ b/go.mod
@@ -3,8 +3,7 @@ module github.com/aiven/terraform-provider-aiven
 go 1.19
 
 require (
-	github.com/aiven/aiven-go-client v1.34.0
-	github.com/avast/retry-go v3.0.0+incompatible
+	github.com/aiven/aiven-go-client v1.34.1-0.20230803140811-2f3554bf4df8
 	github.com/dave/jennifer v1.6.1
 	github.com/docker/go-units v0.5.0
 	github.com/ettle/strcase v0.1.1

--- a/go.sum
+++ b/go.sum
@@ -196,8 +196,8 @@ github.com/acomagu/bufpipe v1.0.4 h1:e3H4WUzM3npvo5uv95QuJM3cQspFNtFBzvJ2oNjKIDQ
 github.com/agext/levenshtein v1.2.1/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=
 github.com/agext/levenshtein v1.2.3 h1:YB2fHEn0UJagG8T1rrWknE3ZQzWM06O8AMAatNn7lmo=
 github.com/agext/levenshtein v1.2.3/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=
-github.com/aiven/aiven-go-client v1.34.0 h1:FThy6mc1PrVveSfEPocUCr+9IkV7O3naiydOy02U6wo=
-github.com/aiven/aiven-go-client v1.34.0/go.mod h1:3Hh1PDNcqNNCYrkU/jSAHMV/b/ynoy73fwhBPKnMe6I=
+github.com/aiven/aiven-go-client v1.34.1-0.20230803140811-2f3554bf4df8 h1:rOrJVr3tHVxCAw+gsUQY8yCw4witihgip2fEgaG6kCY=
+github.com/aiven/aiven-go-client v1.34.1-0.20230803140811-2f3554bf4df8/go.mod h1:3Hh1PDNcqNNCYrkU/jSAHMV/b/ynoy73fwhBPKnMe6I=
 github.com/aiven/go-api-schemas v1.22.0 h1:JGh9T0VLNw7BXyVHwmwDix6F8yx7Z+dK7/u/gOBEbL4=
 github.com/aiven/go-api-schemas v1.22.0/go.mod h1:RmQ8MfxwxAP2ji9eJtP6dICOaTMcQD9b5aQT3Bp7uzI=
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
@@ -206,8 +206,6 @@ github.com/apparentlymart/go-textseg v1.0.0/go.mod h1:z96Txxhf3xSFMPmb5X/1W05FF/
 github.com/apparentlymart/go-textseg/v12 v12.0.0/go.mod h1:S/4uRK2UtaQttw1GenVJEynmyUenKwP++x/+DdGV/Ec=
 github.com/apparentlymart/go-textseg/v13 v13.0.0 h1:Y+KvPE1NYz0xl601PVImeQfFyEy6iT90AvPUL1NNfNw=
 github.com/apparentlymart/go-textseg/v13 v13.0.0/go.mod h1:ZK2fH7c4NqDTLtiYLvIkEghdlcqw7yxLeM89kiTRPUo=
-github.com/avast/retry-go v3.0.0+incompatible h1:4SOWQ7Qs+oroOTQOYnAHqelpCO0biHSxpiH9JdtuBj0=
-github.com/avast/retry-go v3.0.0+incompatible/go.mod h1:XtSnn+n/sHqQIpZ10K1qAevBhOOCWBLXXy3hyiqqBrY=
 github.com/aws/aws-sdk-go v1.44.122 h1:p6mw01WBaNpbdP2xrisz5tIkcNwzj/HysobNoaAHjgo=
 github.com/aws/aws-sdk-go v1.44.122/go.mod h1:y4AeaBuwd2Lk+GepC1E9v0qOiTws0MIWAX4oIKwKHZo=
 github.com/bgentry/go-netrc v0.0.0-20140422174119-9fd32a8b3d3d h1:xDfNPAt8lFiC1UJrqV3uuy861HCTo708pDMbjHHdCas=

--- a/internal/sdkprovider/service/kafka/kafka_connector_test.go
+++ b/internal/sdkprovider/service/kafka/kafka_connector_test.go
@@ -7,12 +7,12 @@ import (
 	"testing"
 
 	"github.com/aiven/aiven-go-client"
-	acc "github.com/aiven/terraform-provider-aiven/internal/acctest"
-	"github.com/aiven/terraform-provider-aiven/internal/schemautil"
-
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	acc "github.com/aiven/terraform-provider-aiven/internal/acctest"
+	"github.com/aiven/terraform-provider-aiven/internal/schemautil"
 )
 
 func TestAccAivenKafkaConnector_basic(t *testing.T) {

--- a/internal/sdkprovider/service/kafka/kafka_topic_data_source_test.go
+++ b/internal/sdkprovider/service/kafka/kafka_topic_data_source_test.go
@@ -6,9 +6,10 @@ import (
 	"regexp"
 	"testing"
 
-	acc "github.com/aiven/terraform-provider-aiven/internal/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	acc "github.com/aiven/terraform-provider-aiven/internal/acctest"
 )
 
 // TestAccAivenDatasourceKafkaTopic_doesnt_exist this datasource shares Read() function with real "resource"
@@ -29,7 +30,7 @@ func TestAccAivenDatasourceKafkaTopic_doesnt_exist(t *testing.T) {
 				// Can't import unknown topic
 				Config:      testAccAivenDatasourceKafkaTopicDoesntExist(prefix, project, true),
 				PlanOnly:    true,
-				ExpectError: regexp.MustCompile(`Topic\(s\) not found`),
+				ExpectError: regexp.MustCompile(`not found`),
 			},
 		},
 	})

--- a/internal/sdkprovider/service/kafka/kafka_topic_wait.go
+++ b/internal/sdkprovider/service/kafka/kafka_topic_wait.go
@@ -61,17 +61,6 @@ func (w *kafkaTopicAvailabilityWaiter) RefreshFunc() resource.StateRefreshFunc {
 			err := w.refresh()
 
 			if err != nil {
-				aivenError, ok := err.(aiven.Error)
-				if !ok {
-					return nil, "CONFIGURING", err
-				}
-
-				// Getting topic info can sometimes temporarily fail with 501 and 502. Don't
-				// treat that as fatal error but keep on retrying instead.
-				if aivenError.Status == 501 || aivenError.Status == 502 {
-					log.Printf("[DEBUG] Got an error while waiting for a topic '%s' to be ACTIVE: %s.", w.TopicName, err)
-					return nil, "CONFIGURING", nil
-				}
 				return nil, "CONFIGURING", err
 			}
 

--- a/internal/sdkprovider/service/serviceintegration/service_integration.go
+++ b/internal/sdkprovider/service/serviceintegration/service_integration.go
@@ -323,7 +323,6 @@ func resourceServiceIntegrationWaitUntilActive(ctx context.Context, d *schema.Re
 			}
 
 			if ii.IntegrationType == "kafka_connect" && ii.DestinationService != nil {
-				// This might fail for a long time with 501: Connector list not currently available
 				if _, err := client.KafkaConnectors.List(projectName, *ii.DestinationService); err != nil {
 					log.Println("[DEBUG] Service Integration: error listing kafka connectors: ", err)
 					return nil, notActive, nil

--- a/internal/sdkprovider/service/vpc/project_vpc_test.go
+++ b/internal/sdkprovider/service/vpc/project_vpc_test.go
@@ -39,7 +39,7 @@ func TestAccAivenProjectVPC_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAivenProjectVPCAttributes("data.aiven_project_vpc.vpc"),
 					resource.TestCheckResourceAttr(resourceName, "project", os.Getenv("AIVEN_PROJECT_NAME")),
-					resource.TestCheckResourceAttr(resourceName, "cloud_name", "google-europe-west1"),
+					resource.TestCheckResourceAttr(resourceName, "cloud_name", "google-europe-west2"),
 					resource.TestCheckResourceAttr(resourceName, "network_cidr", "192.168.0.0/24"),
 					resource.TestCheckResourceAttr(resourceName, "state", "ACTIVE"),
 				),
@@ -66,7 +66,7 @@ data "aiven_project" "foo" {
 
 resource "aiven_project_vpc" "bar" {
   project      = data.aiven_project.foo.project
-  cloud_name   = "google-europe-west1"
+  cloud_name   = "google-europe-west2"
   network_cidr = "192.168.0.0/24"
 }
 


### PR DESCRIPTION
## About this change—what it does

- Uses client's retries for corner cases
- Fixes KafkaConector create (retries 404 on POST)
- Fixes VPC test