### PR TITLE
test(kafka): fix mirrormaker invalid offset syncs topic location

### DIFF
--- a/internal/sdkprovider/service/kafka/mirrormaker_replication_flow_test.go
+++ b/internal/sdkprovider/service/kafka/mirrormaker_replication_flow_test.go
@@ -256,7 +256,7 @@ resource "aiven_mirrormaker_replication_flow" "foo" {
 		Steps: []resource.TestStep{
 			{
 				Config:      config,
-				ExpectError: regexp.MustCompile(`expected offset_syncs_topic_location to be one of \[source target], got lol_offset`),
+				ExpectError: regexp.MustCompile(`expected offset_syncs_topic_location to be one of`),
 			},
 		},
 	})


### PR DESCRIPTION
<!-- All contributors, please complete these sections, including maintainers. -->

## About this change—what it does

<!-- Provide a small sentence that summarizes the change. -->
fixes mirrormaker invalid offset syncs topic location test

<!-- Provide the issue number below, if it exists. -->

## Why this way

<!-- Provide a small explanation on why this is the approach you took for solving this problem. -->
the error message was updated in backend, I've made it a bit more fail-proof as well in this PR
