### PR TITLE
fix: termination_protection diff `true -> null`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ nav_order: 1
 - Use `TypeSet` for `ip_filter`, `ip_filter_string` fields
 - Fix `aiven_organization_user_group` resource - `description` field is required
 - Use golang 1.22
+- Output explicitly `termination_protection = true -> false` when service property is removed
 
 ## [4.13.3] - 2024-01-29
 

--- a/internal/schemautil/service.go
+++ b/internal/schemautil/service.go
@@ -122,6 +122,7 @@ func ServiceCommonSchema() map[string]*schema.Schema {
 		"termination_protection": {
 			Type:        schema.TypeBool,
 			Optional:    true,
+			Default:     false,
 			Description: "Prevents the service from being deleted. It is recommended to set this to `true` for all production services to prevent unintentional service deletion. This does not shield against deleting databases or topics but for services with backups much of the content can at least be restored from backup in case accidental deletion is done.",
 		},
 		"disk_space": {


### PR DESCRIPTION
## About this change—what it does

When `termination_protection = true` is removed the diff shows `true -> null`, and sends zero-value, which is `false` [service.go](https://github.com/aiven/terraform-provider-aiven/blob/d6b602b6e1f136ead0e9a385e23c9e59f99f5b0d/internal/schemautil/service.go#L547-L547).
This PR outputs `true -> false` transition, because explicit is better than implicit.