### PR TITLE
revert(kafka): remove the tiered storage functionality

### DIFF
--- a/docs/data-sources/kafka.md
+++ b/docs/data-sources/kafka.md
@@ -108,7 +108,6 @@ Read-Only:
 - `schema_registry` (Boolean)
 - `schema_registry_config` (List of Object) (see [below for nested schema](#nestedobjatt--kafka_user_config--schema_registry_config))
 - `static_ips` (Boolean)
-- `tiered_storage` (List of Object) (see [below for nested schema](#nestedobjatt--kafka_user_config--tiered_storage))
 
 <a id="nestedobjatt--kafka_user_config--ip_filter_object"></a>
 ### Nested Schema for `kafka_user_config.ip_filter_object`
@@ -158,7 +157,6 @@ Read-Only:
 - `num_partitions` (Number)
 - `offsets_retention_minutes` (Number)
 - `producer_purgatory_purge_interval_requests` (Number)
-- `remote_log_storage_system_enable` (Boolean)
 - `replica_fetch_max_bytes` (Number)
 - `replica_fetch_response_max_bytes` (Number)
 - `socket_request_max_bytes` (Number)
@@ -257,23 +255,6 @@ Read-Only:
 
 - `leader_eligibility` (Boolean)
 - `topic_name` (String)
-
-
-<a id="nestedobjatt--kafka_user_config--tiered_storage"></a>
-### Nested Schema for `kafka_user_config.tiered_storage`
-
-Read-Only:
-
-- `enabled` (Boolean)
-- `local_cache` (List of Object) (see [below for nested schema](#nestedobjatt--kafka_user_config--tiered_storage--local_cache))
-
-<a id="nestedobjatt--kafka_user_config--tiered_storage--local_cache"></a>
-### Nested Schema for `kafka_user_config.tiered_storage.local_cache`
-
-Read-Only:
-
-- `size` (Number)
-
 
 
 

--- a/docs/resources/kafka.md
+++ b/docs/resources/kafka.md
@@ -107,7 +107,6 @@ Optional:
 - `schema_registry` (Boolean) Enable Schema-Registry service. The default value is `false`.
 - `schema_registry_config` (Block List, Max: 1) Schema Registry configuration. (see [below for nested schema](#nestedblock--kafka_user_config--schema_registry_config))
 - `static_ips` (Boolean) Use static public IP addresses.
-- `tiered_storage` (Block List, Max: 1) Tiered storage configuration. (see [below for nested schema](#nestedblock--kafka_user_config--tiered_storage))
 
 <a id="nestedblock--kafka_user_config--ip_filter_object"></a>
 ### Nested Schema for `kafka_user_config.ip_filter_object`
@@ -160,7 +159,6 @@ Optional:
 - `num_partitions` (Number) Number of partitions for autocreated topics.
 - `offsets_retention_minutes` (Number) Log retention window in minutes for offsets topic.
 - `producer_purgatory_purge_interval_requests` (Number) The purge interval (in number of requests) of the producer request purgatory(defaults to 1000).
-- `remote_log_storage_system_enable` (Boolean) Whether to enable the tiered storage functionality.
 - `replica_fetch_max_bytes` (Number) The number of bytes of messages to attempt to fetch for each partition (defaults to 1048576). This is not an absolute maximum, if the first record batch in the first non-empty partition of the fetch is larger than this value, the record batch will still be returned to ensure that progress can be made.
 - `replica_fetch_response_max_bytes` (Number) Maximum bytes expected for the entire fetch response (defaults to 10485760). Records are fetched in batches, and if the first record batch in the first non-empty partition of the fetch is larger than this value, the record batch will still be returned to ensure that progress can be made. As such, this is not an absolute maximum.
 - `socket_request_max_bytes` (Number) The maximum number of bytes in a socket request (defaults to 104857600).
@@ -259,23 +257,6 @@ Optional:
 
 - `leader_eligibility` (Boolean) If true, Karapace / Schema Registry on the service nodes can participate in leader election. It might be needed to disable this when the schemas topic is replicated to a secondary cluster and Karapace / Schema Registry there must not participate in leader election. Defaults to `true`.
 - `topic_name` (String) The durable single partition topic that acts as the durable log for the data. This topic must be compacted to avoid losing data due to retention policy. Please note that changing this configuration in an existing Schema Registry / Karapace setup leads to previous schemas being inaccessible, data encoded with them potentially unreadable and schema ID sequence put out of order. It's only possible to do the switch while Schema Registry / Karapace is disabled. Defaults to `_schemas`.
-
-
-<a id="nestedblock--kafka_user_config--tiered_storage"></a>
-### Nested Schema for `kafka_user_config.tiered_storage`
-
-Optional:
-
-- `enabled` (Boolean) Whether to enable the tiered storage functionality.
-- `local_cache` (Block List, Max: 1) Local cache configuration. (see [below for nested schema](#nestedblock--kafka_user_config--tiered_storage--local_cache))
-
-<a id="nestedblock--kafka_user_config--tiered_storage--local_cache"></a>
-### Nested Schema for `kafka_user_config.tiered_storage.local_cache`
-
-Optional:
-
-- `size` (Number) Local cache size in bytes.
-
 
 
 

--- a/internal/schemautil/userconfig/dist/service_types.go
+++ b/internal/schemautil/userconfig/dist/service_types.go
@@ -2497,11 +2497,6 @@ func ServiceTypeKafka() *schema.Schema {
 					Optional:    true,
 					Type:        schema.TypeInt,
 				},
-				"remote_log_storage_system_enable": {
-					Description: "Whether to enable the tiered storage functionality.",
-					Optional:    true,
-					Type:        schema.TypeBool,
-				},
 				"replica_fetch_max_bytes": {
 					Description: "The number of bytes of messages to attempt to fetch for each partition (defaults to 1048576). This is not an absolute maximum, if the first record batch in the first non-empty partition of the fetch is larger than this value, the record batch will still be returned to ensure that progress can be made.",
 					Optional:    true,
@@ -2698,11 +2693,6 @@ func ServiceTypeKafka() *schema.Schema {
 					Description: "The purge interval (in number of requests) of the producer request purgatory(defaults to 1000).",
 					Optional:    true,
 					Type:        schema.TypeInt,
-				},
-				"remote_log_storage_system_enable": {
-					Description: "Whether to enable the tiered storage functionality.",
-					Optional:    true,
-					Type:        schema.TypeBool,
 				},
 				"replica_fetch_max_bytes": {
 					Description: "The number of bytes of messages to attempt to fetch for each partition (defaults to 1048576). This is not an absolute maximum, if the first record batch in the first non-empty partition of the fetch is larger than this value, the record batch will still be returned to ensure that progress can be made.",
@@ -3294,58 +3284,6 @@ func ServiceTypeKafka() *schema.Schema {
 			Description: "Use static public IP addresses.",
 			Optional:    true,
 			Type:        schema.TypeBool,
-		},
-		"tiered_storage": {
-			Description: "Tiered storage configuration.",
-			DiffSuppressFunc: schemautil.EmptyObjectDiffSuppressFuncSkipArrays(map[string]*schema.Schema{
-				"enabled": {
-					Description: "Whether to enable the tiered storage functionality.",
-					Optional:    true,
-					Type:        schema.TypeBool,
-				},
-				"local_cache": {
-					Description: "Local cache configuration.",
-					DiffSuppressFunc: schemautil.EmptyObjectDiffSuppressFuncSkipArrays(map[string]*schema.Schema{"size": {
-						Description: "Local cache size in bytes.",
-						Optional:    true,
-						Type:        schema.TypeInt,
-					}}),
-					Elem: &schema.Resource{Schema: map[string]*schema.Schema{"size": {
-						Description: "Local cache size in bytes.",
-						Optional:    true,
-						Type:        schema.TypeInt,
-					}}},
-					MaxItems: 1,
-					Optional: true,
-					Type:     schema.TypeList,
-				},
-			}),
-			Elem: &schema.Resource{Schema: map[string]*schema.Schema{
-				"enabled": {
-					Description: "Whether to enable the tiered storage functionality.",
-					Optional:    true,
-					Type:        schema.TypeBool,
-				},
-				"local_cache": {
-					Description: "Local cache configuration.",
-					DiffSuppressFunc: schemautil.EmptyObjectDiffSuppressFuncSkipArrays(map[string]*schema.Schema{"size": {
-						Description: "Local cache size in bytes.",
-						Optional:    true,
-						Type:        schema.TypeInt,
-					}}),
-					Elem: &schema.Resource{Schema: map[string]*schema.Schema{"size": {
-						Description: "Local cache size in bytes.",
-						Optional:    true,
-						Type:        schema.TypeInt,
-					}}},
-					MaxItems: 1,
-					Optional: true,
-					Type:     schema.TypeList,
-				},
-			}},
-			MaxItems: 1,
-			Optional: true,
-			Type:     schema.TypeList,
 		},
 	}
 

--- a/main.go
+++ b/main.go
@@ -15,7 +15,8 @@ import (
 	sdkprovider "github.com/aiven/terraform-provider-aiven/internal/sdkprovider/provider"
 )
 
-//go:generate go test -tags userconfig ./internal/schemautil/userconfig
+// fixme: enable code generation when Tiered Storage is GA
+////go:generate go test -tags userconfig ./internal/schemautil/userconfig
 
 // version is the version of the provider.
 var version = "dev"


### PR DESCRIPTION
## About this change—what it does

Tiered Storage is not GA yet.