### PR TITLE
fix(project_user): invite error handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ nav_order: 1
 
 # Changelog
 
+
+## [3.13.3] - 2023-09-28
+
+- Fix `aiven_project_user` 409 error handling
+
 ## [3.13.2] - 2023-06-01
 
 - Improve Kafka Topic 404 error handling

--- a/internal/service/kafka/kafka_topic_cache_test.go
+++ b/internal/service/kafka/kafka_topic_cache_test.go
@@ -35,6 +35,8 @@ func TestGetTopicCache(t *testing.T) {
 			&kafkaTopicCache{
 				internal: make(map[string]map[string]aiven.KafkaTopic),
 				inQueue:  make(map[string][]string),
+				missing:  make(map[string][]string),
+				v1list:   make(map[string][]string),
 			},
 		},
 	}

--- a/internal/service/project/project_user.go
+++ b/internal/service/project/project_user.go
@@ -47,6 +47,16 @@ func ResourceProjectUser() *schema.Resource {
 	}
 }
 
+// isProjectUserAlreadyInvited return true if user already been invited to the project
+func isProjectUserAlreadyInvited(err error) bool {
+	if e, ok := err.(aiven.Error); ok {
+		if strings.Contains(e.Message, "already been invited to this project") && e.Status == 409 {
+			return true
+		}
+	}
+	return false
+}
+
 func resourceProjectUserCreate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	client := m.(*aiven.Client)
 	projectName := d.Get("project").(string)
@@ -58,7 +68,7 @@ func resourceProjectUserCreate(ctx context.Context, d *schema.ResourceData, m in
 			MemberType: d.Get("member_type").(string),
 		},
 	)
-	if err != nil {
+	if err != nil && !isProjectUserAlreadyInvited(err) {
 		return diag.FromErr(err)
 	}
 


### PR DESCRIPTION
<!-- All contributors, please complete these sections, including maintainers. -->

## About this change—what it does

V3 fix for project user when user invitation has yet to be accepted, but we try to refresh data and send another invitation, resulting in 409 error from Aiven.