### PR TITLE
fix(account_team_member): no err on deletion if it does not exist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ nav_order: 1
 - Add `connection_uri` field to components of all services. This field contains connection information for the
   component, and is a combination of the `host` and `port` fields
 - Add `external_postgresql` and `external_google_cloud_bigquery` service integration endpoints
+- Do not return error on `aiven_account_team_member` deletion if the member does not exist
 
 ## [4.9.3] - 2023-10-27
 

--- a/internal/sdkprovider/service/account/account_team_member.go
+++ b/internal/sdkprovider/service/account/account_team_member.go
@@ -205,21 +205,19 @@ func resourceAccountTeamMemberDelete(ctx context.Context, d *schema.ResourceData
 	}
 
 	// delete account team member
-	found := false
 	for _, m := range r.Members {
 		if m.UserEmail == userEmail {
 			err = client.AccountTeamMembers.Delete(ctx, accountID, teamID, m.UserId)
 			if err != nil && !aiven.IsNotFound(err) {
 				return diag.FromErr(err)
 			}
-			found = true
 			break
 		}
 	}
 
-	if !found {
-		return diag.Errorf("user with email %q is not a part of the team %q", userEmail, teamID)
-	}
+	// we don't need to return an error if a user is not found in the members list
+	// because it means that a user was invited but not yet accepted an invitation,
+	// and we already deleted an invitation above
 
 	return nil
 }


### PR DESCRIPTION
<!-- All contributors, please complete these sections, including maintainers. -->

## About this change—what it does

<!-- Provide a small sentence that summarizes the change. -->
no err on `aiven_account_team_member` deletion if it does not exist

<!-- Provide the issue number below, if it exists. -->

## Why this way

<!-- Provide a small explanation on why this is the approach you took for solving this problem. -->
to avoid edge cases, e.g. invitations
