### PR TITLE
chore(changelog): drop v4 entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,7 @@ nav_order: 1
 ## [5.0.0] - YYYY-MM-DD
 
 - Migrate `aiven_service_integration` to the Plugin Framework
-- Deprecating `project_user`, `account_team` and `account_team_member resources`
-- Fix incorrect read context in MySQL user resource
+- Deprecating `project_user`, `account_team` and `account_team_member` resources
 
 ## [4.9.1] - 2023-10-03
 


### PR DESCRIPTION
<!-- All contributors, please complete these sections, including maintainers. -->

## About this change—what it does

<!-- Provide a small sentence that summarizes the change. -->
drops v4 changelog entry: https://github.com/aiven/terraform-provider-aiven/blob/v4/CHANGELOG.md

<!-- Provide the issue number below, if it exists. -->

## Why this way

<!-- Provide a small explanation on why this is the approach you took for solving this problem. -->
it will already be released in v4, so we don't need to duplicate the changelog entry here
