### PR TITLE
docs(clickhouse): highlight how to grant privilege on all tables

### DIFF
--- a/docs/resources/clickhouse_grant.md
+++ b/docs/resources/clickhouse_grant.md
@@ -6,6 +6,7 @@ description: |-
   The Clickhouse Grant resource allows the creation and management of Grants in Aiven Clickhouse services.
   Notes:
   * Due to a ambiguity in the GRANT syntax in clickhouse you should not have users and roles with the same name. It is not clear if a grant refers to the user or the role.
+  * To grant a privilege on all tables of a database, do not write table = "*". Instead, omit the table and only keep the database.
   * Currently changes will first revoke all grants and then reissue the remaining grants for convergence.
 ---
 
@@ -15,6 +16,7 @@ The Clickhouse Grant resource allows the creation and management of Grants in Ai
 
 Notes:
 * Due to a ambiguity in the GRANT syntax in clickhouse you should not have users and roles with the same name. It is not clear if a grant refers to the user or the role.
+* To grant a privilege on all tables of a database, do not write table = "*". Instead, omit the table and only keep the database.
 * Currently changes will first revoke all grants and then reissue the remaining grants for convergence.
 
 ## Example Usage

--- a/internal/sdkprovider/service/clickhouse/clickhouse_grant.go
+++ b/internal/sdkprovider/service/clickhouse/clickhouse_grant.go
@@ -99,6 +99,7 @@ func ResourceClickhouseGrant() *schema.Resource {
 
 Notes:
 * Due to a ambiguity in the GRANT syntax in clickhouse you should not have users and roles with the same name. It is not clear if a grant refers to the user or the role.
+* To grant a privilege on all tables of a database, do not write table = "*". Instead, omit the table and only keep the database.
 * Currently changes will first revoke all grants and then reissue the remaining grants for convergence.
 `,
 		DeprecationMessage: betaDeprecationMessage,


### PR DESCRIPTION
## About this change—what it does

It's not immediately obvious that the table field should be omitted, instead of specifying a "*" table.
Add a phrase to highlight that trap.

## Why this way

This can reduce user frustration.