### PR TITLE
docs: fix incorrect reference to aiven_opensearch_security_plugin_config

### DIFF
--- a/docs/resources/opensearch_security_plugin_config.md
+++ b/docs/resources/opensearch_security_plugin_config.md
@@ -32,7 +32,7 @@ resource "aiven_opensearch_user" "foo" {
   username     = "user-example"
 }
 
-resource "aiven_opensearch_security_config" "foo" {
+resource "aiven_opensearch_security_plugin_config" "foo" {
   project        = data.aiven_project.foo.project
   service_name   = aiven_opensearch.bar.service_name
   admin_password = "ThisIsATest123^=^"

--- a/examples/resources/aiven_opensearch_security_plugin_config/resource.tf
+++ b/examples/resources/aiven_opensearch_security_plugin_config/resource.tf
@@ -17,7 +17,7 @@ resource "aiven_opensearch_user" "foo" {
   username     = "user-example"
 }
 
-resource "aiven_opensearch_security_config" "foo" {
+resource "aiven_opensearch_security_plugin_config" "foo" {
   project        = data.aiven_project.foo.project
   service_name   = aiven_opensearch.bar.service_name
   admin_password = "ThisIsATest123^=^"


### PR DESCRIPTION
Docs for opensearch_security_plugin_config incorrectly referenced the resource "aiven_opensearch_security_plugin_config" as "aiven_opensearch_security_config".

