### PR TITLE
fix(kafka_schema): compatibility_level import shows non empty plan

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ nav_order: 1
 - Deprecated `account_id` in `aiven_project` and `aiven_billing_group` resources
   - Please use `parent_id` instead, `account_id` is going to be removed in the next major release
 - Fix `parent_id` storing mechanism in `aiven_organizational_unit`
+- Fix `aiven_kafka_schema` import produced non-empty plan for `compatibility_level` attribute
 
 ## [4.6.0] - 2023-06-28
 

--- a/internal/schemautil/schemautil.go
+++ b/internal/schemautil/schemautil.go
@@ -1,11 +1,13 @@
 package schemautil
 
 import (
+	"context"
 	"fmt"
 	"net/url"
 	"regexp"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/aiven/aiven-go-client"
@@ -335,4 +337,28 @@ func unmarshalUserConfig(src interface{}) ([]map[string]interface{}, error) {
 	}
 
 	return []map[string]interface{}{config}, nil
+}
+
+// importingResourceIDs Stores `terraform import` resource id
+// The terraform import command can only import one resource at a time
+// https://developer.hashicorp.com/terraform/cli/import/usage
+// But tests might run multiple imports
+var importingResourceIDs sync.Map
+
+// ImportStatePassthroughContext same as schema.ImportStatePassthroughContext
+// but stores importing resource id to now if Read() handler has been called on `terraform import` command
+func ImportStatePassthroughContext(ctx context.Context, d *schema.ResourceData, m interface{}) ([]*schema.ResourceData, error) {
+	// This will never happen except tests,
+	// because terraform runs one import per resource
+	// but just in case
+	if IsImportingResource(d) {
+		return nil, fmt.Errorf("%q already importing", d.Id())
+	}
+	importingResourceIDs.Store(d.Id(), true)
+	return schema.ImportStatePassthroughContext(ctx, d, m)
+}
+
+func IsImportingResource(d *schema.ResourceData) bool {
+	_, ok := importingResourceIDs.Load(d.Id())
+	return ok
 }

--- a/internal/sdkprovider/service/kafka/kafka_schema.go
+++ b/internal/sdkprovider/service/kafka/kafka_schema.go
@@ -94,7 +94,7 @@ func ResourceKafkaSchema() *schema.Resource {
 		ReadContext:   resourceKafkaSchemaRead,
 		DeleteContext: resourceKafkaSchemaDelete,
 		Importer: &schema.ResourceImporter{
-			StateContext: schema.ImportStatePassthroughContext,
+			StateContext: schemautil.ImportStatePassthroughContext,
 		},
 		CustomizeDiff: resourceKafkaSchemaCustomizeDiff,
 		Timeouts:      schemautil.DefaultResourceTimeouts(),
@@ -254,7 +254,7 @@ func resourceKafkaSchemaRead(_ context.Context, d *schema.ResourceData, m interf
 		}
 	} else {
 		// only update if was set to not empty values by the user
-		if _, ok := d.GetOk("compatibility_level"); ok {
+		if _, ok := d.GetOk("compatibility_level"); ok || schemautil.IsImportingResource(d) {
 			if err := d.Set("compatibility_level", c.CompatibilityLevel); err != nil {
 				return diag.FromErr(err)
 			}


### PR DESCRIPTION
## About this change—what it does

Kafka schema `compatibility_level` is handled in a special way. 
If it is not set by user it is not stored in state.
However, import command get's empty resource with empty compatibility_level.
Then when `plan` is called terraform shows the diff: now it reads compatibility_level value but the state doesn't have it.