### PR TITLE
fix(apiconvert): never skip basic auth username/password

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ nav_order: 1
 
 - Deprecating `project_user`, `account_team` and `account_team_member` resources
 - Fix unmarshalling empty userconfig crash
+- Never skip basic auth username/password in service integrations user config options when sending them to the API
 
 ## [4.9.3] - 2023-10-27
 

--- a/internal/schemautil/userconfig/apiconvert/toapi.go
+++ b/internal/schemautil/userconfig/apiconvert/toapi.go
@@ -236,7 +236,7 @@ func itemToAPI(
 		}
 	}
 
-	if omitValue && isRequired {
+	if omitValue && isRequired || key == "basic_auth_username" || key == "basic_auth_password" {
 		omitValue = false
 	}
 


### PR DESCRIPTION
<!-- All contributors, please complete these sections, including maintainers. -->

## About this change—what it does

<!-- Provide a small sentence that summarizes the change. -->
prevents skipping basic auth username/password in certain service integrations

<!-- Provide the issue number below, if it exists. -->
resolves #1411

## Why this way

<!-- Provide a small explanation on why this is the approach you took for solving this problem. -->
API always wants us to send these details, regardless of if they're changed or not
