### PR TITLE
chore(kafka_topic): remove insufficient brokers retry logic

### DIFF
--- a/internal/sdkprovider/kafkatopicrepository/create.go
+++ b/internal/sdkprovider/kafkatopicrepository/create.go
@@ -4,15 +4,9 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"strings"
 
 	"github.com/aiven/aiven-go-client/v2"
-	"github.com/avast/retry-go"
 )
-
-// insufficientBrokersErr the error message received when kafka is not ready yet, like
-// Cluster only has 2 broker(s), cannot set replication factor to 3
-var insufficientBrokersErr = "cannot set replication factor to"
 
 // Create creates a topic.
 // First checks if the topic does not exist for the safety
@@ -31,36 +25,11 @@ func (rep *repository) Create(ctx context.Context, project, service string, req 
 		return err
 	}
 
-	// When kafka is not ready, it throws reInsufficientBrokers.
-	// Unfortunately, the error might be valid, so it will take a minute to fail.
-	err = retry.Do(func() error {
-		err = rep.client.Create(ctx, project, service, req)
-		if err == nil {
-			return nil
-		}
-
-		// The 501 is retried in the client, so it can return 409
-		if aiven.IsAlreadyExists(err) {
-			return nil
-		}
-
-		// We must retry this one.
-		// Unfortunately, there is no way to tune retries depending on the error.
-		// So this error might be valid (insufficient brokers), then it will retry until context is expired.
-		// This timeout can be adjusted:
-		// https://registry.terraform.io/providers/aiven/aiven/latest/docs/resources/kafka_topic#create
-		if strings.Contains(err.Error(), insufficientBrokersErr) {
-			return err
-		}
-
-		// Other errors are non-retryable
-		return retry.Unrecoverable(err)
-	}, retry.Context(ctx))
-
-	// Retry lib returns a custom error object
-	// we can't compare in tests with
-	if err != nil {
+	err = rep.client.Create(ctx, project, service, req)
+	if err != nil && !aiven.IsAlreadyExists(err) {
 		return fmt.Errorf("topic create error: %w", err)
 	}
-	return err
+
+	return nil
+
 }

--- a/internal/sdkprovider/kafkatopicrepository/create_test.go
+++ b/internal/sdkprovider/kafkatopicrepository/create_test.go
@@ -73,7 +73,6 @@ func TestCreateRecreateMissing(t *testing.T) {
 }
 
 func TestCreateRetries(t *testing.T) {
-	errInsufficientBrokers := fmt.Errorf(`{"errors":[{"message":"Cluster only has 2 broker(s), cannot set replication factor to 3","status":409}],"message":"Cluster only has 2 broker(s), cannot set replication factor to 3"}`)
 	cases := []struct {
 		name         string
 		createErr    []error
@@ -83,13 +82,8 @@ func TestCreateRetries(t *testing.T) {
 		{
 			name:         "bad request error",
 			createErr:    []error{fmt.Errorf("invalid value")},
-			expectErr:    fmt.Errorf("topic create error: All attempts fail:\n#1: invalid value"),
+			expectErr:    fmt.Errorf("topic create error: invalid value"),
 			expectCalled: 1, // exits on the first unknown error
-		},
-		{
-			name:         "emulates insufficient broker error when create topic",
-			createErr:    []error{errInsufficientBrokers, errInsufficientBrokers},
-			expectCalled: 3, // two errors, three calls, the last one successful
 		},
 		{
 			name: "emulates case when 501 retried in client and then 409 received (ignores 409)",


### PR DESCRIPTION
<!-- All contributors, please complete these sections, including maintainers. -->

## About this change—what it does

Remove insufficient brokers retry logic fro Kafka Topic