### PR TITLE
fix(aiven_service_integration_endpoint): can't create external_postgresql

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ nav_order: 1
 - Add `external_aws_cloudwatch_logs`, `external_elasticsearch_logs_user_config`, `external_opensearch_logs_user_config`,
   `prometheus_user_config` service integration configs
 - Fix `aiven_kafka_schema` Protobuf normalization
+- Fix `aiven_service_integration_endpoint` for `external_postgresql` type
 - Add `AIVEN_ALLOW_IP_FILTER_PURGE` environment variable to allow purging of IP filters. This is a safety feature to
   prevent accidental purging of IP filters, which can lead to loss of access to services. To enable purging, set the
   environment variable to any value before running Terraform commands.

--- a/internal/schemautil/service.go
+++ b/internal/schemautil/service.go
@@ -15,7 +15,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 
 	"github.com/aiven/terraform-provider-aiven/internal/sdkprovider/userconfig/converters"
-	"github.com/aiven/terraform-provider-aiven/internal/sdkprovider/userconfig/service"
 )
 
 // defaultTimeout is the default timeout for service operations. This is not a const because it can be changed during
@@ -59,6 +58,12 @@ var TechEmailsResourceSchema = &schema.Resource{
 			Required:    true,
 		},
 	},
+}
+
+func ServiceCommonSchemaWithUserConfig(kind string) map[string]*schema.Schema {
+	s := ServiceCommonSchema()
+	converters.SetUserConfig(converters.ServiceUserConfig, kind, s)
+	return s
 }
 
 func ServiceCommonSchema() map[string]*schema.Schema {
@@ -713,13 +718,9 @@ func copyServicePropertiesFromAPIResponseToTerraform(
 		}
 	}
 
-	newUserConfig, err := FlattenService(serviceType, d, s.UserConfig)
+	err := FlattenService(serviceType, d, s.UserConfig)
 	if err != nil {
 		return err
-	}
-
-	if err := d.Set(serviceType+"_user_config", newUserConfig); err != nil {
-		return fmt.Errorf("cannot set `%s_user_config` : %w; Please make sure that all Aiven services have unique s names", serviceType, err)
 	}
 
 	params := s.URIParams
@@ -886,10 +887,10 @@ func getContactEmailListForAPI(d *schema.ResourceData, field string) *[]aiven.Co
 	return &results
 }
 
-func ExpandService(kind string, d *schema.ResourceData) (map[string]any, error) {
-	return converters.Expand(kind, service.GetUserConfig(kind), d)
+func ExpandService(name string, d *schema.ResourceData) (map[string]any, error) {
+	return converters.Expand(converters.ServiceUserConfig, name, d)
 }
 
-func FlattenService(kind string, d *schema.ResourceData, dto map[string]any) ([]map[string]any, error) {
-	return converters.Flatten(kind, service.GetUserConfig(kind), d, dto)
+func FlattenService(name string, d *schema.ResourceData, dto map[string]any) error {
+	return converters.Flatten(converters.ServiceUserConfig, name, d, dto)
 }

--- a/internal/schemautil/service.go
+++ b/internal/schemautil/service.go
@@ -445,9 +445,7 @@ func resourceServiceCreate(ctx context.Context, d *schema.ResourceData, m interf
 
 	cuc, err := ExpandService(serviceType, d)
 	if err != nil {
-		return diag.Errorf(
-			"error converting user config options for service type %s to API format: %s", serviceType, err,
-		)
+		return diag.FromErr(err)
 	}
 
 	_, err = client.Services.Create(
@@ -534,9 +532,7 @@ func ResourceServiceUpdate(ctx context.Context, d *schema.ResourceData, m interf
 	serviceType := d.Get("service_type").(string)
 	cuc, err := ExpandService(serviceType, d)
 	if err != nil {
-		return diag.Errorf(
-			"error converting user config options for service type %s to API format: %s", serviceType, err,
-		)
+		return diag.FromErr(err)
 	}
 
 	if _, err := client.Services.Update(

--- a/internal/sdkprovider/service/cassandra/cassandra.go
+++ b/internal/sdkprovider/service/cassandra/cassandra.go
@@ -6,11 +6,10 @@ import (
 
 	"github.com/aiven/terraform-provider-aiven/internal/schemautil"
 	"github.com/aiven/terraform-provider-aiven/internal/schemautil/userconfig/stateupgrader"
-	"github.com/aiven/terraform-provider-aiven/internal/sdkprovider/userconfig/service"
 )
 
 func cassandraSchema() map[string]*schema.Schema {
-	s := schemautil.ServiceCommonSchema()
+	s := schemautil.ServiceCommonSchemaWithUserConfig(schemautil.ServiceTypeCassandra)
 	s[schemautil.ServiceTypeCassandra] = &schema.Schema{
 		Type:        schema.TypeList,
 		Computed:    true,
@@ -19,8 +18,6 @@ func cassandraSchema() map[string]*schema.Schema {
 			Schema: map[string]*schema.Schema{},
 		},
 	}
-	s[schemautil.ServiceTypeCassandra+"_user_config"] = service.GetUserConfig(schemautil.ServiceTypeCassandra)
-
 	return s
 }
 

--- a/internal/sdkprovider/service/clickhouse/clickhouse.go
+++ b/internal/sdkprovider/service/clickhouse/clickhouse.go
@@ -5,11 +5,10 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
 	"github.com/aiven/terraform-provider-aiven/internal/schemautil"
-	"github.com/aiven/terraform-provider-aiven/internal/sdkprovider/userconfig/service"
 )
 
 func clickhouseSchema() map[string]*schema.Schema {
-	s := schemautil.ServiceCommonSchema()
+	s := schemautil.ServiceCommonSchemaWithUserConfig(schemautil.ServiceTypeClickhouse)
 	s[schemautil.ServiceTypeClickhouse] = &schema.Schema{
 		Type:        schema.TypeList,
 		Computed:    true,
@@ -18,7 +17,6 @@ func clickhouseSchema() map[string]*schema.Schema {
 			Schema: map[string]*schema.Schema{},
 		},
 	}
-	s[schemautil.ServiceTypeClickhouse+"_user_config"] = service.GetUserConfig(schemautil.ServiceTypeClickhouse)
 	s["service_integrations"] = &schema.Schema{
 		Type:        schema.TypeList,
 		Optional:    true,

--- a/internal/sdkprovider/service/dragonfly/dragonfly.go
+++ b/internal/sdkprovider/service/dragonfly/dragonfly.go
@@ -5,11 +5,10 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
 	"github.com/aiven/terraform-provider-aiven/internal/schemautil"
-	"github.com/aiven/terraform-provider-aiven/internal/schemautil/userconfig/dist"
 )
 
 func dragonflySchema() map[string]*schema.Schema {
-	s := schemautil.ServiceCommonSchema()
+	s := schemautil.ServiceCommonSchemaWithUserConfig(schemautil.ServiceTypeDragonfly)
 	s[schemautil.ServiceTypeDragonfly] = &schema.Schema{
 		Type:        schema.TypeList,
 		Computed:    true,
@@ -18,8 +17,6 @@ func dragonflySchema() map[string]*schema.Schema {
 			Schema: map[string]*schema.Schema{},
 		},
 	}
-	s[schemautil.ServiceTypeDragonfly+"_user_config"] = dist.ServiceTypeDragonfly()
-
 	return s
 }
 

--- a/internal/sdkprovider/service/flink/flink.go
+++ b/internal/sdkprovider/service/flink/flink.go
@@ -10,11 +10,10 @@ import (
 
 	"github.com/aiven/terraform-provider-aiven/internal/schemautil"
 	"github.com/aiven/terraform-provider-aiven/internal/schemautil/userconfig/stateupgrader"
-	"github.com/aiven/terraform-provider-aiven/internal/sdkprovider/userconfig/service"
 )
 
 func aivenFlinkSchema() map[string]*schema.Schema {
-	aivenFlinkSchema := schemautil.ServiceCommonSchema()
+	aivenFlinkSchema := schemautil.ServiceCommonSchemaWithUserConfig(schemautil.ServiceTypeFlink)
 	aivenFlinkSchema[schemautil.ServiceTypeFlink] = &schema.Schema{
 		Type:        schema.TypeList,
 		MaxItems:    1,
@@ -35,8 +34,6 @@ func aivenFlinkSchema() map[string]*schema.Schema {
 			},
 		},
 	}
-	aivenFlinkSchema[schemautil.ServiceTypeFlink+"_user_config"] = service.GetUserConfig(schemautil.ServiceTypeFlink)
-
 	return aivenFlinkSchema
 }
 

--- a/internal/sdkprovider/service/grafana/grafana.go
+++ b/internal/sdkprovider/service/grafana/grafana.go
@@ -6,11 +6,10 @@ import (
 
 	"github.com/aiven/terraform-provider-aiven/internal/schemautil"
 	"github.com/aiven/terraform-provider-aiven/internal/schemautil/userconfig/stateupgrader"
-	"github.com/aiven/terraform-provider-aiven/internal/sdkprovider/userconfig/service"
 )
 
 func grafanaSchema() map[string]*schema.Schema {
-	s := schemautil.ServiceCommonSchema()
+	s := schemautil.ServiceCommonSchemaWithUserConfig(schemautil.ServiceTypeGrafana)
 	s[schemautil.ServiceTypeGrafana] = &schema.Schema{
 		Type:        schema.TypeList,
 		Computed:    true,
@@ -19,7 +18,6 @@ func grafanaSchema() map[string]*schema.Schema {
 			Schema: map[string]*schema.Schema{},
 		},
 	}
-	s[schemautil.ServiceTypeGrafana+"_user_config"] = service.GetUserConfig(schemautil.ServiceTypeGrafana)
 	return s
 }
 

--- a/internal/sdkprovider/service/influxdb/influxdb.go
+++ b/internal/sdkprovider/service/influxdb/influxdb.go
@@ -6,11 +6,10 @@ import (
 
 	"github.com/aiven/terraform-provider-aiven/internal/schemautil"
 	"github.com/aiven/terraform-provider-aiven/internal/schemautil/userconfig/stateupgrader"
-	"github.com/aiven/terraform-provider-aiven/internal/sdkprovider/userconfig/service"
 )
 
 func influxDBSchema() map[string]*schema.Schema {
-	s := schemautil.ServiceCommonSchema()
+	s := schemautil.ServiceCommonSchemaWithUserConfig(schemautil.ServiceTypeInfluxDB)
 	s[schemautil.ServiceTypeInfluxDB] = &schema.Schema{
 		Type:        schema.TypeList,
 		Computed:    true,
@@ -25,8 +24,6 @@ func influxDBSchema() map[string]*schema.Schema {
 			},
 		},
 	}
-	s[schemautil.ServiceTypeInfluxDB+"_user_config"] = service.GetUserConfig(schemautil.ServiceTypeInfluxDB)
-
 	return s
 }
 

--- a/internal/sdkprovider/service/kafka/kafka.go
+++ b/internal/sdkprovider/service/kafka/kafka.go
@@ -11,11 +11,10 @@ import (
 
 	"github.com/aiven/terraform-provider-aiven/internal/schemautil"
 	"github.com/aiven/terraform-provider-aiven/internal/schemautil/userconfig/stateupgrader"
-	"github.com/aiven/terraform-provider-aiven/internal/sdkprovider/userconfig/service"
 )
 
 func aivenKafkaSchema() map[string]*schema.Schema {
-	aivenKafkaSchema := schemautil.ServiceCommonSchema()
+	aivenKafkaSchema := schemautil.ServiceCommonSchemaWithUserConfig(schemautil.ServiceTypeKafka)
 	aivenKafkaSchema["karapace"] = &schema.Schema{
 		Type:             schema.TypeBool,
 		Optional:         true,
@@ -70,7 +69,6 @@ func aivenKafkaSchema() map[string]*schema.Schema {
 			},
 		},
 	}
-	aivenKafkaSchema[schemautil.ServiceTypeKafka+"_user_config"] = service.GetUserConfig(schemautil.ServiceTypeKafka)
 
 	return aivenKafkaSchema
 }

--- a/internal/sdkprovider/service/kafka/kafka_connect.go
+++ b/internal/sdkprovider/service/kafka/kafka_connect.go
@@ -6,12 +6,11 @@ import (
 
 	"github.com/aiven/terraform-provider-aiven/internal/schemautil"
 	"github.com/aiven/terraform-provider-aiven/internal/schemautil/userconfig/stateupgrader"
-	"github.com/aiven/terraform-provider-aiven/internal/sdkprovider/userconfig/service"
 )
 
 func aivenKafkaConnectSchema() map[string]*schema.Schema {
-	kafkaConnectSchema := schemautil.ServiceCommonSchema()
-	kafkaConnectSchema[schemautil.ServiceTypeKafkaConnect] = &schema.Schema{
+	s := schemautil.ServiceCommonSchemaWithUserConfig(schemautil.ServiceTypeKafkaConnect)
+	s[schemautil.ServiceTypeKafkaConnect] = &schema.Schema{
 		Type:        schema.TypeList,
 		Computed:    true,
 		Description: "Kafka Connect server provided values",
@@ -19,9 +18,7 @@ func aivenKafkaConnectSchema() map[string]*schema.Schema {
 			Schema: map[string]*schema.Schema{},
 		},
 	}
-	kafkaConnectSchema[schemautil.ServiceTypeKafkaConnect+"_user_config"] = service.GetUserConfig(schemautil.ServiceTypeKafkaConnect)
-
-	return kafkaConnectSchema
+	return s
 }
 
 func ResourceKafkaConnect() *schema.Resource {

--- a/internal/sdkprovider/service/kafka/kafka_mirrormaker.go
+++ b/internal/sdkprovider/service/kafka/kafka_mirrormaker.go
@@ -6,12 +6,11 @@ import (
 
 	"github.com/aiven/terraform-provider-aiven/internal/schemautil"
 	"github.com/aiven/terraform-provider-aiven/internal/schemautil/userconfig/stateupgrader"
-	"github.com/aiven/terraform-provider-aiven/internal/sdkprovider/userconfig/service"
 )
 
 func aivenKafkaMirrormakerSchema() map[string]*schema.Schema {
-	kafkaMMSchema := schemautil.ServiceCommonSchema()
-	kafkaMMSchema[schemautil.ServiceTypeKafkaMirrormaker] = &schema.Schema{
+	s := schemautil.ServiceCommonSchemaWithUserConfig(schemautil.ServiceTypeKafkaMirrormaker)
+	s[schemautil.ServiceTypeKafkaMirrormaker] = &schema.Schema{
 		Type:        schema.TypeList,
 		Computed:    true,
 		Description: "Kafka MirrorMaker 2 server provided values",
@@ -19,9 +18,7 @@ func aivenKafkaMirrormakerSchema() map[string]*schema.Schema {
 			Schema: map[string]*schema.Schema{},
 		},
 	}
-	kafkaMMSchema[schemautil.ServiceTypeKafkaMirrormaker+"_user_config"] = service.GetUserConfig(schemautil.ServiceTypeKafkaMirrormaker)
-
-	return kafkaMMSchema
+	return s
 }
 func ResourceKafkaMirrormaker() *schema.Resource {
 	return &schema.Resource{

--- a/internal/sdkprovider/service/m3db/m3aggregator.go
+++ b/internal/sdkprovider/service/m3db/m3aggregator.go
@@ -6,12 +6,11 @@ import (
 
 	"github.com/aiven/terraform-provider-aiven/internal/schemautil"
 	"github.com/aiven/terraform-provider-aiven/internal/schemautil/userconfig/stateupgrader"
-	"github.com/aiven/terraform-provider-aiven/internal/sdkprovider/userconfig/service"
 )
 
 func aivenM3AggregatorSchema() map[string]*schema.Schema {
-	schemaM3 := schemautil.ServiceCommonSchema()
-	schemaM3[schemautil.ServiceTypeM3Aggregator] = &schema.Schema{
+	s := schemautil.ServiceCommonSchemaWithUserConfig(schemautil.ServiceTypeM3Aggregator)
+	s[schemautil.ServiceTypeM3Aggregator] = &schema.Schema{
 		Type:        schema.TypeList,
 		Computed:    true,
 		Description: "M3 aggregator specific server provided values",
@@ -19,9 +18,7 @@ func aivenM3AggregatorSchema() map[string]*schema.Schema {
 			Schema: map[string]*schema.Schema{},
 		},
 	}
-	schemaM3[schemautil.ServiceTypeM3Aggregator+"_user_config"] = service.GetUserConfig(schemautil.ServiceTypeM3Aggregator)
-
-	return schemaM3
+	return s
 }
 func ResourceM3Aggregator() *schema.Resource {
 	return &schema.Resource{

--- a/internal/sdkprovider/service/m3db/m3db.go
+++ b/internal/sdkprovider/service/m3db/m3db.go
@@ -6,11 +6,10 @@ import (
 
 	"github.com/aiven/terraform-provider-aiven/internal/schemautil"
 	"github.com/aiven/terraform-provider-aiven/internal/schemautil/userconfig/stateupgrader"
-	"github.com/aiven/terraform-provider-aiven/internal/sdkprovider/userconfig/service"
 )
 
 func aivenM3DBSchema() map[string]*schema.Schema {
-	schemaM3 := schemautil.ServiceCommonSchema()
+	schemaM3 := schemautil.ServiceCommonSchemaWithUserConfig(schemautil.ServiceTypeM3)
 	schemaM3[schemautil.ServiceTypeM3] = &schema.Schema{
 		Type:        schema.TypeList,
 		Computed:    true,
@@ -19,8 +18,6 @@ func aivenM3DBSchema() map[string]*schema.Schema {
 			Schema: map[string]*schema.Schema{},
 		},
 	}
-	schemaM3[schemautil.ServiceTypeM3+"_user_config"] = service.GetUserConfig(schemautil.ServiceTypeM3)
-
 	return schemaM3
 }
 func ResourceM3DB() *schema.Resource {

--- a/internal/sdkprovider/service/mysql/mysql.go
+++ b/internal/sdkprovider/service/mysql/mysql.go
@@ -6,11 +6,10 @@ import (
 
 	"github.com/aiven/terraform-provider-aiven/internal/schemautil"
 	"github.com/aiven/terraform-provider-aiven/internal/schemautil/userconfig/stateupgrader"
-	"github.com/aiven/terraform-provider-aiven/internal/sdkprovider/userconfig/service"
 )
 
 func aivenMySQLSchema() map[string]*schema.Schema {
-	schemaMySQL := schemautil.ServiceCommonSchema()
+	schemaMySQL := schemautil.ServiceCommonSchemaWithUserConfig(schemautil.ServiceTypeMySQL)
 	schemaMySQL[schemautil.ServiceTypeMySQL] = &schema.Schema{
 		Type:        schema.TypeList,
 		Computed:    true,
@@ -19,8 +18,6 @@ func aivenMySQLSchema() map[string]*schema.Schema {
 			Schema: map[string]*schema.Schema{},
 		},
 	}
-	schemaMySQL[schemautil.ServiceTypeMySQL+"_user_config"] = service.GetUserConfig(schemautil.ServiceTypeMySQL)
-
 	return schemaMySQL
 }
 func ResourceMySQL() *schema.Resource {

--- a/internal/sdkprovider/service/opensearch/opensearch.go
+++ b/internal/sdkprovider/service/opensearch/opensearch.go
@@ -6,11 +6,10 @@ import (
 
 	"github.com/aiven/terraform-provider-aiven/internal/schemautil"
 	"github.com/aiven/terraform-provider-aiven/internal/schemautil/userconfig/stateupgrader"
-	"github.com/aiven/terraform-provider-aiven/internal/sdkprovider/userconfig/service"
 )
 
 func opensearchSchema() map[string]*schema.Schema {
-	s := schemautil.ServiceCommonSchema()
+	s := schemautil.ServiceCommonSchemaWithUserConfig(schemautil.ServiceTypeOpenSearch)
 	s[schemautil.ServiceTypeOpenSearch] = &schema.Schema{
 		Type:        schema.TypeList,
 		Computed:    true,
@@ -26,8 +25,6 @@ func opensearchSchema() map[string]*schema.Schema {
 			},
 		},
 	}
-	s[schemautil.ServiceTypeOpenSearch+"_user_config"] = service.GetUserConfig(schemautil.ServiceTypeOpenSearch)
-
 	return s
 }
 

--- a/internal/sdkprovider/service/pg/pg.go
+++ b/internal/sdkprovider/service/pg/pg.go
@@ -13,12 +13,11 @@ import (
 
 	"github.com/aiven/terraform-provider-aiven/internal/schemautil"
 	"github.com/aiven/terraform-provider-aiven/internal/schemautil/userconfig/stateupgrader"
-	"github.com/aiven/terraform-provider-aiven/internal/sdkprovider/userconfig/service"
 )
 
 func aivenPGSchema() map[string]*schema.Schema {
-	schemaPG := schemautil.ServiceCommonSchema()
-	schemaPG[schemautil.ServiceTypePG] = &schema.Schema{
+	s := schemautil.ServiceCommonSchemaWithUserConfig(schemautil.ServiceTypePG)
+	s[schemautil.ServiceTypePG] = &schema.Schema{
 		Type:        schema.TypeList,
 		MaxItems:    1,
 		Computed:    true,
@@ -78,9 +77,7 @@ func aivenPGSchema() map[string]*schema.Schema {
 			},
 		},
 	}
-	schemaPG[schemautil.ServiceTypePG+"_user_config"] = service.GetUserConfig(schemautil.ServiceTypePG)
-
-	return schemaPG
+	return s
 }
 
 func ResourcePG() *schema.Resource {

--- a/internal/sdkprovider/service/redis/redis.go
+++ b/internal/sdkprovider/service/redis/redis.go
@@ -6,11 +6,10 @@ import (
 
 	"github.com/aiven/terraform-provider-aiven/internal/schemautil"
 	"github.com/aiven/terraform-provider-aiven/internal/schemautil/userconfig/stateupgrader"
-	"github.com/aiven/terraform-provider-aiven/internal/sdkprovider/userconfig/service"
 )
 
 func redisSchema() map[string]*schema.Schema {
-	s := schemautil.ServiceCommonSchema()
+	s := schemautil.ServiceCommonSchemaWithUserConfig(schemautil.ServiceTypeRedis)
 	s[schemautil.ServiceTypeRedis] = &schema.Schema{
 		Type:        schema.TypeList,
 		Computed:    true,
@@ -19,8 +18,6 @@ func redisSchema() map[string]*schema.Schema {
 			Schema: map[string]*schema.Schema{},
 		},
 	}
-	s[schemautil.ServiceTypeRedis+"_user_config"] = service.GetUserConfig(schemautil.ServiceTypeRedis)
-
 	return s
 }
 

--- a/internal/sdkprovider/service/serviceintegration/service_integration.go
+++ b/internal/sdkprovider/service/serviceintegration/service_integration.go
@@ -82,7 +82,7 @@ func aivenServiceIntegrationSchema() map[string]*schema.Schema {
 
 	// Adds user configs
 	for _, k := range serviceintegration.UserConfigTypes() {
-		s[k+"_user_config"] = serviceintegration.GetUserConfig(k)
+		converters.SetUserConfig(converters.ServiceIntegrationUserConfig, k, s)
 	}
 	return s
 }
@@ -144,7 +144,7 @@ func resourceServiceIntegrationCreate(ctx context.Context, d *schema.ResourceDat
 	}
 
 	if hasIntegrationConfig(integrationType) {
-		uc, err := converters.Expand(integrationType, serviceintegration.GetUserConfig(integrationType), d)
+		uc, err := converters.Expand(converters.ServiceIntegrationUserConfig, integrationType, d)
 		if err != nil {
 			return diag.FromErr(err)
 		}
@@ -359,15 +359,9 @@ func resourceServiceIntegrationCopyAPIResponseToTerraform(
 	}
 
 	if hasIntegrationConfig(integrationType) {
-		userConfig, err := converters.Flatten(integrationType, serviceintegration.GetUserConfig(integrationType), d, res.UserConfig)
+		err := converters.Flatten(converters.ServiceIntegrationUserConfig, integrationType, d, res.UserConfig)
 		if err != nil {
 			return err
-		}
-		if len(userConfig) > 0 {
-			err := d.Set(integrationType+"_user_config", userConfig)
-			if err != nil {
-				return err
-			}
 		}
 	}
 


### PR DESCRIPTION
## About this change—what it does

This PR covers two related to the issue bugs:

- user config field required for `aiven_service_integration_endpoint`
- the `external_postgresql` doesn't have `_user_config` suffix, which was expected in a few cases. The field name generation is now managed by a single source of truth

Resolves #1589