### PR TITLE
refactor(kafka_topic_cache): init cache on module level

### DIFF
--- a/internal/sdkprovider/service/kafka/kafka_topic.go
+++ b/internal/sdkprovider/service/kafka/kafka_topic.go
@@ -224,8 +224,6 @@ var aivenKafkaTopicSchema = map[string]*schema.Schema{
 }
 
 func ResourceKafkaTopic() *schema.Resource {
-	initTopicCache()
-
 	return &schema.Resource{
 		Description:   "The Kafka Topic resource allows the creation and management of Aiven Kafka Topics.",
 		CreateContext: resourceKafkaTopicCreate,

--- a/internal/sdkprovider/service/kafka/kafka_topic_cache.go
+++ b/internal/sdkprovider/service/kafka/kafka_topic_cache.go
@@ -8,10 +8,7 @@ import (
 	"golang.org/x/exp/slices"
 )
 
-var (
-	once       sync.Once
-	topicCache *kafkaTopicCache
-)
+var topicCache = newTopicCache()
 
 // kafkaTopicCache represents Kafka Topics cache based on Service and Project identifiers
 type kafkaTopicCache struct {
@@ -22,18 +19,14 @@ type kafkaTopicCache struct {
 	v1list   map[string][]string
 }
 
-// initTopicCache creates new global instance of Kafka Topic Cache
-func initTopicCache() {
-	log.Print("[DEBUG] Creating an instance of kafkaTopicCache ...")
-
-	once.Do(func() {
-		topicCache = &kafkaTopicCache{
-			internal: make(map[string]map[string]aiven.KafkaTopic),
-			inQueue:  make(map[string][]string),
-			missing:  make(map[string][]string),
-			v1list:   make(map[string][]string),
-		}
-	})
+// newTopicCache creates new instance of Kafka Topic Cache
+func newTopicCache() *kafkaTopicCache {
+	return &kafkaTopicCache{
+		internal: make(map[string]map[string]aiven.KafkaTopic),
+		inQueue:  make(map[string][]string),
+		missing:  make(map[string][]string),
+		v1list:   make(map[string][]string),
+	}
 }
 
 // getTopicCache gets a global Kafka Topics Cache


### PR DESCRIPTION
## About this change—what it does

Inits cache on module level to run unit test without having provided initialized. See `initTopicCache()`.