### PR TITLE
fix(project): organizations test

### DIFF
--- a/internal/sdkprovider/service/project/project_test.go
+++ b/internal/sdkprovider/service/project/project_test.go
@@ -87,7 +87,7 @@ func TestAccAivenProject_organizations(t *testing.T) {
 			{
 				Config: testAccProjectResourceOrganizations(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAivenProjectAttributes("data.aiven_project.project", "parent_id"),
+					testAccCheckAivenProjectAttributes(resourceName, "parent_id"),
 					resource.TestCheckResourceAttr(resourceName, "project", fmt.Sprintf("test-acc-pr-%s", rName)),
 				),
 			},
@@ -159,12 +159,6 @@ resource "aiven_project" "foo" {
     key   = "test"
     value = "val"
   }
-}
-
-data "aiven_project" "project" {
-  project = aiven_project.foo.project
-
-  depends_on = [aiven_project.foo]
 }`, name, name)
 }
 


### PR DESCRIPTION
<!-- All contributors, please complete these sections, including maintainers. -->

## About this change—what it does

<!-- Provide a small sentence that summarizes the change. -->
currently, data source for `aiven_project` does not supports `parent_id` properly because it's a pseudo-field not currently implemented in the API

<!-- Provide the issue number below, if it exists. -->

## Why this way

<!-- Provide a small explanation on why this is the approach you took for solving this problem. -->
we need to have the test functioning
