### PR TITLE
ci(test): proper project name prefix var substitution

### DIFF
--- a/.github/workflows/acceptance-tests.yml
+++ b/.github/workflows/acceptance-tests.yml
@@ -13,21 +13,21 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  setup_aiven_project:
+  setup_aiven_project_suffix:
     runs-on: ubuntu-latest
     outputs:
-      project_name: ${{ steps.selproj.outputs.project_name }}
+      project_name_suffix: ${{ steps.selproj.outputs.project_name_suffix }}
     steps:
       - uses: actions/checkout@v4
 
       - id: selproj
-        run: echo "project_name=$(make ci-selproj)" >> $GITHUB_OUTPUT
+        run: echo "project_name_suffix=$(make -s ci-selproj | tr -d '\n')" >> $GITHUB_OUTPUT
         env:
           AIVEN_TOKEN: ${{ secrets.AIVEN_TOKEN }}
           AIVEN_PROJECT_NAME_PREFIX: ${{ secrets.AIVEN_PROJECT_NAME_PREFIX }}
 
   acceptance_tests:
-    needs: setup_aiven_project
+    needs: setup_aiven_project_suffix
     runs-on: ubuntu-latest
     strategy:
       max-parallel: 5
@@ -83,14 +83,15 @@ jobs:
       - run: make test-acc
         env:
           AIVEN_TOKEN: ${{ secrets.AIVEN_TOKEN }}
-          AIVEN_PROJECT_NAME: ${{ needs.setup_aiven_project.outputs.project_name }}
+          AIVEN_PROJECT_NAME: >-
+            ${{ secrets.AIVEN_PROJECT_NAME_PREFIX }}${{ needs.setup_aiven_project_suffix.outputs.project_name_suffix }}
           AIVEN_ORGANIZATION_NAME: ${{ secrets.AIVEN_ORGANIZATION_NAME }}
           AIVEN_ACCOUNT_NAME: ${{ secrets.AIVEN_ORGANIZATION_NAME }}
           PKG: ${{ matrix.pkg }}
 
   sweep:
     if: always()
-    needs: [acceptance_tests, setup_aiven_project]
+    needs: [acceptance_tests, setup_aiven_project_suffix]
     runs-on: ubuntu-latest
     steps:
       - uses: softprops/turnstyle@v1
@@ -123,6 +124,7 @@ jobs:
           command: make sweep
         env:
           AIVEN_TOKEN: ${{ secrets.AIVEN_TOKEN }}
-          AIVEN_PROJECT_NAME: ${{ needs.setup_aiven_project.outputs.project_name }}
+          AIVEN_PROJECT_NAME: >-
+            ${{ secrets.AIVEN_PROJECT_NAME_PREFIX }}${{ needs.setup_aiven_project_suffix.outputs.project_name_suffix }}
           AIVEN_ORGANIZATION_NAME: ${{ secrets.AIVEN_ORGANIZATION_NAME }}
           AIVEN_ACCOUNT_NAME: ${{ secrets.AIVEN_ORGANIZATION_NAME }}

--- a/.github/workflows/examples-tests.yml
+++ b/.github/workflows/examples-tests.yml
@@ -13,21 +13,21 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  setup_aiven_project:
+  setup_aiven_project_suffix:
     runs-on: ubuntu-latest
     outputs:
-      project_name: ${{ steps.selproj.outputs.project_name }}
+      project_name_suffix: ${{ steps.selproj.outputs.project_name_suffix }}
     steps:
       - uses: actions/checkout@v4
 
       - id: selproj
-        run: echo "project_name=$(make ci-selproj)" >> $GITHUB_OUTPUT
+        run: echo "project_name_suffix=$(make -s ci-selproj | tr -d '\n')" >> $GITHUB_OUTPUT
         env:
           AIVEN_TOKEN: ${{ secrets.AIVEN_TOKEN }}
           AIVEN_PROJECT_NAME_PREFIX: ${{ secrets.AIVEN_PROJECT_NAME_PREFIX }}
 
   examples_tests:
-    needs: setup_aiven_project
+    needs: setup_aiven_project_suffix
     runs-on: ubuntu-latest
     steps:
       - uses: softprops/turnstyle@v1
@@ -55,4 +55,5 @@ jobs:
       - run: make test-examples
         env:
           AIVEN_TOKEN: ${{ secrets.AIVEN_TOKEN }}
-          AIVEN_PROJECT_NAME: ${{ needs.setup_aiven_project.outputs.project_name }}
+          AIVEN_PROJECT_NAME: >-
+            ${{ secrets.AIVEN_PROJECT_NAME_PREFIX }}${{ needs.setup_aiven_project_suffix.outputs.project_name_suffix }}

--- a/.github/workflows/sweep.yml
+++ b/.github/workflows/sweep.yml
@@ -9,14 +9,23 @@ permissions:
   contents: read
 
 concurrency:
-  group: ci-${{ github.ref }}
-  cancel-in-progress: false
+  group: ci-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
 
 jobs:
   sweep:
     runs-on: ubuntu-latest
+    strategy:
+      max-parallel: 2
+      matrix:
+        aiven_project_name_suffix: [
+          '',
+          '-2',
+          '-3',
+          '-4',
+          '-5',
+        ]
     steps:
-
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
@@ -32,4 +41,4 @@ jobs:
           command: make sweep
         env:
           AIVEN_TOKEN: ${{ secrets.AIVEN_TOKEN }}
-          AIVEN_PROJECT_NAME: ${{ secrets.AIVEN_PROJECT_NAME }}
+          AIVEN_PROJECT_NAME: ${{ secrets.AIVEN_PROJECT_NAME_PREFIX }}${{ matrix.aiven_project_name_suffix }}

--- a/tools/selproj/README.md
+++ b/tools/selproj/README.md
@@ -1,6 +1,6 @@
 # selproj
 
-A tool to select an empty project from a list of projects using a prefix.
+A tool to select an empty project's suffix from a list of projects using a prefix.
 
 ## Usage
 
@@ -17,7 +17,7 @@ The tool requires the following environment variables to be set:
 
 ```text
 $ AIVEN_TOKEN=... AIVEN_PROJECT_NAME_PREFIX=test go run -tags tools .
-test-project-2
+-project-2
 ```
 
 ## Testing

--- a/tools/selproj/main.go
+++ b/tools/selproj/main.go
@@ -34,5 +34,5 @@ func main() {
 		panic(err)
 	}
 
-	fmt.Print(selectedProject)
+	fmt.Println(selectedProject)
 }

--- a/tools/selproj/selectproject.go
+++ b/tools/selproj/selectproject.go
@@ -29,7 +29,7 @@ func selectProject(ctx context.Context, client AivenClient, prefix string) (stri
 		}
 
 		if len(services) == 0 {
-			return project.Name, nil
+			return strings.TrimPrefix(project.Name, prefix), nil
 		}
 	}
 

--- a/tools/selproj/selectproject_test.go
+++ b/tools/selproj/selectproject_test.go
@@ -52,7 +52,7 @@ func TestSelectProject_Basic(t *testing.T) {
 
 	assert.NoError(t, err, "selectProject should not return an error")
 	assert.Equal(
-		t, "test-project-2", projectName, "selectProject should return the correct project name",
+		t, "-project-2", projectName, "selectProject should return the correct project name",
 	)
 }
 


### PR DESCRIPTION
<!-- All contributors, please complete these sections, including maintainers. -->

## About this change—what it does

<!-- Provide a small sentence that summarizes the change. -->

- proper project name prefix var substitution.
- additionally adds support for `sweep.yml` (forgot to do this earlier)

<!-- Provide the issue number below, if it exists. -->

## Why this way

<!-- Provide a small explanation on why this is the approach you took for solving this problem. -->
resolves CI error https://github.com/aiven/terraform-provider-aiven/actions/runs/7247944868/job/19742908213
