### PR TITLE
refactor: use v2/helpers/retry instead of helper/resource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ nav_order: 1
 
 <!-- TODO: uncomment when dragonfly is supported -->
 <!-- - Dragonfly support -->
+- Refactor deprecated `resource.StateChangeConf`/`resource.StateRefreshFunc` usage to their equivalent with `retry`
 - Fix `aiven_kafka_schema` JSON object diff suppress function
 - Add new user config generator
 - Use `TypeSet` for `ip_filter`, `ip_filter_string` fields

--- a/internal/schemautil/database.go
+++ b/internal/schemautil/database.go
@@ -5,7 +5,7 @@ import (
 	"time"
 
 	"github.com/aiven/aiven-go-client/v2"
-	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 
 	"github.com/aiven/terraform-provider-aiven/internal/common"
 )
@@ -19,9 +19,8 @@ type DatabaseDeleteWaiter struct {
 	Database    string
 }
 
-// RefreshFunc will call the Aiven client and refresh it's state.
-// nolint:staticcheck // TODO: Migrate to helper/retry package to avoid deprecated resource.StateRefreshFunc.
-func (w *DatabaseDeleteWaiter) RefreshFunc() resource.StateRefreshFunc {
+// RefreshFunc will call the Aiven client and refresh its state.
+func (w *DatabaseDeleteWaiter) RefreshFunc() retry.StateRefreshFunc {
 	return func() (interface{}, string, error) {
 		err := w.Client.Databases.Delete(w.Context, w.ProjectName, w.ServiceName, w.Database)
 		if common.IsCritical(err) {
@@ -33,9 +32,8 @@ func (w *DatabaseDeleteWaiter) RefreshFunc() resource.StateRefreshFunc {
 }
 
 // Conf sets up the configuration to refresh.
-// nolint:staticcheck // TODO: Migrate to helper/retry package to avoid deprecated resource.StateRefreshFunc.
-func (w *DatabaseDeleteWaiter) Conf(timeout time.Duration) *resource.StateChangeConf {
-	return &resource.StateChangeConf{
+func (w *DatabaseDeleteWaiter) Conf(timeout time.Duration) *retry.StateChangeConf {
+	return &retry.StateChangeConf{
 		Pending:    []string{"REMOVING"},
 		Target:     []string{"DELETED"},
 		Refresh:    w.RefreshFunc(),

--- a/internal/schemautil/wait.go
+++ b/internal/schemautil/wait.go
@@ -9,8 +9,8 @@ import (
 	"time"
 
 	"github.com/aiven/aiven-go-client/v2"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 
 	"github.com/aiven/terraform-provider-aiven/internal/common"
 )
@@ -22,7 +22,6 @@ const (
 	aivenServicesStartingState = "WAITING_FOR_SERVICES"
 )
 
-// nolint:staticcheck // TODO: Migrate to helper/retry package to avoid deprecated resource.StateRefreshFunc.
 func WaitForServiceCreation(ctx context.Context, d *schema.ResourceData, m interface{}) (*aiven.Service, error) {
 	client := m.(*aiven.Client)
 
@@ -31,7 +30,7 @@ func WaitForServiceCreation(ctx context.Context, d *schema.ResourceData, m inter
 	timeout := d.Timeout(schema.TimeoutCreate)
 	log.Printf("[DEBUG] Service creation waiter timeout %.0f minutes", timeout.Minutes())
 
-	conf := &resource.StateChangeConf{
+	conf := &retry.StateChangeConf{
 		Pending:                   []string{aivenPendingState, aivenRebalancingState, aivenServicesStartingState},
 		Target:                    []string{aivenTargetState},
 		Delay:                     10 * time.Second,
@@ -79,7 +78,6 @@ func WaitForServiceCreation(ctx context.Context, d *schema.ResourceData, m inter
 	return aux.(*aiven.Service), nil
 }
 
-// nolint:staticcheck // TODO: Migrate to helper/retry package to avoid deprecated resource.StateRefreshFunc.
 func WaitForServiceUpdate(ctx context.Context, d *schema.ResourceData, m interface{}) (*aiven.Service, error) {
 	client := m.(*aiven.Client)
 
@@ -88,7 +86,7 @@ func WaitForServiceUpdate(ctx context.Context, d *schema.ResourceData, m interfa
 	timeout := d.Timeout(schema.TimeoutCreate)
 	log.Printf("[DEBUG] Service update waiter timeout %.0f minutes", timeout.Minutes())
 
-	conf := &resource.StateChangeConf{
+	conf := &retry.StateChangeConf{
 		Pending:                   []string{"updating"},
 		Target:                    []string{"updated"},
 		Delay:                     10 * time.Second,
@@ -131,12 +129,11 @@ func WaitForServiceUpdate(ctx context.Context, d *schema.ResourceData, m interfa
 	return aux.(*aiven.Service), nil
 }
 
-// nolint:staticcheck // TODO: Migrate to helper/retry package to avoid deprecated resource.StateRefreshFunc.
 func WaitStaticIpsDissassociation(ctx context.Context, d *schema.ResourceData, m interface{}) error {
 	timeout := d.Timeout(schema.TimeoutDelete)
 	log.Printf("[DEBUG] Static Ip dissassociation timeout %.0f minutes", timeout.Minutes())
 
-	conf := &resource.StateChangeConf{
+	conf := &retry.StateChangeConf{
 		Pending:                   []string{"doing"},
 		Target:                    []string{"done"},
 		Delay:                     10 * time.Second,
@@ -161,7 +158,6 @@ func WaitStaticIpsDissassociation(ctx context.Context, d *schema.ResourceData, m
 	return nil
 }
 
-// nolint:staticcheck // TODO: Migrate to helper/retry package to avoid deprecated resource.StateRefreshFunc.
 func WaitForDeletion(ctx context.Context, d *schema.ResourceData, m interface{}) error {
 	client := m.(*aiven.Client)
 
@@ -170,7 +166,7 @@ func WaitForDeletion(ctx context.Context, d *schema.ResourceData, m interface{})
 	timeout := d.Timeout(schema.TimeoutDelete)
 	log.Printf("[DEBUG] Service deletion waiter timeout %.0f minutes", timeout.Minutes())
 
-	conf := &resource.StateChangeConf{
+	conf := &retry.StateChangeConf{
 		Pending:                   []string{"deleting"},
 		Target:                    []string{"deleted"},
 		Delay:                     10 * time.Second,

--- a/internal/sdkprovider/service/flink/flink_application_deployment.go
+++ b/internal/sdkprovider/service/flink/flink_application_deployment.go
@@ -7,9 +7,9 @@ import (
 
 	"github.com/aiven/aiven-go-client/v2"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 
 	"github.com/aiven/terraform-provider-aiven/internal/schemautil"
 )
@@ -123,8 +123,6 @@ func resourceFlinkApplicationDeploymentCreate(
 }
 
 // resourceFlinkApplicationDeploymentDelete deletes an existing Flink Application Deployment resource.
-//
-//nolint:staticcheck // Ignore resource.StateChangeConf deprecation warning.
 func resourceFlinkApplicationDeploymentDelete(
 	ctx context.Context,
 	d *schema.ResourceData,
@@ -143,7 +141,7 @@ func resourceFlinkApplicationDeploymentDelete(
 	}
 
 	//goland:noinspection GoDeprecation
-	conf := &resource.StateChangeConf{
+	conf := &retry.StateChangeConf{
 		Pending: []string{
 			"CANCELLING",
 		},

--- a/internal/sdkprovider/service/influxdb/influxdb_database.go
+++ b/internal/sdkprovider/service/influxdb/influxdb_database.go
@@ -121,7 +121,6 @@ func resourceInfluxDBDatabaseDelete(ctx context.Context, d *schema.ResourceData,
 
 	timeout := d.Timeout(schema.TimeoutDelete)
 
-	// nolint:staticcheck // TODO: Migrate to helper/retry package to avoid deprecated WaitForStateContext.
 	_, err = waiter.Conf(timeout).WaitForStateContext(ctx)
 	if err != nil {
 		return diag.Errorf("error waiting for Aiven Database to be DELETED: %s", err)

--- a/internal/sdkprovider/service/kafka/kafka_connector.go
+++ b/internal/sdkprovider/service/kafka/kafka_connector.go
@@ -11,7 +11,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 
 	"github.com/aiven/terraform-provider-aiven/internal/common"
 	"github.com/aiven/terraform-provider-aiven/internal/schemautil"
@@ -149,14 +148,13 @@ func flattenKafkaConnectorTasks(r *aiven.KafkaConnector) []map[string]interface{
 	return tasks
 }
 
-// nolint:staticcheck // TODO: Migrate to helper/retry package to avoid deprecated resource.StateRefreshFunc.
 func resourceKafkaConnectorRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	project, serviceName, connectorName, err := schemautil.SplitResourceID3(d.Id())
 	if err != nil {
 		return diag.FromErr(err)
 	}
 
-	stateChangeConf := &resource.StateChangeConf{
+	stateChangeConf := &retry.StateChangeConf{
 		Pending: []string{"IN_PROGRESS"},
 		Target:  []string{"OK"},
 		Refresh: func() (interface{}, string, error) {

--- a/internal/sdkprovider/service/mysql/mysql_database.go
+++ b/internal/sdkprovider/service/mysql/mysql_database.go
@@ -121,7 +121,6 @@ func resourceMySQLDatabaseDelete(ctx context.Context, d *schema.ResourceData, m 
 
 	timeout := d.Timeout(schema.TimeoutDelete)
 
-	// nolint:staticcheck // TODO: Migrate to helper/retry package to avoid deprecated WaitForStateContext.
 	_, err = waiter.Conf(timeout).WaitForStateContext(ctx)
 	if err != nil {
 		return diag.Errorf("error waiting for Aiven Database to be DELETED: %s", err)

--- a/internal/sdkprovider/service/pg/pg_database.go
+++ b/internal/sdkprovider/service/pg/pg_database.go
@@ -153,7 +153,6 @@ func resourcePGDatabaseDelete(ctx context.Context, d *schema.ResourceData, m int
 
 	timeout := d.Timeout(schema.TimeoutDelete)
 
-	// nolint:staticcheck // TODO: Migrate to helper/retry package to avoid deprecated WaitForStateContext.
 	_, err = waiter.Conf(timeout).WaitForStateContext(ctx)
 	if err != nil {
 		return diag.Errorf("error waiting for Aiven Database to be DELETED: %s", err)

--- a/internal/sdkprovider/service/project/project.go
+++ b/internal/sdkprovider/service/project/project.go
@@ -13,8 +13,8 @@ import (
 	"github.com/aiven/aiven-go-client/v2"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 
 	"github.com/aiven/terraform-provider-aiven/internal/schemautil"
 	"github.com/aiven/terraform-provider-aiven/internal/schemautil/userconfig"
@@ -263,12 +263,11 @@ func resourceProjectAssignToBillingGroup(
 	return nil
 }
 
-// nolint:staticcheck // TODO: Migrate to helper/retry package to avoid deprecated resource.StateRefreshFunc.
 func resourceProjectRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	client := m.(*aiven.Client)
 
 	//goland:noinspection GoDeprecation
-	conf := &resource.StateChangeConf{
+	conf := &retry.StateChangeConf{
 		Pending:    []string{"pending"},
 		Target:     []string{"target"},
 		Timeout:    time.Minute,

--- a/internal/sdkprovider/service/serviceintegration/service_integration.go
+++ b/internal/sdkprovider/service/serviceintegration/service_integration.go
@@ -9,9 +9,9 @@ import (
 
 	"github.com/aiven/aiven-go-client/v2"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 
 	"github.com/aiven/terraform-provider-aiven/internal/common"
 	"github.com/aiven/terraform-provider-aiven/internal/schemautil"
@@ -292,7 +292,6 @@ func resourceServiceIntegrationCheckForPreexistingResource(ctx context.Context, 
 	return nil, nil
 }
 
-// nolint:staticcheck // TODO: Migrate to helper/retry package to avoid deprecated resource.StateRefreshFunc.
 func resourceServiceIntegrationWaitUntilActive(ctx context.Context, d *schema.ResourceData, m interface{}) error {
 	const (
 		active    = "ACTIVE"
@@ -305,7 +304,7 @@ func resourceServiceIntegrationWaitUntilActive(ctx context.Context, d *schema.Re
 		return err
 	}
 
-	stateChangeConf := &resource.StateChangeConf{
+	stateChangeConf := &retry.StateChangeConf{
 		Pending: []string{notActive},
 		Target:  []string{active},
 		Refresh: func() (interface{}, string, error) {

--- a/internal/sdkprovider/service/staticip/static_ip.go
+++ b/internal/sdkprovider/service/staticip/static_ip.go
@@ -7,8 +7,8 @@ import (
 
 	"github.com/aiven/aiven-go-client/v2"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 
 	"github.com/aiven/terraform-provider-aiven/internal/common"
 	"github.com/aiven/terraform-provider-aiven/internal/schemautil"
@@ -145,7 +145,6 @@ func resourceStaticIPDelete(ctx context.Context, d *schema.ResourceData, m inter
 	return nil
 }
 
-// nolint:staticcheck // TODO: Migrate to helper/retry package to avoid deprecated resource.StateRefreshFunc.
 func resourceStaticIPWait(ctx context.Context, d *schema.ResourceData, m interface{}) error {
 	client := m.(*aiven.Client)
 
@@ -154,7 +153,7 @@ func resourceStaticIPWait(ctx context.Context, d *schema.ResourceData, m interfa
 		return err
 	}
 
-	conf := resource.StateChangeConf{
+	conf := retry.StateChangeConf{
 		Target:  []string{schemautil.StaticIPCreated},
 		Pending: []string{"waiting", schemautil.StaticIPCreating},
 		Timeout: d.Timeout(schema.TimeoutCreate),

--- a/internal/sdkprovider/service/vpc/aws_vpc_peering_connection.go
+++ b/internal/sdkprovider/service/vpc/aws_vpc_peering_connection.go
@@ -6,8 +6,8 @@ import (
 
 	"github.com/aiven/aiven-go-client/v2"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 
 	"github.com/aiven/terraform-provider-aiven/internal/common"
 	"github.com/aiven/terraform-provider-aiven/internal/schemautil"
@@ -75,7 +75,6 @@ func ResourceAWSVPCPeeringConnection() *schema.Resource {
 	}
 }
 
-// nolint:staticcheck // TODO: Migrate to helper/retry package to avoid deprecated resource.StateRefreshFunc.
 func resourceAWSVPCPeeringConnectionCreate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	var (
 		pc     *aiven.VPCPeeringConnection
@@ -125,7 +124,7 @@ func resourceAWSVPCPeeringConnectionCreate(ctx context.Context, d *schema.Resour
 		return diag.Errorf("Error waiting for AWS VPC peering connection creation: %s", err)
 	}
 
-	stateChangeConf := &resource.StateChangeConf{
+	stateChangeConf := &retry.StateChangeConf{
 		Pending: []string{"APPROVED"},
 		Target: []string{
 			"ACTIVE",
@@ -196,7 +195,6 @@ func resourceAWSVPCPeeringConnectionRead(ctx context.Context, d *schema.Resource
 	return copyAWSVPCPeeringConnectionPropertiesFromAPIResponseToTerraform(d, pc, p.projectName, p.vpcID)
 }
 
-// nolint:staticcheck // TODO: Migrate to helper/retry package to avoid deprecated resource.StateRefreshFunc.
 func resourceAWSVPCPeeringConnectionDelete(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	client := m.(*aiven.Client)
 
@@ -217,7 +215,7 @@ func resourceAWSVPCPeeringConnectionDelete(ctx context.Context, d *schema.Resour
 		return diag.Errorf("Error deleting VPC peering connection: %s", err)
 	}
 
-	stateChangeConf := &resource.StateChangeConf{
+	stateChangeConf := &retry.StateChangeConf{
 		Pending: []string{
 			"ACTIVE",
 			"APPROVED",

--- a/internal/sdkprovider/service/vpc/azure_privatelink.go
+++ b/internal/sdkprovider/service/vpc/azure_privatelink.go
@@ -7,8 +7,8 @@ import (
 
 	"github.com/aiven/aiven-go-client/v2"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 
 	"github.com/aiven/terraform-provider-aiven/internal/common"
 	"github.com/aiven/terraform-provider-aiven/internal/schemautil"
@@ -87,7 +87,6 @@ func resourceAzurePrivatelinkCreate(ctx context.Context, d *schema.ResourceData,
 		return diag.FromErr(err)
 	}
 
-	// nolint:staticcheck // TODO: Migrate to helper/retry package to avoid deprecated WaitForStateContext.
 	_, err = waitForAzurePrivatelinkToBeActive(
 		ctx,
 		client,
@@ -165,7 +164,6 @@ func resourceAzurePrivatelinkUpdate(ctx context.Context, d *schema.ResourceData,
 		return diag.FromErr(err)
 	}
 
-	// nolint:staticcheck // TODO: Migrate to helper/retry package to avoid deprecated WaitForStateContext.
 	_, err = waitForAzurePrivatelinkToBeActive(
 		ctx,
 		client,
@@ -181,15 +179,14 @@ func resourceAzurePrivatelinkUpdate(ctx context.Context, d *schema.ResourceData,
 }
 
 // waitForAzurePrivatelinkToBeActive waits until the Azure privatelink is active
-// nolint:staticcheck // TODO: Migrate to helper/retry package to avoid deprecated resource.StateRefreshFunc.
 func waitForAzurePrivatelinkToBeActive(
 	ctx context.Context,
 	client *aiven.Client,
 	project string,
 	serviceName string,
 	t time.Duration,
-) *resource.StateChangeConf {
-	return &resource.StateChangeConf{
+) *retry.StateChangeConf {
+	return &retry.StateChangeConf{
 		Pending: []string{"creating"},
 		Target:  []string{"active"},
 		Refresh: func() (interface{}, string, error) {
@@ -208,7 +205,6 @@ func waitForAzurePrivatelinkToBeActive(
 	}
 }
 
-// nolint:staticcheck // TODO: Migrate to helper/retry package to avoid deprecated resource.StateRefreshFunc.
 func resourceAzurePrivatelinkDelete(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	client := m.(*aiven.Client)
 	project, serviceName, err := schemautil.SplitResourceID2(d.Id())
@@ -221,7 +217,7 @@ func resourceAzurePrivatelinkDelete(ctx context.Context, d *schema.ResourceData,
 		return diag.FromErr(err)
 	}
 
-	stateChangeConf := &resource.StateChangeConf{
+	stateChangeConf := &retry.StateChangeConf{
 		Pending: []string{"deleting"},
 		Target:  []string{"deleted"},
 		Refresh: func() (interface{}, string, error) {

--- a/internal/sdkprovider/service/vpc/azure_privatelink_connection_approve.go
+++ b/internal/sdkprovider/service/vpc/azure_privatelink_connection_approve.go
@@ -7,8 +7,8 @@ import (
 
 	"github.com/aiven/aiven-go-client/v2"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 
 	"github.com/aiven/terraform-provider-aiven/internal/schemautil"
 )
@@ -50,7 +50,6 @@ func ResourceAzurePrivatelinkConnectionApproval() *schema.Resource {
 	}
 }
 
-// nolint:staticcheck // TODO: Migrate to helper/retry package to avoid deprecated resource.StateRefreshFunc.
 func waitForAzureConnectionState(
 	ctx context.Context,
 	client *aiven.Client,
@@ -59,8 +58,8 @@ func waitForAzureConnectionState(
 	t time.Duration,
 	pending []string,
 	target []string,
-) *resource.StateChangeConf {
-	return &resource.StateChangeConf{
+) *retry.StateChangeConf {
+	return &retry.StateChangeConf{
 		Pending: pending,
 		Target:  target,
 		Refresh: func() (interface{}, string, error) {
@@ -105,7 +104,6 @@ func resourceAzurePrivatelinkConnectionApprovalUpdate(ctx context.Context, d *sc
 	pending := []string{""}
 	target := []string{"pending-user-approval", "user-approved", "connected", "active"}
 
-	// nolint:staticcheck // TODO: Migrate to helper/retry package to avoid deprecated WaitForStateContext.
 	_, err = waitForAzureConnectionState(ctx, client, project, serviceName, d.Timeout(schema.TimeoutCreate), pending, target).WaitForStateContext(ctx)
 	if err != nil {
 		return diag.Errorf("Error waiting for privatelink connection after refresh: %s", err)
@@ -133,7 +131,6 @@ func resourceAzurePrivatelinkConnectionApprovalUpdate(ctx context.Context, d *sc
 	pending = []string{"user-approved"}
 	target = []string{"connected"}
 
-	// nolint:staticcheck // TODO: Migrate to helper/retry package to avoid deprecated WaitForStateContext.
 	_, err = waitForAzureConnectionState(ctx, client, project, serviceName, d.Timeout(schema.TimeoutCreate), pending, target).WaitForStateContext(ctx)
 	if err != nil {
 		return diag.Errorf("Error waiting for privatelink connection after approval: %s", err)
@@ -150,7 +147,6 @@ func resourceAzurePrivatelinkConnectionApprovalUpdate(ctx context.Context, d *sc
 	pending = []string{"connected"}
 	target = []string{"active"}
 
-	// nolint:staticcheck // TODO: Migrate to helper/retry package to avoid deprecated WaitForStateContext.
 	_, err = waitForAzureConnectionState(ctx, client, project, serviceName, d.Timeout(schema.TimeoutCreate), pending, target).WaitForStateContext(ctx)
 	if err != nil {
 		return diag.Errorf("Error waiting for privatelink connection after update: %s", err)

--- a/internal/sdkprovider/service/vpc/azure_vpc_peering_connection.go
+++ b/internal/sdkprovider/service/vpc/azure_vpc_peering_connection.go
@@ -6,8 +6,8 @@ import (
 
 	"github.com/aiven/aiven-go-client/v2"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 
 	"github.com/aiven/terraform-provider-aiven/internal/common"
 	"github.com/aiven/terraform-provider-aiven/internal/schemautil"
@@ -84,7 +84,6 @@ func ResourceAzureVPCPeeringConnection() *schema.Resource {
 	}
 }
 
-// nolint:staticcheck // TODO: Migrate to helper/retry package to avoid deprecated resource.StateRefreshFunc.
 func resourceAzureVPCPeeringConnectionCreate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	client := m.(*aiven.Client)
 	projectName, vpcID, err := schemautil.SplitResourceID2(d.Get("vpc_id").(string))
@@ -140,7 +139,7 @@ func resourceAzureVPCPeeringConnectionCreate(ctx context.Context, d *schema.Reso
 		return diag.Errorf("Error waiting for VPC peering connection creation: %s", err)
 	}
 
-	stateChangeConf := &resource.StateChangeConf{
+	stateChangeConf := &retry.StateChangeConf{
 		Pending: []string{"APPROVED"},
 		Target: []string{
 			"ACTIVE",
@@ -212,7 +211,6 @@ func resourceAzureVPCPeeringConnectionRead(ctx context.Context, d *schema.Resour
 	return copyAzureVPCPeeringConnectionPropertiesFromAPIResponseToTerraform(d, pc, p.projectName, p.vpcID)
 }
 
-// nolint:staticcheck // TODO: Migrate to helper/retry package to avoid deprecated resource.StateRefreshFunc.
 func resourceAzureVPCPeeringConnectionDelete(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	client := m.(*aiven.Client)
 
@@ -234,7 +232,7 @@ func resourceAzureVPCPeeringConnectionDelete(ctx context.Context, d *schema.Reso
 		return diag.Errorf("Error deleting VPC peering connection with resource group: %s", err)
 	}
 
-	stateChangeConf := &resource.StateChangeConf{
+	stateChangeConf := &retry.StateChangeConf{
 		Pending: []string{
 			"ACTIVE",
 			"APPROVED",

--- a/internal/sdkprovider/service/vpc/gcp_privatelink_connection_approve.go
+++ b/internal/sdkprovider/service/vpc/gcp_privatelink_connection_approve.go
@@ -7,8 +7,8 @@ import (
 
 	"github.com/aiven/aiven-go-client/v2"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 
 	"github.com/aiven/terraform-provider-aiven/internal/schemautil"
 )
@@ -56,7 +56,6 @@ func ResourceGCPPrivatelinkConnectionApproval() *schema.Resource {
 	}
 }
 
-// nolint:staticcheck // TODO: Migrate to helper/retry package to avoid deprecated resource.StateRefreshFunc.
 func waitForGCPConnectionState(
 	ctx context.Context,
 	client *aiven.Client,
@@ -65,8 +64,8 @@ func waitForGCPConnectionState(
 	t time.Duration,
 	pending []string,
 	target []string,
-) *resource.StateChangeConf {
-	return &resource.StateChangeConf{
+) *retry.StateChangeConf {
+	return &retry.StateChangeConf{
 		Pending: pending,
 		Target:  target,
 		Refresh: func() (interface{}, string, error) {
@@ -116,7 +115,6 @@ func resourceGCPPrivatelinkConnectionApprovalUpdate(
 	pending := []string{""}
 	target := []string{"pending-user-approval", "user-approved", "connected", "active"}
 
-	// nolint:staticcheck // TODO: Migrate to helper/retry package to avoid deprecated WaitForStateContext.
 	_, err = waitForGCPConnectionState(
 		ctx, client, project, serviceName, d.Timeout(schema.TimeoutCreate), pending, target,
 	).WaitForStateContext(ctx)
@@ -156,7 +154,6 @@ func resourceGCPPrivatelinkConnectionApprovalUpdate(
 	pending = []string{"user-approved"}
 	target = []string{"connected", "active"}
 
-	// nolint:staticcheck // TODO: Migrate to helper/retry package to avoid deprecated WaitForStateContext.
 	_, err = waitForGCPConnectionState(
 		ctx, client, project, serviceName, d.Timeout(schema.TimeoutCreate), pending, target,
 	).WaitForStateContext(ctx)

--- a/internal/sdkprovider/service/vpc/gcp_vpc_peering_connection.go
+++ b/internal/sdkprovider/service/vpc/gcp_vpc_peering_connection.go
@@ -7,8 +7,8 @@ import (
 
 	"github.com/aiven/aiven-go-client/v2"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 
 	"github.com/aiven/terraform-provider-aiven/internal/common"
 	"github.com/aiven/terraform-provider-aiven/internal/schemautil"
@@ -69,7 +69,6 @@ func ResourceGCPVPCPeeringConnection() *schema.Resource {
 	}
 }
 
-// nolint:staticcheck // TODO: Migrate to helper/retry package to avoid deprecated resource.StateRefreshFunc.
 func resourceGCPVPCPeeringConnectionCreate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	var (
 		pc  *aiven.VPCPeeringConnection
@@ -113,7 +112,7 @@ func resourceGCPVPCPeeringConnectionCreate(ctx context.Context, d *schema.Resour
 		return diag.Errorf("Error waiting for VPC peering connection creation: %s", err)
 	}
 
-	stateChangeConf := &resource.StateChangeConf{
+	stateChangeConf := &retry.StateChangeConf{
 		Pending: []string{"APPROVED"},
 		Target: []string{
 			"ACTIVE",
@@ -185,7 +184,6 @@ func resourceGCPVPCPeeringConnectionRead(ctx context.Context, d *schema.Resource
 	return copyGCPVPCPeeringConnectionPropertiesFromAPIResponseToTerraform(d, pc, p.projectName, p.vpcID)
 }
 
-// nolint:staticcheck // TODO: Migrate to helper/retry package to avoid deprecated resource.StateRefreshFunc.
 func resourceGCPVPCPeeringConnectionDelete(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	client := m.(*aiven.Client)
 	p, err := parsePeerVPCID(d.Id())
@@ -204,7 +202,7 @@ func resourceGCPVPCPeeringConnectionDelete(ctx context.Context, d *schema.Resour
 		return diag.Errorf("Error deleting GCP VPC peering connection: %s", err)
 	}
 
-	stateChangeConf := &resource.StateChangeConf{
+	stateChangeConf := &retry.StateChangeConf{
 		Pending: []string{
 			"ACTIVE",
 			"APPROVED",

--- a/internal/sdkprovider/service/vpc/vpc_peering_connection.go
+++ b/internal/sdkprovider/service/vpc/vpc_peering_connection.go
@@ -8,13 +8,12 @@ import (
 
 	"github.com/aiven/aiven-go-client/v2"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 
 	"github.com/aiven/terraform-provider-aiven/internal/schemautil"
 )
 
-// nolint:staticcheck // TODO: Migrate to helper/retry package to avoid deprecated resource.StateRefreshFunc.
 func resourceVPCPeeringConnectionCreate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	var (
 		pc     *aiven.VPCPeeringConnection
@@ -74,7 +73,7 @@ func resourceVPCPeeringConnectionCreate(ctx context.Context, d *schema.ResourceD
 		return diag.Errorf("error waiting for VPC peering connection creation: %s", err)
 	}
 
-	stateChangeConf := &resource.StateChangeConf{
+	stateChangeConf := &retry.StateChangeConf{
 		Pending: []string{"APPROVED"},
 		Target: []string{
 			"ACTIVE",
@@ -231,7 +230,6 @@ func resourceVPCPeeringConnectionRead(ctx context.Context, d *schema.ResourceDat
 	return copyVPCPeeringConnectionPropertiesFromAPIResponseToTerraform(d, pc, p.projectName, p.vpcID)
 }
 
-// nolint:staticcheck // TODO: Migrate to helper/retry package to avoid deprecated resource.StateRefreshFunc.
 func resourceVPCPeeringConnectionDelete(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	client := m.(*aiven.Client)
 
@@ -273,7 +271,7 @@ func resourceVPCPeeringConnectionDelete(ctx context.Context, d *schema.ResourceD
 		return diag.Errorf("Error deleting VPC peering connection: %s", err)
 	}
 
-	stateChangeConf := &resource.StateChangeConf{
+	stateChangeConf := &retry.StateChangeConf{
 		Pending: []string{
 			"ACTIVE",
 			"APPROVED",


### PR DESCRIPTION
## About this change—what it does

github.com/hashicorp/terraform-plugin-testing/helper/resource is deprecated, and it was recommend that github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry be used instead.

<!-- Provide the issue number below, if it exists. -->
Resolves: #xxxxx.

## Why this way

To eliminate the use of deprecated APIs
