### PR TITLE
feat(org): add user group member support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ nav_order: 1
 ## [MAJOR.MINOR.PATCH] - YYYY-MM-DD
 
 - Allow to modify `pg_user` replication settings
+- Add organization user group memeber support
 
 ## [4.9.0] - 2023-09-18
 

--- a/internal/sdkprovider/provider/provider.go
+++ b/internal/sdkprovider/provider/provider.go
@@ -181,9 +181,10 @@ func Provider(version string) *schema.Provider {
 			"aiven_account_authentication": account.ResourceAccountAuthentication(),
 
 			// organization
-			"aiven_organizational_unit":     organization.ResourceOrganizationalUnit(),
-			"aiven_organization_user":       organization.ResourceOrganizationUser(),
-			"aiven_organization_user_group": organization.ResourceOrganizationUserGroup(),
+			"aiven_organizational_unit":            organization.ResourceOrganizationalUnit(),
+			"aiven_organization_user":              organization.ResourceOrganizationUser(),
+			"aiven_organization_user_group":        organization.ResourceOrganizationUserGroup(),
+			"aiven_organization_user_group_member": organization.ResourceOrganizationUserGroupMember(),
 
 			// project
 			"aiven_project":       project.ResourceProject(),

--- a/internal/sdkprovider/service/organization/organization_user_group_member.go
+++ b/internal/sdkprovider/service/organization/organization_user_group_member.go
@@ -1,0 +1,126 @@
+package organization
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/aiven/aiven-go-client"
+	"github.com/aiven/terraform-provider-aiven/internal/schemautil"
+	"github.com/aiven/terraform-provider-aiven/internal/schemautil/userconfig"
+)
+
+var aivenOrganizationUserGroupMemberSchema = map[string]*schema.Schema{
+	"organization_id": {
+		Type:        schema.TypeString,
+		Required:    true,
+		ForceNew:    true,
+		Description: userconfig.Desc("The unique organization ID").ForceNew().Build(),
+	},
+	"group_id": {
+		Type:        schema.TypeString,
+		Required:    true,
+		ForceNew:    true,
+		Description: userconfig.Desc("The unique organization user group ID").ForceNew().Build(),
+	},
+	"user_id": {
+		Type:        schema.TypeString,
+		Required:    true,
+		ForceNew:    true,
+		Description: userconfig.Desc("The organization user group user ID").ForceNew().Build(),
+	},
+	"state": {
+		Type:        schema.TypeString,
+		Computed:    true,
+		Description: "State of the organization user group member",
+	},
+}
+
+func ResourceOrganizationUserGroupMember() *schema.Resource {
+	return &schema.Resource{
+		Description:   "The Organization User Group Member resource allows the creation and management of an Aiven Organization Group Members.",
+		CreateContext: resourceOrganizationUserGroupMemberCreate,
+		ReadContext:   resourceOrganizationUserGroupMemberRead,
+		DeleteContext: resourceOrganizationUserGroupMemberDelete,
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+		Timeouts: schemautil.DefaultResourceTimeouts(),
+
+		Schema: aivenOrganizationUserGroupMemberSchema,
+	}
+}
+
+func resourceOrganizationUserGroupMemberCreate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	client := m.(*aiven.Client)
+
+	orgID := d.Get("organization_id").(string)
+	grID := d.Get("group_id").(string)
+	userID := d.Get("user_id").(string)
+	err := client.OrganizationUserGroupMembers.Modify(orgID, grID, aiven.OrganizationUserGroupMemberRequest{
+		Operation: "add_members", // TODO: update with the go-client const when v2 client gets merged
+		MemberIDs: []string{userID},
+	},
+	)
+	if err != nil {
+		return diag.Errorf("error creating user group member %s: %s", schemautil.BuildResourceID(orgID, grID, userID), err)
+	}
+
+	d.SetId(schemautil.BuildResourceID(orgID, grID, userID))
+
+	return resourceOrganizationUserGroupMemberRead(ctx, d, m)
+}
+
+func resourceOrganizationUserGroupMemberRead(_ context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	client := m.(*aiven.Client)
+
+	orgID, grID, userID, err := schemautil.SplitResourceID3(d.Id())
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	r, err := client.OrganizationUserGroupMembers.List(orgID, grID)
+	if err != nil {
+		return diag.FromErr(schemautil.ResourceReadHandleNotFound(err, d))
+	}
+
+	var user *aiven.OrganizationUserGroupMember
+	for i, u := range r.Members {
+		if u.UserID == userID {
+			user = &r.Members[i]
+			break
+		}
+	}
+
+	if user == nil {
+		d.SetId("")
+		return nil
+	}
+
+	if err := d.Set("state", user.UserInfo.State); err != nil {
+		return diag.FromErr(err)
+	}
+
+	return nil
+}
+
+func resourceOrganizationUserGroupMemberDelete(_ context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	client := m.(*aiven.Client)
+
+	orgID, grID, userID, err := schemautil.SplitResourceID3(d.Id())
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	err = client.OrganizationUserGroupMembers.Modify(orgID, grID, aiven.OrganizationUserGroupMemberRequest{
+		Operation: "remove_members", // TODO: update with the go-client const when v2 client gets merged
+		MemberIDs: []string{userID},
+	},
+	)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	return nil
+}


### PR DESCRIPTION
<!-- All contributors, please complete these sections, including maintainers. -->

## About this change—what it does

Adding organization user group member support.

I cannot add acceptance tests for this feature because the `user_id` of the newly invited member will be known only after an invitation is accepted. And we cannot simulate this during the test. Moreover, if we invite already existing Aiven users to a different organization, `user_id` is still unavailable, and we have to accept an invitation.

This is revived version of this PR: https://github.com/aiven/terraform-provider-aiven/pull/1282

@ngilles-aiven wrote this feedback: 

> Something didn't sit quite right after going over this, but I couldn't quite put my finger on it, but it looks like it's because user management within the Aiven platform being not a great fit Terraform as fully declarative system.

> I also am not fully sure why it seems to be more complicated in the case of organization users (and groups) than it was with teams, and it seems it comes down to managing things with user ids instead of email? (as invites are done with emails).

> Maybe this warrants more discussion on the overall approach or at least the need to extra api/functionality?

The difference between `aiven_account_team_member` and new `aiven_organization_user_group_member` is following: 
- The organization version requires a user ID for creation, and the user ID is only known after the user has accepted an invitation; that makes our life much more problematic when testing it since we cannot close the loop using only Terraform.
- The account version accepts the user's email address and, moreover, accepts it even if the user hasn't accepted an email invitation. 

Ideally we want to keep using email address for the instead of user ID if possible, cc @ngilles-aiven @rsalevsky 