### PR TITLE
ci(release-artifacts): incorrect reference in ldflags

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -5,7 +5,7 @@ builds:
     flags:
       - -trimpath
     ldflags:
-      - '-s -w -X github.com/aiven/terraform-provider-aiven/main.version={{.Version}}'
+      - '-s -w -X main.version={{.Version}}'
     goos:
       - freebsd
       - windows


### PR DESCRIPTION
<!-- All contributors, please complete these sections, including maintainers. -->

## About this change—what it does

<!-- Provide a small sentence that summarizes the change. -->
fixes incorrect reference to `version` variable of the `main` package in `ldflags` of `.goreleaser.yml` config file

<!-- Provide the issue number below, if it exists. -->

## Why this way

<!-- Provide a small explanation on why this is the approach you took for solving this problem. -->
to have proper version in the `User-Agent`
