### PR TITLE
fix(schemautil): unmarshalling empty userconfig crash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ nav_order: 1
 
 ## [X.Y.Z] - YYYY-MM-DD
 
+- Fix unmarshalling empty userconfig crash
+
 ## [4.9.3] - 2023-10-27
 
 - Deprecating `project_user`, `account_team` and `account_team_member` resources

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build build-dev test test-unit test-acc test-examples lint lint-go lint-test lint-docs fmt fmt-test fmt-imports clean clean-tools clean-examples sweep generate gen-go docs
+.PHONY: build build-dev debug test test-unit test-acc test-examples lint lint-go lint-test lint-docs fmt fmt-test fmt-imports clean clean-tools clean-examples sweep generate gen-go docs
 
 #################################################
 # Global
@@ -34,6 +34,7 @@ $(TERRAFMT): $(TOOLS_BIN_DIR) $(TOOLS_DIR)/go.mod
 # See https://github.com/hashicorp/terraform/blob/main/tools/protobuf-compile/protobuf-compile.go#L215
 ARCH ?= $(shell $(GO) env GOOS GOARCH | tr '\n' '_' | sed '$$s/_$$//')
 BUILD_DEV_DIR ?= ~/.terraform.d/plugins/registry.terraform.io/aiven-dev/aiven/0.0.0+dev/$(ARCH)
+BUILD_DEV_BIN ?= $(BUILD_DEV_DIR)/terraform-provider-aiven_v0.0.0+dev
 
 $(BUILD_DEV_DIR):
 	mkdir -p $(BUILD_DEV_DIR)
@@ -57,7 +58,14 @@ build:
 #  }
 #}
 build-dev: $(BUILD_DEV_DIR)
-	$(GO) build -o $(BUILD_DEV_DIR)/terraform-provider-aiven_v0.0.0+dev
+	$(GO) build -gcflags='all=-N -l' -o $(BUILD_DEV_BIN)
+
+#################################################
+# Debug
+#################################################
+
+debug: build-dev
+	$(BUILD_DEV_BIN) -debug
 
 #################################################
 # Test

--- a/internal/schemautil/schemautil.go
+++ b/internal/schemautil/schemautil.go
@@ -325,7 +325,10 @@ func unmarshalUserConfig(src interface{}) ([]map[string]interface{}, error) {
 		return nil, fmt.Errorf("%w: expected []interface{}", errInvalidStateType)
 	}
 
-	if len(configList) == 0 {
+	// For some reason, it looks like this is never empty, even if the user config is not set.
+	// We will keep this check here just in case, but the actual check that breaks the code is
+	// the one where we check if the first element is nil.
+	if len(configList) == 0 || configList[0] == nil {
 		return nil, nil
 	}
 

--- a/main.go
+++ b/main.go
@@ -13,6 +13,9 @@ import (
 
 //go:generate go test -tags userconfig ./internal/schemautil/userconfig
 
+// registryPrefix is the registry prefix for the provider.
+const registryPrefix = "registry.terraform.io/"
+
 // version is the version of the provider.
 var version = "dev"
 
@@ -31,8 +34,15 @@ func main() {
 		serveOpts = append(serveOpts, tf6server.WithManagedDebug())
 	}
 
+	name := registryPrefix + "aiven/aiven"
+
+	//goland:noinspection GoBoolExpressions
+	if version == "dev" {
+		name = registryPrefix + "aiven-dev/aiven"
+	}
+
 	err = tf6server.Serve(
-		"registry.terraform.io/aiven/aiven",
+		name,
 		func() tfprotov6.ProviderServer {
 			return muxServer
 		},


### PR DESCRIPTION
<!-- All contributors, please complete these sections, including maintainers. -->

## About this change—what it does

<!-- Provide a small sentence that summarizes the change. -->
- fixes unmarshalling empty userconfig crash
- improves debugging experience

<!-- Provide the issue number below, if it exists. -->

## Why this way

<!-- Provide a small explanation on why this is the approach you took for solving this problem. -->
- to have userconfig unmarshalling working
- to be able to debug in a more efficient way
