### PR TITLE
docs: add deprecation notice to account and authentication resources

### DIFF
--- a/docs/resources/account.md
+++ b/docs/resources/account.md
@@ -3,12 +3,15 @@
 page_title: "aiven_account Resource - terraform-provider-aiven"
 subcategory: ""
 description: |-
-  The Account resource allows the creation and management of an Aiven Account.
+  Creates and manages an Aiven account.
+  This resource is deprecated. Use aiven_organization instead.
 ---
 
 # aiven_account (Resource)
 
-The Account resource allows the creation and management of an Aiven Account.
+Creates and manages an Aiven account.
+		
+**This resource is deprecated.** Use `aiven_organization` instead.
 
 ## Example Usage
 

--- a/docs/resources/account_authentication.md
+++ b/docs/resources/account_authentication.md
@@ -3,12 +3,15 @@
 page_title: "aiven_account_authentication Resource - terraform-provider-aiven"
 subcategory: ""
 description: |-
-  The Account Authentication resource allows the creation and management of an Aiven Account Authentications.
+  This resource is deprecated.
+  Creates and manages an authentication method.
 ---
 
 # aiven_account_authentication (Resource)
 
-The Account Authentication resource allows the creation and management of an Aiven Account Authentications.
+**This resource is deprecated**. 
+		
+Creates and manages an authentication method.
 
 ## Example Usage
 

--- a/internal/sdkprovider/service/account/account.go
+++ b/internal/sdkprovider/service/account/account.go
@@ -63,7 +63,10 @@ var aivenAccountSchema = map[string]*schema.Schema{
 
 func ResourceAccount() *schema.Resource {
 	return &schema.Resource{
-		Description:   "The Account resource allows the creation and management of an Aiven Account.",
+		Description: `Creates and manages an Aiven account.
+		
+**This resource is deprecated.** Use ` + "`aiven_organization`" + ` instead.
+		`,
 		CreateContext: resourceAccountCreate,
 		ReadContext:   resourceAccountRead,
 		UpdateContext: resourceAccountUpdate,
@@ -75,7 +78,7 @@ func ResourceAccount() *schema.Resource {
 
 		Schema: aivenAccountSchema,
 
-		DeprecationMessage: "This resource will be removed in v5.0.0, use aiven_organization instead.",
+		DeprecationMessage: "This resource will be removed in v5.0.0. Use aiven_organization instead.",
 	}
 }
 

--- a/internal/sdkprovider/service/account/account_authentication.go
+++ b/internal/sdkprovider/service/account/account_authentication.go
@@ -144,7 +144,10 @@ var aivenAccountAuthenticationSchema = map[string]*schema.Schema{
 
 func ResourceAccountAuthentication() *schema.Resource {
 	return &schema.Resource{
-		Description:   "The Account Authentication resource allows the creation and management of an Aiven Account Authentications.",
+		Description: `**This resource is deprecated**. 
+		
+Creates and manages an authentication method.
+		`,
 		CreateContext: resourceAccountAuthenticationCreate,
 		ReadContext:   resourceAccountAuthenticationRead,
 		UpdateContext: resourceAccountAuthenticationUpdate,
@@ -155,7 +158,7 @@ func ResourceAccountAuthentication() *schema.Resource {
 		Timeouts: schemautil.DefaultResourceTimeouts(),
 
 		Schema:             aivenAccountAuthenticationSchema,
-		DeprecationMessage: "This resource is deprecated",
+		DeprecationMessage: "This resource is deprecated.",
 	}
 }
 


### PR DESCRIPTION
## About this change—what it does

Add notice in the docs that `account` and `account_authentication` have been deprecated.
