### PR TITLE
chore(go): use same go 1.18 everywhere

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -42,7 +42,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v4
         with:
-          go-version: 1.19
+          go-version: 1.18
 
       - run: make lint
 
@@ -53,7 +53,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v4
         with:
-          go-version: 1.19
+          go-version: 1.18
 
       - run: make docs
       - run: git diff --exit-code


### PR DESCRIPTION
## About this change—what it does

Linter fails to provide output because of version difference.