### PR TITLE
ci(acctests): run for v4 branch

### DIFF
--- a/.github/workflows/acceptance-tests-v4.yml
+++ b/.github/workflows/acceptance-tests-v4.yml
@@ -1,9 +1,8 @@
-name: Acceptance Tests
+name: Acceptance Tests (v4)
 
 on:
   schedule:
-    - cron: "0 0 * * *"
-  workflow_dispatch:
+    - cron: "0 3 * * *"
 
 permissions:
   contents: read
@@ -54,6 +53,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          ref: v4
       - uses: actions/setup-go@v4
         with:
           go-version-file: go.mod
@@ -91,6 +91,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          ref: v4
       - uses: actions/setup-go@v4
         with:
           go-version-file: go.mod

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -32,6 +32,8 @@ jobs:
           - go
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - uses: actions/setup-go@v4
         with:
           go-version-file: go.mod

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -27,4 +27,6 @@ jobs:
     if: (github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'skip workflows')) || github.event_name == 'push'
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - uses: actions/dependency-review-action@v3

--- a/.github/workflows/examples-tests.yml
+++ b/.github/workflows/examples-tests.yml
@@ -23,6 +23,8 @@ jobs:
           same-branch-only: true
 
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - uses: actions/setup-go@v4
         with:
           go-version-file: go.mod

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -33,6 +33,8 @@ jobs:
     if: (github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'skip workflows')) || github.event_name == 'push'
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - uses: returntocorp/semgrep-action@v1
 
   make_lint:
@@ -40,6 +42,8 @@ jobs:
     if: (github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'skip workflows')) || github.event_name == 'push'
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - uses: actions/setup-go@v4
         with:
           go-version-file: go.mod
@@ -51,6 +55,8 @@ jobs:
     if: (github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'skip workflows')) || github.event_name == 'push'
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - uses: actions/setup-go@v4
         with:
           go-version-file: go.mod

--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -11,6 +11,8 @@ jobs:
     steps:
 
     - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
     - uses: actions/setup-go@v4
       with:
         go-version-file: go.mod

--- a/.github/workflows/sweep.yml
+++ b/.github/workflows/sweep.yml
@@ -18,6 +18,8 @@ jobs:
     steps:
 
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - uses: actions/setup-go@v4
         with:
           go-version-file: go.mod

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -25,6 +25,8 @@ jobs:
     if: (github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'skip workflows')) || github.event_name == 'push'
     steps:
     - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
     - uses: actions/setup-go@v4
       with:
         go-version-file: go.mod


### PR DESCRIPTION
<!-- All contributors, please complete these sections, including maintainers. -->

## About this change—what it does

<!-- Provide a small sentence that summarizes the change. -->
- ci(checkout): set fetch-depth zero globally
- ci(acctests): run for v4 branch

<!-- Provide the issue number below, if it exists. -->

## Why this way

<!-- Provide a small explanation on why this is the approach you took for solving this problem. -->
- we want to have CI in place for v4 and v3 branches
- we want the CI to work properly
