### PR TITLE
chore: deprecating account and project user

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ nav_order: 1
 
 # Changelog
 
+- Deprecating `project_user`, `account_team` and `account_team_member resources`
 ## [5.0.0] - YYYY-MM-DD
 
 - Migrate `aiven_service_integration` to the Plugin Framework

--- a/internal/sdkprovider/service/account/account_team.go
+++ b/internal/sdkprovider/service/account/account_team.go
@@ -50,7 +50,8 @@ func ResourceAccountTeam() *schema.Resource {
 		},
 		Timeouts: schemautil.DefaultResourceTimeouts(),
 
-		Schema: aivenAccountTeamSchema,
+		Schema:             aivenAccountTeamSchema,
+		DeprecationMessage: "This resource is deprecated",
 	}
 }
 

--- a/internal/sdkprovider/service/account/account_team_member.go
+++ b/internal/sdkprovider/service/account/account_team_member.go
@@ -67,7 +67,8 @@ eliminate an account team member if one has accepted an invitation previously.
 		},
 		Timeouts: schemautil.DefaultResourceTimeouts(),
 
-		Schema: aivenAccountTeamMemberSchema,
+		Schema:             aivenAccountTeamMemberSchema,
+		DeprecationMessage: "This resource is deprecated",
 	}
 }
 

--- a/internal/sdkprovider/service/project/project_user.go
+++ b/internal/sdkprovider/service/project/project_user.go
@@ -44,7 +44,8 @@ func ResourceProjectUser() *schema.Resource {
 		},
 		Timeouts: schemautil.DefaultResourceTimeouts(),
 
-		Schema: aivenProjectUserSchema,
+		Schema:             aivenProjectUserSchema,
+		DeprecationMessage: "This resource is deprecated",
 	}
 }
 


### PR DESCRIPTION
<!-- All contributors, please complete these sections, including maintainers. -->

## About this change—what it does

Deprecating account teams and team member resources alongside project users, as discussed internally. 

:warning: The deprecation message does not contain a particular resource as the recommended replacement because we do not expect a 1-to-1 transition from account to organization, and not all organization-related functionality will be transferred to the Terraform provider due to an internal investigation.

