### PR TITLE
chore(kafka_topic): improve config zero-value test

### DIFF
--- a/internal/sdkprovider/service/kafkatopic/kafka_topic_test.go
+++ b/internal/sdkprovider/service/kafkatopic/kafka_topic_test.go
@@ -43,7 +43,6 @@ func TestAccAivenKafkaTopic_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "replication", "2"),
 					resource.TestCheckResourceAttr(resourceName, "termination_protection", "false"),
 					resource.TestCheckResourceAttr(resourceName, "config.0.retention_bytes", "1234"),
-					resource.TestCheckResourceAttr(resourceName, "config.0.local_retention_bytes", "123"),
 				),
 			},
 		},
@@ -165,7 +164,6 @@ resource "aiven_kafka_topic" "foo" {
     min_cleanable_dirty_ratio = 0.01
     delete_retention_ms       = 50000
     retention_bytes           = 1234
-    local_retention_bytes     = 123
   }
 }
 


### PR DESCRIPTION
## About this change—what it does

User story test case doesn't have `local_retention_bytes` value.
This PR just proves user case is covered.