### PR TITLE
docs(clickhouse): remove deprecation warnings

### DIFF
--- a/internal/sdkprovider/service/clickhouse/clickhouse_grant.go
+++ b/internal/sdkprovider/service/clickhouse/clickhouse_grant.go
@@ -102,11 +102,11 @@ Notes:
 * To grant a privilege on all tables of a database, do not write table = "*". Instead, omit the table and only keep the database.
 * Currently changes will first revoke all grants and then reissue the remaining grants for convergence.
 `,
-		CreateContext:      resourceClickhouseGrantCreate,
-		ReadContext:        resourceClickhouseGrantRead,
-		DeleteContext:      resourceClickhouseGrantDelete,
-		Schema:             aivenClickhouseGrantSchema,
-		Timeouts:           schemautil.DefaultResourceTimeouts(),
+		CreateContext: resourceClickhouseGrantCreate,
+		ReadContext:   resourceClickhouseGrantRead,
+		DeleteContext: resourceClickhouseGrantDelete,
+		Schema:        aivenClickhouseGrantSchema,
+		Timeouts:      schemautil.DefaultResourceTimeouts(),
 	}
 }
 

--- a/internal/sdkprovider/service/clickhouse/clickhouse_grant.go
+++ b/internal/sdkprovider/service/clickhouse/clickhouse_grant.go
@@ -102,7 +102,6 @@ Notes:
 * To grant a privilege on all tables of a database, do not write table = "*". Instead, omit the table and only keep the database.
 * Currently changes will first revoke all grants and then reissue the remaining grants for convergence.
 `,
-		DeprecationMessage: betaDeprecationMessage,
 		CreateContext:      resourceClickhouseGrantCreate,
 		ReadContext:        resourceClickhouseGrantRead,
 		DeleteContext:      resourceClickhouseGrantDelete,

--- a/internal/sdkprovider/service/clickhouse/clickhouse_role.go
+++ b/internal/sdkprovider/service/clickhouse/clickhouse_role.go
@@ -26,7 +26,6 @@ var aivenClickhouseRoleSchema = map[string]*schema.Schema{
 func ResourceClickhouseRole() *schema.Resource {
 	return &schema.Resource{
 		Description:        "The Clickhouse Role resource allows the creation and management of Roles in Aiven Clickhouse services",
-		DeprecationMessage: betaDeprecationMessage,
 		CreateContext:      resourceClickhouseRoleCreate,
 		ReadContext:        resourceClickhouseRoleRead,
 		DeleteContext:      resourceClickhouseRoleDelete,

--- a/internal/sdkprovider/service/clickhouse/clickhouse_role.go
+++ b/internal/sdkprovider/service/clickhouse/clickhouse_role.go
@@ -25,10 +25,10 @@ var aivenClickhouseRoleSchema = map[string]*schema.Schema{
 
 func ResourceClickhouseRole() *schema.Resource {
 	return &schema.Resource{
-		Description:        "The Clickhouse Role resource allows the creation and management of Roles in Aiven Clickhouse services",
-		CreateContext:      resourceClickhouseRoleCreate,
-		ReadContext:        resourceClickhouseRoleRead,
-		DeleteContext:      resourceClickhouseRoleDelete,
+		Description:   "The Clickhouse Role resource allows the creation and management of Roles in Aiven Clickhouse services",
+		CreateContext: resourceClickhouseRoleCreate,
+		ReadContext:   resourceClickhouseRoleRead,
+		DeleteContext: resourceClickhouseRoleDelete,
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},

--- a/internal/sdkprovider/service/clickhouse/clickhouse_user.go
+++ b/internal/sdkprovider/service/clickhouse/clickhouse_user.go
@@ -42,10 +42,10 @@ var aivenClickhouseUserSchema = map[string]*schema.Schema{
 
 func ResourceClickhouseUser() *schema.Resource {
 	return &schema.Resource{
-		Description:        "The Clickhouse User resource allows the creation and management of Aiven Clikhouse Users.",
-		CreateContext:      resourceClickhouseUserCreate,
-		ReadContext:        resourceClickhouseUserRead,
-		DeleteContext:      resourceClickhouseUserDelete,
+		Description:   "The Clickhouse User resource allows the creation and management of Aiven Clikhouse Users.",
+		CreateContext: resourceClickhouseUserCreate,
+		ReadContext:   resourceClickhouseUserRead,
+		DeleteContext: resourceClickhouseUserDelete,
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},

--- a/internal/sdkprovider/service/clickhouse/clickhouse_user.go
+++ b/internal/sdkprovider/service/clickhouse/clickhouse_user.go
@@ -43,7 +43,6 @@ var aivenClickhouseUserSchema = map[string]*schema.Schema{
 func ResourceClickhouseUser() *schema.Resource {
 	return &schema.Resource{
 		Description:        "The Clickhouse User resource allows the creation and management of Aiven Clikhouse Users.",
-		DeprecationMessage: betaDeprecationMessage,
 		CreateContext:      resourceClickhouseUserCreate,
 		ReadContext:        resourceClickhouseUserRead,
 		DeleteContext:      resourceClickhouseUserDelete,

--- a/internal/sdkprovider/service/clickhouse/common.go
+++ b/internal/sdkprovider/service/clickhouse/common.go
@@ -3,5 +3,3 @@ package clickhouse
 // default database used for statements that do not target a particular database
 // think CREATE ROLE / GRANT / etc...
 const defaultDatabase = "system"
-
-const betaDeprecationMessage = "This Resource is not yet generally available and may be subject to breaking changes without warning"


### PR DESCRIPTION
<!-- All contributors, please complete these sections, including maintainers. -->

## About this change—what it does
Clickhouse ressources are in place for more a years and we still have deprecated warning message.

<img width="682" alt="image" src="https://github.com/aiven/terraform-provider-aiven/assets/90185671/cb949da2-e7a3-4cad-8d92-77f683c15b59">

The purpose of this pull request is to remove this deprecated message from clickhouse ressources
aiven_clickhouse_user
aiven_clickhouse_grant
aiven_clickhouse_role

<!-- Provide a small sentence that summarizes the change. -->



## Why this way
I'm not 100% sure why those ressources was still not in GA if i look the change log ressource seem to be in GA since a while ([3.0.0] - 2022-05-13)
If this ressource should stay in beta feel free to update this PR to update documentation on those ressources.


<!-- Provide a small explanation on why this is the approach you took for solving this problem. -->
