### PR TITLE
fix(organization): wrong ID used

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ nav_order: 1
 
 ## [MAJOR.MINOR.PATCH] - YYYY-MM-DD
 
+- Fix wrong ID used for `organization` resources
+
 ## [4.5.0] - 2023-06-14
 
 - Fix not being able to be set `ip_filter` and similar array fields in user config options to an empty array

--- a/internal/sdkprovider/service/opensearch/opensearch_acl_config.go
+++ b/internal/sdkprovider/service/opensearch/opensearch_acl_config.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/aiven/aiven-go-client"
+
 	"github.com/aiven/terraform-provider-aiven/internal/schemautil"
 	"github.com/aiven/terraform-provider-aiven/internal/schemautil/userconfig"
 
@@ -81,7 +82,7 @@ func resourceOpensearchACLConfigUpdate(ctx context.Context, d *schema.ResourceDa
 	modifier := resourceElasticsearchACLModifierToggleConfigFields(d.Get("enabled").(bool), d.Get("extended_acl").(bool))
 	err := resourceOpensearchACLModifyRemoteConfig(project, serviceName, client, modifier)
 	if err != nil {
-		return diag.FromErr(schemautil.ResourceReadHandleNotFound(err, d))
+		return diag.FromErr(err)
 	}
 
 	d.SetId(schemautil.BuildResourceID(project, serviceName))
@@ -98,7 +99,7 @@ func resourceOpensearchACLConfigDelete(_ context.Context, d *schema.ResourceData
 	modifier := resourceElasticsearchACLModifierToggleConfigFields(false, false)
 	err := resourceOpensearchACLModifyRemoteConfig(project, serviceName, client, modifier)
 	if err != nil {
-		return diag.FromErr(schemautil.ResourceReadHandleNotFound(err, d))
+		return diag.FromErr(err)
 	}
 
 	return nil

--- a/internal/sdkprovider/service/opensearch/opensearch_acl_rule.go
+++ b/internal/sdkprovider/service/opensearch/opensearch_acl_rule.go
@@ -4,11 +4,12 @@ import (
 	"context"
 
 	"github.com/aiven/aiven-go-client"
-	"github.com/aiven/terraform-provider-aiven/internal/schemautil"
-	"github.com/aiven/terraform-provider-aiven/internal/schemautil/userconfig"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/aiven/terraform-provider-aiven/internal/schemautil"
+	"github.com/aiven/terraform-provider-aiven/internal/schemautil/userconfig"
 )
 
 var aivenOpensearchACLRuleSchema = map[string]*schema.Schema{
@@ -126,7 +127,7 @@ func resourceOpensearchACLRuleUpdate(ctx context.Context, d *schema.ResourceData
 	modifier := resourceElasticsearchACLModifierUpdateACLRule(username, index, permission)
 	err := resourceOpensearchACLModifyRemoteConfig(project, serviceName, client, modifier)
 	if err != nil {
-		return diag.FromErr(schemautil.ResourceReadHandleNotFound(err, d))
+		return diag.FromErr(err)
 	}
 
 	d.SetId(schemautil.BuildResourceID(project, serviceName, username, index))
@@ -146,7 +147,7 @@ func resourceOpensearchACLRuleDelete(_ context.Context, d *schema.ResourceData, 
 	modifier := resourceElasticsearchACLModifierDeleteACLRule(username, index, permission)
 	err := resourceOpensearchACLModifyRemoteConfig(project, serviceName, client, modifier)
 	if err != nil {
-		return diag.FromErr(schemautil.ResourceReadHandleNotFound(err, d))
+		return diag.FromErr(err)
 	}
 	return nil
 }

--- a/internal/sdkprovider/service/organization/organizational_unit.go
+++ b/internal/sdkprovider/service/organization/organizational_unit.go
@@ -58,7 +58,11 @@ func ResourceOrganizationalUnit() *schema.Resource {
 func resourceOrganizationalUnitCreate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	client := m.(*aiven.Client)
 	name := d.Get("name").(string)
-	parentID := d.Get("parent_id").(string)
+
+	parentID, err := normalizeID(client, d.Get("parent_id").(string))
+	if err != nil {
+		return diag.FromErr(err)
+	}
 
 	r, err := client.Accounts.Create(
 		aiven.Account{
@@ -120,8 +124,7 @@ func resourceOrganizationalUnitUpdate(ctx context.Context, d *schema.ResourceDat
 func resourceOrganizationalUnitDelete(_ context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	client := m.(*aiven.Client)
 
-	err := client.Accounts.Delete(d.Id())
-	if err != nil && !aiven.IsNotFound(err) {
+	if err := client.Accounts.Delete(d.Id()); err != nil && !aiven.IsNotFound(err) {
 		return diag.FromErr(err)
 	}
 

--- a/internal/sdkprovider/service/organization/util.go
+++ b/internal/sdkprovider/service/organization/util.go
@@ -1,0 +1,25 @@
+// Package organization contains the organization related resources and utilities.
+package organization
+
+import (
+	"strings"
+
+	"github.com/aiven/aiven-go-client"
+)
+
+// normalizeID is a helper function that returns the ID to use for the API call.
+// If the ID is an organization ID, it will be converted to an account ID via the API.
+// If the ID is an account ID, it will be returned as is, without performing any API calls.
+func normalizeID(client *aiven.Client, id string) (string, error) {
+	if strings.HasPrefix(id, "org") {
+		r, err := client.Organizations.Get(id)
+
+		if err != nil {
+			return "", err
+		}
+
+		id = r.AccountID
+	}
+
+	return id, nil
+}


### PR DESCRIPTION
<!-- All contributors, please complete these sections, including maintainers. -->

## About this change—what it does

<!-- Provide a small sentence that summarizes the change. -->
fixes wrong ID used for `organization` resources

<!-- Provide the issue number below, if it exists. -->

## Why this way

<!-- Provide a small explanation on why this is the approach you took for solving this problem. -->
the `aiven_organization` resource should have `organization_id` used as its ID, while still being able to create nested units, which require organization's account ID

this ID is more important to us since it's used in other organization-related resources (which aren't implemented yet), thus abolishing the need in organization's account ID
