### PR TITLE
chore(go): upgrade go 1.22

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ nav_order: 1
 - Add new user config generator
 - Use `TypeSet` for `ip_filter`, `ip_filter_string` fields
 - Fix `aiven_organization_user_group` resource - `description` field is required
+- Use golang 1.22
 
 ## [4.13.3] - 2024-01-29
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,7 +10,7 @@ Contributions are very welcome on terraform-provider-aiven. When contributing pl
 
 ### Local environment
 
-[Go](https://go.dev/doc/install) >=1.18 \
+[Go](https://go.dev/doc/install) >=1.22 \
 [Terraform](https://learn.hashicorp.com/tutorials/terraform/install-cli) >=1.2
 
 #### Alternative command to build/test inside a container

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/aiven/terraform-provider-aiven
 
-go 1.21
+go 1.22
 
 require (
 	github.com/aiven/aiven-go-client/v2 v2.12.0

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -1,6 +1,6 @@
 module github.com/aiven/terraform-provider-aiven/tools
 
-go 1.21
+go 1.22
 
 require (
 	github.com/aiven/terraform-provider-aiven/tools/selproj v0.0.0-00010101000000-000000000000

--- a/tools/selproj/go.mod
+++ b/tools/selproj/go.mod
@@ -1,6 +1,6 @@
 module github.com/aiven/terraform-provider-aiven/tools/selproj
 
-go 1.21
+go 1.22
 
 require (
 	github.com/aiven/aiven-go-client/v2 v2.4.0


### PR DESCRIPTION
<!-- All contributors, please complete these sections, including maintainers. -->

Use the latest version of golang.

<!-- Provide a small sentence that summarizes the change. -->

<!-- Provide the issue number below, if it exists. -->

## Why this way

<!-- Provide a small explanation on why this is the approach you took for solving this problem. -->

Go 1.22 brings performance improvements, see: https://go.dev/blog/go1.22
