### PR TITLE
chore(ci): quiet terraform fmt linter

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -102,7 +102,7 @@ lint-go: $(GOLANGCILINT)
 
 
 lint-test: $(TERRAFMT)
-	$(TERRAFMT) diff ./internal -cfv
+	$(TERRAFMT) diff ./internal -cfq
 
 
 lint-docs: $(TFPLUGINDOCS)


### PR DESCRIPTION
## About this change—what it does

Verbose output is displayed as linter errors on github. 
This pr runs terraform format check in quiet mode.