### PR TITLE
docs: document other env vars for make test-acc

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,11 +31,15 @@ Run the tests with the command below:
 make test
 ```
 
+Acceptance tests interact with the real Aiven API and require an API token and existing project and organization on Aiven to create resources in. A non-default API URL can be used by setting the `AIVEN_WEB_URL` environment variable to e.g. `https://your.custom.api:443`.
+
 Run the acceptance tests with the commands below:
 
 ```bash
 export AIVEN_TOKEN="your-token"
 export AIVEN_PROJECT_NAME="your-project-name"
+export AIVEN_ORGANIZATION_NAME="your-existing-org-name"
+export AIVEN_ACCOUNT_NAME="$AIVEN_ORGANIZATION_NAME"
 
 # run all acceptance tests
 make test-acc


### PR DESCRIPTION
<!-- All contributors, please complete these sections, including maintainers. -->

## About this change—what it does

Improves documentation of the environment variables that are used or influence the running of the acceptance tests.

<!-- Provide a small sentence that summarizes the change. -->

<!-- Provide the issue number below, if it exists. -->

## Why this way

Fully running the acceptance tests uses more than just a project, there are tests which interact with accounts and orgs, and it took some questioning on Slack and searching the source code to figure out how to properly run these tests locally and against a dev environment, so we should probably document how to get them to run here to save future engineers time.

<!-- Provide a small explanation on why this is the approach you took for solving this problem. -->
