### PR TITLE
test(flink_application_version): fix incorrect sql

### DIFF
--- a/docs/resources/flink_application_version.md
+++ b/docs/resources/flink_application_version.md
@@ -18,35 +18,35 @@ resource "aiven_flink_application_version" "foo" {
   service_name   = aiven_flink.foo.service_name
   application_id = aiven_flink_application.foo.application_id
   statement      = <<EOT
-   INSERT INTO kafka_known_pizza SELECT * FROM kafka_pizza WHERE shop LIKE '%Luigis Pizza%'
+    INSERT INTO kafka_known_pizza SELECT * FROM kafka_pizza WHERE shop LIKE '%Luigis Pizza%'
   EOT
   sink {
     create_table   = <<EOT
-    CREATE TABLE kafka_known_pizza (
+      CREATE TABLE kafka_known_pizza (
         shop STRING,
         name STRING
-    ) WITH (
+      ) WITH (
         'connector' = 'kafka',
         'properties.bootstrap.servers' = '',
         'scan.startup.mode' = 'earliest-offset',
-        'topic' = 'test_out',
+        'topic' = 'sink_topic',
         'value.format' = 'json'
-    )
-  EOT
+      )
+    EOT
     integration_id = aiven_service_integration.flink_to_kafka.integration_id
   }
   source {
     create_table   = <<EOT
-    CREATE TABLE kafka_pizza (
+      CREATE TABLE kafka_pizza (
         shop STRING,
         name STRING
-    ) WITH (
+      ) WITH (
         'connector' = 'kafka',
         'properties.bootstrap.servers' = '',
         'scan.startup.mode' = 'earliest-offset',
-        'topic' = 'test',
+        'topic' = 'source_topic',
         'value.format' = 'json'
-    )
+      )
     EOT
     integration_id = aiven_service_integration.flink_to_kafka.integration_id
   }

--- a/docs/resources/kafka_schema.md
+++ b/docs/resources/kafka_schema.md
@@ -21,19 +21,21 @@ resource "aiven_kafka_schema" "kafka-schema1" {
 
   schema = <<EOT
     {
-       "doc": "example",
-       "fields": [{
-           "default": 5,
-           "doc": "my test number",
-           "name": "test",
-           "namespace": "test",
-           "type": "int"
-       }],
-       "name": "example",
-       "namespace": "example",
-       "type": "record"
+      "doc": "example",
+      "fields": [
+        {
+          "default": 5,
+          "doc": "my test number",
+          "name": "test",
+          "namespace": "test",
+          "type": "int"
+        }
+      ],
+      "name": "example",
+      "namespace": "example",
+      "type": "record"
     }
-    EOT
+  EOT
 }
 ```
 

--- a/examples/flink/main.tf
+++ b/examples/flink/main.tf
@@ -69,35 +69,35 @@ resource "aiven_flink_application_version" "app_version" {
   service_name   = aiven_flink.flink.service_name
   application_id = aiven_flink_application.app.application_id
   statement      = <<EOT
-   INSERT INTO kafka_known_pizza SELECT * FROM kafka_pizza WHERE shop LIKE '%Luigis Pizza%'
+    INSERT INTO kafka_known_pizza SELECT * FROM kafka_pizza WHERE shop LIKE '%Luigis Pizza%'
   EOT
   sink {
     create_table   = <<EOT
-    CREATE TABLE kafka_known_pizza (
+      CREATE TABLE kafka_known_pizza (
         shop STRING,
         name STRING
-    ) WITH (
+      ) WITH (
         'connector' = 'kafka',
         'properties.bootstrap.servers' = '',
         'scan.startup.mode' = 'earliest-offset',
         'topic' = 'sink_topic',
         'value.format' = 'json'
-    )
-  EOT
+      )
+    EOT
     integration_id = aiven_service_integration.flink_to_kafka.integration_id
   }
   source {
     create_table   = <<EOT
-    CREATE TABLE kafka_pizza (
+      CREATE TABLE kafka_pizza (
         shop STRING,
         name STRING
-    ) WITH (
+      ) WITH (
         'connector' = 'kafka',
         'properties.bootstrap.servers' = '',
         'scan.startup.mode' = 'earliest-offset',
         'topic' = 'source_topic',
         'value.format' = 'json'
-    )
+      )
     EOT
     integration_id = aiven_service_integration.flink_to_kafka.integration_id
   }

--- a/examples/kafka_schemas/kafka_schema.tf
+++ b/examples/kafka_schemas/kafka_schema.tf
@@ -12,20 +12,22 @@ resource "aiven_kafka_schema" "kafka-schema1" {
   subject_name = "kafka-schema1"
 
   schema = <<EOT
-   	  {
-          "doc": "example",
-          "fields": [{
-              "default": 5,
-              "doc": "my test number",
-              "name": "test",
-              "namespace": "test",
-              "type": "int"
-          }],
-          "name": "example",
-          "namespace": "example",
-          "type": "record"
-      }
-    EOT
+    {
+      "doc": "example",
+      "fields": [
+        {
+          "default": 5,
+          "doc": "my test number",
+          "name": "test",
+          "namespace": "test",
+          "type": "int"
+        }
+      ],
+      "name": "example",
+      "namespace": "example",
+      "type": "record"
+    }
+  EOT
 }
 
 # External schema file

--- a/examples/resources/aiven_flink_application_version/resource.tf
+++ b/examples/resources/aiven_flink_application_version/resource.tf
@@ -3,35 +3,35 @@ resource "aiven_flink_application_version" "foo" {
   service_name   = aiven_flink.foo.service_name
   application_id = aiven_flink_application.foo.application_id
   statement      = <<EOT
-   INSERT INTO kafka_known_pizza SELECT * FROM kafka_pizza WHERE shop LIKE '%Luigis Pizza%'
+    INSERT INTO kafka_known_pizza SELECT * FROM kafka_pizza WHERE shop LIKE '%Luigis Pizza%'
   EOT
   sink {
     create_table   = <<EOT
-    CREATE TABLE kafka_known_pizza (
+      CREATE TABLE kafka_known_pizza (
         shop STRING,
         name STRING
-    ) WITH (
+      ) WITH (
         'connector' = 'kafka',
         'properties.bootstrap.servers' = '',
         'scan.startup.mode' = 'earliest-offset',
-        'topic' = 'test_out',
+        'topic' = 'sink_topic',
         'value.format' = 'json'
-    )
-  EOT
+      )
+    EOT
     integration_id = aiven_service_integration.flink_to_kafka.integration_id
   }
   source {
     create_table   = <<EOT
-    CREATE TABLE kafka_pizza (
+      CREATE TABLE kafka_pizza (
         shop STRING,
         name STRING
-    ) WITH (
+      ) WITH (
         'connector' = 'kafka',
         'properties.bootstrap.servers' = '',
         'scan.startup.mode' = 'earliest-offset',
-        'topic' = 'test',
+        'topic' = 'source_topic',
         'value.format' = 'json'
-    )
+      )
     EOT
     integration_id = aiven_service_integration.flink_to_kafka.integration_id
   }

--- a/examples/resources/aiven_kafka_schema/resource.tf
+++ b/examples/resources/aiven_kafka_schema/resource.tf
@@ -6,17 +6,19 @@ resource "aiven_kafka_schema" "kafka-schema1" {
 
   schema = <<EOT
     {
-       "doc": "example",
-       "fields": [{
-           "default": 5,
-           "doc": "my test number",
-           "name": "test",
-           "namespace": "test",
-           "type": "int"
-       }],
-       "name": "example",
-       "namespace": "example",
-       "type": "record"
+      "doc": "example",
+      "fields": [
+        {
+          "default": 5,
+          "doc": "my test number",
+          "name": "test",
+          "namespace": "test",
+          "type": "int"
+        }
+      ],
+      "name": "example",
+      "namespace": "example",
+      "type": "record"
     }
-    EOT
+  EOT
 }

--- a/internal/sdkprovider/service/flink/flink_application_version_test.go
+++ b/internal/sdkprovider/service/flink/flink_application_version_test.go
@@ -133,13 +133,37 @@ resource "aiven_flink_application_version" "foo" {
   project        = data.aiven_project.foo.project
   service_name   = aiven_flink.foo.service_name
   application_id = aiven_flink_application.foo.application_id
-  statement      = "INSERT INTO kafka_known_pizza SELECT * FROM kafka_pizza WHERE shop LIKE 'Luigis Pizza'"
+  statement      = <<EOT
+    INSERT INTO kafka_known_pizza SELECT * FROM kafka_pizza WHERE shop LIKE '%%Luigis Pizza%%'
+  EOT
   sink {
-    create_table   = "CREATE TABLE kafka_known_pizza (shop STRING,name STRING) WITH ('connector' = 'kafka','properties.bootstrap.servers' = '','scan.startup.mode' = 'earliest-offset','topic' = 'test_out','value.format' = 'json')"
+    create_table   = <<EOT
+      CREATE TABLE kafka_known_pizza (
+        shop STRING,
+        name STRING
+      ) WITH (
+        'connector' = 'kafka',
+        'properties.bootstrap.servers' = '',
+        'scan.startup.mode' = 'earliest-offset',
+        'topic' = 'sink_topic',
+        'value.format' = 'json'
+      )
+    EOT
     integration_id = aiven_service_integration.flink_to_kafka.integration_id
   }
   source {
-    create_table   = "CREATE TABLE kafka_pizza (shop STRING, name STRING) WITH ('connector' = 'kafka','properties.bootstrap.servers' = '','scan.startup.mode' = 'earliest-offset','topic' = 'test','value.format' = 'json')"
+    create_table   = <<EOT
+      CREATE TABLE kafka_pizza (
+        shop STRING,
+        name STRING
+      ) WITH (
+        'connector' = 'kafka',
+        'properties.bootstrap.servers' = '',
+        'scan.startup.mode' = 'earliest-offset',
+        'topic' = 'source_topic',
+        'value.format' = 'json'
+      )
+    EOT
     integration_id = aiven_service_integration.flink_to_kafka.integration_id
   }
 }

--- a/internal/sdkprovider/service/kafkaschema/kafka_schema_test.go
+++ b/internal/sdkprovider/service/kafkaschema/kafka_schema_test.go
@@ -76,19 +76,21 @@ resource "aiven_kafka_schema" "schema" {
 
   schema = <<EOT
     {
-       "doc": "example",
-       "fields": [{
-           "default": 5,
-           "doc": "my test number",
-           "name": "test",
-           "namespace": "test",
-           "type": "int"
-       }],
-       "name": "example",
-       "namespace": "example",
-       "type": "record"
+      "doc": "example",
+      "fields": [
+        {
+          "default": 5,
+          "doc": "my test number",
+          "name": "test",
+          "namespace": "test",
+          "type": "int"
+        }
+      ],
+      "name": "example",
+      "namespace": "example",
+      "type": "record"
     }
-    EOT
+  EOT
 }
 `, project, serviceName, subjectName)
 }
@@ -277,19 +279,19 @@ resource "aiven_kafka_schema" "foo" {
   schema_type  = "JSON"
 
   schema = <<EOT
-		{
-		"type": "object",
-		"title": "example",
-		"description": "example",
-		"properties": {
-		"test": {
-		"type": "integer",
-		"title": "my test number",
-		"default": 5
-		}
-		}
-		}
-		  EOT
+    {
+      "type": "object",
+      "title": "example",
+      "description": "example",
+      "properties": {
+        "test": {
+          "type": "integer",
+          "title": "my test number",
+          "default": 5
+        }
+      }
+    }
+  EOT
 }
 
 data "aiven_kafka_schema" "schema" {
@@ -307,13 +309,12 @@ resource "aiven_kafka_schema" "bar" {
   schema_type  = "PROTOBUF"
 
   schema = <<EOT
-syntax = "proto3";
+    syntax = "proto3";
 
-message Example {
-  int32 test = 5;
-}
-
-EOT
+    message Example {
+      int32 test = 5;
+    }
+  EOT
 }
 
 data "aiven_kafka_schema" "schema2" {
@@ -361,20 +362,22 @@ resource "aiven_kafka_schema" "foo" {
   subject_name = "kafka-schema-%s"
 
   schema = <<EOT
-		    {
-		      "doc": "example",
-		      "fields": [{
-		        "default": 5,
-		        "doc": "my test number",
-		        "name": "test",
-		        "namespace": "test",
-		        "type": "int"
-		      }],
-		      "name": "example",
-		      "namespace": "example",
-		      "type": "record"
-		    }
-		  EOT
+    {
+      "doc": "example",
+      "fields": [
+        {
+          "default": 5,
+          "doc": "my test number",
+          "name": "test",
+          "namespace": "test",
+          "type": "int"
+        }
+      ],
+      "name": "example",
+      "namespace": "example",
+      "type": "record"
+    }
+  EOT
 }
 
 data "aiven_kafka_schema" "schema" {
@@ -421,20 +424,22 @@ resource "aiven_kafka_schema" "foo" {
   subject_name = "kafka-schema-%s"
 
   schema = <<EOT
-		    {
-		      "doc": "example",
-		      "fields": [{
-		        "default": "foo",
-		        "doc": "my test string",
-		        "name": "test",
-		        "namespace": "test",
-		        "type": "string"
-		      }],
-		      "name": "example",
-		      "namespace": "example",
-		      "type": "record"
-		    }
-		  EOT
+    {
+      "doc": "example",
+      "fields": [
+        {
+          "default": "foo",
+          "doc": "my test string",
+          "name": "test",
+          "namespace": "test",
+          "type": "string"
+        }
+      ],
+      "name": "example",
+      "namespace": "example",
+      "type": "record"
+    }
+  EOT
 }
 
 data "aiven_kafka_schema" "schema" {
@@ -481,26 +486,29 @@ resource "aiven_kafka_schema" "foo" {
   subject_name = "kafka-schema-%s"
 
   schema = <<EOT
-		    {
-		      "doc": "example",
-		      "fields": [{
-		        "default": 5,
-		        "doc": "my test number",
-		        "name": "test",
-		        "namespace": "test",
-		        "type": "int"
-		      },{
-		        "default": "str",
-		        "doc": "my test string",
-		        "name": "test_2",
-		        "namespace": "test",
-		        "type": "string"
-		      }],
-		      "name": "example",
-		      "namespace": "example",
-		      "type": "record"
-		    }
-		  EOT
+    {
+      "doc": "example",
+      "fields": [
+        {
+          "default": 5,
+          "doc": "my test number",
+          "name": "test",
+          "namespace": "test",
+          "type": "int"
+        },
+        {
+          "default": "str",
+          "doc": "my test string",
+          "name": "test_2",
+          "namespace": "test",
+          "type": "string"
+        }
+      ],
+      "name": "example",
+      "namespace": "example",
+      "type": "record"
+    }
+  EOT
 }
 
 data "aiven_kafka_schema" "schema" {


### PR DESCRIPTION
## Merging strategy

- [x] Merge
- [ ] Squash

<!-- All contributors, please complete these sections, including maintainers. -->

## About this change—what it does

<!-- Provide a small sentence that summarizes the change. -->
- fixes incorrect sql in `aiven_flink_application_version` resource's test, which resulted the job being in infinite `RESTARTING` state right after its creation
- fixes heredoc formatting in all docs and tests

<!-- Provide the issue number below, if it exists. -->

## Why this way

<!-- Provide a small explanation on why this is the approach you took for solving this problem. -->
- sql should be correct in the test to reduce the load the test generates on the service
  - maintainers should later decide whether this is incorrect to report success on creation of such job or not
- heredoc formatting was broken
