### PR TITLE
feat(service): add connection_info field to components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ nav_order: 1
 - Add `emit_backward_heartbeats_enabled` field support in Mirrormaker replication flow
 - Add validation for email fields in `account_team_member`, `organization_user` and `project_user` resources to check
   if email is lowercase and valid
+- Add `connection_info` field to components of all services. This field contains connection information for the
+  component, and is a combination of the `host` and `port` fields
 
 ## [4.9.3] - 2023-10-27
 

--- a/docs/data-sources/cassandra.md
+++ b/docs/data-sources/cassandra.md
@@ -126,6 +126,7 @@ Read-Only:
 Read-Only:
 
 - `component` (String)
+- `connection_info` (String)
 - `host` (String)
 - `kafka_authentication_method` (String)
 - `port` (Number)

--- a/docs/data-sources/clickhouse.md
+++ b/docs/data-sources/clickhouse.md
@@ -128,6 +128,7 @@ Read-Only:
 Read-Only:
 
 - `component` (String)
+- `connection_info` (String)
 - `host` (String)
 - `kafka_authentication_method` (String)
 - `port` (Number)

--- a/docs/data-sources/flink.md
+++ b/docs/data-sources/flink.md
@@ -62,6 +62,7 @@ data "aiven_flink" "flink" {
 Read-Only:
 
 - `component` (String)
+- `connection_info` (String)
 - `host` (String)
 - `kafka_authentication_method` (String)
 - `port` (Number)

--- a/docs/data-sources/grafana.md
+++ b/docs/data-sources/grafana.md
@@ -62,6 +62,7 @@ data "aiven_grafana" "gr1" {
 Read-Only:
 
 - `component` (String)
+- `connection_info` (String)
 - `host` (String)
 - `kafka_authentication_method` (String)
 - `port` (Number)

--- a/docs/data-sources/influxdb.md
+++ b/docs/data-sources/influxdb.md
@@ -62,6 +62,7 @@ data "aiven_influxdb" "inf1" {
 Read-Only:
 
 - `component` (String)
+- `connection_info` (String)
 - `host` (String)
 - `kafka_authentication_method` (String)
 - `port` (Number)

--- a/docs/data-sources/kafka.md
+++ b/docs/data-sources/kafka.md
@@ -64,6 +64,7 @@ data "aiven_kafka" "kafka1" {
 Read-Only:
 
 - `component` (String)
+- `connection_info` (String)
 - `host` (String)
 - `kafka_authentication_method` (String)
 - `port` (Number)

--- a/docs/data-sources/kafka_connect.md
+++ b/docs/data-sources/kafka_connect.md
@@ -62,6 +62,7 @@ data "aiven_kafka_connect" "kc1" {
 Read-Only:
 
 - `component` (String)
+- `connection_info` (String)
 - `host` (String)
 - `kafka_authentication_method` (String)
 - `port` (Number)

--- a/docs/data-sources/kafka_mirrormaker.md
+++ b/docs/data-sources/kafka_mirrormaker.md
@@ -62,6 +62,7 @@ data "aiven_kafka_mirrormaker" "mm1" {
 Read-Only:
 
 - `component` (String)
+- `connection_info` (String)
 - `host` (String)
 - `kafka_authentication_method` (String)
 - `port` (Number)

--- a/docs/data-sources/m3aggregator.md
+++ b/docs/data-sources/m3aggregator.md
@@ -62,6 +62,7 @@ data "aiven_m3aggregator" "m3a" {
 Read-Only:
 
 - `component` (String)
+- `connection_info` (String)
 - `host` (String)
 - `kafka_authentication_method` (String)
 - `port` (Number)

--- a/docs/data-sources/m3db.md
+++ b/docs/data-sources/m3db.md
@@ -62,6 +62,7 @@ data "aiven_m3db" "m3" {
 Read-Only:
 
 - `component` (String)
+- `connection_info` (String)
 - `host` (String)
 - `kafka_authentication_method` (String)
 - `port` (Number)

--- a/docs/data-sources/mysql.md
+++ b/docs/data-sources/mysql.md
@@ -62,6 +62,7 @@ data "aiven_mysql" "mysql1" {
 Read-Only:
 
 - `component` (String)
+- `connection_info` (String)
 - `host` (String)
 - `kafka_authentication_method` (String)
 - `port` (Number)

--- a/docs/data-sources/opensearch.md
+++ b/docs/data-sources/opensearch.md
@@ -62,6 +62,7 @@ data "aiven_opensearch" "os1" {
 Read-Only:
 
 - `component` (String)
+- `connection_info` (String)
 - `host` (String)
 - `kafka_authentication_method` (String)
 - `port` (Number)

--- a/docs/data-sources/pg.md
+++ b/docs/data-sources/pg.md
@@ -62,6 +62,7 @@ data "aiven_pg" "pg" {
 Read-Only:
 
 - `component` (String)
+- `connection_info` (String)
 - `host` (String)
 - `kafka_authentication_method` (String)
 - `port` (Number)

--- a/docs/data-sources/redis.md
+++ b/docs/data-sources/redis.md
@@ -62,6 +62,7 @@ data "aiven_redis" "redis1" {
 Read-Only:
 
 - `component` (String)
+- `connection_info` (String)
 - `host` (String)
 - `kafka_authentication_method` (String)
 - `port` (Number)

--- a/docs/resources/cassandra.md
+++ b/docs/resources/cassandra.md
@@ -175,6 +175,7 @@ Read-Only:
 Read-Only:
 
 - `component` (String)
+- `connection_info` (String)
 - `host` (String)
 - `kafka_authentication_method` (String)
 - `port` (Number)

--- a/docs/resources/clickhouse.md
+++ b/docs/resources/clickhouse.md
@@ -169,6 +169,7 @@ Read-Only:
 Read-Only:
 
 - `component` (String)
+- `connection_info` (String)
 - `host` (String)
 - `kafka_authentication_method` (String)
 - `port` (Number)

--- a/docs/resources/flink.md
+++ b/docs/resources/flink.md
@@ -148,6 +148,7 @@ Optional:
 Read-Only:
 
 - `component` (String)
+- `connection_info` (String)
 - `host` (String)
 - `kafka_authentication_method` (String)
 - `port` (Number)

--- a/docs/resources/grafana.md
+++ b/docs/resources/grafana.md
@@ -320,6 +320,7 @@ Optional:
 Read-Only:
 
 - `component` (String)
+- `connection_info` (String)
 - `host` (String)
 - `kafka_authentication_method` (String)
 - `port` (Number)

--- a/docs/resources/influxdb.md
+++ b/docs/resources/influxdb.md
@@ -176,6 +176,7 @@ Optional:
 Read-Only:
 
 - `component` (String)
+- `connection_info` (String)
 - `host` (String)
 - `kafka_authentication_method` (String)
 - `port` (Number)

--- a/docs/resources/kafka.md
+++ b/docs/resources/kafka.md
@@ -321,6 +321,7 @@ Optional:
 Read-Only:
 
 - `component` (String)
+- `connection_info` (String)
 - `host` (String)
 - `kafka_authentication_method` (String)
 - `port` (Number)

--- a/docs/resources/kafka_connect.md
+++ b/docs/resources/kafka_connect.md
@@ -189,6 +189,7 @@ Optional:
 Read-Only:
 
 - `component` (String)
+- `connection_info` (String)
 - `host` (String)
 - `kafka_authentication_method` (String)
 - `port` (Number)

--- a/docs/resources/kafka_mirrormaker.md
+++ b/docs/resources/kafka_mirrormaker.md
@@ -150,6 +150,7 @@ Optional:
 Read-Only:
 
 - `component` (String)
+- `connection_info` (String)
 - `host` (String)
 - `kafka_authentication_method` (String)
 - `port` (Number)

--- a/docs/resources/m3aggregator.md
+++ b/docs/resources/m3aggregator.md
@@ -130,6 +130,7 @@ Optional:
 Read-Only:
 
 - `component` (String)
+- `connection_info` (String)
 - `host` (String)
 - `kafka_authentication_method` (String)
 - `port` (Number)

--- a/docs/resources/m3db.md
+++ b/docs/resources/m3db.md
@@ -271,6 +271,7 @@ Optional:
 Read-Only:
 
 - `component` (String)
+- `connection_info` (String)
 - `host` (String)
 - `kafka_authentication_method` (String)
 - `port` (Number)

--- a/docs/resources/mysql.md
+++ b/docs/resources/mysql.md
@@ -236,6 +236,7 @@ Optional:
 Read-Only:
 
 - `component` (String)
+- `connection_info` (String)
 - `host` (String)
 - `kafka_authentication_method` (String)
 - `port` (Number)

--- a/docs/resources/opensearch.md
+++ b/docs/resources/opensearch.md
@@ -340,6 +340,7 @@ Optional:
 Read-Only:
 
 - `component` (String)
+- `connection_info` (String)
 - `host` (String)
 - `kafka_authentication_method` (String)
 - `port` (Number)

--- a/docs/resources/pg.md
+++ b/docs/resources/pg.md
@@ -330,6 +330,7 @@ Optional:
 Read-Only:
 
 - `component` (String)
+- `connection_info` (String)
 - `host` (String)
 - `kafka_authentication_method` (String)
 - `port` (Number)

--- a/docs/resources/redis.md
+++ b/docs/resources/redis.md
@@ -195,6 +195,7 @@ Optional:
 Read-Only:
 
 - `component` (String)
+- `connection_info` (String)
 - `host` (String)
 - `kafka_authentication_method` (String)
 - `port` (Number)

--- a/internal/schemautil/service.go
+++ b/internal/schemautil/service.go
@@ -210,17 +210,23 @@ func ServiceCommonSchema() map[string]*schema.Schema {
 					"host": {
 						Type:        schema.TypeString,
 						Computed:    true,
-						Description: "DNS name for connecting to the service component",
-					},
-					"kafka_authentication_method": {
-						Type:        schema.TypeString,
-						Computed:    true,
-						Description: "Kafka authentication method. This is a value specific to the 'kafka' service component",
+						Description: "Host name for connecting to the service component",
 					},
 					"port": {
 						Type:        schema.TypeInt,
 						Computed:    true,
 						Description: "Port number for connecting to the service component",
+					},
+					"connection_info": {
+						Type:     schema.TypeString,
+						Computed: true,
+						Description: "Connection info for connecting to the service component." +
+							" This is a combination of host and port.",
+					},
+					"kafka_authentication_method": {
+						Type:        schema.TypeString,
+						Computed:    true,
+						Description: "Kafka authentication method. This is a value specific to the 'kafka' service component",
 					},
 					"route": {
 						Type:        schema.TypeString,
@@ -744,12 +750,13 @@ func FlattenServiceComponents(r *aiven.Service) []map[string]interface{} {
 			"component":                   c.Component,
 			"host":                        c.Host,
 			"port":                        c.Port,
-			"route":                       c.Route,
-			"usage":                       c.Usage,
+			"connection_info":             fmt.Sprintf("%s:%d", c.Host, c.Port),
 			"kafka_authentication_method": c.KafkaAuthenticationMethod,
+			"route":                       c.Route,
 			// By default, endpoints are always encrypted and
 			// this property is only included for service components that may disable encryption.
-			"ssl": PointerValueOrDefault(c.Ssl, true),
+			"ssl":   PointerValueOrDefault(c.Ssl, true),
+			"usage": c.Usage,
 		}
 		components = append(components, component)
 	}


### PR DESCRIPTION
<!-- All contributors, please complete these sections, including maintainers. -->

## About this change—what it does

<!-- Provide a small sentence that summarizes the change. -->
adds `connection_info` field to components of all services

<!-- Provide the issue number below, if it exists. -->
resolves #1444 

## Why this way

<!-- Provide a small explanation on why this is the approach you took for solving this problem. -->
to provide with a convenient way to retrieve `host:port` string and ease the process of usage of those fields
