### PR TITLE
docs: update flink_application_version docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ nav_order: 1
 
 ## [MAJOR.MINOR.PATCH] - YYYY-MM-DD
 
+- Update example code in flink_application_version docs to be valid and not use deprecated schema members
+
 ## [4.13.2] - 2024-01-25
 
 - Fix `aiven_organization_group_memeber` fill model

--- a/docs/resources/flink_application_version.md
+++ b/docs/resources/flink_application_version.md
@@ -18,11 +18,11 @@ resource "aiven_flink_application_version" "foo" {
   service_name   = aiven_flink.foo.service_name
   application_id = aiven_flink_application.foo.application_id
   statement      = <<EOT
-   INSERT INTO kafka_known_pizza SELECT * FROM kafka_pizza WHERE shop LIKE '%Luigis Pizza%'"
+   INSERT INTO kafka_known_pizza SELECT * FROM kafka_pizza WHERE shop LIKE '%Luigis Pizza%'
   EOT
-  sinks {
+  sink {
     create_table   = <<EOT
-    "CREATE TABLE kafka_known_pizza (
+    CREATE TABLE kafka_known_pizza (
         shop STRING,
         name STRING
     ) WITH (
@@ -35,7 +35,7 @@ resource "aiven_flink_application_version" "foo" {
   EOT
     integration_id = aiven_service_integration.flink_to_kafka.integration_id
   }
-  sources {
+  source {
     create_table   = <<EOT
     CREATE TABLE kafka_pizza (
         shop STRING,

--- a/examples/resources/aiven_flink_application_version/resource.tf
+++ b/examples/resources/aiven_flink_application_version/resource.tf
@@ -3,11 +3,11 @@ resource "aiven_flink_application_version" "foo" {
   service_name   = aiven_flink.foo.service_name
   application_id = aiven_flink_application.foo.application_id
   statement      = <<EOT
-   INSERT INTO kafka_known_pizza SELECT * FROM kafka_pizza WHERE shop LIKE '%Luigis Pizza%'"
+   INSERT INTO kafka_known_pizza SELECT * FROM kafka_pizza WHERE shop LIKE '%Luigis Pizza%'
   EOT
-  sinks {
+  sink {
     create_table   = <<EOT
-    "CREATE TABLE kafka_known_pizza (
+    CREATE TABLE kafka_known_pizza (
         shop STRING,
         name STRING
     ) WITH (
@@ -20,7 +20,7 @@ resource "aiven_flink_application_version" "foo" {
   EOT
     integration_id = aiven_service_integration.flink_to_kafka.integration_id
   }
-  sources {
+  source {
     create_table   = <<EOT
     CREATE TABLE kafka_pizza (
         shop STRING,


### PR DESCRIPTION
- Fix extraneous quotation marks
- Remove references to deprecated schema values and use current ones instead (`sinks` and `sources` -> `sink` and `source`)

## Why this way
We shouldn't display invalid code in our examples