### PR TITLE
refactor: encapsulate user config checks

### DIFF
--- a/internal/sdkprovider/userconfig/service/service.go
+++ b/internal/sdkprovider/userconfig/service/service.go
@@ -37,7 +37,7 @@ func GetUserConfig(kind string) *schema.Schema {
 	case "redis":
 		return redisUserConfig()
 	default:
-		panic("unknown user config type: " + kind)
+		return nil
 	}
 }
 func UserConfigTypes() []string {

--- a/internal/sdkprovider/userconfig/serviceintegration/serviceintegration.go
+++ b/internal/sdkprovider/userconfig/serviceintegration/serviceintegration.go
@@ -33,7 +33,7 @@ func GetUserConfig(kind string) *schema.Schema {
 	case "prometheus":
 		return prometheusUserConfig()
 	default:
-		panic("unknown user config type: " + kind)
+		return nil
 	}
 }
 func UserConfigTypes() []string {

--- a/internal/sdkprovider/userconfig/serviceintegrationendpoint/serviceintegrationendpoint.go
+++ b/internal/sdkprovider/userconfig/serviceintegrationendpoint/serviceintegrationendpoint.go
@@ -33,7 +33,7 @@ func GetUserConfig(kind string) *schema.Schema {
 	case "rsyslog":
 		return rsyslogUserConfig()
 	default:
-		panic("unknown user config type: " + kind)
+		return nil
 	}
 }
 func UserConfigTypes() []string {

--- a/main.go
+++ b/main.go
@@ -11,7 +11,6 @@ import (
 	"github.com/aiven/terraform-provider-aiven/internal/server"
 )
 
-//go:generate go test -tags userconfig ./internal/schemautil/userconfig
 //go:generate go run ./ucgenerator/... --excludeServices elasticsearch
 
 // registryPrefix is the registry prefix for the provider.

--- a/ucgenerator/main.go
+++ b/ucgenerator/main.go
@@ -126,7 +126,7 @@ func generate(kind string, data []byte, exclude []string) error {
 	}
 
 	// Panics if unknown kind requested
-	cases = append(cases, jen.Default().Block(jen.Panic(jen.Lit("unknown user config type: ").Op("+").Id("kind"))))
+	cases = append(cases, jen.Default().Block(jen.Return(jen.Nil())))
 
 	f := jen.NewFile(kind)
 	f.HeaderComment(codeGenerated)


### PR DESCRIPTION
## About this change—what it does

- replaces old converter in service integration update handler
- the check if resource has a user config is moved to the converter to encapsulate the logic further