### PR TITLE
fix(mirrormaker_replication_flow): incorrect behavior of schema fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,12 @@ nav_order: 1
   prevent accidental purging of IP filters, which can lead to loss of access to services. To enable purging, set the
   environment variable to any value before running Terraform commands.
 - Use `TypeSet` for `ip_filter_object`
+- Fix incorrect behavior of `aiven_mirrormaker_replication_flow` schema fields:
+  - `sync_group_offsets_enabled`
+  - `sync_group_offsets_interval_seconds`
+  - `emit_backward_heartbeats_enabled`
+  - `offset_syncs_topic_location`
+  - `replication_policy_class`
 
 ## [4.14.0] - 2024-02-20
 

--- a/docs/resources/mirrormaker_replication_flow.md
+++ b/docs/resources/mirrormaker_replication_flow.md
@@ -38,7 +38,9 @@ resource "aiven_mirrormaker_replication_flow" "f1" {
 ### Required
 
 - `enable` (Boolean) Enable of disable replication flows for a service.
+- `offset_syncs_topic_location` (String) Offset syncs topic location.
 - `project` (String) Identifies the project this resource belongs to. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
+- `replication_policy_class` (String) Replication policy class. The possible values are `org.apache.kafka.connect.mirror.DefaultReplicationPolicy` and `org.apache.kafka.connect.mirror.IdentityReplicationPolicy`. The default value is `org.apache.kafka.connect.mirror.DefaultReplicationPolicy`.
 - `service_name` (String) Identifies the project this resource belongs to. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
 - `source_cluster` (String) Source cluster alias. Maximum length: `128`.
 - `target_cluster` (String) Target cluster alias. Maximum length: `128`.
@@ -47,8 +49,6 @@ resource "aiven_mirrormaker_replication_flow" "f1" {
 
 - `emit_backward_heartbeats_enabled` (Boolean) Whether to emit heartbeats to the direction opposite to the flow, i.e. to the source cluster. The default value is `false`.
 - `emit_heartbeats_enabled` (Boolean) Whether to emit heartbeats to the target cluster. The default value is `false`.
-- `offset_syncs_topic_location` (String) Offset syncs topic location.
-- `replication_policy_class` (String) Replication policy class. The possible values are `org.apache.kafka.connect.mirror.DefaultReplicationPolicy` and `org.apache.kafka.connect.mirror.IdentityReplicationPolicy`. The default value is `org.apache.kafka.connect.mirror.DefaultReplicationPolicy`.
 - `sync_group_offsets_enabled` (Boolean) Sync consumer group offsets. The default value is `false`.
 - `sync_group_offsets_interval_seconds` (Number) Frequency of consumer group offset sync. The default value is `1`.
 - `timeouts` (Block, Optional) (see [below for nested schema](#nestedblock--timeouts))

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/aiven/terraform-provider-aiven
 go 1.22
 
 require (
-	github.com/aiven/aiven-go-client/v2 v2.13.0
+	github.com/aiven/aiven-go-client/v2 v2.14.0
 	github.com/aiven/go-client-codegen v0.3.0
 	github.com/avast/retry-go v3.0.0+incompatible
 	github.com/dave/jennifer v1.7.0

--- a/go.sum
+++ b/go.sum
@@ -199,6 +199,8 @@ github.com/agext/levenshtein v1.2.3 h1:YB2fHEn0UJagG8T1rrWknE3ZQzWM06O8AMAatNn7l
 github.com/agext/levenshtein v1.2.3/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=
 github.com/aiven/aiven-go-client/v2 v2.13.0 h1:N2c+EdRh9gg2PBKAwII6vMy9+WnDnbVU4Uy1mQGmMKg=
 github.com/aiven/aiven-go-client/v2 v2.13.0/go.mod h1:x0xhzxWEKAwKv0xY5FvECiI6tesWshcPHvjwl0B/1SU=
+github.com/aiven/aiven-go-client/v2 v2.14.0 h1:4FEbB3baj+jA3Gd3vXpzoN6Vi9lGLCcIAYo75vSnx4k=
+github.com/aiven/aiven-go-client/v2 v2.14.0/go.mod h1:x0xhzxWEKAwKv0xY5FvECiI6tesWshcPHvjwl0B/1SU=
 github.com/aiven/go-api-schemas v1.65.0 h1:r4ooY83kWwkQQPCq55W4oHitNv+SZ2fzVDxuY3KwU28=
 github.com/aiven/go-api-schemas v1.65.0/go.mod h1:/bPxBUHza/2Aeer6hIIdB++GxKiw9K1KCBtRa2rtZ5I=
 github.com/aiven/go-client-codegen v0.3.0 h1:RoIHSjMpJ+adYDJPfu9TBHaikQzMPocp1bwD2gqritc=


### PR DESCRIPTION
<!-- All contributors, please complete these sections, including maintainers. -->

## About this change—what it does

Fix incorrect behavior of `aiven_mirrormaker_replication_flow` schema fields:
  - `sync_group_offsets_enabled`
  - `sync_group_offsets_interval_seconds`
  - `emit_heartbeats_enabled`
  - `emit_backward_heartbeats_enabled`
  - `offset_syncs_topic_location`
  - `replication_policy_class`

<!-- Provide the issue number below, if it exists. -->
Resolves: #1632.

## Why this way

<!-- Provide a small explanation on why this is the approach you took for solving this problem. -->
The current way it works is broken. Additionally, `offset_syncs_topic_location` and `replication_policy_class` should be required, because they can't be empty, and API then converts an empty string to their default values, `source` and `org.apache.kafka.connect.mirror.DefaultReplicationPolicy` respectively.
