### PR TITLE
fix(ip_filter_object): use set type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ nav_order: 1
 - Add `AIVEN_ALLOW_IP_FILTER_PURGE` environment variable to allow purging of IP filters. This is a safety feature to
   prevent accidental purging of IP filters, which can lead to loss of access to services. To enable purging, set the
   environment variable to any value before running Terraform commands.
+- Use `TypeSet` for `ip_filter_object`
 
 ## [4.14.0] - 2024-02-20
 

--- a/docs/data-sources/cassandra.md
+++ b/docs/data-sources/cassandra.md
@@ -75,7 +75,7 @@ Read-Only:
 - `cassandra` (List of Object) (see [below for nested schema](#nestedobjatt--cassandra_user_config--cassandra))
 - `cassandra_version` (String)
 - `ip_filter` (Set of String)
-- `ip_filter_object` (List of Object) (see [below for nested schema](#nestedobjatt--cassandra_user_config--ip_filter_object))
+- `ip_filter_object` (Set of Object) (see [below for nested schema](#nestedobjatt--cassandra_user_config--ip_filter_object))
 - `ip_filter_string` (Set of String)
 - `migrate_sstableloader` (Boolean)
 - `private_access` (List of Object) (see [below for nested schema](#nestedobjatt--cassandra_user_config--private_access))

--- a/docs/data-sources/clickhouse.md
+++ b/docs/data-sources/clickhouse.md
@@ -71,7 +71,7 @@ Read-Only:
 
 - `additional_backup_regions` (List of String)
 - `ip_filter` (Set of String)
-- `ip_filter_object` (List of Object) (see [below for nested schema](#nestedobjatt--clickhouse_user_config--ip_filter_object))
+- `ip_filter_object` (Set of Object) (see [below for nested schema](#nestedobjatt--clickhouse_user_config--ip_filter_object))
 - `ip_filter_string` (Set of String)
 - `private_access` (List of Object) (see [below for nested schema](#nestedobjatt--clickhouse_user_config--private_access))
 - `privatelink_access` (List of Object) (see [below for nested schema](#nestedobjatt--clickhouse_user_config--privatelink_access))

--- a/docs/data-sources/flink.md
+++ b/docs/data-sources/flink.md
@@ -88,7 +88,7 @@ Read-Only:
 - `additional_backup_regions` (List of String)
 - `flink_version` (String)
 - `ip_filter` (Set of String)
-- `ip_filter_object` (List of Object) (see [below for nested schema](#nestedobjatt--flink_user_config--ip_filter_object))
+- `ip_filter_object` (Set of Object) (see [below for nested schema](#nestedobjatt--flink_user_config--ip_filter_object))
 - `ip_filter_string` (Set of String)
 - `number_of_task_slots` (Number)
 - `privatelink_access` (List of Object) (see [below for nested schema](#nestedobjatt--flink_user_config--privatelink_access))

--- a/docs/data-sources/grafana.md
+++ b/docs/data-sources/grafana.md
@@ -109,7 +109,7 @@ Read-Only:
 - `external_image_storage` (List of Object) (see [below for nested schema](#nestedobjatt--grafana_user_config--external_image_storage))
 - `google_analytics_ua_id` (String)
 - `ip_filter` (Set of String)
-- `ip_filter_object` (List of Object) (see [below for nested schema](#nestedobjatt--grafana_user_config--ip_filter_object))
+- `ip_filter_object` (Set of Object) (see [below for nested schema](#nestedobjatt--grafana_user_config--ip_filter_object))
 - `ip_filter_string` (Set of String)
 - `metrics_enabled` (Boolean)
 - `oauth_allow_insecure_email_lookup` (Boolean)

--- a/docs/data-sources/kafka.md
+++ b/docs/data-sources/kafka.md
@@ -95,7 +95,7 @@ Read-Only:
 - `aiven_kafka_topic_messages` (Boolean)
 - `custom_domain` (String)
 - `ip_filter` (Set of String)
-- `ip_filter_object` (List of Object) (see [below for nested schema](#nestedobjatt--kafka_user_config--ip_filter_object))
+- `ip_filter_object` (Set of Object) (see [below for nested schema](#nestedobjatt--kafka_user_config--ip_filter_object))
 - `ip_filter_string` (Set of String)
 - `kafka` (List of Object) (see [below for nested schema](#nestedobjatt--kafka_user_config--kafka))
 - `kafka_authentication_methods` (List of Object) (see [below for nested schema](#nestedobjatt--kafka_user_config--kafka_authentication_methods))

--- a/docs/data-sources/kafka_connect.md
+++ b/docs/data-sources/kafka_connect.md
@@ -86,7 +86,7 @@ Read-Only:
 
 - `additional_backup_regions` (List of String)
 - `ip_filter` (Set of String)
-- `ip_filter_object` (List of Object) (see [below for nested schema](#nestedobjatt--kafka_connect_user_config--ip_filter_object))
+- `ip_filter_object` (Set of Object) (see [below for nested schema](#nestedobjatt--kafka_connect_user_config--ip_filter_object))
 - `ip_filter_string` (Set of String)
 - `kafka_connect` (List of Object) (see [below for nested schema](#nestedobjatt--kafka_connect_user_config--kafka_connect))
 - `private_access` (List of Object) (see [below for nested schema](#nestedobjatt--kafka_connect_user_config--private_access))

--- a/docs/data-sources/kafka_mirrormaker.md
+++ b/docs/data-sources/kafka_mirrormaker.md
@@ -86,7 +86,7 @@ Read-Only:
 
 - `additional_backup_regions` (List of String)
 - `ip_filter` (Set of String)
-- `ip_filter_object` (List of Object) (see [below for nested schema](#nestedobjatt--kafka_mirrormaker_user_config--ip_filter_object))
+- `ip_filter_object` (Set of Object) (see [below for nested schema](#nestedobjatt--kafka_mirrormaker_user_config--ip_filter_object))
 - `ip_filter_string` (Set of String)
 - `kafka_mirrormaker` (List of Object) (see [below for nested schema](#nestedobjatt--kafka_mirrormaker_user_config--kafka_mirrormaker))
 - `service_log` (Boolean)

--- a/docs/data-sources/m3aggregator.md
+++ b/docs/data-sources/m3aggregator.md
@@ -86,7 +86,7 @@ Read-Only:
 
 - `custom_domain` (String)
 - `ip_filter` (Set of String)
-- `ip_filter_object` (List of Object) (see [below for nested schema](#nestedobjatt--m3aggregator_user_config--ip_filter_object))
+- `ip_filter_object` (Set of Object) (see [below for nested schema](#nestedobjatt--m3aggregator_user_config--ip_filter_object))
 - `ip_filter_string` (Set of String)
 - `m3_version` (String)
 - `m3aggregator_version` (String)

--- a/docs/data-sources/m3db.md
+++ b/docs/data-sources/m3db.md
@@ -87,7 +87,7 @@ Read-Only:
 - `additional_backup_regions` (List of String)
 - `custom_domain` (String)
 - `ip_filter` (Set of String)
-- `ip_filter_object` (List of Object) (see [below for nested schema](#nestedobjatt--m3db_user_config--ip_filter_object))
+- `ip_filter_object` (Set of Object) (see [below for nested schema](#nestedobjatt--m3db_user_config--ip_filter_object))
 - `ip_filter_string` (Set of String)
 - `limits` (List of Object) (see [below for nested schema](#nestedobjatt--m3db_user_config--limits))
 - `m3` (List of Object) (see [below for nested schema](#nestedobjatt--m3db_user_config--m3))

--- a/docs/data-sources/mysql.md
+++ b/docs/data-sources/mysql.md
@@ -91,7 +91,7 @@ Read-Only:
 - `backup_minute` (Number)
 - `binlog_retention_period` (Number)
 - `ip_filter` (Set of String)
-- `ip_filter_object` (List of Object) (see [below for nested schema](#nestedobjatt--mysql_user_config--ip_filter_object))
+- `ip_filter_object` (Set of Object) (see [below for nested schema](#nestedobjatt--mysql_user_config--ip_filter_object))
 - `ip_filter_string` (Set of String)
 - `migration` (List of Object) (see [below for nested schema](#nestedobjatt--mysql_user_config--migration))
 - `mysql` (List of Object) (see [below for nested schema](#nestedobjatt--mysql_user_config--mysql))

--- a/docs/data-sources/opensearch.md
+++ b/docs/data-sources/opensearch.md
@@ -91,7 +91,7 @@ Read-Only:
 - `index_patterns` (List of Object) (see [below for nested schema](#nestedobjatt--opensearch_user_config--index_patterns))
 - `index_template` (List of Object) (see [below for nested schema](#nestedobjatt--opensearch_user_config--index_template))
 - `ip_filter` (Set of String)
-- `ip_filter_object` (List of Object) (see [below for nested schema](#nestedobjatt--opensearch_user_config--ip_filter_object))
+- `ip_filter_object` (Set of Object) (see [below for nested schema](#nestedobjatt--opensearch_user_config--ip_filter_object))
 - `ip_filter_string` (Set of String)
 - `keep_index_refresh_interval` (Boolean)
 - `max_index_count` (Number)

--- a/docs/data-sources/pg.md
+++ b/docs/data-sources/pg.md
@@ -100,7 +100,7 @@ Read-Only:
 - `backup_minute` (Number)
 - `enable_ipv6` (Boolean)
 - `ip_filter` (Set of String)
-- `ip_filter_object` (List of Object) (see [below for nested schema](#nestedobjatt--pg_user_config--ip_filter_object))
+- `ip_filter_object` (Set of Object) (see [below for nested schema](#nestedobjatt--pg_user_config--ip_filter_object))
 - `ip_filter_string` (Set of String)
 - `migration` (List of Object) (see [below for nested schema](#nestedobjatt--pg_user_config--migration))
 - `pg` (List of Object) (see [below for nested schema](#nestedobjatt--pg_user_config--pg))

--- a/docs/data-sources/redis.md
+++ b/docs/data-sources/redis.md
@@ -86,7 +86,7 @@ Read-Only:
 
 - `additional_backup_regions` (List of String)
 - `ip_filter` (Set of String)
-- `ip_filter_object` (List of Object) (see [below for nested schema](#nestedobjatt--redis_user_config--ip_filter_object))
+- `ip_filter_object` (Set of Object) (see [below for nested schema](#nestedobjatt--redis_user_config--ip_filter_object))
 - `ip_filter_string` (Set of String)
 - `migration` (List of Object) (see [below for nested schema](#nestedobjatt--redis_user_config--migration))
 - `private_access` (List of Object) (see [below for nested schema](#nestedobjatt--redis_user_config--private_access))

--- a/docs/resources/cassandra.md
+++ b/docs/resources/cassandra.md
@@ -84,7 +84,7 @@ Optional:
 - `cassandra` (Block List, Max: 1) cassandra configuration values (see [below for nested schema](#nestedblock--cassandra_user_config--cassandra))
 - `cassandra_version` (String) Cassandra version.
 - `ip_filter` (Set of String, Deprecated) Allow incoming connections from CIDR address block, e.g. '10.20.0.0/16'.
-- `ip_filter_object` (Block List, Max: 1024) Allow incoming connections from CIDR address block, e.g. '10.20.0.0/16' (see [below for nested schema](#nestedblock--cassandra_user_config--ip_filter_object))
+- `ip_filter_object` (Block Set, Max: 1024) Allow incoming connections from CIDR address block, e.g. '10.20.0.0/16' (see [below for nested schema](#nestedblock--cassandra_user_config--ip_filter_object))
 - `ip_filter_string` (Set of String) Allow incoming connections from CIDR address block, e.g. '10.20.0.0/16'.
 - `migrate_sstableloader` (Boolean) Sets the service into migration mode enabling the sstableloader utility to be used to upload Cassandra data files. Available only on service create.
 - `private_access` (Block List, Max: 1) Allow access to selected service ports from private networks (see [below for nested schema](#nestedblock--cassandra_user_config--private_access))

--- a/docs/resources/clickhouse.md
+++ b/docs/resources/clickhouse.md
@@ -72,7 +72,7 @@ Optional:
 
 - `additional_backup_regions` (List of String, Deprecated) Additional Cloud Regions for Backup Replication.
 - `ip_filter` (Set of String, Deprecated) Allow incoming connections from CIDR address block, e.g. '10.20.0.0/16'.
-- `ip_filter_object` (Block List, Max: 1024) Allow incoming connections from CIDR address block, e.g. '10.20.0.0/16' (see [below for nested schema](#nestedblock--clickhouse_user_config--ip_filter_object))
+- `ip_filter_object` (Block Set, Max: 1024) Allow incoming connections from CIDR address block, e.g. '10.20.0.0/16' (see [below for nested schema](#nestedblock--clickhouse_user_config--ip_filter_object))
 - `ip_filter_string` (Set of String) Allow incoming connections from CIDR address block, e.g. '10.20.0.0/16'.
 - `private_access` (Block List, Max: 1) Allow access to selected service ports from private networks (see [below for nested schema](#nestedblock--clickhouse_user_config--private_access))
 - `privatelink_access` (Block List, Max: 1) Allow access to selected service components through Privatelink (see [below for nested schema](#nestedblock--clickhouse_user_config--privatelink_access))

--- a/docs/resources/flink.md
+++ b/docs/resources/flink.md
@@ -85,7 +85,7 @@ Optional:
 - `additional_backup_regions` (List of String, Deprecated) Additional Cloud Regions for Backup Replication.
 - `flink_version` (String) Flink major version.
 - `ip_filter` (Set of String, Deprecated) Allow incoming connections from CIDR address block, e.g. '10.20.0.0/16'.
-- `ip_filter_object` (Block List, Max: 1024) Allow incoming connections from CIDR address block, e.g. '10.20.0.0/16' (see [below for nested schema](#nestedblock--flink_user_config--ip_filter_object))
+- `ip_filter_object` (Block Set, Max: 1024) Allow incoming connections from CIDR address block, e.g. '10.20.0.0/16' (see [below for nested schema](#nestedblock--flink_user_config--ip_filter_object))
 - `ip_filter_string` (Set of String) Allow incoming connections from CIDR address block, e.g. '10.20.0.0/16'.
 - `number_of_task_slots` (Number) Task slots per node. For a 3 node plan, total number of task slots is 3x this value.
 - `privatelink_access` (Block List, Max: 1) Allow access to selected service components through Privatelink (see [below for nested schema](#nestedblock--flink_user_config--privatelink_access))

--- a/docs/resources/grafana.md
+++ b/docs/resources/grafana.md
@@ -103,7 +103,7 @@ Optional:
 - `external_image_storage` (Block List, Max: 1) External image store settings (see [below for nested schema](#nestedblock--grafana_user_config--external_image_storage))
 - `google_analytics_ua_id` (String) Google Analytics ID.
 - `ip_filter` (Set of String, Deprecated) Allow incoming connections from CIDR address block, e.g. '10.20.0.0/16'.
-- `ip_filter_object` (Block List, Max: 1024) Allow incoming connections from CIDR address block, e.g. '10.20.0.0/16' (see [below for nested schema](#nestedblock--grafana_user_config--ip_filter_object))
+- `ip_filter_object` (Block Set, Max: 1024) Allow incoming connections from CIDR address block, e.g. '10.20.0.0/16' (see [below for nested schema](#nestedblock--grafana_user_config--ip_filter_object))
 - `ip_filter_string` (Set of String) Allow incoming connections from CIDR address block, e.g. '10.20.0.0/16'.
 - `metrics_enabled` (Boolean) Enable Grafana /metrics endpoint.
 - `oauth_allow_insecure_email_lookup` (Boolean) Enforce user lookup based on email instead of the unique ID provided by the IdP.

--- a/docs/resources/kafka.md
+++ b/docs/resources/kafka.md
@@ -93,7 +93,7 @@ Optional:
 - `aiven_kafka_topic_messages` (Boolean) Allow access to read Kafka topic messages in the Aiven Console and REST API.
 - `custom_domain` (String) Serve the web frontend using a custom CNAME pointing to the Aiven DNS name.
 - `ip_filter` (Set of String, Deprecated) Allow incoming connections from CIDR address block, e.g. '10.20.0.0/16'.
-- `ip_filter_object` (Block List, Max: 1024) Allow incoming connections from CIDR address block, e.g. '10.20.0.0/16' (see [below for nested schema](#nestedblock--kafka_user_config--ip_filter_object))
+- `ip_filter_object` (Block Set, Max: 1024) Allow incoming connections from CIDR address block, e.g. '10.20.0.0/16' (see [below for nested schema](#nestedblock--kafka_user_config--ip_filter_object))
 - `ip_filter_string` (Set of String) Allow incoming connections from CIDR address block, e.g. '10.20.0.0/16'.
 - `kafka` (Block List, Max: 1) Kafka broker configuration values (see [below for nested schema](#nestedblock--kafka_user_config--kafka))
 - `kafka_authentication_methods` (Block List, Max: 1) Kafka authentication methods (see [below for nested schema](#nestedblock--kafka_user_config--kafka_authentication_methods))

--- a/docs/resources/kafka_connect.md
+++ b/docs/resources/kafka_connect.md
@@ -82,7 +82,7 @@ Optional:
 
 - `additional_backup_regions` (List of String, Deprecated) Additional Cloud Regions for Backup Replication.
 - `ip_filter` (Set of String, Deprecated) Allow incoming connections from CIDR address block, e.g. '10.20.0.0/16'.
-- `ip_filter_object` (Block List, Max: 1024) Allow incoming connections from CIDR address block, e.g. '10.20.0.0/16' (see [below for nested schema](#nestedblock--kafka_connect_user_config--ip_filter_object))
+- `ip_filter_object` (Block Set, Max: 1024) Allow incoming connections from CIDR address block, e.g. '10.20.0.0/16' (see [below for nested schema](#nestedblock--kafka_connect_user_config--ip_filter_object))
 - `ip_filter_string` (Set of String) Allow incoming connections from CIDR address block, e.g. '10.20.0.0/16'.
 - `kafka_connect` (Block List, Max: 1) Kafka Connect configuration values (see [below for nested schema](#nestedblock--kafka_connect_user_config--kafka_connect))
 - `private_access` (Block List, Max: 1) Allow access to selected service ports from private networks (see [below for nested schema](#nestedblock--kafka_connect_user_config--private_access))

--- a/docs/resources/kafka_mirrormaker.md
+++ b/docs/resources/kafka_mirrormaker.md
@@ -80,7 +80,7 @@ Optional:
 
 - `additional_backup_regions` (List of String, Deprecated) Additional Cloud Regions for Backup Replication.
 - `ip_filter` (Set of String, Deprecated) Allow incoming connections from CIDR address block, e.g. '10.20.0.0/16'.
-- `ip_filter_object` (Block List, Max: 1024) Allow incoming connections from CIDR address block, e.g. '10.20.0.0/16' (see [below for nested schema](#nestedblock--kafka_mirrormaker_user_config--ip_filter_object))
+- `ip_filter_object` (Block Set, Max: 1024) Allow incoming connections from CIDR address block, e.g. '10.20.0.0/16' (see [below for nested schema](#nestedblock--kafka_mirrormaker_user_config--ip_filter_object))
 - `ip_filter_string` (Set of String) Allow incoming connections from CIDR address block, e.g. '10.20.0.0/16'.
 - `kafka_mirrormaker` (Block List, Max: 1) Kafka MirrorMaker configuration values (see [below for nested schema](#nestedblock--kafka_mirrormaker_user_config--kafka_mirrormaker))
 - `service_log` (Boolean) Store logs for the service so that they are available in the HTTP API and console.

--- a/docs/resources/m3aggregator.md
+++ b/docs/resources/m3aggregator.md
@@ -76,7 +76,7 @@ Optional:
 
 - `custom_domain` (String) Serve the web frontend using a custom CNAME pointing to the Aiven DNS name.
 - `ip_filter` (Set of String, Deprecated) Allow incoming connections from CIDR address block, e.g. '10.20.0.0/16'.
-- `ip_filter_object` (Block List, Max: 1024) Allow incoming connections from CIDR address block, e.g. '10.20.0.0/16' (see [below for nested schema](#nestedblock--m3aggregator_user_config--ip_filter_object))
+- `ip_filter_object` (Block Set, Max: 1024) Allow incoming connections from CIDR address block, e.g. '10.20.0.0/16' (see [below for nested schema](#nestedblock--m3aggregator_user_config--ip_filter_object))
 - `ip_filter_string` (Set of String) Allow incoming connections from CIDR address block, e.g. '10.20.0.0/16'.
 - `m3_version` (String) M3 major version (deprecated, use m3aggregator_version).
 - `m3aggregator_version` (String) M3 major version (the minimum compatible version).

--- a/docs/resources/m3db.md
+++ b/docs/resources/m3db.md
@@ -82,7 +82,7 @@ Optional:
 - `additional_backup_regions` (List of String, Deprecated) Additional Cloud Regions for Backup Replication.
 - `custom_domain` (String) Serve the web frontend using a custom CNAME pointing to the Aiven DNS name.
 - `ip_filter` (Set of String, Deprecated) Allow incoming connections from CIDR address block, e.g. '10.20.0.0/16'.
-- `ip_filter_object` (Block List, Max: 1024) Allow incoming connections from CIDR address block, e.g. '10.20.0.0/16' (see [below for nested schema](#nestedblock--m3db_user_config--ip_filter_object))
+- `ip_filter_object` (Block Set, Max: 1024) Allow incoming connections from CIDR address block, e.g. '10.20.0.0/16' (see [below for nested schema](#nestedblock--m3db_user_config--ip_filter_object))
 - `ip_filter_string` (Set of String) Allow incoming connections from CIDR address block, e.g. '10.20.0.0/16'.
 - `limits` (Block List, Max: 1) M3 limits (see [below for nested schema](#nestedblock--m3db_user_config--limits))
 - `m3` (Block List, Max: 1) M3 specific configuration options (see [below for nested schema](#nestedblock--m3db_user_config--m3))

--- a/docs/resources/mysql.md
+++ b/docs/resources/mysql.md
@@ -90,7 +90,7 @@ Optional:
 - `backup_minute` (Number) The minute of an hour when backup for the service is started. New backup is only started if previous backup has already completed.
 - `binlog_retention_period` (Number) The minimum amount of time in seconds to keep binlog entries before deletion. This may be extended for services that require binlog entries for longer than the default for example if using the MySQL Debezium Kafka connector.
 - `ip_filter` (Set of String, Deprecated) Allow incoming connections from CIDR address block, e.g. '10.20.0.0/16'.
-- `ip_filter_object` (Block List, Max: 1024) Allow incoming connections from CIDR address block, e.g. '10.20.0.0/16' (see [below for nested schema](#nestedblock--mysql_user_config--ip_filter_object))
+- `ip_filter_object` (Block Set, Max: 1024) Allow incoming connections from CIDR address block, e.g. '10.20.0.0/16' (see [below for nested schema](#nestedblock--mysql_user_config--ip_filter_object))
 - `ip_filter_string` (Set of String) Allow incoming connections from CIDR address block, e.g. '10.20.0.0/16'.
 - `migration` (Block List, Max: 1) Migrate data from existing server (see [below for nested schema](#nestedblock--mysql_user_config--migration))
 - `mysql` (Block List, Max: 1) mysql.conf configuration values (see [below for nested schema](#nestedblock--mysql_user_config--mysql))

--- a/docs/resources/opensearch.md
+++ b/docs/resources/opensearch.md
@@ -90,7 +90,7 @@ Optional:
 - `index_patterns` (Block List, Max: 512) Index patterns (see [below for nested schema](#nestedblock--opensearch_user_config--index_patterns))
 - `index_template` (Block List, Max: 1) Template settings for all new indexes (see [below for nested schema](#nestedblock--opensearch_user_config--index_template))
 - `ip_filter` (Set of String, Deprecated) Allow incoming connections from CIDR address block, e.g. '10.20.0.0/16'.
-- `ip_filter_object` (Block List, Max: 1024) Allow incoming connections from CIDR address block, e.g. '10.20.0.0/16' (see [below for nested schema](#nestedblock--opensearch_user_config--ip_filter_object))
+- `ip_filter_object` (Block Set, Max: 1024) Allow incoming connections from CIDR address block, e.g. '10.20.0.0/16' (see [below for nested schema](#nestedblock--opensearch_user_config--ip_filter_object))
 - `ip_filter_string` (Set of String) Allow incoming connections from CIDR address block, e.g. '10.20.0.0/16'.
 - `keep_index_refresh_interval` (Boolean) Aiven automation resets index.refresh_interval to default value for every index to be sure that indices are always visible to search. If it doesn't fit your case, you can disable this by setting up this flag to true.
 - `max_index_count` (Number) use index_patterns instead. The default value is `0`.

--- a/docs/resources/pg.md
+++ b/docs/resources/pg.md
@@ -123,7 +123,7 @@ Optional:
 - `backup_minute` (Number) The minute of an hour when backup for the service is started. New backup is only started if previous backup has already completed.
 - `enable_ipv6` (Boolean) Register AAAA DNS records for the service, and allow IPv6 packets to service ports.
 - `ip_filter` (Set of String, Deprecated) Allow incoming connections from CIDR address block, e.g. '10.20.0.0/16'.
-- `ip_filter_object` (Block List, Max: 1024) Allow incoming connections from CIDR address block, e.g. '10.20.0.0/16' (see [below for nested schema](#nestedblock--pg_user_config--ip_filter_object))
+- `ip_filter_object` (Block Set, Max: 1024) Allow incoming connections from CIDR address block, e.g. '10.20.0.0/16' (see [below for nested schema](#nestedblock--pg_user_config--ip_filter_object))
 - `ip_filter_string` (Set of String) Allow incoming connections from CIDR address block, e.g. '10.20.0.0/16'.
 - `migration` (Block List, Max: 1) Migrate data from existing server (see [below for nested schema](#nestedblock--pg_user_config--migration))
 - `pg` (Block List, Max: 1) postgresql.conf configuration values (see [below for nested schema](#nestedblock--pg_user_config--pg))

--- a/docs/resources/redis.md
+++ b/docs/resources/redis.md
@@ -80,7 +80,7 @@ Optional:
 
 - `additional_backup_regions` (List of String, Deprecated) Additional Cloud Regions for Backup Replication.
 - `ip_filter` (Set of String, Deprecated) Allow incoming connections from CIDR address block, e.g. '10.20.0.0/16'.
-- `ip_filter_object` (Block List, Max: 1024) Allow incoming connections from CIDR address block, e.g. '10.20.0.0/16' (see [below for nested schema](#nestedblock--redis_user_config--ip_filter_object))
+- `ip_filter_object` (Block Set, Max: 1024) Allow incoming connections from CIDR address block, e.g. '10.20.0.0/16' (see [below for nested schema](#nestedblock--redis_user_config--ip_filter_object))
 - `ip_filter_string` (Set of String) Allow incoming connections from CIDR address block, e.g. '10.20.0.0/16'.
 - `migration` (Block List, Max: 1) Migrate data from existing server (see [below for nested schema](#nestedblock--redis_user_config--migration))
 - `private_access` (Block List, Max: 1) Allow access to selected service ports from private networks (see [below for nested schema](#nestedblock--redis_user_config--private_access))

--- a/internal/sdkprovider/service/grafana/grafana_test.go
+++ b/internal/sdkprovider/service/grafana/grafana_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 
 	acc "github.com/aiven/terraform-provider-aiven/internal/acctest"
+	"github.com/aiven/terraform-provider-aiven/internal/sdkprovider/userconfig/converters"
 )
 
 func TestAccAiven_grafana(t *testing.T) {
@@ -49,9 +50,11 @@ func TestAccAiven_grafana(t *testing.T) {
 }
 
 func TestAccAiven_grafana_user_config(t *testing.T) {
+	// Parallel tests share os env, can't isolate this one
+	os.Setenv(converters.AllowIPFilterPurge, "1")
+
 	resourceName := "aiven_grafana.bar"
 	rName := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
-
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acc.TestAccPreCheck(t) },
 		ProtoV6ProviderFactories: acc.TestProtoV6ProviderFactories,
@@ -560,4 +563,131 @@ data "aiven_grafana" "common" {
 
   depends_on = [aiven_grafana.bar]
 }`, os.Getenv("AIVEN_PROJECT_NAME"), name, teamIDs)
+}
+
+func TestAccAiven_grafana_user_config_ip_filter_object(t *testing.T) {
+	// Parallel tests share os env, can't isolate this one
+	os.Setenv(converters.AllowIPFilterPurge, "1")
+
+	resourceName := "aiven_grafana.bar"
+	rName := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
+	ipCount := "grafana_user_config.0.ip_filter_object.#"
+	ipValue := "grafana_user_config.0.ip_filter_object.*"
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acc.TestAccPreCheck(t) },
+		ProtoV6ProviderFactories: acc.TestProtoV6ProviderFactories,
+		CheckDestroy:             acc.TestAccCheckAivenServiceResourceDestroy,
+		Steps: []resource.TestStep{
+			{
+				// Creates a service with one ip_filter_object
+				Config: testAccAivenGrafanaUserConfigIPFilterObject(rName, `["10.0.0.0/8"]`),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, ipCount, "1"),
+					resource.TestCheckTypeSetElemNestedAttrs(
+						resourceName,
+						ipValue,
+						map[string]string{"network": "10.0.0.0/8", "description": "my 10.0.0.0/8"},
+					),
+				),
+			},
+			{
+				// Adds two more
+				Config: testAccAivenGrafanaUserConfigIPFilterObject(rName, `["10.0.0.0/8", "172.16.0.0/12", "192.168.0.0/16"]`),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, ipCount, "3"),
+					resource.TestCheckTypeSetElemNestedAttrs(
+						resourceName,
+						ipValue,
+						map[string]string{
+							"network":     "10.0.0.0/8",
+							"description": "my 10.0.0.0/8",
+						},
+					),
+					resource.TestCheckTypeSetElemNestedAttrs(
+						resourceName,
+						ipValue,
+						map[string]string{
+							"network":     "172.16.0.0/12",
+							"description": "my 172.16.0.0/12",
+						},
+					),
+					resource.TestCheckTypeSetElemNestedAttrs(
+						resourceName,
+						ipValue,
+						map[string]string{
+							"network":     "192.168.0.0/16",
+							"description": "my 192.168.0.0/16",
+						},
+					),
+				),
+			},
+			{
+				// Removes one
+				Config: testAccAivenGrafanaUserConfigIPFilterObject(rName, `["10.0.0.0/8", "192.168.0.0/16"]`),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, ipCount, "2"),
+					resource.TestCheckTypeSetElemNestedAttrs(
+						resourceName,
+						ipValue,
+						map[string]string{
+							"network":     "10.0.0.0/8",
+							"description": "my 10.0.0.0/8",
+						},
+					),
+					resource.TestCheckResourceAttr(resourceName, ipCount, "2"),
+					resource.TestCheckTypeSetElemNestedAttrs(
+						resourceName,
+						ipValue,
+						map[string]string{
+							"network":     "192.168.0.0/16",
+							"description": "my 192.168.0.0/16",
+						},
+					),
+				),
+			},
+			{
+				// Reorders ip_filter_objects, but the plan is empty because it is set type
+				Config:   testAccAivenGrafanaUserConfigIPFilterObject(rName, `["192.168.0.0/16", "10.0.0.0/8"]`),
+				PlanOnly: true,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, ipCount, "2"),
+				),
+			},
+			{
+				// Removes entries
+				Config: testAccAivenGrafanaUserConfigIPFilterObject(rName, `[]`),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, ipCount, "0"),
+				),
+			},
+		},
+	})
+}
+
+func testAccAivenGrafanaUserConfigIPFilterObject(name, networks string) string {
+	return fmt.Sprintf(`
+variable "networks" {
+  type    = list(string)
+  default = %s
+}
+
+resource "aiven_grafana" "bar" {
+  project                 = %q
+  cloud_name              = "google-europe-west1"
+  plan                    = "startup-1"
+  service_name            = "test-acc-sr-%s"
+  maintenance_window_dow  = "monday"
+  maintenance_window_time = "10:00:00"
+
+  grafana_user_config {
+    dynamic "ip_filter_object" {
+      for_each = var.networks
+      content {
+        network     = ip_filter_object.value
+        description = "my ${ip_filter_object.value}"
+      }
+    }
+  }
+}
+`, networks, os.Getenv("AIVEN_PROJECT_NAME"), name)
 }

--- a/internal/sdkprovider/userconfig/converters/utils.go
+++ b/internal/sdkprovider/userconfig/converters/utils.go
@@ -3,40 +3,8 @@ package converters
 import (
 	"fmt"
 	"reflect"
-	"sort"
 	"strings"
 )
-
-// sortByKey sorts the given array of objects by values in the original array by the given key.
-// For instance, when ip_filter_object list is sent, it is sorted on the backend.
-// That makes a diff, because user defined order is violated.
-func sortByKey(sortBy string, originalSrc, dtoSrc any) any {
-	original := asMapList(originalSrc)
-	dto := asMapList(dtoSrc)
-	if len(original) != len(dto) {
-		return dtoSrc
-	}
-
-	sortMap := make(map[string]int)
-	for i, v := range original {
-		sortMap[v[sortBy].(string)] = i
-	}
-
-	sort.Slice(dto, func(i, j int) bool {
-		ii := dto[i][sortBy].(string)
-		jj := dto[j][sortBy].(string)
-		return sortMap[ii] > sortMap[jj]
-	})
-
-	// Need to cast to "any",
-	// otherwise it might blow up in flattenObj function
-	// with type mismatch (map[string]any vs any)
-	result := make([]any, 0, len(dto))
-	for _, v := range dto {
-		result = append(result, v)
-	}
-	return result
-}
 
 // drillKey gets deep down key value
 func drillKey(dto map[string]any, path string) (any, bool) {
@@ -75,21 +43,6 @@ func drillKey(dto map[string]any, path string) (any, bool) {
 		}
 		dto = next
 	}
-}
-
-// asList converts "any" to specific typed list
-func asList[T any](v any) []T {
-	list := v.([]any)
-	result := make([]T, 0, len(list))
-	for _, item := range list {
-		result = append(result, item.(T))
-	}
-	return result
-}
-
-// asMapList converts "any" to a list of objects
-func asMapList(v any) []map[string]any {
-	return asList[map[string]any](v)
 }
 
 // castType returns an error on invalid type

--- a/internal/sdkprovider/userconfig/diff/diff.go
+++ b/internal/sdkprovider/userconfig/diff/diff.go
@@ -7,8 +7,11 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
-// reIsSetElement Set item ends with a 9-length hash int.
-var reIsSetElement = regexp.MustCompile(`\.[0-9]{9}$`)
+var (
+	// reIsSetElement Set item ends with a 9-length hash int.
+	reIsSetElement      = regexp.MustCompile(`\.[0-9]{9}$`)
+	reIsIPFilterStrings = regexp.MustCompile(`\.(ip_filter|ip_filter_string)\.`)
+)
 
 // SuppressUnchanged suppresses diff for unchanged fields.
 // Applied for all nested values: both for objects and arrays.
@@ -24,12 +27,18 @@ func SuppressUnchanged(k, old, new string, d *schema.ResourceData) bool {
 			return ok && len(v) == 1 && v[0] == nil
 		}
 
-		// Suppress empty objects and empty arrays
-		return true
+		// Suppresses object diff, because it might have been received as default value from the API.
+		// So the diff happens when the object's field is changed.
+		// Object is a list, and both set and list end with "#".
+		// So set == list == object (by type).
+		// A set of objects is different.
+		// Because hash is calculated for the whole object, not per field.
+		return !isObjectSet(k, d)
 	}
 
+	// SuppressUnchanged is applied to each nested field.
 	// Ip filter items handled with a special suppressor.
-	if strings.Contains(k, ".ip_filter.") || strings.Contains(k, ".ip_filter_string.") {
+	if reIsIPFilterStrings.MatchString(k) {
 		return suppressIPFilterSet(k, old, new, d)
 	}
 
@@ -63,4 +72,25 @@ func suppressIPFilterSet(k, old, new string, d *schema.ResourceData) bool {
 	v, ok := d.GetOk(strings.Join(path[:len(path)-1], ".") + ".#")
 	// Literally, if the value is "0.0.0.0/0" and the parent's length is "1"
 	return old == "0.0.0.0/0" && new == "" && ok && v.(int) == 1
+}
+
+// isObjectSet returns true if given k is for collection of objects
+func isObjectSet(k string, d *schema.ResourceData) bool {
+	path := strings.Split(strings.TrimSuffix(k, ".#"), ".")
+	value := d.GetRawState().AsValueMap()[path[0]]
+
+	// user_config field
+	path = path[1:]
+
+	// Drills down the field
+	for _, v := range path {
+		if v == "0" {
+			value = value.AsValueSlice()[0]
+			continue
+		}
+		value = value.GetAttr(v)
+	}
+
+	t := value.Type()
+	return t.IsSetType() && t.ElementType().IsObjectType()
 }

--- a/internal/sdkprovider/userconfig/service/cassandra.go
+++ b/internal/sdkprovider/userconfig/service/cassandra.go
@@ -91,7 +91,7 @@ func cassandraUserConfig() *schema.Schema {
 				}},
 				MaxItems: 1024,
 				Optional: true,
-				Type:     schema.TypeList,
+				Type:     schema.TypeSet,
 			},
 			"ip_filter_string": {
 				Description: "Allow incoming connections from CIDR address block, e.g. '10.20.0.0/16'.",

--- a/internal/sdkprovider/userconfig/service/clickhouse.go
+++ b/internal/sdkprovider/userconfig/service/clickhouse.go
@@ -51,7 +51,7 @@ func clickhouseUserConfig() *schema.Schema {
 				}},
 				MaxItems: 1024,
 				Optional: true,
-				Type:     schema.TypeList,
+				Type:     schema.TypeSet,
 			},
 			"ip_filter_string": {
 				Description: "Allow incoming connections from CIDR address block, e.g. '10.20.0.0/16'.",

--- a/internal/sdkprovider/userconfig/service/flink.go
+++ b/internal/sdkprovider/userconfig/service/flink.go
@@ -58,7 +58,7 @@ func flinkUserConfig() *schema.Schema {
 				}},
 				MaxItems: 1024,
 				Optional: true,
-				Type:     schema.TypeList,
+				Type:     schema.TypeSet,
 			},
 			"ip_filter_string": {
 				Description: "Allow incoming connections from CIDR address block, e.g. '10.20.0.0/16'.",

--- a/internal/sdkprovider/userconfig/service/grafana.go
+++ b/internal/sdkprovider/userconfig/service/grafana.go
@@ -477,7 +477,7 @@ func grafanaUserConfig() *schema.Schema {
 				}},
 				MaxItems: 1024,
 				Optional: true,
-				Type:     schema.TypeList,
+				Type:     schema.TypeSet,
 			},
 			"ip_filter_string": {
 				Description: "Allow incoming connections from CIDR address block, e.g. '10.20.0.0/16'.",

--- a/internal/sdkprovider/userconfig/service/influxdb.go
+++ b/internal/sdkprovider/userconfig/service/influxdb.go
@@ -99,7 +99,7 @@ func influxdbUserConfig() *schema.Schema {
 				}},
 				MaxItems: 1024,
 				Optional: true,
-				Type:     schema.TypeList,
+				Type:     schema.TypeSet,
 			},
 			"ip_filter_string": {
 				Description: "Allow incoming connections from CIDR address block, e.g. '10.20.0.0/16'.",

--- a/internal/sdkprovider/userconfig/service/kafka.go
+++ b/internal/sdkprovider/userconfig/service/kafka.go
@@ -62,7 +62,7 @@ func kafkaUserConfig() *schema.Schema {
 				}},
 				MaxItems: 1024,
 				Optional: true,
-				Type:     schema.TypeList,
+				Type:     schema.TypeSet,
 			},
 			"ip_filter_string": {
 				Description: "Allow incoming connections from CIDR address block, e.g. '10.20.0.0/16'.",

--- a/internal/sdkprovider/userconfig/service/kafka_connect.go
+++ b/internal/sdkprovider/userconfig/service/kafka_connect.go
@@ -52,7 +52,7 @@ func kafkaConnectUserConfig() *schema.Schema {
 				}},
 				MaxItems: 1024,
 				Optional: true,
-				Type:     schema.TypeList,
+				Type:     schema.TypeSet,
 			},
 			"ip_filter_string": {
 				Description: "Allow incoming connections from CIDR address block, e.g. '10.20.0.0/16'.",

--- a/internal/sdkprovider/userconfig/service/kafka_mirrormaker.go
+++ b/internal/sdkprovider/userconfig/service/kafka_mirrormaker.go
@@ -51,7 +51,7 @@ func kafkaMirrormakerUserConfig() *schema.Schema {
 				}},
 				MaxItems: 1024,
 				Optional: true,
-				Type:     schema.TypeList,
+				Type:     schema.TypeSet,
 			},
 			"ip_filter_string": {
 				Description: "Allow incoming connections from CIDR address block, e.g. '10.20.0.0/16'.",

--- a/internal/sdkprovider/userconfig/service/m3aggregator.go
+++ b/internal/sdkprovider/userconfig/service/m3aggregator.go
@@ -46,7 +46,7 @@ func m3aggregatorUserConfig() *schema.Schema {
 				}},
 				MaxItems: 1024,
 				Optional: true,
-				Type:     schema.TypeList,
+				Type:     schema.TypeSet,
 			},
 			"ip_filter_string": {
 				Description: "Allow incoming connections from CIDR address block, e.g. '10.20.0.0/16'.",

--- a/internal/sdkprovider/userconfig/service/m3db.go
+++ b/internal/sdkprovider/userconfig/service/m3db.go
@@ -57,7 +57,7 @@ func m3dbUserConfig() *schema.Schema {
 				}},
 				MaxItems: 1024,
 				Optional: true,
-				Type:     schema.TypeList,
+				Type:     schema.TypeSet,
 			},
 			"ip_filter_string": {
 				Description: "Allow incoming connections from CIDR address block, e.g. '10.20.0.0/16'.",

--- a/internal/sdkprovider/userconfig/service/mysql.go
+++ b/internal/sdkprovider/userconfig/service/mysql.go
@@ -79,7 +79,7 @@ func mysqlUserConfig() *schema.Schema {
 				}},
 				MaxItems: 1024,
 				Optional: true,
-				Type:     schema.TypeList,
+				Type:     schema.TypeSet,
 			},
 			"ip_filter_string": {
 				Description: "Allow incoming connections from CIDR address block, e.g. '10.20.0.0/16'.",

--- a/internal/sdkprovider/userconfig/service/opensearch.go
+++ b/internal/sdkprovider/userconfig/service/opensearch.go
@@ -109,7 +109,7 @@ func opensearchUserConfig() *schema.Schema {
 				}},
 				MaxItems: 1024,
 				Optional: true,
-				Type:     schema.TypeList,
+				Type:     schema.TypeSet,
 			},
 			"ip_filter_string": {
 				Description: "Allow incoming connections from CIDR address block, e.g. '10.20.0.0/16'.",

--- a/internal/sdkprovider/userconfig/service/pg.go
+++ b/internal/sdkprovider/userconfig/service/pg.go
@@ -79,7 +79,7 @@ func pgUserConfig() *schema.Schema {
 				}},
 				MaxItems: 1024,
 				Optional: true,
-				Type:     schema.TypeList,
+				Type:     schema.TypeSet,
 			},
 			"ip_filter_string": {
 				Description: "Allow incoming connections from CIDR address block, e.g. '10.20.0.0/16'.",

--- a/internal/sdkprovider/userconfig/service/redis.go
+++ b/internal/sdkprovider/userconfig/service/redis.go
@@ -52,7 +52,7 @@ func redisUserConfig() *schema.Schema {
 				}},
 				MaxItems: 1024,
 				Optional: true,
-				Type:     schema.TypeList,
+				Type:     schema.TypeSet,
 			},
 			"ip_filter_string": {
 				Description: "Allow incoming connections from CIDR address block, e.g. '10.20.0.0/16'.",

--- a/ucgenerator/main.go
+++ b/ucgenerator/main.go
@@ -355,25 +355,11 @@ func scalarArrayLit(o *object, args []jen.Code) (*jen.Statement, error) {
 }
 
 func isTypeSet(o *object) bool {
-	// Only scalars can be set type.
-	// Nested sets of objects do not work well in Terraform:
-	// - Changing a field shows diff for the whole object,
-	//   because hash is calculated for the object, not per field.
-	//   So no per-field updates, whole object replacement only.
-	//   https://discuss.hashicorp.com/t/provider-schema-typeset-detect-changes/32546
-	// - There is a bug that doesn't let you put a set deep inside ResourceData
-	//   https://github.com/hashicorp/terraform-plugin-sdk/issues/459
-	// - The diff itself is invalid for nested sets (not on the root level).
-	//   It just doesn't work as expected in all cases.
-	if !(o.isArray() && o.ArrayItems.isScalar()) {
-		return false
-	}
-
 	// Allowlist for set types
+	// Warning: test each type you add!
 	switch o.path() {
-	case "ip_filter", "ip_filter_string":
+	case "ip_filter", "ip_filter_string", "ip_filter_object":
 		return true
 	}
-
 	return false
 }


### PR DESCRIPTION
## About this change—what it does

Set type is the only way to fix `ip_filter_object` field.

- renames `hasValue` to `isNull` in `converters.go`, as it missleading
- uses `TypeSet` for `ip_filter_object`

Resolves #1638, #1107.