### PR TITLE
fix(kafka_topic): remove expect non empty diff in test

### DIFF
--- a/internal/sdkprovider/service/kafkatopic/kafka_topic_test.go
+++ b/internal/sdkprovider/service/kafkatopic/kafka_topic_test.go
@@ -401,8 +401,7 @@ func TestAccAivenKafkaTopic_recreate_missing(t *testing.T) {
 			},
 			{
 				// Step 3: recreates the topic
-				ExpectNonEmptyPlan: true,
-				Config:             config,
+				Config: config,
 				Check: resource.ComposeTestCheckFunc(
 					// Saved in state
 					resource.TestCheckResourceAttr(kafkaResource, "id", kafkaID),
@@ -419,7 +418,7 @@ func TestAccAivenKafkaTopic_recreate_missing(t *testing.T) {
 								tc, err := client.KafkaTopics.Get(ctx, project, kafkaName, topicName)
 								if err != nil {
 									return &retry.RetryError{
-										Err:       err,
+										Err:       fmt.Errorf(`can't get the "missing" topic: %w`, err),
 										Retryable: aiven.IsNotFound(err),
 									}
 								}


### PR DESCRIPTION
## About this change—what it does

Should not expect non-empty plan:

> When a test is ran, Terraform runs plan, apply, refresh, and then final plan for each TestStep in the TestCase. If the last plan results in a non-empty plan, Terraform will exit with an error. This enables developers to ensure that configurations apply cleanly. In the case of introducing regression tests or otherwise testing specific error behavior, TestStep offers a boolean field [ExpectNonEmptyPlan](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-testing/helper/resource#TestStep.ExpectNonEmptyPlan) as well ExpectError regex field to specify ways the test framework can handle expected failures. If these properties are omitted and either a non-empty plan occurs or an error encountered, Terraform will fail the test.