### PR TITLE
docs: update org and project user descriptions

### DIFF
--- a/docs/data-sources/aws_privatelink.md
+++ b/docs/data-sources/aws_privatelink.md
@@ -24,8 +24,8 @@ data "aiven_aws_privatelink" "main" {
 
 ### Required
 
-- `project` (String) Identifies the project this resource belongs to. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
-- `service_name` (String) Specifies the name of the service that this resource belongs to. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
+- `project` (String) The name of the project this resource belongs to. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
+- `service_name` (String) The name of the service that this resource belongs to. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
 
 ### Read-Only
 

--- a/docs/data-sources/azure_privatelink.md
+++ b/docs/data-sources/azure_privatelink.md
@@ -24,8 +24,8 @@ data "aiven_azure_privatelink" "main" {
 
 ### Required
 
-- `project` (String) Identifies the project this resource belongs to. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
-- `service_name` (String) Specifies the name of the service that this resource belongs to. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
+- `project` (String) The name of the project this resource belongs to. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
+- `service_name` (String) The name of the service that this resource belongs to. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
 
 ### Read-Only
 

--- a/docs/data-sources/cassandra.md
+++ b/docs/data-sources/cassandra.md
@@ -24,7 +24,7 @@ data "aiven_cassandra" "bar" {
 
 ### Required
 
-- `project` (String) Identifies the project this resource belongs to. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
+- `project` (String) The name of the project this resource belongs to. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
 - `service_name` (String) Specifies the actual name of the service. The name cannot be changed later without destroying and re-creating the service so name should be picked based on intended service usage rather than current attributes.
 
 ### Read-Only

--- a/docs/data-sources/cassandra_user.md
+++ b/docs/data-sources/cassandra_user.md
@@ -25,8 +25,8 @@ data "aiven_cassandra_user" "user" {
 
 ### Required
 
-- `project` (String) Identifies the project this resource belongs to. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
-- `service_name` (String) Specifies the name of the service that this resource belongs to. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
+- `project` (String) The name of the project this resource belongs to. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
+- `service_name` (String) The name of the service that this resource belongs to. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
 - `username` (String) The actual name of the Cassandra User. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
 
 ### Read-Only

--- a/docs/data-sources/clickhouse.md
+++ b/docs/data-sources/clickhouse.md
@@ -24,7 +24,7 @@ data "aiven_clickhouse" "clickhouse" {
 
 ### Required
 
-- `project` (String) Identifies the project this resource belongs to. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
+- `project` (String) The name of the project this resource belongs to. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
 - `service_name` (String) Specifies the actual name of the service. The name cannot be changed later without destroying and re-creating the service so name should be picked based on intended service usage rather than current attributes.
 
 ### Read-Only

--- a/docs/data-sources/clickhouse_database.md
+++ b/docs/data-sources/clickhouse_database.md
@@ -26,8 +26,8 @@ data "aiven_clickhouse_database" "clickhouse_db" {
 ### Required
 
 - `name` (String) The name of the Clickhouse database. Changing this property forces recreation of the resource.
-- `project` (String) Identifies the project this resource belongs to. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
-- `service_name` (String) Specifies the name of the service that this resource belongs to. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
+- `project` (String) The name of the project this resource belongs to. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
+- `service_name` (String) The name of the service that this resource belongs to. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
 
 ### Read-Only
 

--- a/docs/data-sources/clickhouse_user.md
+++ b/docs/data-sources/clickhouse_user.md
@@ -25,8 +25,8 @@ data "aiven_clickhouse_user" "ch-user" {
 
 ### Required
 
-- `project` (String) Identifies the project this resource belongs to. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
-- `service_name` (String) Specifies the name of the service that this resource belongs to. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
+- `project` (String) The name of the project this resource belongs to. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
+- `service_name` (String) The name of the service that this resource belongs to. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
 - `username` (String) The actual name of the Clickhouse user. Changing this property forces recreation of the resource.
 
 ### Read-Only

--- a/docs/data-sources/connection_pool.md
+++ b/docs/data-sources/connection_pool.md
@@ -26,8 +26,8 @@ data "aiven_connection_pool" "mytestpool" {
 ### Required
 
 - `pool_name` (String) The name of the created pool. Changing this property forces recreation of the resource.
-- `project` (String) Identifies the project this resource belongs to. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
-- `service_name` (String) Specifies the name of the service that this resource belongs to. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
+- `project` (String) The name of the project this resource belongs to. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
+- `service_name` (String) The name of the service that this resource belongs to. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
 
 ### Read-Only
 

--- a/docs/data-sources/dragonfly.md
+++ b/docs/data-sources/dragonfly.md
@@ -24,7 +24,7 @@ data "aiven_dragonfly" "example_dragonfly" {
 
 ### Required
 
-- `project` (String) Identifies the project this resource belongs to. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
+- `project` (String) The name of the project this resource belongs to. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
 - `service_name` (String) Specifies the actual name of the service. The name cannot be changed later without destroying and re-creating the service so name should be picked based on intended service usage rather than current attributes.
 
 ### Read-Only

--- a/docs/data-sources/flink.md
+++ b/docs/data-sources/flink.md
@@ -24,7 +24,7 @@ data "aiven_flink" "flink" {
 
 ### Required
 
-- `project` (String) Identifies the project this resource belongs to. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
+- `project` (String) The name of the project this resource belongs to. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
 - `service_name` (String) Specifies the actual name of the service. The name cannot be changed later without destroying and re-creating the service so name should be picked based on intended service usage rather than current attributes.
 
 ### Read-Only

--- a/docs/data-sources/flink_application.md
+++ b/docs/data-sources/flink_application.md
@@ -26,8 +26,8 @@ data "aiven_flink_application" "app1" {
 ### Required
 
 - `name` (String) Application name
-- `project` (String) Identifies the project this resource belongs to. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
-- `service_name` (String) Specifies the name of the service that this resource belongs to. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
+- `project` (String) The name of the project this resource belongs to. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
+- `service_name` (String) The name of the service that this resource belongs to. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
 
 ### Read-Only
 

--- a/docs/data-sources/flink_application_version.md
+++ b/docs/data-sources/flink_application_version.md
@@ -28,8 +28,8 @@ data "aiven_flink_application_version" "app1" {
 
 - `application_id` (String) Application ID
 - `application_version_id` (String) Application version ID
-- `project` (String) Identifies the project this resource belongs to. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
-- `service_name` (String) Specifies the name of the service that this resource belongs to. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
+- `project` (String) The name of the project this resource belongs to. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
+- `service_name` (String) The name of the service that this resource belongs to. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
 
 ### Read-Only
 

--- a/docs/data-sources/gcp_privatelink.md
+++ b/docs/data-sources/gcp_privatelink.md
@@ -24,8 +24,8 @@ data "aiven_gcp_privatelink" "main" {
 
 ### Required
 
-- `project` (String) Identifies the project this resource belongs to. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
-- `service_name` (String) Specifies the name of the service that this resource belongs to. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
+- `project` (String) The name of the project this resource belongs to. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
+- `service_name` (String) The name of the service that this resource belongs to. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
 
 ### Read-Only
 

--- a/docs/data-sources/grafana.md
+++ b/docs/data-sources/grafana.md
@@ -24,7 +24,7 @@ data "aiven_grafana" "gr1" {
 
 ### Required
 
-- `project` (String) Identifies the project this resource belongs to. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
+- `project` (String) The name of the project this resource belongs to. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
 - `service_name` (String) Specifies the actual name of the service. The name cannot be changed later without destroying and re-creating the service so name should be picked based on intended service usage rather than current attributes.
 
 ### Read-Only

--- a/docs/data-sources/kafka.md
+++ b/docs/data-sources/kafka.md
@@ -24,7 +24,7 @@ data "aiven_kafka" "kafka1" {
 
 ### Required
 
-- `project` (String) Identifies the project this resource belongs to. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
+- `project` (String) The name of the project this resource belongs to. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
 - `service_name` (String) Specifies the actual name of the service. The name cannot be changed later without destroying and re-creating the service so name should be picked based on intended service usage rather than current attributes.
 
 ### Read-Only

--- a/docs/data-sources/kafka_acl.md
+++ b/docs/data-sources/kafka_acl.md
@@ -28,8 +28,8 @@ data "aiven_kafka_acl" "mytestacl" {
 ### Required
 
 - `permission` (String) Kafka permission to grant. The possible values are `admin`, `read`, `readwrite` and `write`. Changing this property forces recreation of the resource.
-- `project` (String) Identifies the project this resource belongs to. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
-- `service_name` (String) Specifies the name of the service that this resource belongs to. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
+- `project` (String) The name of the project this resource belongs to. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
+- `service_name` (String) The name of the service that this resource belongs to. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
 - `topic` (String) Topic name pattern for the ACL entry. Changing this property forces recreation of the resource.
 - `username` (String) Username pattern for the ACL entry. Changing this property forces recreation of the resource.
 

--- a/docs/data-sources/kafka_connect.md
+++ b/docs/data-sources/kafka_connect.md
@@ -24,7 +24,7 @@ data "aiven_kafka_connect" "kc1" {
 
 ### Required
 
-- `project` (String) Identifies the project this resource belongs to. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
+- `project` (String) The name of the project this resource belongs to. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
 - `service_name` (String) Specifies the actual name of the service. The name cannot be changed later without destroying and re-creating the service so name should be picked based on intended service usage rather than current attributes.
 
 ### Read-Only

--- a/docs/data-sources/kafka_connector.md
+++ b/docs/data-sources/kafka_connector.md
@@ -26,8 +26,8 @@ data "aiven_kafka_connector" "kafka-es-con1" {
 ### Required
 
 - `connector_name` (String) The kafka connector name. Changing this property forces recreation of the resource.
-- `project` (String) Identifies the project this resource belongs to. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
-- `service_name` (String) Specifies the name of the service that this resource belongs to. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
+- `project` (String) The name of the project this resource belongs to. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
+- `service_name` (String) The name of the service that this resource belongs to. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
 
 ### Read-Only
 

--- a/docs/data-sources/kafka_mirrormaker.md
+++ b/docs/data-sources/kafka_mirrormaker.md
@@ -24,7 +24,7 @@ data "aiven_kafka_mirrormaker" "mm1" {
 
 ### Required
 
-- `project` (String) Identifies the project this resource belongs to. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
+- `project` (String) The name of the project this resource belongs to. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
 - `service_name` (String) Specifies the actual name of the service. The name cannot be changed later without destroying and re-creating the service so name should be picked based on intended service usage rather than current attributes.
 
 ### Read-Only

--- a/docs/data-sources/kafka_schema.md
+++ b/docs/data-sources/kafka_schema.md
@@ -24,8 +24,8 @@ data "aiven_kafka_schema_configuration" "config" {
 
 ### Required
 
-- `project` (String) Identifies the project this resource belongs to. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
-- `service_name` (String) Specifies the name of the service that this resource belongs to. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
+- `project` (String) The name of the project this resource belongs to. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
+- `service_name` (String) The name of the service that this resource belongs to. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
 - `subject_name` (String) The Kafka Schema Subject name. Changing this property forces recreation of the resource.
 
 ### Read-Only

--- a/docs/data-sources/kafka_schema_configuration.md
+++ b/docs/data-sources/kafka_schema_configuration.md
@@ -25,8 +25,8 @@ resource "aiven_kafka_schema_configuration" "config" {
 
 ### Required
 
-- `project` (String) Identifies the project this resource belongs to. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
-- `service_name` (String) Specifies the name of the service that this resource belongs to. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
+- `project` (String) The name of the project this resource belongs to. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
+- `service_name` (String) The name of the service that this resource belongs to. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
 
 ### Read-Only
 

--- a/docs/data-sources/kafka_schema_registry_acl.md
+++ b/docs/data-sources/kafka_schema_registry_acl.md
@@ -18,9 +18,9 @@ The Data Source Kafka Schema Registry ACL data source provides information about
 ### Required
 
 - `permission` (String) Kafka Schema Registry permission to grant. The possible values are `schema_registry_read` and `schema_registry_write`. Changing this property forces recreation of the resource.
-- `project` (String) Identifies the project this resource belongs to. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
+- `project` (String) The name of the project this resource belongs to. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
 - `resource` (String) Resource name pattern for the Schema Registry ACL entry. Changing this property forces recreation of the resource.
-- `service_name` (String) Specifies the name of the service that this resource belongs to. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
+- `service_name` (String) The name of the service that this resource belongs to. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
 - `username` (String) Username pattern for the ACL entry. Changing this property forces recreation of the resource.
 
 ### Read-Only

--- a/docs/data-sources/kafka_topic.md
+++ b/docs/data-sources/kafka_topic.md
@@ -25,8 +25,8 @@ data "aiven_kafka_topic" "mytesttopic" {
 
 ### Required
 
-- `project` (String) Identifies the project this resource belongs to. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
-- `service_name` (String) Specifies the name of the service that this resource belongs to. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
+- `project` (String) The name of the project this resource belongs to. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
+- `service_name` (String) The name of the service that this resource belongs to. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
 - `topic_name` (String) The name of the topic. Changing this property forces recreation of the resource.
 
 ### Read-Only

--- a/docs/data-sources/kafka_user.md
+++ b/docs/data-sources/kafka_user.md
@@ -25,8 +25,8 @@ data "aiven_kafka_user" "user" {
 
 ### Required
 
-- `project` (String) Identifies the project this resource belongs to. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
-- `service_name` (String) Specifies the name of the service that this resource belongs to. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
+- `project` (String) The name of the project this resource belongs to. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
+- `service_name` (String) The name of the service that this resource belongs to. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
 - `username` (String) The actual name of the Kafka User. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
 
 ### Read-Only

--- a/docs/data-sources/m3aggregator.md
+++ b/docs/data-sources/m3aggregator.md
@@ -24,7 +24,7 @@ data "aiven_m3aggregator" "m3a" {
 
 ### Required
 
-- `project` (String) Identifies the project this resource belongs to. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
+- `project` (String) The name of the project this resource belongs to. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
 - `service_name` (String) Specifies the actual name of the service. The name cannot be changed later without destroying and re-creating the service so name should be picked based on intended service usage rather than current attributes.
 
 ### Read-Only

--- a/docs/data-sources/m3db.md
+++ b/docs/data-sources/m3db.md
@@ -24,7 +24,7 @@ data "aiven_m3db" "m3" {
 
 ### Required
 
-- `project` (String) Identifies the project this resource belongs to. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
+- `project` (String) The name of the project this resource belongs to. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
 - `service_name` (String) Specifies the actual name of the service. The name cannot be changed later without destroying and re-creating the service so name should be picked based on intended service usage rather than current attributes.
 
 ### Read-Only

--- a/docs/data-sources/m3db_user.md
+++ b/docs/data-sources/m3db_user.md
@@ -25,8 +25,8 @@ data "aiven_m3db_user" "user" {
 
 ### Required
 
-- `project` (String) Identifies the project this resource belongs to. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
-- `service_name` (String) Specifies the name of the service that this resource belongs to. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
+- `project` (String) The name of the project this resource belongs to. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
+- `service_name` (String) The name of the service that this resource belongs to. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
 - `username` (String) The actual name of the M3DB User. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
 
 ### Read-Only

--- a/docs/data-sources/mirrormaker_replication_flow.md
+++ b/docs/data-sources/mirrormaker_replication_flow.md
@@ -26,8 +26,8 @@ data "aiven_mirrormaker_replication_flow" "f1" {
 
 ### Required
 
-- `project` (String) Identifies the project this resource belongs to. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
-- `service_name` (String) Identifies the project this resource belongs to. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
+- `project` (String) The name of the project this resource belongs to. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
+- `service_name` (String) The name of the project this resource belongs to. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
 - `source_cluster` (String) Source cluster alias. Maximum length: `128`.
 - `target_cluster` (String) Target cluster alias. Maximum length: `128`.
 

--- a/docs/data-sources/mysql.md
+++ b/docs/data-sources/mysql.md
@@ -24,7 +24,7 @@ data "aiven_mysql" "mysql1" {
 
 ### Required
 
-- `project` (String) Identifies the project this resource belongs to. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
+- `project` (String) The name of the project this resource belongs to. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
 - `service_name` (String) Specifies the actual name of the service. The name cannot be changed later without destroying and re-creating the service so name should be picked based on intended service usage rather than current attributes.
 
 ### Read-Only

--- a/docs/data-sources/mysql_database.md
+++ b/docs/data-sources/mysql_database.md
@@ -26,8 +26,8 @@ data "aiven_mysql_database" "mydatabase" {
 ### Required
 
 - `database_name` (String) The name of the service database. Changing this property forces recreation of the resource.
-- `project` (String) Identifies the project this resource belongs to. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
-- `service_name` (String) Specifies the name of the service that this resource belongs to. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
+- `project` (String) The name of the project this resource belongs to. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
+- `service_name` (String) The name of the service that this resource belongs to. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
 
 ### Read-Only
 

--- a/docs/data-sources/mysql_user.md
+++ b/docs/data-sources/mysql_user.md
@@ -25,8 +25,8 @@ data "aiven_mysql_user" "user" {
 
 ### Required
 
-- `project` (String) Identifies the project this resource belongs to. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
-- `service_name` (String) Specifies the name of the service that this resource belongs to. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
+- `project` (String) The name of the project this resource belongs to. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
+- `service_name` (String) The name of the service that this resource belongs to. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
 - `username` (String) The actual name of the MySQL User. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
 
 ### Read-Only

--- a/docs/data-sources/opensearch.md
+++ b/docs/data-sources/opensearch.md
@@ -24,7 +24,7 @@ data "aiven_opensearch" "os1" {
 
 ### Required
 
-- `project` (String) Identifies the project this resource belongs to. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
+- `project` (String) The name of the project this resource belongs to. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
 - `service_name` (String) Specifies the actual name of the service. The name cannot be changed later without destroying and re-creating the service so name should be picked based on intended service usage rather than current attributes.
 
 ### Read-Only

--- a/docs/data-sources/opensearch_acl_config.md
+++ b/docs/data-sources/opensearch_acl_config.md
@@ -24,8 +24,8 @@ data "aiven_opensearch_acl_config" "os-acl-config" {
 
 ### Required
 
-- `project` (String) Identifies the project this resource belongs to. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
-- `service_name` (String) Specifies the name of the service that this resource belongs to. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
+- `project` (String) The name of the project this resource belongs to. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
+- `service_name` (String) The name of the service that this resource belongs to. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
 
 ### Read-Only
 

--- a/docs/data-sources/opensearch_acl_rule.md
+++ b/docs/data-sources/opensearch_acl_rule.md
@@ -28,8 +28,8 @@ data "aiven_opensearch_acl_rule" "os_acl_rule" {
 
 - `index` (String) The index pattern for this ACL entry. Maximum length: `249`. Changing this property forces recreation of the resource.
 - `permission` (String) The permissions for this ACL entry. The possible values are `deny`, `admin`, `read`, `readwrite` and `write`.
-- `project` (String) Identifies the project this resource belongs to. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
-- `service_name` (String) Specifies the name of the service that this resource belongs to. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
+- `project` (String) The name of the project this resource belongs to. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
+- `service_name` (String) The name of the service that this resource belongs to. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
 - `username` (String) The username for the ACL entry. Maximum length: `40`. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
 
 ### Read-Only

--- a/docs/data-sources/opensearch_security_plugin_config.md
+++ b/docs/data-sources/opensearch_security_plugin_config.md
@@ -24,8 +24,8 @@ data "aiven_opensearch_security_plugin_config" "os-sec-config" {
 
 ### Required
 
-- `project` (String) Identifies the project this resource belongs to. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
-- `service_name` (String) Specifies the name of the service that this resource belongs to. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
+- `project` (String) The name of the project this resource belongs to. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
+- `service_name` (String) The name of the service that this resource belongs to. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
 
 ### Read-Only
 

--- a/docs/data-sources/opensearch_user.md
+++ b/docs/data-sources/opensearch_user.md
@@ -25,8 +25,8 @@ data "aiven_opensearch_user" "user" {
 
 ### Required
 
-- `project` (String) Identifies the project this resource belongs to. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
-- `service_name` (String) Specifies the name of the service that this resource belongs to. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
+- `project` (String) The name of the project this resource belongs to. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
+- `service_name` (String) The name of the service that this resource belongs to. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
 - `username` (String) The actual name of the OpenSearch User. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
 
 ### Read-Only

--- a/docs/data-sources/pg.md
+++ b/docs/data-sources/pg.md
@@ -24,7 +24,7 @@ data "aiven_pg" "pg" {
 
 ### Required
 
-- `project` (String) Identifies the project this resource belongs to. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
+- `project` (String) The name of the project this resource belongs to. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
 - `service_name` (String) Specifies the actual name of the service. The name cannot be changed later without destroying and re-creating the service so name should be picked based on intended service usage rather than current attributes.
 
 ### Read-Only

--- a/docs/data-sources/pg_database.md
+++ b/docs/data-sources/pg_database.md
@@ -26,8 +26,8 @@ data "aiven_pg_database" "mydatabase" {
 ### Required
 
 - `database_name` (String) The name of the service database. Changing this property forces recreation of the resource.
-- `project` (String) Identifies the project this resource belongs to. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
-- `service_name` (String) Specifies the name of the service that this resource belongs to. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
+- `project` (String) The name of the project this resource belongs to. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
+- `service_name` (String) The name of the service that this resource belongs to. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
 
 ### Read-Only
 

--- a/docs/data-sources/pg_user.md
+++ b/docs/data-sources/pg_user.md
@@ -25,8 +25,8 @@ data "aiven_pg_user" "user" {
 
 ### Required
 
-- `project` (String) Identifies the project this resource belongs to. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
-- `service_name` (String) Specifies the name of the service that this resource belongs to. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
+- `project` (String) The name of the project this resource belongs to. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
+- `service_name` (String) The name of the service that this resource belongs to. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
 - `username` (String) The actual name of the PG User. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
 
 ### Read-Only

--- a/docs/data-sources/project_user.md
+++ b/docs/data-sources/project_user.md
@@ -24,11 +24,11 @@ data "aiven_project_user" "mytestuser" {
 
 ### Required
 
-- `email` (String) Email address of the user. Should be lowercase. Changing this property forces recreation of the resource.
-- `project` (String) Identifies the project this resource belongs to. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
+- `email` (String) Email address of the user in lowercase. Changing this property forces recreation of the resource.
+- `project` (String) The name of the project this resource belongs to. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
 
 ### Read-Only
 
-- `accepted` (Boolean) Whether the user has accepted the request to join the project; adding user to a project sends an invitation to the target user and the actual membership is only created once the user accepts the invitation.
+- `accepted` (Boolean) Whether the user has accepted the request to join the project. Users get an invite and become project members after accepting the invite.
 - `id` (String) The ID of this resource.
 - `member_type` (String) Project membership type. The possible values are `admin`, `developer` and `operator`.

--- a/docs/data-sources/redis.md
+++ b/docs/data-sources/redis.md
@@ -24,7 +24,7 @@ data "aiven_redis" "redis1" {
 
 ### Required
 
-- `project` (String) Identifies the project this resource belongs to. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
+- `project` (String) The name of the project this resource belongs to. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
 - `service_name` (String) Specifies the actual name of the service. The name cannot be changed later without destroying and re-creating the service so name should be picked based on intended service usage rather than current attributes.
 
 ### Read-Only

--- a/docs/data-sources/redis_user.md
+++ b/docs/data-sources/redis_user.md
@@ -25,8 +25,8 @@ data "aiven_redis_user" "user" {
 
 ### Required
 
-- `project` (String) Identifies the project this resource belongs to. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
-- `service_name` (String) Specifies the name of the service that this resource belongs to. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
+- `project` (String) The name of the project this resource belongs to. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
+- `service_name` (String) The name of the service that this resource belongs to. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
 - `username` (String) The actual name of the Redis User. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
 
 ### Read-Only

--- a/docs/resources/account_authentication.md
+++ b/docs/resources/account_authentication.md
@@ -87,5 +87,5 @@ Optional:
 Import is supported using the following syntax:
 
 ```shell
-terraform import aiven_account_authentication.foo account_id/authentication_id
+terraform import aiven_account_authentication.foo ACCOUNT_ID/AUTHENTICATION_ID
 ```

--- a/docs/resources/account_team_member.md
+++ b/docs/resources/account_team_member.md
@@ -61,5 +61,5 @@ Optional:
 ## Import
 Import is supported using the following syntax:
 ```shell
-terraform import aiven_account_team_member.foo account_id/team_id/user_email
+terraform import aiven_account_team_member.foo ACCOUNT_ID/TEAM_ID/USER_EMAIL
 ```

--- a/docs/resources/aws_privatelink.md
+++ b/docs/resources/aws_privatelink.md
@@ -29,8 +29,8 @@ resource "aiven_aws_privatelink" "main" {
 ### Required
 
 - `principals` (Set of String) List of the ARNs of the AWS accounts or IAM users allowed to connect to the VPC endpoint.
-- `project` (String) Identifies the project this resource belongs to. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
-- `service_name` (String) Specifies the name of the service that this resource belongs to. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
+- `project` (String) The name of the project this resource belongs to. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
+- `service_name` (String) The name of the service that this resource belongs to. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
 
 ### Optional
 

--- a/docs/resources/azure_privatelink.md
+++ b/docs/resources/azure_privatelink.md
@@ -29,8 +29,8 @@ resource "aiven_azure_privatelink" "main" {
 
 ### Required
 
-- `project` (String) Identifies the project this resource belongs to. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
-- `service_name` (String) Specifies the name of the service that this resource belongs to. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
+- `project` (String) The name of the project this resource belongs to. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
+- `service_name` (String) The name of the service that this resource belongs to. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
 - `user_subscription_ids` (Set of String) A list of allowed subscription IDs. Maximum length: `16`.
 
 ### Optional

--- a/docs/resources/azure_privatelink_connection_approval.md
+++ b/docs/resources/azure_privatelink_connection_approval.md
@@ -74,8 +74,8 @@ resource "aiven_azure_privatelink_connection_approval" "approval" {
 
 ### Required
 
-- `project` (String) Identifies the project this resource belongs to. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
-- `service_name` (String) Specifies the name of the service that this resource belongs to. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
+- `project` (String) The name of the project this resource belongs to. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
+- `service_name` (String) The name of the service that this resource belongs to. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
 
 ### Optional
 

--- a/docs/resources/cassandra.md
+++ b/docs/resources/cassandra.md
@@ -37,7 +37,7 @@ resource "aiven_cassandra" "bar" {
 ### Required
 
 - `plan` (String) Defines what kind of computing resources are allocated for the service. It can be changed after creation, though there are some restrictions when going to a smaller plan such as the new plan must have sufficient amount of disk space to store all current data and switching to a plan with fewer nodes might not be supported. The basic plan names are `hobbyist`, `startup-x`, `business-x` and `premium-x` where `x` is (roughly) the amount of memory on each node (also other attributes like number of CPUs and amount of disk space varies but naming is based on memory). The available options can be seem from the [Aiven pricing page](https://aiven.io/pricing).
-- `project` (String) Identifies the project this resource belongs to. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
+- `project` (String) The name of the project this resource belongs to. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
 - `service_name` (String) Specifies the actual name of the service. The name cannot be changed later without destroying and re-creating the service so name should be picked based on intended service usage rather than current attributes.
 
 ### Optional
@@ -198,5 +198,5 @@ Read-Only:
 Import is supported using the following syntax:
 
 ```shell
-terraform import aiven_cassandra.bar project/service_name
+terraform import aiven_cassandra.bar PROJECT/SERVICE_NAME
 ```

--- a/docs/resources/cassandra_user.md
+++ b/docs/resources/cassandra_user.md
@@ -26,8 +26,8 @@ resource "aiven_cassandra_user" "foo" {
 
 ### Required
 
-- `project` (String) Identifies the project this resource belongs to. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
-- `service_name` (String) Specifies the name of the service that this resource belongs to. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
+- `project` (String) The name of the project this resource belongs to. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
+- `service_name` (String) The name of the service that this resource belongs to. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
 - `username` (String) The actual name of the Cassandra User. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
 
 ### Optional
@@ -58,5 +58,5 @@ Optional:
 Import is supported using the following syntax:
 
 ```shell
-terraform import aiven_cassandra_user.foo project/service_name/username
+terraform import aiven_cassandra_user.foo PROJECT/SERVICE_NAME/USERNAME
 ```

--- a/docs/resources/clickhouse.md
+++ b/docs/resources/clickhouse.md
@@ -29,7 +29,7 @@ resource "aiven_clickhouse" "clickhouse" {
 ### Required
 
 - `plan` (String) Defines what kind of computing resources are allocated for the service. It can be changed after creation, though there are some restrictions when going to a smaller plan such as the new plan must have sufficient amount of disk space to store all current data and switching to a plan with fewer nodes might not be supported. The basic plan names are `hobbyist`, `startup-x`, `business-x` and `premium-x` where `x` is (roughly) the amount of memory on each node (also other attributes like number of CPUs and amount of disk space varies but naming is based on memory). The available options can be seem from the [Aiven pricing page](https://aiven.io/pricing).
-- `project` (String) Identifies the project this resource belongs to. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
+- `project` (String) The name of the project this resource belongs to. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
 - `service_name` (String) Specifies the actual name of the service. The name cannot be changed later without destroying and re-creating the service so name should be picked based on intended service usage rather than current attributes.
 
 ### Optional
@@ -192,5 +192,5 @@ Read-Only:
 Import is supported using the following syntax:
 
 ```shell
-terraform import aiven_clickhouse.clickhouse project/service_name
+terraform import aiven_clickhouse.clickhouse PROJECT/SERVICE_NAME
 ```

--- a/docs/resources/clickhouse_database.md
+++ b/docs/resources/clickhouse_database.md
@@ -26,8 +26,8 @@ resource "aiven_clickhouse_database" "clickhouse_db" {
 ### Required
 
 - `name` (String) The name of the Clickhouse database. Changing this property forces recreation of the resource.
-- `project` (String) Identifies the project this resource belongs to. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
-- `service_name` (String) Specifies the name of the service that this resource belongs to. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
+- `project` (String) The name of the project this resource belongs to. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
+- `service_name` (String) The name of the service that this resource belongs to. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
 
 ### Optional
 
@@ -54,5 +54,5 @@ Optional:
 Import is supported using the following syntax:
 
 ```shell
-terraform import aiven_clickhouse_database.clickhouse_db project/service_name/name
+terraform import aiven_clickhouse_database.clickhouse_db PROJECT/SERVICE_NAME/NAME
 ```

--- a/docs/resources/clickhouse_grant.md
+++ b/docs/resources/clickhouse_grant.md
@@ -80,8 +80,8 @@ resource "aiven_clickhouse_grant" "demo-user-grant" {
 
 ### Required
 
-- `project` (String) Identifies the project this resource belongs to. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
-- `service_name` (String) Specifies the name of the service that this resource belongs to. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
+- `project` (String) The name of the project this resource belongs to. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
+- `service_name` (String) The name of the service that this resource belongs to. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
 
 ### Optional
 

--- a/docs/resources/clickhouse_role.md
+++ b/docs/resources/clickhouse_role.md
@@ -34,9 +34,9 @@ resource "aiven_clickhouse_role" "foo" {
 
 ### Required
 
-- `project` (String) Identifies the project this resource belongs to. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
+- `project` (String) The name of the project this resource belongs to. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
 - `role` (String) The role that is to be created. Changing this property forces recreation of the resource.
-- `service_name` (String) Specifies the name of the service that this resource belongs to. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
+- `service_name` (String) The name of the service that this resource belongs to. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
 
 ### Optional
 
@@ -62,5 +62,5 @@ Optional:
 Import is supported using the following syntax:
 
 ```shell
-terraform import aiven_clickhouse_role.foo project/service_name/role
+terraform import aiven_clickhouse_role.foo PROJECT/SERVICE_NAME/ROLE
 ```

--- a/docs/resources/clickhouse_user.md
+++ b/docs/resources/clickhouse_user.md
@@ -25,8 +25,8 @@ resource "aiven_clickhouse_user" "ch-user" {
 
 ### Required
 
-- `project` (String) Identifies the project this resource belongs to. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
-- `service_name` (String) Specifies the name of the service that this resource belongs to. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
+- `project` (String) The name of the project this resource belongs to. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
+- `service_name` (String) The name of the service that this resource belongs to. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
 - `username` (String) The actual name of the Clickhouse user. Changing this property forces recreation of the resource.
 
 ### Optional

--- a/docs/resources/connection_pool.md
+++ b/docs/resources/connection_pool.md
@@ -31,8 +31,8 @@ resource "aiven_connection_pool" "mytestpool" {
 
 - `database_name` (String) The name of the database the pool connects to. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
 - `pool_name` (String) The name of the created pool. Changing this property forces recreation of the resource.
-- `project` (String) Identifies the project this resource belongs to. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
-- `service_name` (String) Specifies the name of the service that this resource belongs to. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
+- `project` (String) The name of the project this resource belongs to. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
+- `service_name` (String) The name of the service that this resource belongs to. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
 
 ### Optional
 
@@ -62,5 +62,5 @@ Optional:
 Import is supported using the following syntax:
 
 ```shell
-terraform import aiven_connection_pool.mytestpool project/service_name/pool_name
+terraform import aiven_connection_pool.mytestpool PROJECT/SERVICE_NAME/POOL_NAME
 ```

--- a/docs/resources/dragonfly.md
+++ b/docs/resources/dragonfly.md
@@ -31,7 +31,7 @@ resource "aiven_dragonfly" "example_dragonfly" {
 ### Required
 
 - `plan` (String) Defines what kind of computing resources are allocated for the service. It can be changed after creation, though there are some restrictions when going to a smaller plan such as the new plan must have sufficient amount of disk space to store all current data and switching to a plan with fewer nodes might not be supported. The basic plan names are `hobbyist`, `startup-x`, `business-x` and `premium-x` where `x` is (roughly) the amount of memory on each node (also other attributes like number of CPUs and amount of disk space varies but naming is based on memory). The available options can be seem from the [Aiven pricing page](https://aiven.io/pricing).
-- `project` (String) Identifies the project this resource belongs to. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
+- `project` (String) The name of the project this resource belongs to. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
 - `service_name` (String) Specifies the actual name of the service. The name cannot be changed later without destroying and re-creating the service so name should be picked based on intended service usage rather than current attributes.
 
 ### Optional

--- a/docs/resources/flink.md
+++ b/docs/resources/flink.md
@@ -33,7 +33,7 @@ resource "aiven_flink" "flink" {
 ### Required
 
 - `plan` (String) Defines what kind of computing resources are allocated for the service. It can be changed after creation, though there are some restrictions when going to a smaller plan such as the new plan must have sufficient amount of disk space to store all current data and switching to a plan with fewer nodes might not be supported. The basic plan names are `hobbyist`, `startup-x`, `business-x` and `premium-x` where `x` is (roughly) the amount of memory on each node (also other attributes like number of CPUs and amount of disk space varies but naming is based on memory). The available options can be seem from the [Aiven pricing page](https://aiven.io/pricing).
-- `project` (String) Identifies the project this resource belongs to. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
+- `project` (String) The name of the project this resource belongs to. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
 - `service_name` (String) Specifies the actual name of the service. The name cannot be changed later without destroying and re-creating the service so name should be picked based on intended service usage rather than current attributes.
 
 ### Optional
@@ -171,5 +171,5 @@ Read-Only:
 Import is supported using the following syntax:
 
 ```shell
-terraform import aiven_flink.flink project/service_name
+terraform import aiven_flink.flink PROJECT/SERVICE_NAME
 ```

--- a/docs/resources/flink_application.md
+++ b/docs/resources/flink_application.md
@@ -26,8 +26,8 @@ resource "aiven_flink_application" "foo" {
 ### Required
 
 - `name` (String) Application name
-- `project` (String) Identifies the project this resource belongs to. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
-- `service_name` (String) Specifies the name of the service that this resource belongs to. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
+- `project` (String) The name of the project this resource belongs to. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
+- `service_name` (String) The name of the service that this resource belongs to. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
 
 ### Optional
 
@@ -58,5 +58,5 @@ Optional:
 Import is supported using the following syntax:
 
 ```shell
-terraform import aiven_flink_application.myapp project/service/application_name
+terraform import aiven_flink_application.myapp PROJECT/SERVICE/APPLICATION_NAME
 ```

--- a/docs/resources/flink_application_deployment.md
+++ b/docs/resources/flink_application_deployment.md
@@ -27,8 +27,8 @@ resource "aiven_flink_application_deployment" "deployment" {
 ### Required
 
 - `application_id` (String) Application ID
-- `project` (String) Identifies the project this resource belongs to. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
-- `service_name` (String) Specifies the name of the service that this resource belongs to. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
+- `project` (String) The name of the project this resource belongs to. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
+- `service_name` (String) The name of the service that this resource belongs to. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
 - `version_id` (String) ApplicationVersion ID
 
 ### Optional
@@ -60,5 +60,5 @@ Optional:
 Import is supported using the following syntax:
 
 ```shell
-terraform import aiven_flink_application_deployment.foo_deploy project/service/application_id/application_version_id/deployment_id
+terraform import aiven_flink_application_deployment.foo_deploy PROJECT/SERVICE/APPLICATION_ID/APPLICATION_VERSION_ID/DEPLOYMENT_ID
 ```

--- a/docs/resources/flink_application_version.md
+++ b/docs/resources/flink_application_version.md
@@ -59,8 +59,8 @@ resource "aiven_flink_application_version" "foo" {
 ### Required
 
 - `application_id` (String) Application ID
-- `project` (String) Identifies the project this resource belongs to. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
-- `service_name` (String) Specifies the name of the service that this resource belongs to. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
+- `project` (String) The name of the project this resource belongs to. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
+- `service_name` (String) The name of the service that this resource belongs to. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
 - `statement` (String) Job SQL statement
 
 ### Optional

--- a/docs/resources/gcp_privatelink.md
+++ b/docs/resources/gcp_privatelink.md
@@ -24,8 +24,8 @@ resource "aiven_gcp_privatelink" "main" {
 
 ### Required
 
-- `project` (String) Identifies the project this resource belongs to. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
-- `service_name` (String) Specifies the name of the service that this resource belongs to. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
+- `project` (String) The name of the project this resource belongs to. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
+- `service_name` (String) The name of the service that this resource belongs to. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
 
 ### Optional
 

--- a/docs/resources/gcp_privatelink_connection_approval.md
+++ b/docs/resources/gcp_privatelink_connection_approval.md
@@ -25,8 +25,8 @@ resource "aiven_gcp_privatelink_connection_approval" "approve" {
 
 ### Required
 
-- `project` (String) Identifies the project this resource belongs to. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
-- `service_name` (String) Specifies the name of the service that this resource belongs to. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
+- `project` (String) The name of the project this resource belongs to. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
+- `service_name` (String) The name of the service that this resource belongs to. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
 - `user_ip_address` (String) The Private Service Connect connection user IP address.
 
 ### Optional

--- a/docs/resources/gcp_vpc_peering_connection.md
+++ b/docs/resources/gcp_vpc_peering_connection.md
@@ -56,5 +56,5 @@ Optional:
 Import is supported using the following syntax:
 
 ```shell
-terraform import aiven_gcp_vpc_peering_connection.foo project_name/vpc_id/gcp_project_id/peer_vpc
+terraform import aiven_gcp_vpc_peering_connection.foo PROJECT_NAME/VPC_ID/GCP_PROJECT_ID/PEER_VPC
 ```

--- a/docs/resources/grafana.md
+++ b/docs/resources/grafana.md
@@ -37,7 +37,7 @@ resource "aiven_grafana" "gr1" {
 ### Required
 
 - `plan` (String) Defines what kind of computing resources are allocated for the service. It can be changed after creation, though there are some restrictions when going to a smaller plan such as the new plan must have sufficient amount of disk space to store all current data and switching to a plan with fewer nodes might not be supported. The basic plan names are `hobbyist`, `startup-x`, `business-x` and `premium-x` where `x` is (roughly) the amount of memory on each node (also other attributes like number of CPUs and amount of disk space varies but naming is based on memory). The available options can be seem from the [Aiven pricing page](https://aiven.io/pricing).
-- `project` (String) Identifies the project this resource belongs to. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
+- `project` (String) The name of the project this resource belongs to. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
 - `service_name` (String) Specifies the actual name of the service. The name cannot be changed later without destroying and re-creating the service so name should be picked based on intended service usage rather than current attributes.
 
 ### Optional

--- a/docs/resources/kafka.md
+++ b/docs/resources/kafka.md
@@ -46,7 +46,7 @@ resource "aiven_kafka" "kafka1" {
 ### Required
 
 - `plan` (String) Defines what kind of computing resources are allocated for the service. It can be changed after creation, though there are some restrictions when going to a smaller plan such as the new plan must have sufficient amount of disk space to store all current data and switching to a plan with fewer nodes might not be supported. The basic plan names are `hobbyist`, `startup-x`, `business-x` and `premium-x` where `x` is (roughly) the amount of memory on each node (also other attributes like number of CPUs and amount of disk space varies but naming is based on memory). The available options can be seem from the [Aiven pricing page](https://aiven.io/pricing).
-- `project` (String) Identifies the project this resource belongs to. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
+- `project` (String) The name of the project this resource belongs to. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
 - `service_name` (String) Specifies the actual name of the service. The name cannot be changed later without destroying and re-creating the service so name should be picked based on intended service usage rather than current attributes.
 
 ### Optional

--- a/docs/resources/kafka_acl.md
+++ b/docs/resources/kafka_acl.md
@@ -28,8 +28,8 @@ resource "aiven_kafka_acl" "mytestacl" {
 ### Required
 
 - `permission` (String) Kafka permission to grant. The possible values are `admin`, `read`, `readwrite` and `write`. Changing this property forces recreation of the resource.
-- `project` (String) Identifies the project this resource belongs to. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
-- `service_name` (String) Specifies the name of the service that this resource belongs to. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
+- `project` (String) The name of the project this resource belongs to. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
+- `service_name` (String) The name of the service that this resource belongs to. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
 - `topic` (String) Topic name pattern for the ACL entry. Changing this property forces recreation of the resource.
 - `username` (String) Username pattern for the ACL entry. Changing this property forces recreation of the resource.
 
@@ -58,5 +58,5 @@ Optional:
 Import is supported using the following syntax:
 
 ```shell
-terraform import aiven_kafka_acl.mytestacl project/service_name/id
+terraform import aiven_kafka_acl.mytestacl PROJECT/SERVICE_NAME/ID
 ```

--- a/docs/resources/kafka_connect.md
+++ b/docs/resources/kafka_connect.md
@@ -39,7 +39,7 @@ resource "aiven_kafka_connect" "kc1" {
 ### Required
 
 - `plan` (String) Defines what kind of computing resources are allocated for the service. It can be changed after creation, though there are some restrictions when going to a smaller plan such as the new plan must have sufficient amount of disk space to store all current data and switching to a plan with fewer nodes might not be supported. The basic plan names are `hobbyist`, `startup-x`, `business-x` and `premium-x` where `x` is (roughly) the amount of memory on each node (also other attributes like number of CPUs and amount of disk space varies but naming is based on memory). The available options can be seem from the [Aiven pricing page](https://aiven.io/pricing).
-- `project` (String) Identifies the project this resource belongs to. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
+- `project` (String) The name of the project this resource belongs to. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
 - `service_name` (String) Specifies the actual name of the service. The name cannot be changed later without destroying and re-creating the service so name should be picked based on intended service usage rather than current attributes.
 
 ### Optional

--- a/docs/resources/kafka_connector.md
+++ b/docs/resources/kafka_connector.md
@@ -37,8 +37,8 @@ resource "aiven_kafka_connector" "kafka-os-con1" {
 
 - `config` (Map of String) The Kafka Connector configuration parameters.
 - `connector_name` (String) The kafka connector name. Changing this property forces recreation of the resource.
-- `project` (String) Identifies the project this resource belongs to. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
-- `service_name` (String) Specifies the name of the service that this resource belongs to. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
+- `project` (String) The name of the project this resource belongs to. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
+- `service_name` (String) The name of the service that this resource belongs to. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
 
 ### Optional
 

--- a/docs/resources/kafka_mirrormaker.md
+++ b/docs/resources/kafka_mirrormaker.md
@@ -37,7 +37,7 @@ resource "aiven_kafka_mirrormaker" "mm1" {
 ### Required
 
 - `plan` (String) Defines what kind of computing resources are allocated for the service. It can be changed after creation, though there are some restrictions when going to a smaller plan such as the new plan must have sufficient amount of disk space to store all current data and switching to a plan with fewer nodes might not be supported. The basic plan names are `hobbyist`, `startup-x`, `business-x` and `premium-x` where `x` is (roughly) the amount of memory on each node (also other attributes like number of CPUs and amount of disk space varies but naming is based on memory). The available options can be seem from the [Aiven pricing page](https://aiven.io/pricing).
-- `project` (String) Identifies the project this resource belongs to. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
+- `project` (String) The name of the project this resource belongs to. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
 - `service_name` (String) Specifies the actual name of the service. The name cannot be changed later without destroying and re-creating the service so name should be picked based on intended service usage rather than current attributes.
 
 ### Optional

--- a/docs/resources/kafka_schema.md
+++ b/docs/resources/kafka_schema.md
@@ -44,9 +44,9 @@ resource "aiven_kafka_schema" "kafka-schema1" {
 
 ### Required
 
-- `project` (String) Identifies the project this resource belongs to. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
+- `project` (String) The name of the project this resource belongs to. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
 - `schema` (String) Kafka Schema configuration. Should be a valid Avro, JSON, or Protobuf schema, depending on the schema type.
-- `service_name` (String) Specifies the name of the service that this resource belongs to. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
+- `service_name` (String) The name of the service that this resource belongs to. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
 - `subject_name` (String) The Kafka Schema Subject name. Changing this property forces recreation of the resource.
 
 ### Optional

--- a/docs/resources/kafka_schema_configuration.md
+++ b/docs/resources/kafka_schema_configuration.md
@@ -25,8 +25,8 @@ resource "aiven_kafka_schema_configuration" "config" {
 
 ### Required
 
-- `project` (String) Identifies the project this resource belongs to. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
-- `service_name` (String) Specifies the name of the service that this resource belongs to. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
+- `project` (String) The name of the project this resource belongs to. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
+- `service_name` (String) The name of the service that this resource belongs to. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
 
 ### Optional
 
@@ -53,5 +53,5 @@ Optional:
 Import is supported using the following syntax:
 
 ```shell
-terraform import aiven_kafka_schema_configuration.config project/service_name
+terraform import aiven_kafka_schema_configuration.config PROJECT/SERVICE_NAME
 ```

--- a/docs/resources/kafka_schema_registry_acl.md
+++ b/docs/resources/kafka_schema_registry_acl.md
@@ -18,9 +18,9 @@ The Resource Kafka Schema Registry ACL resource allows the creation and manageme
 ### Required
 
 - `permission` (String) Kafka Schema Registry permission to grant. The possible values are `schema_registry_read` and `schema_registry_write`. Changing this property forces recreation of the resource.
-- `project` (String) Identifies the project this resource belongs to. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
+- `project` (String) The name of the project this resource belongs to. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
 - `resource` (String) Resource name pattern for the Schema Registry ACL entry. Changing this property forces recreation of the resource.
-- `service_name` (String) Specifies the name of the service that this resource belongs to. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
+- `service_name` (String) The name of the service that this resource belongs to. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
 - `username` (String) Username pattern for the ACL entry. Changing this property forces recreation of the resource.
 
 ### Optional

--- a/docs/resources/kafka_topic.md
+++ b/docs/resources/kafka_topic.md
@@ -40,9 +40,9 @@ resource "aiven_kafka_topic" "mytesttopic" {
 ### Required
 
 - `partitions` (Number) The number of partitions to create in the topic.
-- `project` (String) Identifies the project this resource belongs to. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
+- `project` (String) The name of the project this resource belongs to. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
 - `replication` (Number) The replication factor for the topic.
-- `service_name` (String) Specifies the name of the service that this resource belongs to. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
+- `service_name` (String) The name of the service that this resource belongs to. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
 - `topic_name` (String) The name of the topic. Changing this property forces recreation of the resource.
 
 ### Optional
@@ -118,5 +118,5 @@ Optional:
 Import is supported using the following syntax:
 
 ```shell
-terraform import aiven_kafka_topic.mytesttopic project/service_name/topic_name
+terraform import aiven_kafka_topic.mytesttopic PROJECT/SERVICE_NAME/TOPIC_NAME
 ```

--- a/docs/resources/kafka_user.md
+++ b/docs/resources/kafka_user.md
@@ -26,8 +26,8 @@ resource "aiven_kafka_user" "foo" {
 
 ### Required
 
-- `project` (String) Identifies the project this resource belongs to. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
-- `service_name` (String) Specifies the name of the service that this resource belongs to. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
+- `project` (String) The name of the project this resource belongs to. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
+- `service_name` (String) The name of the service that this resource belongs to. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
 - `username` (String) The actual name of the Kafka User. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
 
 ### Optional
@@ -58,5 +58,5 @@ Optional:
 Import is supported using the following syntax:
 
 ```shell
-terraform import aiven_kafka_user.foo project/service_name/username
+terraform import aiven_kafka_user.foo PROJECT/SERVICE_NAME/USERNAME
 ```

--- a/docs/resources/m3aggregator.md
+++ b/docs/resources/m3aggregator.md
@@ -33,7 +33,7 @@ resource "aiven_m3aggregator" "m3a" {
 ### Required
 
 - `plan` (String) Defines what kind of computing resources are allocated for the service. It can be changed after creation, though there are some restrictions when going to a smaller plan such as the new plan must have sufficient amount of disk space to store all current data and switching to a plan with fewer nodes might not be supported. The basic plan names are `hobbyist`, `startup-x`, `business-x` and `premium-x` where `x` is (roughly) the amount of memory on each node (also other attributes like number of CPUs and amount of disk space varies but naming is based on memory). The available options can be seem from the [Aiven pricing page](https://aiven.io/pricing).
-- `project` (String) Identifies the project this resource belongs to. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
+- `project` (String) The name of the project this resource belongs to. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
 - `service_name` (String) Specifies the actual name of the service. The name cannot be changed later without destroying and re-creating the service so name should be picked based on intended service usage rather than current attributes.
 
 ### Optional

--- a/docs/resources/m3db.md
+++ b/docs/resources/m3db.md
@@ -38,7 +38,7 @@ resource "aiven_m3db" "m3" {
 ### Required
 
 - `plan` (String) Defines what kind of computing resources are allocated for the service. It can be changed after creation, though there are some restrictions when going to a smaller plan such as the new plan must have sufficient amount of disk space to store all current data and switching to a plan with fewer nodes might not be supported. The basic plan names are `hobbyist`, `startup-x`, `business-x` and `premium-x` where `x` is (roughly) the amount of memory on each node (also other attributes like number of CPUs and amount of disk space varies but naming is based on memory). The available options can be seem from the [Aiven pricing page](https://aiven.io/pricing).
-- `project` (String) Identifies the project this resource belongs to. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
+- `project` (String) The name of the project this resource belongs to. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
 - `service_name` (String) Specifies the actual name of the service. The name cannot be changed later without destroying and re-creating the service so name should be picked based on intended service usage rather than current attributes.
 
 ### Optional

--- a/docs/resources/m3db_user.md
+++ b/docs/resources/m3db_user.md
@@ -26,8 +26,8 @@ resource "aiven_m3db_user" "foo" {
 
 ### Required
 
-- `project` (String) Identifies the project this resource belongs to. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
-- `service_name` (String) Specifies the name of the service that this resource belongs to. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
+- `project` (String) The name of the project this resource belongs to. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
+- `service_name` (String) The name of the service that this resource belongs to. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
 - `username` (String) The actual name of the M3DB User. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
 
 ### Optional

--- a/docs/resources/mirrormaker_replication_flow.md
+++ b/docs/resources/mirrormaker_replication_flow.md
@@ -39,9 +39,9 @@ resource "aiven_mirrormaker_replication_flow" "f1" {
 
 - `enable` (Boolean) Enable of disable replication flows for a service.
 - `offset_syncs_topic_location` (String) Offset syncs topic location.
-- `project` (String) Identifies the project this resource belongs to. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
+- `project` (String) The name of the project this resource belongs to. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
 - `replication_policy_class` (String) Replication policy class. The possible values are `org.apache.kafka.connect.mirror.DefaultReplicationPolicy` and `org.apache.kafka.connect.mirror.IdentityReplicationPolicy`. The default value is `org.apache.kafka.connect.mirror.DefaultReplicationPolicy`.
-- `service_name` (String) Identifies the project this resource belongs to. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
+- `service_name` (String) The name of the project this resource belongs to. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
 - `source_cluster` (String) Source cluster alias. Maximum length: `128`.
 - `target_cluster` (String) Target cluster alias. Maximum length: `128`.
 

--- a/docs/resources/mysql.md
+++ b/docs/resources/mysql.md
@@ -42,7 +42,7 @@ resource "aiven_mysql" "mysql1" {
 ### Required
 
 - `plan` (String) Defines what kind of computing resources are allocated for the service. It can be changed after creation, though there are some restrictions when going to a smaller plan such as the new plan must have sufficient amount of disk space to store all current data and switching to a plan with fewer nodes might not be supported. The basic plan names are `hobbyist`, `startup-x`, `business-x` and `premium-x` where `x` is (roughly) the amount of memory on each node (also other attributes like number of CPUs and amount of disk space varies but naming is based on memory). The available options can be seem from the [Aiven pricing page](https://aiven.io/pricing).
-- `project` (String) Identifies the project this resource belongs to. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
+- `project` (String) The name of the project this resource belongs to. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
 - `service_name` (String) Specifies the actual name of the service. The name cannot be changed later without destroying and re-creating the service so name should be picked based on intended service usage rather than current attributes.
 
 ### Optional

--- a/docs/resources/mysql_database.md
+++ b/docs/resources/mysql_database.md
@@ -26,8 +26,8 @@ resource "aiven_mysql_database" "mydatabase" {
 ### Required
 
 - `database_name` (String) The name of the service database. Changing this property forces recreation of the resource.
-- `project` (String) Identifies the project this resource belongs to. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
-- `service_name` (String) Specifies the name of the service that this resource belongs to. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
+- `project` (String) The name of the project this resource belongs to. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
+- `service_name` (String) The name of the service that this resource belongs to. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
 
 ### Optional
 
@@ -54,5 +54,5 @@ Optional:
 Import is supported using the following syntax:
 
 ```shell
-terraform import aiven_mysql_database.mydatabase project/service_name/database_name
+terraform import aiven_mysql_database.mydatabase PROJECT/SERVICE_NAME/DATABASE_NAME
 ```

--- a/docs/resources/mysql_user.md
+++ b/docs/resources/mysql_user.md
@@ -26,8 +26,8 @@ resource "aiven_mysql_user" "foo" {
 
 ### Required
 
-- `project` (String) Identifies the project this resource belongs to. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
-- `service_name` (String) Specifies the name of the service that this resource belongs to. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
+- `project` (String) The name of the project this resource belongs to. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
+- `service_name` (String) The name of the service that this resource belongs to. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
 - `username` (String) The actual name of the MySQL User. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
 
 ### Optional
@@ -59,5 +59,5 @@ Optional:
 Import is supported using the following syntax:
 
 ```shell
-terraform import aiven_mysql_user.foo project/service_name/username
+terraform import aiven_mysql_user.foo PROJECT/SERVICE_NAME/USERNAME
 ```

--- a/docs/resources/opensearch.md
+++ b/docs/resources/opensearch.md
@@ -43,7 +43,7 @@ resource "aiven_opensearch" "os1" {
 ### Required
 
 - `plan` (String) Defines what kind of computing resources are allocated for the service. It can be changed after creation, though there are some restrictions when going to a smaller plan such as the new plan must have sufficient amount of disk space to store all current data and switching to a plan with fewer nodes might not be supported. The basic plan names are `hobbyist`, `startup-x`, `business-x` and `premium-x` where `x` is (roughly) the amount of memory on each node (also other attributes like number of CPUs and amount of disk space varies but naming is based on memory). The available options can be seem from the [Aiven pricing page](https://aiven.io/pricing).
-- `project` (String) Identifies the project this resource belongs to. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
+- `project` (String) The name of the project this resource belongs to. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
 - `service_name` (String) Specifies the actual name of the service. The name cannot be changed later without destroying and re-creating the service so name should be picked based on intended service usage rather than current attributes.
 
 ### Optional

--- a/docs/resources/opensearch_acl_config.md
+++ b/docs/resources/opensearch_acl_config.md
@@ -45,8 +45,8 @@ resource "aiven_opensearch_acl_config" "foo" {
 
 ### Required
 
-- `project` (String) Identifies the project this resource belongs to. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
-- `service_name` (String) Specifies the name of the service that this resource belongs to. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
+- `project` (String) The name of the project this resource belongs to. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
+- `service_name` (String) The name of the service that this resource belongs to. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
 
 ### Optional
 
@@ -74,5 +74,5 @@ Optional:
 Import is supported using the following syntax:
 
 ```shell
-terraform import aiven_opensearch_acl_config.foo project/service_name
+TERRAFORM IMPORT AIVEN_OPENSEARCH_ACL_CONFIG.FOO project/service_name
 ```

--- a/docs/resources/opensearch_acl_rule.md
+++ b/docs/resources/opensearch_acl_rule.md
@@ -80,8 +80,8 @@ resource "aiven_opensearch_acl_rule" "os_acl_rule" {
 
 - `index` (String) The index pattern for this ACL entry. Maximum length: `249`. Changing this property forces recreation of the resource.
 - `permission` (String) The permissions for this ACL entry. The possible values are `deny`, `admin`, `read`, `readwrite` and `write`.
-- `project` (String) Identifies the project this resource belongs to. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
-- `service_name` (String) Specifies the name of the service that this resource belongs to. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
+- `project` (String) The name of the project this resource belongs to. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
+- `service_name` (String) The name of the service that this resource belongs to. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
 - `username` (String) The username for the ACL entry. Maximum length: `40`. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
 
 ### Optional
@@ -108,5 +108,5 @@ Optional:
 Import is supported using the following syntax:
 
 ```shell
-terraform import aiven_opensearch_acl_rule.os_acl_rule project/service_name/username/index
+terraform import aiven_opensearch_acl_rule.os_acl_rule PROJECT/SERVICE_NAME/USERNAME/INDEX
 ```

--- a/docs/resources/opensearch_security_plugin_config.md
+++ b/docs/resources/opensearch_security_plugin_config.md
@@ -45,8 +45,8 @@ resource "aiven_opensearch_security_plugin_config" "foo" {
 ### Required
 
 - `admin_password` (String, Sensitive) The password for the os-sec-admin user.
-- `project` (String) Identifies the project this resource belongs to. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
-- `service_name` (String) Specifies the name of the service that this resource belongs to. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
+- `project` (String) The name of the project this resource belongs to. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
+- `service_name` (String) The name of the service that this resource belongs to. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
 
 ### Optional
 
@@ -75,5 +75,5 @@ Optional:
 Import is supported using the following syntax:
 
 ```shell
-terraform import aiven_opensearch_security_plugin_config.foo project/service_name
+terraform import aiven_opensearch_security_plugin_config.foo PROJECT/SERVICE_NAME
 ```

--- a/docs/resources/opensearch_user.md
+++ b/docs/resources/opensearch_user.md
@@ -26,8 +26,8 @@ resource "aiven_opensearch_user" "foo" {
 
 ### Required
 
-- `project` (String) Identifies the project this resource belongs to. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
-- `service_name` (String) Specifies the name of the service that this resource belongs to. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
+- `project` (String) The name of the project this resource belongs to. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
+- `service_name` (String) The name of the service that this resource belongs to. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
 - `username` (String) The actual name of the OpenSearch User. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
 
 ### Optional
@@ -56,5 +56,5 @@ Optional:
 Import is supported using the following syntax:
 
 ```shell
-terraform import aiven_opensearch_user.foo project/service_name/username
+terraform import aiven_opensearch_user.foo PROJECT/SERVICE_NAME/USERNAME
 ```

--- a/docs/resources/organization_group_project.md
+++ b/docs/resources/organization_group_project.md
@@ -32,7 +32,7 @@ resource "aiven_organization_user_group_member" "project_admin" {
 
 resource "aiven_organization_group_project" "example" {
   group_id = aiven_organization_user_group.example.group_id
-  project = aiven_project.example_project.project
+  project = data.aiven_project.example_project.project
   role = "admin"
 }
 ```

--- a/docs/resources/organization_user.md
+++ b/docs/resources/organization_user.md
@@ -3,27 +3,27 @@
 page_title: "aiven_organization_user Resource - terraform-provider-aiven"
 subcategory: ""
 description: |-
-  **This resource is deprecated**. Use the `aiven_organization_user` data source instead.
+  **This resource is deprecated**. Users cannot be invited to an organization using Terraform.
+      Use the [Aiven Console](https://console.aiven.io/) to [invite users](https://aiven.io/docs/platform/howto/manage-org-users)
+      to your organization. 
   
+  After the user accepts the invite you can get their information using the aiven_organization_user
+  data source. You can manage user access to projects with the aiven_organization_user_group,
+  aiven_organization_user_group_member, and aiven_organization_group_project resources.
   The organization user resource allows the creation and management of an Aiven organization user.
-  During the creation of aiven_organization_userresource, an email invitation will be sent
-  to a user using user_email address. If the user accepts an invitation, they will become
-  a member of the organization. The deletion of aiven_organization_user will not only
-  delete the invitation if one was sent but not yet accepted by the user, it will also
-  eliminate the member from the organization if one has accepted an invitation previously.
 ---
 
 # aiven_organization_user (Resource)
 
-**This resource is deprecated**. Use the `aiven_organization_user` data source instead.
+**This resource is deprecated**. Users cannot be invited to an organization using Terraform.
+		Use the [Aiven Console](https://console.aiven.io/) to [invite users](https://aiven.io/docs/platform/howto/manage-org-users)
+		to your organization. 
+		
+After the user accepts the invite you can get their information using the `aiven_organization_user`
+data source. You can manage user access to projects with the `aiven_organization_user_group`, 
+`aiven_organization_user_group_member`, and `aiven_organization_group_project` resources.
 
 The organization user resource allows the creation and management of an Aiven organization user.
-
-During the creation of `aiven_organization_user`resource, an email invitation will be sent
-to a user using `user_email` address. If the user accepts an invitation, they will become
-a member of the organization. The deletion of `aiven_organization_user` will not only
-delete the invitation if one was sent but not yet accepted by the user, it will also 
-eliminate the member from the organization if one has accepted an invitation previously.
 
 
 

--- a/docs/resources/pg.md
+++ b/docs/resources/pg.md
@@ -56,7 +56,7 @@ resource "aiven_pg" "pg" {
 ### Required
 
 - `plan` (String) Defines what kind of computing resources are allocated for the service. It can be changed after creation, though there are some restrictions when going to a smaller plan such as the new plan must have sufficient amount of disk space to store all current data and switching to a plan with fewer nodes might not be supported. The basic plan names are `hobbyist`, `startup-x`, `business-x` and `premium-x` where `x` is (roughly) the amount of memory on each node (also other attributes like number of CPUs and amount of disk space varies but naming is based on memory). The available options can be seem from the [Aiven pricing page](https://aiven.io/pricing).
-- `project` (String) Identifies the project this resource belongs to. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
+- `project` (String) The name of the project this resource belongs to. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
 - `service_name` (String) Specifies the actual name of the service. The name cannot be changed later without destroying and re-creating the service so name should be picked based on intended service usage rather than current attributes.
 
 ### Optional
@@ -388,5 +388,5 @@ Read-Only:
 Import is supported using the following syntax:
 
 ```shell
-terraform import aiven_pg.pg project/service_name
+terraform import aiven_pg.pg PROJECT/SERVICE_NAME
 ```

--- a/docs/resources/pg_database.md
+++ b/docs/resources/pg_database.md
@@ -26,8 +26,8 @@ resource "aiven_pg_database" "mydatabase" {
 ### Required
 
 - `database_name` (String) The name of the service database. Changing this property forces recreation of the resource.
-- `project` (String) Identifies the project this resource belongs to. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
-- `service_name` (String) Specifies the name of the service that this resource belongs to. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
+- `project` (String) The name of the project this resource belongs to. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
+- `service_name` (String) The name of the service that this resource belongs to. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
 
 ### Optional
 
@@ -56,5 +56,5 @@ Optional:
 Import is supported using the following syntax:
 
 ```shell
-terraform import aiven_pg_database.mydatabase project/service_name/database_name
+terraform import aiven_pg_database.mydatabase PROJECT/SERVICE_NAME/DATABASE_NAME
 ```

--- a/docs/resources/pg_user.md
+++ b/docs/resources/pg_user.md
@@ -26,8 +26,8 @@ resource "aiven_pg_user" "foo" {
 
 ### Required
 
-- `project` (String) Identifies the project this resource belongs to. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
-- `service_name` (String) Specifies the name of the service that this resource belongs to. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
+- `project` (String) The name of the project this resource belongs to. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
+- `service_name` (String) The name of the service that this resource belongs to. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
 - `username` (String) The actual name of the PG User. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
 
 ### Optional
@@ -59,5 +59,5 @@ Optional:
 Import is supported using the following syntax:
 
 ```shell
-terraform import aiven_pg_user.user project/service_name/username
+terraform import aiven_pg_user.user PROJECT/SERVICE_NAME/USERNAME
 ```

--- a/docs/resources/project_user.md
+++ b/docs/resources/project_user.md
@@ -3,12 +3,12 @@
 page_title: "aiven_project_user Resource - terraform-provider-aiven"
 subcategory: ""
 description: |-
-  The Project User resource allows the creation and management of Aiven Project Users.
+  Creates and manages an Aiven project member.
 ---
 
 # aiven_project_user (Resource)
 
-The Project User resource allows the creation and management of Aiven Project Users.
+Creates and manages an Aiven project member.
 
 ## Example Usage
 
@@ -25,9 +25,9 @@ resource "aiven_project_user" "mytestuser" {
 
 ### Required
 
-- `email` (String) Email address of the user. Should be lowercase. Changing this property forces recreation of the resource.
+- `email` (String) Email address of the user in lowercase. Changing this property forces recreation of the resource.
 - `member_type` (String) Project membership type. The possible values are `admin`, `developer` and `operator`.
-- `project` (String) Identifies the project this resource belongs to. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
+- `project` (String) The name of the project this resource belongs to. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
 
 ### Optional
 
@@ -35,7 +35,7 @@ resource "aiven_project_user" "mytestuser" {
 
 ### Read-Only
 
-- `accepted` (Boolean) Whether the user has accepted the request to join the project; adding user to a project sends an invitation to the target user and the actual membership is only created once the user accepts the invitation.
+- `accepted` (Boolean) Whether the user has accepted the request to join the project. Users get an invite and become project members after accepting the invite.
 - `id` (String) The ID of this resource.
 
 <a id="nestedblock--timeouts"></a>
@@ -54,5 +54,5 @@ Optional:
 Import is supported using the following syntax:
 
 ```shell
-terraform import aiven_project_user.mytestuser project/email
+terraform import aiven_project_user.mytestuser PROJECT/EMAIL
 ```

--- a/docs/resources/project_vpc.md
+++ b/docs/resources/project_vpc.md
@@ -31,7 +31,7 @@ resource "aiven_project_vpc" "example_vpc" {
 
 - `cloud_name` (String) The cloud provider and region where the service is hosted in the format `CLOUD_PROVIDER-REGION_NAME`. For example, `google-europe-west1` or `aws-us-east-2`. Changing this property forces recreation of the resource.
 - `network_cidr` (String) Network address range used by the VPC. For example, `192.168.0.0/24`.
-- `project` (String) Identifies the project this resource belongs to. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
+- `project` (String) The name of the project this resource belongs to. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
 
 ### Optional
 

--- a/docs/resources/redis.md
+++ b/docs/resources/redis.md
@@ -37,7 +37,7 @@ resource "aiven_redis" "redis1" {
 ### Required
 
 - `plan` (String) Defines what kind of computing resources are allocated for the service. It can be changed after creation, though there are some restrictions when going to a smaller plan such as the new plan must have sufficient amount of disk space to store all current data and switching to a plan with fewer nodes might not be supported. The basic plan names are `hobbyist`, `startup-x`, `business-x` and `premium-x` where `x` is (roughly) the amount of memory on each node (also other attributes like number of CPUs and amount of disk space varies but naming is based on memory). The available options can be seem from the [Aiven pricing page](https://aiven.io/pricing).
-- `project` (String) Identifies the project this resource belongs to. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
+- `project` (String) The name of the project this resource belongs to. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
 - `service_name` (String) Specifies the actual name of the service. The name cannot be changed later without destroying and re-creating the service so name should be picked based on intended service usage rather than current attributes.
 
 ### Optional

--- a/docs/resources/redis_user.md
+++ b/docs/resources/redis_user.md
@@ -26,8 +26,8 @@ resource "aiven_redis_user" "foo" {
 
 ### Required
 
-- `project` (String) Identifies the project this resource belongs to. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
-- `service_name` (String) Specifies the name of the service that this resource belongs to. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
+- `project` (String) The name of the project this resource belongs to. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
+- `service_name` (String) The name of the service that this resource belongs to. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
 - `username` (String) The actual name of the Redis User. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
 
 ### Optional
@@ -60,5 +60,5 @@ Optional:
 Import is supported using the following syntax:
 
 ```shell
-terraform import aiven_redis_user.foo project/service_name/username
+terraform import aiven_redis_user.foo PROJECT/SERVICE_NAME/USERNAME
 ```

--- a/docs/resources/service_integration.md
+++ b/docs/resources/service_integration.md
@@ -375,5 +375,5 @@ Optional:
 ## Import
 Import is supported using the following syntax:
 ```shell
-terraform import aiven_service_integration.myintegration project/integration_id
+terraform import aiven_service_integration.myintegration PROJECT/INTEGRATION_ID
 ```

--- a/docs/resources/static_ip.md
+++ b/docs/resources/static_ip.md
@@ -18,7 +18,7 @@ The aiven_static_ip resource allows the creation and deletion of static ips. Ple
 ### Required
 
 - `cloud_name` (String) Specifies the cloud that the static ip belongs to. Changing this property forces recreation of the resource.
-- `project` (String) Identifies the project this resource belongs to. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
+- `project` (String) The name of the project this resource belongs to. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
 
 ### Optional
 

--- a/docs/resources/transit_gateway_vpc_attachment.md
+++ b/docs/resources/transit_gateway_vpc_attachment.md
@@ -62,5 +62,5 @@ Optional:
 Import is supported using the following syntax:
 
 ```shell
-terraform import aiven_transit_gateway_vpc_attachment.attachment project/vpc_id/peer_cloud_account/peer_vpc/peer_region
+terraform import aiven_transit_gateway_vpc_attachment.attachment PROJECT/VPC_ID/PEER_CLOUD_ACCOUNT/PEER_VPC/PEER_REGION
 ```

--- a/examples/resources/aiven_account_authentication/import.sh
+++ b/examples/resources/aiven_account_authentication/import.sh
@@ -1,1 +1,1 @@
-terraform import aiven_account_authentication.foo account_id/authentication_id
+terraform import aiven_account_authentication.foo ACCOUNT_ID/AUTHENTICATION_ID

--- a/examples/resources/aiven_account_team_member/import.sh
+++ b/examples/resources/aiven_account_team_member/import.sh
@@ -1,1 +1,1 @@
-terraform import aiven_account_team_member.foo account_id/team_id/user_email
+terraform import aiven_account_team_member.foo ACCOUNT_ID/TEAM_ID/USER_EMAIL

--- a/examples/resources/aiven_cassandra/import.sh
+++ b/examples/resources/aiven_cassandra/import.sh
@@ -1,1 +1,1 @@
-terraform import aiven_cassandra.bar project/service_name
+terraform import aiven_cassandra.bar PROJECT/SERVICE_NAME

--- a/examples/resources/aiven_cassandra_user/import.sh
+++ b/examples/resources/aiven_cassandra_user/import.sh
@@ -1,1 +1,1 @@
-terraform import aiven_cassandra_user.foo project/service_name/username
+terraform import aiven_cassandra_user.foo PROJECT/SERVICE_NAME/USERNAME

--- a/examples/resources/aiven_clickhouse/import.sh
+++ b/examples/resources/aiven_clickhouse/import.sh
@@ -1,1 +1,1 @@
-terraform import aiven_clickhouse.clickhouse project/service_name
+terraform import aiven_clickhouse.clickhouse PROJECT/SERVICE_NAME

--- a/examples/resources/aiven_clickhouse_database/import.sh
+++ b/examples/resources/aiven_clickhouse_database/import.sh
@@ -1,1 +1,1 @@
-terraform import aiven_clickhouse_database.clickhouse_db project/service_name/name
+terraform import aiven_clickhouse_database.clickhouse_db PROJECT/SERVICE_NAME/NAME

--- a/examples/resources/aiven_clickhouse_role/import.sh
+++ b/examples/resources/aiven_clickhouse_role/import.sh
@@ -1,1 +1,1 @@
-terraform import aiven_clickhouse_role.foo project/service_name/role
+terraform import aiven_clickhouse_role.foo PROJECT/SERVICE_NAME/ROLE

--- a/examples/resources/aiven_connection_pool/import.sh
+++ b/examples/resources/aiven_connection_pool/import.sh
@@ -1,1 +1,1 @@
-terraform import aiven_connection_pool.mytestpool project/service_name/pool_name
+terraform import aiven_connection_pool.mytestpool PROJECT/SERVICE_NAME/POOL_NAME

--- a/examples/resources/aiven_flink/import.sh
+++ b/examples/resources/aiven_flink/import.sh
@@ -1,1 +1,1 @@
-terraform import aiven_flink.flink project/service_name
+terraform import aiven_flink.flink PROJECT/SERVICE_NAME

--- a/examples/resources/aiven_flink_application/import.sh
+++ b/examples/resources/aiven_flink_application/import.sh
@@ -1,1 +1,1 @@
-terraform import aiven_flink_application.myapp project/service/application_name
+terraform import aiven_flink_application.myapp PROJECT/SERVICE/APPLICATION_NAME

--- a/examples/resources/aiven_flink_application_deployment/import.sh
+++ b/examples/resources/aiven_flink_application_deployment/import.sh
@@ -1,1 +1,1 @@
-terraform import aiven_flink_application_deployment.foo_deploy project/service/application_id/application_version_id/deployment_id
+terraform import aiven_flink_application_deployment.foo_deploy PROJECT/SERVICE/APPLICATION_ID/APPLICATION_VERSION_ID/DEPLOYMENT_ID

--- a/examples/resources/aiven_gcp_vpc_peering_connection/import.sh
+++ b/examples/resources/aiven_gcp_vpc_peering_connection/import.sh
@@ -1,1 +1,1 @@
-terraform import aiven_gcp_vpc_peering_connection.foo project_name/vpc_id/gcp_project_id/peer_vpc
+terraform import aiven_gcp_vpc_peering_connection.foo PROJECT_NAME/VPC_ID/GCP_PROJECT_ID/PEER_VPC

--- a/examples/resources/aiven_influxdb_user/import.sh
+++ b/examples/resources/aiven_influxdb_user/import.sh
@@ -1,1 +1,1 @@
-terraform import aiven_influxdb_user.foo project/service_name/username
+terraform import aiven_influxdb_user.foo PROJECT/SERVICE_NAME/USERNAME

--- a/examples/resources/aiven_kafka_acl/import.sh
+++ b/examples/resources/aiven_kafka_acl/import.sh
@@ -1,1 +1,1 @@
-terraform import aiven_kafka_acl.mytestacl project/service_name/id
+terraform import aiven_kafka_acl.mytestacl PROJECT/SERVICE_NAME/ID

--- a/examples/resources/aiven_kafka_schema_configuration/import.sh
+++ b/examples/resources/aiven_kafka_schema_configuration/import.sh
@@ -1,1 +1,1 @@
-terraform import aiven_kafka_schema_configuration.config project/service_name
+terraform import aiven_kafka_schema_configuration.config PROJECT/SERVICE_NAME

--- a/examples/resources/aiven_kafka_topic/import.sh
+++ b/examples/resources/aiven_kafka_topic/import.sh
@@ -1,1 +1,1 @@
-terraform import aiven_kafka_topic.mytesttopic project/service_name/topic_name
+terraform import aiven_kafka_topic.mytesttopic PROJECT/SERVICE_NAME/TOPIC_NAME

--- a/examples/resources/aiven_kafka_user/import.sh
+++ b/examples/resources/aiven_kafka_user/import.sh
@@ -1,1 +1,1 @@
-terraform import aiven_kafka_user.foo project/service_name/username
+terraform import aiven_kafka_user.foo PROJECT/SERVICE_NAME/USERNAME

--- a/examples/resources/aiven_mysql_database/import.sh
+++ b/examples/resources/aiven_mysql_database/import.sh
@@ -1,1 +1,1 @@
-terraform import aiven_mysql_database.mydatabase project/service_name/database_name
+terraform import aiven_mysql_database.mydatabase PROJECT/SERVICE_NAME/DATABASE_NAME

--- a/examples/resources/aiven_mysql_user/import.sh
+++ b/examples/resources/aiven_mysql_user/import.sh
@@ -1,1 +1,1 @@
-terraform import aiven_mysql_user.foo project/service_name/username
+terraform import aiven_mysql_user.foo PROJECT/SERVICE_NAME/USERNAME

--- a/examples/resources/aiven_opensearch_acl_config/import.sh
+++ b/examples/resources/aiven_opensearch_acl_config/import.sh
@@ -1,1 +1,1 @@
-terraform import aiven_opensearch_acl_config.foo project/service_name
+TERRAFORM IMPORT AIVEN_OPENSEARCH_ACL_CONFIG.FOO project/service_name

--- a/examples/resources/aiven_opensearch_acl_rule/import.sh
+++ b/examples/resources/aiven_opensearch_acl_rule/import.sh
@@ -1,1 +1,1 @@
-terraform import aiven_opensearch_acl_rule.os_acl_rule project/service_name/username/index
+terraform import aiven_opensearch_acl_rule.os_acl_rule PROJECT/SERVICE_NAME/USERNAME/INDEX

--- a/examples/resources/aiven_opensearch_security_plugin_config/import.sh
+++ b/examples/resources/aiven_opensearch_security_plugin_config/import.sh
@@ -1,1 +1,1 @@
-terraform import aiven_opensearch_security_plugin_config.foo project/service_name
+terraform import aiven_opensearch_security_plugin_config.foo PROJECT/SERVICE_NAME

--- a/examples/resources/aiven_opensearch_user/import.sh
+++ b/examples/resources/aiven_opensearch_user/import.sh
@@ -1,1 +1,1 @@
-terraform import aiven_opensearch_user.foo project/service_name/username
+terraform import aiven_opensearch_user.foo PROJECT/SERVICE_NAME/USERNAME

--- a/examples/resources/aiven_organization_group_project/resource.tf
+++ b/examples/resources/aiven_organization_group_project/resource.tf
@@ -17,6 +17,6 @@ resource "aiven_organization_user_group_member" "project_admin" {
 
 resource "aiven_organization_group_project" "example" {
   group_id = aiven_organization_user_group.example.group_id
-  project = aiven_project.example_project.project
+  project = data.aiven_project.example_project.project
   role = "admin"
 }

--- a/examples/resources/aiven_pg/import.sh
+++ b/examples/resources/aiven_pg/import.sh
@@ -1,1 +1,1 @@
-terraform import aiven_pg.pg project/service_name
+terraform import aiven_pg.pg PROJECT/SERVICE_NAME

--- a/examples/resources/aiven_pg_database/import.sh
+++ b/examples/resources/aiven_pg_database/import.sh
@@ -1,1 +1,1 @@
-terraform import aiven_pg_database.mydatabase project/service_name/database_name
+terraform import aiven_pg_database.mydatabase PROJECT/SERVICE_NAME/DATABASE_NAME

--- a/examples/resources/aiven_pg_user/import.sh
+++ b/examples/resources/aiven_pg_user/import.sh
@@ -1,1 +1,1 @@
-terraform import aiven_pg_user.user project/service_name/username
+terraform import aiven_pg_user.user PROJECT/SERVICE_NAME/USERNAME

--- a/examples/resources/aiven_project_user/import.sh
+++ b/examples/resources/aiven_project_user/import.sh
@@ -1,1 +1,1 @@
-terraform import aiven_project_user.mytestuser project/email
+terraform import aiven_project_user.mytestuser PROJECT/EMAIL

--- a/examples/resources/aiven_redis_user/import.sh
+++ b/examples/resources/aiven_redis_user/import.sh
@@ -1,1 +1,1 @@
-terraform import aiven_redis_user.foo project/service_name/username
+terraform import aiven_redis_user.foo PROJECT/SERVICE_NAME/USERNAME

--- a/examples/resources/aiven_service_integration/import.sh
+++ b/examples/resources/aiven_service_integration/import.sh
@@ -1,1 +1,1 @@
-terraform import aiven_service_integration.myintegration project/integration_id
+terraform import aiven_service_integration.myintegration PROJECT/INTEGRATION_ID

--- a/examples/resources/aiven_transit_gateway_vpc_attachment/import.sh
+++ b/examples/resources/aiven_transit_gateway_vpc_attachment/import.sh
@@ -1,1 +1,1 @@
-terraform import aiven_transit_gateway_vpc_attachment.attachment project/vpc_id/peer_cloud_account/peer_vpc/peer_region
+terraform import aiven_transit_gateway_vpc_attachment.attachment PROJECT/VPC_ID/PEER_CLOUD_ACCOUNT/PEER_VPC/PEER_REGION

--- a/internal/schemautil/common.go
+++ b/internal/schemautil/common.go
@@ -14,7 +14,7 @@ import (
 func GetACLUserValidateFunc() schema.SchemaValidateFunc { //nolint:staticcheck
 	return validation.StringMatch(
 		regexp.MustCompile(`^[-._*?A-Za-z0-9]+$`),
-		"Must consist of alpha-numeric characters, underscores, dashes, dots and glob characters '*' and '?'")
+		"Must consist of alpha-numeric characters, underscores, dashes, dots, and glob characters '*' and '?'")
 }
 
 //goland:noinspection GoDeprecation
@@ -30,7 +30,7 @@ var (
 		Required:     true,
 		ForceNew:     true,
 		ValidateFunc: validation.StringMatch(regexp.MustCompile("^[a-zA-Z0-9_-]*$"), "project name should be alphanumeric"),
-		Description:  userconfig.Desc("Identifies the project this resource belongs to.").ForceNew().Referenced().Build(),
+		Description:  userconfig.Desc("The name of the project this resource belongs to.").ForceNew().Referenced().Build(),
 	}
 
 	CommonSchemaServiceNameReference = &schema.Schema{
@@ -38,7 +38,7 @@ var (
 		Required:     true,
 		ForceNew:     true,
 		ValidateFunc: validation.StringMatch(regexp.MustCompile("^[a-zA-Z0-9_-]*$"), "common name should be alphanumeric"),
-		Description:  userconfig.Desc("Specifies the name of the service that this resource belongs to.").ForceNew().Referenced().Build(),
+		Description:  userconfig.Desc("The name of the service that this resource belongs to.").ForceNew().Referenced().Build(),
 	}
 )
 

--- a/internal/sdkprovider/service/organization/organization_user.go
+++ b/internal/sdkprovider/service/organization/organization_user.go
@@ -57,15 +57,15 @@ var aivenOrganizationUserSchema = map[string]*schema.Schema{
 func ResourceOrganizationUser() *schema.Resource {
 	return &schema.Resource{
 		Description: `
-		**This resource is deprecated**. Use the ` + "`aiven_organization_user`" + ` data source instead.
+		**This resource is deprecated**. Users cannot be invited to an organization using Terraform.
+		Use the [Aiven Console](https://console.aiven.io/) to [invite users](https://aiven.io/docs/platform/howto/manage-org-users)
+		to your organization. 
+		
+After the user accepts the invite you can get their information using the ` + "`aiven_organization_user`" + `
+data source. You can manage user access to projects with the ` + "`aiven_organization_user_group`" + `, 
+` + "`aiven_organization_user_group_member`" + `, and ` + "`aiven_organization_group_project`" + ` resources.
 
 The organization user resource allows the creation and management of an Aiven organization user.
-
-During the creation of ` + "`aiven_organization_user`" + `resource, an email invitation will be sent
-to a user using ` + "`user_email`" + ` address. If the user accepts an invitation, they will become
-a member of the organization. The deletion of ` + "`aiven_organization_user`" + ` will not only
-delete the invitation if one was sent but not yet accepted by the user, it will also 
-eliminate the member from the organization if one has accepted an invitation previously.
 `,
 		CreateContext: resourceOrganizationUserCreate,
 		ReadContext:   resourceOrganizationUserRead,
@@ -76,12 +76,11 @@ eliminate the member from the organization if one has accepted an invitation pre
 		Timeouts: schemautil.DefaultResourceTimeouts(),
 		Schema:   aivenOrganizationUserSchema,
 		DeprecationMessage: `
-This resource is deprecated; please use aiven_organization_user data source instead. 
-Invitation of organization users is not supported anymore via Terraform. Therefore 
-creation of this resource is not supported anymore. We recommend using WebUI to create
-and organization user invitations. Upon receiving an invitation, a user can accept it 
-using WebUI. Once accepted, the user will become a member of the organization and will 
-be able to access it via Terraform.
+This resource is deprecated. Users cannot be invited to an organization using Terraform.
+Use the Aiven Console to invite users to your organization. After the user accepts the invite
+you can get their information using the aiven_organization_user data source. You can manage
+user access to projects with the aiven_organization_user_group, aiven_organization_user_group_member,
+and aiven_organization_group_project resources.
 		`,
 	}
 }

--- a/internal/sdkprovider/service/project/project_user.go
+++ b/internal/sdkprovider/service/project/project_user.go
@@ -20,7 +20,7 @@ var aivenProjectUserSchema = map[string]*schema.Schema{
 		ForceNew:     true,
 		Required:     true,
 		Type:         schema.TypeString,
-		Description:  userconfig.Desc("Email address of the user. Should be lowercase.").ForceNew().Build(),
+		Description:  userconfig.Desc("Email address of the user in lowercase.").ForceNew().Build(),
 		ValidateFunc: schemautil.ValidateEmailAddress,
 	},
 	"member_type": {
@@ -31,13 +31,13 @@ var aivenProjectUserSchema = map[string]*schema.Schema{
 	"accepted": {
 		Computed:    true,
 		Type:        schema.TypeBool,
-		Description: "Whether the user has accepted the request to join the project; adding user to a project sends an invitation to the target user and the actual membership is only created once the user accepts the invitation.",
+		Description: "Whether the user has accepted the request to join the project. Users get an invite and become project members after accepting the invite.",
 	},
 }
 
 func ResourceProjectUser() *schema.Resource {
 	return &schema.Resource{
-		Description:   "The Project User resource allows the creation and management of Aiven Project Users.",
+		Description:   "Creates and manages an Aiven project member.",
 		CreateContext: resourceProjectUserCreate,
 		ReadContext:   resourceProjectUserRead,
 		UpdateContext: resourceProjectUserUpdate,
@@ -48,7 +48,7 @@ func ResourceProjectUser() *schema.Resource {
 		Timeouts: schemautil.DefaultResourceTimeouts(),
 
 		Schema:             aivenProjectUserSchema,
-		DeprecationMessage: "This resource is deprecated",
+		DeprecationMessage: "This resource is deprecated.",
 	}
 }
 


### PR DESCRIPTION
## About this change—what it does

Primarily adds some additional information to the `aiven_organization_user` deprecation notice in the docs with guidance on alternatives. Minor updates to `aiven_project_user` for now with a more detailed deprecation notice to follow when we have more information.

There are also changes to common fields and a quick fix to format all the import commands, hence the large number of changed files.
