### PR TITLE
fix(frameworkprovider): remove defaultfunc workaround

### DIFF
--- a/internal/sdkprovider/provider/provider.go
+++ b/internal/sdkprovider/provider/provider.go
@@ -2,7 +2,6 @@ package provider
 
 import (
 	"context"
-	"os"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -36,9 +35,10 @@ func Provider(version string) *schema.Provider {
 	p := &schema.Provider{
 		Schema: map[string]*schema.Schema{
 			"api_token": {
-				Type:      schema.TypeString,
-				Optional:  true,
-				Sensitive: true,
+				Type:        schema.TypeString,
+				Optional:    true,
+				Sensitive:   true,
+				DefaultFunc: schema.EnvDefaultFunc("AIVEN_TOKEN", ""),
 				// Description should match the one in internal/provider/provider.go.
 				Description: "Aiven authentication token. Can also be set with the AIVEN_TOKEN environment variable.",
 			},
@@ -243,12 +243,7 @@ func Provider(version string) *schema.Provider {
 	}
 
 	p.ConfigureContextFunc = func(_ context.Context, d *schema.ResourceData) (interface{}, diag.Diagnostics) {
-		token := d.Get("api_token").(string)
-		if token == "" {
-			token = os.Getenv("AIVEN_TOKEN")
-		}
-
-		client, err := common.NewCustomAivenClient(token, p.TerraformVersion, version)
+		client, err := common.NewCustomAivenClient(d.Get("api_token").(string), p.TerraformVersion, version)
 		if err != nil {
 			return nil, diag.FromErr(err)
 		}


### PR DESCRIPTION
<!-- All contributors, please complete these sections, including maintainers. -->

## About this change—what it does

<!-- Provide a small sentence that summarizes the change. -->
partially reverts workaround introduced in #1311

<!-- Provide the issue number below, if it exists. -->

## Why this way

<!-- Provide a small explanation on why this is the approach you took for solving this problem. -->
we need to use `DefaultFunc` properly
