### PR TITLE
fix(kafka_topic): configure insufficient brokers error retries timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,9 @@ nav_order: 1
 <!-- [MAJOR.MINOR.PATCH] - YYYY-MM-DD -->
 
 ## [MAJOR.MINOR.PATCH] - YYYY-MM-DD
+
 - Add organization application users support
+- Configure "insufficient broker" error retries timeout 
 
 ## [4.12.1] - 2024-01-05
 

--- a/internal/sdkprovider/kafkatopicrepository/read.go
+++ b/internal/sdkprovider/kafkatopicrepository/read.go
@@ -142,7 +142,7 @@ func (rep *repository) fetch(ctx context.Context, queue map[string]*request) {
 
 				list = rspList
 				return nil
-			}, retry.Delay(rep.v2ListRetryDelay))
+			}, retry.Context(ctx), retry.Delay(rep.v2ListRetryDelay))
 
 			if err != nil {
 				// Send errors


### PR DESCRIPTION
## About this change—what it does

Uses default context timeout for kafka topic create operation when gets "insufficient broker" error.