### PR TITLE
fix(kafkatopic): replication for startup-2 plan

### DIFF
--- a/internal/sdkprovider/service/kafkatopic/kafka_topic_test.go
+++ b/internal/sdkprovider/service/kafkatopic/kafka_topic_test.go
@@ -447,7 +447,7 @@ resource "aiven_kafka_topic" "topic" {
   service_name = aiven_kafka.kafka.service_name
   topic_name   = "topic"
   partitions   = 5
-  replication  = 3
+  replication  = 2
 }`, prefix, project)
 }
 
@@ -513,7 +513,7 @@ resource "aiven_kafka_topic" "topic" {
   service_name = aiven_kafka.kafka.service_name
   topic_name   = "topic"
   partitions   = 5
-  replication  = 3
+  replication  = 2
 }
 `, prefix, project)
 	return result
@@ -554,7 +554,7 @@ resource "aiven_kafka_topic" "topic" {
   service_name = aiven_kafka.kafka.service_name
   topic_name   = "conflict"
   partitions   = 5
-  replication  = 3
+  replication  = 2
 }
 
 resource "aiven_kafka_topic" "topic_conflict" {
@@ -562,7 +562,7 @@ resource "aiven_kafka_topic" "topic_conflict" {
   service_name = aiven_kafka.kafka.service_name
   topic_name   = "conflict"
   partitions   = 5
-  replication  = 3
+  replication  = 2
 
   depends_on = [
     aiven_kafka_topic.topic


### PR DESCRIPTION
<!-- All contributors, please complete these sections, including maintainers. -->

## About this change—what it does

Fixing 409 error:
```
 Error: 409: {"errors":[{"message":"Cluster only has 2 broker(s), cannot set replication factor to 3","status":409}],"message":"Cluster only has 2 broker(s), cannot set replication factor to 3"} - 
```