### PR TITLE
refactor(kafka): split kafka package to run tests faster

### DIFF
--- a/.github/workflows/acceptance-tests.yml
+++ b/.github/workflows/acceptance-tests.yml
@@ -22,6 +22,8 @@ jobs:
       matrix:
         pkg: [
           kafka,
+          kafkatopic,
+          kafkaschema,
           account,
           cassandra,
           clickhouse,

--- a/internal/sdkprovider/provider/provider.go
+++ b/internal/sdkprovider/provider/provider.go
@@ -16,6 +16,8 @@ import (
 	"github.com/aiven/terraform-provider-aiven/internal/sdkprovider/service/grafana"
 	"github.com/aiven/terraform-provider-aiven/internal/sdkprovider/service/influxdb"
 	"github.com/aiven/terraform-provider-aiven/internal/sdkprovider/service/kafka"
+	"github.com/aiven/terraform-provider-aiven/internal/sdkprovider/service/kafkaschema"
+	"github.com/aiven/terraform-provider-aiven/internal/sdkprovider/service/kafkatopic"
 	"github.com/aiven/terraform-provider-aiven/internal/sdkprovider/service/m3db"
 	"github.com/aiven/terraform-provider-aiven/internal/sdkprovider/service/mysql"
 	"github.com/aiven/terraform-provider-aiven/internal/sdkprovider/service/opensearch"
@@ -125,10 +127,10 @@ func Provider(version string) *schema.Provider {
 			"aiven_kafka":                        kafka.DatasourceKafka(),
 			"aiven_kafka_user":                   kafka.DatasourceKafkaUser(),
 			"aiven_kafka_acl":                    kafka.DatasourceKafkaACL(),
-			"aiven_kafka_schema_registry_acl":    kafka.DatasourceKafkaSchemaRegistryACL(),
-			"aiven_kafka_topic":                  kafka.DatasourceKafkaTopic(),
-			"aiven_kafka_schema":                 kafka.DatasourceKafkaSchema(),
-			"aiven_kafka_schema_configuration":   kafka.DatasourceKafkaSchemaConfiguration(),
+			"aiven_kafka_schema_registry_acl":    kafkaschema.DatasourceKafkaSchemaRegistryACL(),
+			"aiven_kafka_topic":                  kafkatopic.DatasourceKafkaTopic(),
+			"aiven_kafka_schema":                 kafkaschema.DatasourceKafkaSchema(),
+			"aiven_kafka_schema_configuration":   kafkaschema.DatasourceKafkaSchemaConfiguration(),
 			"aiven_kafka_connector":              kafka.DatasourceKafkaConnector(),
 			"aiven_mirrormaker_replication_flow": kafka.DatasourceMirrorMakerReplicationFlowTopic(),
 			"aiven_kafka_connect":                kafka.DatasourceKafkaConnect(),
@@ -224,10 +226,10 @@ func Provider(version string) *schema.Provider {
 			"aiven_kafka":                        kafka.ResourceKafka(),
 			"aiven_kafka_user":                   kafka.ResourceKafkaUser(),
 			"aiven_kafka_acl":                    kafka.ResourceKafkaACL(),
-			"aiven_kafka_schema_registry_acl":    kafka.ResourceKafkaSchemaRegistryACL(),
-			"aiven_kafka_topic":                  kafka.ResourceKafkaTopic(),
-			"aiven_kafka_schema":                 kafka.ResourceKafkaSchema(),
-			"aiven_kafka_schema_configuration":   kafka.ResourceKafkaSchemaConfiguration(),
+			"aiven_kafka_schema_registry_acl":    kafkaschema.ResourceKafkaSchemaRegistryACL(),
+			"aiven_kafka_topic":                  kafkatopic.ResourceKafkaTopic(),
+			"aiven_kafka_schema":                 kafkaschema.ResourceKafkaSchema(),
+			"aiven_kafka_schema_configuration":   kafkaschema.ResourceKafkaSchemaConfiguration(),
 			"aiven_kafka_connector":              kafka.ResourceKafkaConnector(),
 			"aiven_mirrormaker_replication_flow": kafka.ResourceMirrorMakerReplicationFlow(),
 			"aiven_kafka_connect":                kafka.ResourceKafkaConnect(),

--- a/internal/sdkprovider/service/kafka/kafka_test.go
+++ b/internal/sdkprovider/service/kafka/kafka_test.go
@@ -339,14 +339,6 @@ func testAccCheckAivenServiceKafkaAttributes(n string) resource.TestCheckFunc {
 	}
 }
 
-// partitions returns a slice, of empty aiven.Partition, of specified size
-func partitions(numPartitions int) (partitions []*aiven.Partition) {
-	for i := 0; i < numPartitions; i++ {
-		partitions = append(partitions, &aiven.Partition{})
-	}
-	return
-}
-
 func testAccKafkaResourceUserConfigKafkaNullFieldsOnly(project, prefix string) string {
 	return fmt.Sprintf(`
 resource "aiven_kafka" "kafka" {

--- a/internal/sdkprovider/service/kafkaschema/kafka_schema.go
+++ b/internal/sdkprovider/service/kafkaschema/kafka_schema.go
@@ -1,4 +1,4 @@
-package kafka
+package kafkaschema
 
 import (
 	"context"

--- a/internal/sdkprovider/service/kafkaschema/kafka_schema_configuration.go
+++ b/internal/sdkprovider/service/kafkaschema/kafka_schema_configuration.go
@@ -1,4 +1,4 @@
-package kafka
+package kafkaschema
 
 import (
 	"context"

--- a/internal/sdkprovider/service/kafkaschema/kafka_schema_configuration_data_source.go
+++ b/internal/sdkprovider/service/kafkaschema/kafka_schema_configuration_data_source.go
@@ -1,4 +1,4 @@
-package kafka
+package kafkaschema
 
 import (
 	"context"

--- a/internal/sdkprovider/service/kafkaschema/kafka_schema_configuration_test.go
+++ b/internal/sdkprovider/service/kafkaschema/kafka_schema_configuration_test.go
@@ -1,4 +1,4 @@
-package kafka_test
+package kafkaschema_test
 
 import (
 	"fmt"

--- a/internal/sdkprovider/service/kafkaschema/kafka_schema_data_source.go
+++ b/internal/sdkprovider/service/kafkaschema/kafka_schema_data_source.go
@@ -1,4 +1,4 @@
-package kafka
+package kafkaschema
 
 import (
 	"context"

--- a/internal/sdkprovider/service/kafkaschema/kafka_schema_registry_acl.go
+++ b/internal/sdkprovider/service/kafkaschema/kafka_schema_registry_acl.go
@@ -1,4 +1,4 @@
-package kafka
+package kafkaschema
 
 import (
 	"context"

--- a/internal/sdkprovider/service/kafkaschema/kafka_schema_registry_acl_data_source.go
+++ b/internal/sdkprovider/service/kafkaschema/kafka_schema_registry_acl_data_source.go
@@ -1,4 +1,4 @@
-package kafka
+package kafkaschema
 
 import (
 	"context"

--- a/internal/sdkprovider/service/kafkaschema/kafka_schema_registry_acl_test.go
+++ b/internal/sdkprovider/service/kafkaschema/kafka_schema_registry_acl_test.go
@@ -1,4 +1,4 @@
-package kafka_test
+package kafkaschema_test
 
 import (
 	"fmt"

--- a/internal/sdkprovider/service/kafkaschema/kafka_schema_test.go
+++ b/internal/sdkprovider/service/kafkaschema/kafka_schema_test.go
@@ -1,4 +1,4 @@
-package kafka_test
+package kafkaschema_test
 
 import (
 	"fmt"

--- a/internal/sdkprovider/service/kafkatopic/kafka_topic.go
+++ b/internal/sdkprovider/service/kafkatopic/kafka_topic.go
@@ -1,4 +1,4 @@
-package kafka
+package kafkatopic
 
 import (
 	"context"

--- a/internal/sdkprovider/service/kafkatopic/kafka_topic_cache.go
+++ b/internal/sdkprovider/service/kafkatopic/kafka_topic_cache.go
@@ -1,4 +1,4 @@
-package kafka
+package kafkatopic
 
 import (
 	"log"

--- a/internal/sdkprovider/service/kafkatopic/kafka_topic_cache_test.go
+++ b/internal/sdkprovider/service/kafkatopic/kafka_topic_cache_test.go
@@ -1,4 +1,4 @@
-package kafka
+package kafkatopic
 
 import (
 	"reflect"

--- a/internal/sdkprovider/service/kafkatopic/kafka_topic_create.go
+++ b/internal/sdkprovider/service/kafkatopic/kafka_topic_create.go
@@ -1,4 +1,4 @@
-package kafka
+package kafkatopic
 
 import (
 	"log"

--- a/internal/sdkprovider/service/kafkatopic/kafka_topic_data_source.go
+++ b/internal/sdkprovider/service/kafkatopic/kafka_topic_data_source.go
@@ -1,4 +1,4 @@
-package kafka
+package kafkatopic
 
 import (
 	"context"

--- a/internal/sdkprovider/service/kafkatopic/kafka_topic_data_source_test.go
+++ b/internal/sdkprovider/service/kafkatopic/kafka_topic_data_source_test.go
@@ -1,4 +1,4 @@
-package kafka_test
+package kafkatopic_test
 
 import (
 	"fmt"

--- a/internal/sdkprovider/service/kafkatopic/kafka_topic_test.go
+++ b/internal/sdkprovider/service/kafkatopic/kafka_topic_test.go
@@ -1,4 +1,4 @@
-package kafka_test
+package kafkatopic_test
 
 import (
 	"context"
@@ -19,7 +19,7 @@ import (
 
 	acc "github.com/aiven/terraform-provider-aiven/internal/acctest"
 	"github.com/aiven/terraform-provider-aiven/internal/schemautil"
-	"github.com/aiven/terraform-provider-aiven/internal/sdkprovider/service/kafka"
+	"github.com/aiven/terraform-provider-aiven/internal/sdkprovider/service/kafkatopic"
 )
 
 func TestAccAivenKafkaTopic_basic(t *testing.T) {
@@ -389,7 +389,7 @@ func TestAccAivenKafkaTopic_recreate_missing(t *testing.T) {
 					assert.True(t, aiven.IsNotFound(err))
 
 					// Invalidates cache for the topic
-					kafka.DeleteTopicFromCache(project, kafkaName, topicName)
+					kafkatopic.DeleteTopicFromCache(project, kafkaName, topicName)
 				},
 				// Now plan shows a diff
 				ExpectNonEmptyPlan: true,
@@ -569,4 +569,12 @@ resource "aiven_kafka_topic" "topic_conflict" {
   ]
 }
 `, prefix, project)
+}
+
+// partitions returns a slice, of empty aiven.Partition, of specified size
+func partitions(numPartitions int) (partitions []*aiven.Partition) {
+	for i := 0; i < numPartitions; i++ {
+		partitions = append(partitions, &aiven.Partition{})
+	}
+	return
 }

--- a/internal/sdkprovider/service/kafkatopic/kafka_topic_wait.go
+++ b/internal/sdkprovider/service/kafkatopic/kafka_topic_wait.go
@@ -1,4 +1,4 @@
-package kafka
+package kafkatopic
 
 import (
 	"fmt"


### PR DESCRIPTION
## About this change—what it does

Splits `kafka` package to run tests faster.