### PR TITLE
docs(security): change bugbounty provider from h1 to bugcrowd

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -10,7 +10,7 @@ We release patches for security vulnerabilities. Which versions are eligible to 
 
 ## Reporting a vulnerability
 
-Please report (suspected) security vulnerabilities to our **[bug bounty program](https://hackerone.com/aiven_ltd)**. You will receive a response from us within 2 working days. If the issue is confirmed, we will release a patch as soon as possible depending on impact and complexity.
+Please report (suspected) security vulnerabilities to our **[bug bounty program](https://bugcrowd.com/aiven-mbb-og)**. You will receive a response from us within 2 working days. If the issue is confirmed, we will release a patch as soon as possible depending on impact and complexity.
 
 ## Qualifying vulnerabilities
 


### PR DESCRIPTION
Our bugbounty program is now with Bugcrowd. The HackerOne program is deprecated.