### PR TITLE
refactor: mark user_group_member and group_project as ga

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ nav_order: 1
   - `emit_backward_heartbeats_enabled`
   - `offset_syncs_topic_location`
   - `replication_policy_class`
+- Remove the beta flag for `aiven_organization_user_group_member` and `aiven_organization_group_project` resources 
 
 ## [4.14.0] - 2024-02-20
 

--- a/docs/resources/organization_group_project.md
+++ b/docs/resources/organization_group_project.md
@@ -4,15 +4,11 @@ page_title: "aiven_organization_group_project Resource - terraform-provider-aive
 subcategory: ""
 description: |-
   Adds and manages a group https://aiven.io/docs/platform/concepts/projects_accounts_access#groups of users as members of a project https://aiven.io/docs/platform/reference/project-member-privileges.
-  This resource is in the beta stage and may change without notice. Set
-  the PROVIDER_AIVEN_ENABLE_BETA environment variable to use the resource.
 ---
 
 # aiven_organization_group_project (Resource)
 
-Adds and manages a [group](https://aiven.io/docs/platform/concepts/projects_accounts_access#groups) of users as [members of a project](https://aiven.io/docs/platform/reference/project-member-privileges). 
-**This resource is in the beta stage and may change without notice.** Set
-the `PROVIDER_AIVEN_ENABLE_BETA` environment variable to use the resource.
+Adds and manages a [group](https://aiven.io/docs/platform/concepts/projects_accounts_access#groups) of users as [members of a project](https://aiven.io/docs/platform/reference/project-member-privileges).
 
 ## Example Usage
 

--- a/docs/resources/organization_user_group_member.md
+++ b/docs/resources/organization_user_group_member.md
@@ -4,15 +4,11 @@ page_title: "aiven_organization_user_group_member Resource - terraform-provider-
 subcategory: ""
 description: |-
   Adds and manages users in a user group https://aiven.io/docs/platform/concepts/projects_accounts_access#groups.
-  This resource is in the beta stage and may change without notice. Set
-  the PROVIDER_AIVEN_ENABLE_BETA environment variable to use the resource.
 ---
 
 # aiven_organization_user_group_member (Resource)
 
-Adds and manages users in a [user group](https://aiven.io/docs/platform/concepts/projects_accounts_access#groups). 
-**This resource is in the beta stage and may change without notice.** Set
-the `PROVIDER_AIVEN_ENABLE_BETA` environment variable to use the resource.
+Adds and manages users in a [user group](https://aiven.io/docs/platform/concepts/projects_accounts_access#groups).
 
 ## Example Usage
 

--- a/internal/plugin/provider.go
+++ b/internal/plugin/provider.go
@@ -112,13 +112,13 @@ func (p *AivenProvider) Resources(context.Context) []func() resource.Resource {
 	// List of resources that are currently available in the provider.
 	resources := []func() resource.Resource{
 		organization.NewOrganizationResource,
+		organization.NewOrganizationUserGroupMembersResource,
+		organization.NewOrganizationGroupProjectResource,
 	}
 
 	// Add to a list of resources that are currently in beta.
 	if util.IsBeta() {
 		betaResources := []func() resource.Resource{
-			organization.NewOrganizationUserGroupMembersResource,
-			organization.NewOrganizationGroupProjectResource,
 			organization.NewOrganizationApplicationUser,
 			organization.NewOrganizationApplicationUserToken,
 		}

--- a/internal/plugin/service/organization/organization_group_project.go
+++ b/internal/plugin/service/organization/organization_group_project.go
@@ -83,7 +83,6 @@ func (r *organizationGroupProjectResource) Schema(
 				"[group](https://aiven.io/docs/platform/concepts/projects_accounts_access#groups) of users as " +
 				"[members of a project](https://aiven.io/docs/platform/reference/project-member-privileges).",
 		).
-			AvailabilityType(userconfig.Beta).
 			Build(),
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{

--- a/internal/plugin/service/organization/organization_user_group_member.go
+++ b/internal/plugin/service/organization/organization_user_group_member.go
@@ -81,7 +81,6 @@ func (r *organizationUserGroupMembersResource) Schema(
 			"Adds and manages users in a " +
 				"[user group](https://aiven.io/docs/platform/concepts/projects_accounts_access#groups).",
 		).
-			AvailabilityType(userconfig.Beta).
 			Build(),
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{


### PR DESCRIPTION
## About this change—what it does

Removes the beta flag for `aiven_organization_user_group_member` and `aiven_organization_group_project`