### PR TITLE
chore(backport): deprecate unclean_leader_election_enable in aiven_kafka_topic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ nav_order: 1
 
 ## [X.Y.Z] - YYYY-MM-DD
 
+- `aiven_kafka_topic` field `unclean_leader_election_enable` is deprecated
 - Fix incorrect read context in MySQL user resource
 
 ## [3.13.4] - 2023-09-28

--- a/docs/resources/kafka_topic.md
+++ b/docs/resources/kafka_topic.md
@@ -85,7 +85,7 @@ Optional:
 - `segment_index_bytes` (String) segment.index.bytes value
 - `segment_jitter_ms` (String) segment.jitter.ms value
 - `segment_ms` (String) segment.ms value
-- `unclean_leader_election_enable` (String) unclean.leader.election.enable value
+- `unclean_leader_election_enable` (String, Deprecated) unclean.leader.election.enable value; deprecated
 
 
 <a id="nestedblock--tag"></a>

--- a/internal/service/kafka/kafka_topic.go
+++ b/internal/service/kafka/kafka_topic.go
@@ -210,9 +210,10 @@ var aivenKafkaTopicSchema = map[string]*schema.Schema{
 				},
 				"unclean_leader_election_enable": {
 					Type:             schema.TypeString,
-					Description:      "unclean.leader.election.enable value",
+					Description:      "unclean.leader.election.enable value; deprecated",
 					Optional:         true,
 					DiffSuppressFunc: schemautil.EmptyObjectDiffSuppressFunc,
+					Deprecated:       "This field is deprecated and no longer functional",
 				},
 			},
 		},
@@ -322,7 +323,6 @@ func getKafkaTopicConfig(d *schema.ResourceData) aiven.KafkaTopicConfig {
 		SegmentIndexBytes:               schemautil.ParseOptionalStringToInt64(configRaw["segment_index_bytes"]),
 		SegmentJitterMs:                 schemautil.ParseOptionalStringToInt64(configRaw["segment_jitter_ms"]),
 		SegmentMs:                       schemautil.ParseOptionalStringToInt64(configRaw["segment_ms"]),
-		UncleanLeaderElectionEnable:     schemautil.ParseOptionalStringToBool(configRaw["unclean_leader_election_enable"]),
 	}
 }
 
@@ -510,7 +510,6 @@ func flattenKafkaTopicConfig(t *aiven.KafkaTopic) []map[string]interface{} {
 			"segment_index_bytes":                 schemautil.ToOptionalString(t.Config.SegmentIndexBytes.Value),
 			"segment_jitter_ms":                   schemautil.ToOptionalString(t.Config.SegmentJitterMs.Value),
 			"segment_ms":                          schemautil.ToOptionalString(t.Config.SegmentMs.Value),
-			"unclean_leader_election_enable":      schemautil.ToOptionalString(t.Config.UncleanLeaderElectionEnable.Value),
 		},
 	}
 }


### PR DESCRIPTION
<!-- All contributors, please complete these sections, including maintainers. -->

## About this change—what it does

Kafka Topic config options `unclean_leader_election_enable` deprecation, since it is no longer function on the back-end side.