### PR TITLE
fix(transit_gateway_vpc_attachment): send empty slices on update, not nil

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ nav_order: 1
 
 ## [MAJOR.MINOR.PATCH] - YYYY-MM-DD
 
+- Fix `aiven_transit_gateway_vpc_attachment` resource update
+
 ## [4.8.1] - 2023-08-23
 
 - Add Organization User Groups support

--- a/internal/sdkprovider/service/vpc/transit_gateway_vpc_attachment.go
+++ b/internal/sdkprovider/service/vpc/transit_gateway_vpc_attachment.go
@@ -103,7 +103,7 @@ func resourceTransitGatewayVPCAttachmentUpdate(ctx context.Context, d *schema.Re
 	}
 
 	// prepare a list of new transit gateway vpc attachment that needs to be added
-	var add []aiven.TransitGatewayVPCAttachment
+	add := make([]aiven.TransitGatewayVPCAttachment, 0)
 	for _, fresh := range cidrs {
 		var isNew = true
 
@@ -129,7 +129,7 @@ func resourceTransitGatewayVPCAttachmentUpdate(ctx context.Context, d *schema.Re
 	}
 
 	// prepare a list of old cirds for deletion
-	var deleteCIDRs []string
+	deleteCIDRs := make([]string, 0)
 	for _, old := range peeringConnection.UserPeerNetworkCIDRs {
 		var forDeletion = true
 


### PR DESCRIPTION
## About this change—what it does

Sends empty slices as arrays, not nil for `aiven_transit_gateway_vpc_attachment`. 
API doesn't accept nil for arrays.

Resolves #1310 

## Why this way

Zero value slice is [equal to nil](https://go.dev/blog/slices-intro).

```golang
var p []int // == nil
```
