### PR TITLE
chore: remove redundant service connection info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ nav_order: 1
 - Fix sending `false` values in `aiven_kafka_topic` config
 - Validate `aiven_kafka_topic` topic name conflict on `terraform plan`
 - Mark service connection info blocks as `sensitive`. See SDK [bug](https://github.com/hashicorp/terraform-plugin-sdk/issues/201).
+- Remove redundant service connection info fields 
 
 ## [4.15.0] - 2024-03-21
 

--- a/docs/data-sources/cassandra.md
+++ b/docs/data-sources/cassandra.md
@@ -30,7 +30,6 @@ data "aiven_cassandra" "bar" {
 ### Read-Only
 
 - `additional_disk_space` (String) Additional disk space. Possible values depend on the service type, the cloud provider and the project. Therefore, reducing will result in the service rebalancing.
-- `cassandra` (List of Object) Cassandra server provided values (see [below for nested schema](#nestedatt--cassandra))
 - `cassandra_user_config` (List of Object) Cassandra user configurable settings (see [below for nested schema](#nestedatt--cassandra_user_config))
 - `cloud_name` (String) Defines where the cloud provider and region where the service is hosted in. This can be changed freely after service is created. Changing the value will trigger a potentially lengthy migration process for the service. Format is cloud provider name (`aws`, `azure`, `do` `google`, `upcloud`, etc.), dash, and the cloud provider specific region name. These are documented on each Cloud provider's own support articles, like [here for Google](https://cloud.google.com/compute/docs/regions-zones/) and [here for AWS](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Concepts.RegionsAndAvailabilityZones.html).
 - `components` (List of Object) Service component information objects (see [below for nested schema](#nestedatt--components))
@@ -56,13 +55,6 @@ data "aiven_cassandra" "bar" {
 - `tag` (Set of Object) Tags are key-value pairs that allow you to categorize services. (see [below for nested schema](#nestedatt--tag))
 - `tech_emails` (Set of Object) The email addresses for [service contacts](https://aiven.io/docs/platform/howto/technical-emails), who will receive important alerts and updates about this service. You can also set email contacts at the project level. (see [below for nested schema](#nestedatt--tech_emails))
 - `termination_protection` (Boolean) Prevents the service from being deleted. It is recommended to set this to `true` for all production services to prevent unintentional service deletion. This does not shield against deleting databases or topics but for services with backups much of the content can at least be restored from backup in case accidental deletion is done.
-
-<a id="nestedatt--cassandra"></a>
-### Nested Schema for `cassandra`
-
-Read-Only:
-
-
 
 <a id="nestedatt--cassandra_user_config"></a>
 ### Nested Schema for `cassandra_user_config`

--- a/docs/data-sources/clickhouse.md
+++ b/docs/data-sources/clickhouse.md
@@ -30,7 +30,6 @@ data "aiven_clickhouse" "clickhouse" {
 ### Read-Only
 
 - `additional_disk_space` (String) Additional disk space. Possible values depend on the service type, the cloud provider and the project. Therefore, reducing will result in the service rebalancing.
-- `clickhouse` (List of Object, Sensitive) Clickhouse server provided values (see [below for nested schema](#nestedatt--clickhouse))
 - `clickhouse_user_config` (List of Object) Clickhouse user configurable settings (see [below for nested schema](#nestedatt--clickhouse_user_config))
 - `cloud_name` (String) Defines where the cloud provider and region where the service is hosted in. This can be changed freely after service is created. Changing the value will trigger a potentially lengthy migration process for the service. Format is cloud provider name (`aws`, `azure`, `do` `google`, `upcloud`, etc.), dash, and the cloud provider specific region name. These are documented on each Cloud provider's own support articles, like [here for Google](https://cloud.google.com/compute/docs/regions-zones/) and [here for AWS](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Concepts.RegionsAndAvailabilityZones.html).
 - `components` (List of Object) Service component information objects (see [below for nested schema](#nestedatt--components))
@@ -56,13 +55,6 @@ data "aiven_clickhouse" "clickhouse" {
 - `tag` (Set of Object) Tags are key-value pairs that allow you to categorize services. (see [below for nested schema](#nestedatt--tag))
 - `tech_emails` (Set of Object) The email addresses for [service contacts](https://aiven.io/docs/platform/howto/technical-emails), who will receive important alerts and updates about this service. You can also set email contacts at the project level. (see [below for nested schema](#nestedatt--tech_emails))
 - `termination_protection` (Boolean) Prevents the service from being deleted. It is recommended to set this to `true` for all production services to prevent unintentional service deletion. This does not shield against deleting databases or topics but for services with backups much of the content can at least be restored from backup in case accidental deletion is done.
-
-<a id="nestedatt--clickhouse"></a>
-### Nested Schema for `clickhouse`
-
-Read-Only:
-
-
 
 <a id="nestedatt--clickhouse_user_config"></a>
 ### Nested Schema for `clickhouse_user_config`

--- a/docs/data-sources/dragonfly.md
+++ b/docs/data-sources/dragonfly.md
@@ -37,7 +37,6 @@ data "aiven_dragonfly" "example_dragonfly" {
 - `disk_space_default` (String) The default disk space of the service, possible values depend on the service type, the cloud provider and the project. Its also the minimum value for `disk_space`
 - `disk_space_step` (String) The default disk space step of the service, possible values depend on the service type, the cloud provider and the project. `disk_space` needs to increment from `disk_space_default` by increments of this size.
 - `disk_space_used` (String) Disk space that service is currently using
-- `dragonfly` (List of Object, Sensitive) Dragonfly server provided values (see [below for nested schema](#nestedatt--dragonfly))
 - `dragonfly_user_config` (List of Object) Dragonfly user configurable settings (see [below for nested schema](#nestedatt--dragonfly_user_config))
 - `id` (String) The ID of this resource.
 - `maintenance_window_dow` (String) Day of week when maintenance operations should be performed. One monday, tuesday, wednesday, etc.
@@ -70,13 +69,6 @@ Read-Only:
 - `route` (String)
 - `ssl` (Boolean)
 - `usage` (String)
-
-
-<a id="nestedatt--dragonfly"></a>
-### Nested Schema for `dragonfly`
-
-Read-Only:
-
 
 
 <a id="nestedatt--dragonfly_user_config"></a>

--- a/docs/data-sources/grafana.md
+++ b/docs/data-sources/grafana.md
@@ -37,7 +37,6 @@ data "aiven_grafana" "gr1" {
 - `disk_space_default` (String) The default disk space of the service, possible values depend on the service type, the cloud provider and the project. Its also the minimum value for `disk_space`
 - `disk_space_step` (String) The default disk space step of the service, possible values depend on the service type, the cloud provider and the project. `disk_space` needs to increment from `disk_space_default` by increments of this size.
 - `disk_space_used` (String) Disk space that service is currently using
-- `grafana` (List of Object) Grafana server provided values (see [below for nested schema](#nestedatt--grafana))
 - `grafana_user_config` (List of Object) Grafana user configurable settings (see [below for nested schema](#nestedatt--grafana_user_config))
 - `id` (String) The ID of this resource.
 - `maintenance_window_dow` (String) Day of week when maintenance operations should be performed. One monday, tuesday, wednesday, etc.
@@ -70,13 +69,6 @@ Read-Only:
 - `route` (String)
 - `ssl` (Boolean)
 - `usage` (String)
-
-
-<a id="nestedatt--grafana"></a>
-### Nested Schema for `grafana`
-
-Read-Only:
-
 
 
 <a id="nestedatt--grafana_user_config"></a>

--- a/docs/data-sources/kafka_connect.md
+++ b/docs/data-sources/kafka_connect.md
@@ -38,7 +38,6 @@ data "aiven_kafka_connect" "kc1" {
 - `disk_space_step` (String) The default disk space step of the service, possible values depend on the service type, the cloud provider and the project. `disk_space` needs to increment from `disk_space_default` by increments of this size.
 - `disk_space_used` (String) Disk space that service is currently using
 - `id` (String) The ID of this resource.
-- `kafka_connect` (List of Object) Kafka Connect server provided values (see [below for nested schema](#nestedatt--kafka_connect))
 - `kafka_connect_user_config` (List of Object) KafkaConnect user configurable settings (see [below for nested schema](#nestedatt--kafka_connect_user_config))
 - `maintenance_window_dow` (String) Day of week when maintenance operations should be performed. One monday, tuesday, wednesday, etc.
 - `maintenance_window_time` (String) Time of day when maintenance operations should be performed. UTC time in HH:mm:ss format.
@@ -70,13 +69,6 @@ Read-Only:
 - `route` (String)
 - `ssl` (Boolean)
 - `usage` (String)
-
-
-<a id="nestedatt--kafka_connect"></a>
-### Nested Schema for `kafka_connect`
-
-Read-Only:
-
 
 
 <a id="nestedatt--kafka_connect_user_config"></a>

--- a/docs/data-sources/kafka_mirrormaker.md
+++ b/docs/data-sources/kafka_mirrormaker.md
@@ -38,7 +38,6 @@ data "aiven_kafka_mirrormaker" "mm1" {
 - `disk_space_step` (String) The default disk space step of the service, possible values depend on the service type, the cloud provider and the project. `disk_space` needs to increment from `disk_space_default` by increments of this size.
 - `disk_space_used` (String) Disk space that service is currently using
 - `id` (String) The ID of this resource.
-- `kafka_mirrormaker` (List of Object) Kafka MirrorMaker 2 server provided values (see [below for nested schema](#nestedatt--kafka_mirrormaker))
 - `kafka_mirrormaker_user_config` (List of Object) KafkaMirrormaker user configurable settings (see [below for nested schema](#nestedatt--kafka_mirrormaker_user_config))
 - `maintenance_window_dow` (String) Day of week when maintenance operations should be performed. One monday, tuesday, wednesday, etc.
 - `maintenance_window_time` (String) Time of day when maintenance operations should be performed. UTC time in HH:mm:ss format.
@@ -70,13 +69,6 @@ Read-Only:
 - `route` (String)
 - `ssl` (Boolean)
 - `usage` (String)
-
-
-<a id="nestedatt--kafka_mirrormaker"></a>
-### Nested Schema for `kafka_mirrormaker`
-
-Read-Only:
-
 
 
 <a id="nestedatt--kafka_mirrormaker_user_config"></a>

--- a/docs/data-sources/m3aggregator.md
+++ b/docs/data-sources/m3aggregator.md
@@ -38,7 +38,6 @@ data "aiven_m3aggregator" "m3a" {
 - `disk_space_step` (String) The default disk space step of the service, possible values depend on the service type, the cloud provider and the project. `disk_space` needs to increment from `disk_space_default` by increments of this size.
 - `disk_space_used` (String) Disk space that service is currently using
 - `id` (String) The ID of this resource.
-- `m3aggregator` (List of Object) M3 aggregator specific server provided values (see [below for nested schema](#nestedatt--m3aggregator))
 - `m3aggregator_user_config` (List of Object) M3aggregator user configurable settings (see [below for nested schema](#nestedatt--m3aggregator_user_config))
 - `maintenance_window_dow` (String) Day of week when maintenance operations should be performed. One monday, tuesday, wednesday, etc.
 - `maintenance_window_time` (String) Time of day when maintenance operations should be performed. UTC time in HH:mm:ss format.
@@ -70,13 +69,6 @@ Read-Only:
 - `route` (String)
 - `ssl` (Boolean)
 - `usage` (String)
-
-
-<a id="nestedatt--m3aggregator"></a>
-### Nested Schema for `m3aggregator`
-
-Read-Only:
-
 
 
 <a id="nestedatt--m3aggregator_user_config"></a>

--- a/docs/data-sources/m3db.md
+++ b/docs/data-sources/m3db.md
@@ -38,7 +38,6 @@ data "aiven_m3db" "m3" {
 - `disk_space_step` (String) The default disk space step of the service, possible values depend on the service type, the cloud provider and the project. `disk_space` needs to increment from `disk_space_default` by increments of this size.
 - `disk_space_used` (String) Disk space that service is currently using
 - `id` (String) The ID of this resource.
-- `m3db` (List of Object) M3 specific server provided values (see [below for nested schema](#nestedatt--m3db))
 - `m3db_user_config` (List of Object) M3db user configurable settings (see [below for nested schema](#nestedatt--m3db_user_config))
 - `maintenance_window_dow` (String) Day of week when maintenance operations should be performed. One monday, tuesday, wednesday, etc.
 - `maintenance_window_time` (String) Time of day when maintenance operations should be performed. UTC time in HH:mm:ss format.
@@ -70,13 +69,6 @@ Read-Only:
 - `route` (String)
 - `ssl` (Boolean)
 - `usage` (String)
-
-
-<a id="nestedatt--m3db"></a>
-### Nested Schema for `m3db`
-
-Read-Only:
-
 
 
 <a id="nestedatt--m3db_user_config"></a>

--- a/docs/data-sources/mysql.md
+++ b/docs/data-sources/mysql.md
@@ -40,7 +40,6 @@ data "aiven_mysql" "mysql1" {
 - `id` (String) The ID of this resource.
 - `maintenance_window_dow` (String) Day of week when maintenance operations should be performed. One monday, tuesday, wednesday, etc.
 - `maintenance_window_time` (String) Time of day when maintenance operations should be performed. UTC time in HH:mm:ss format.
-- `mysql` (List of Object) MySQL specific server provided values (see [below for nested schema](#nestedatt--mysql))
 - `mysql_user_config` (List of Object) Mysql user configurable settings (see [below for nested schema](#nestedatt--mysql_user_config))
 - `plan` (String) Defines what kind of computing resources are allocated for the service. It can be changed after creation, though there are some restrictions when going to a smaller plan such as the new plan must have sufficient amount of disk space to store all current data and switching to a plan with fewer nodes might not be supported. The basic plan names are `hobbyist`, `startup-x`, `business-x` and `premium-x` where `x` is (roughly) the amount of memory on each node (also other attributes like number of CPUs and amount of disk space varies but naming is based on memory). The available options can be seem from the [Aiven pricing page](https://aiven.io/pricing).
 - `project_vpc_id` (String) Specifies the VPC the service should run in. If the value is not set the service is not run inside a VPC. When set, the value should be given as a reference to set up dependencies correctly and the VPC must be in the same cloud and region as the service itself. Project can be freely moved to and from VPC after creation but doing so triggers migration to new servers so the operation can take significant amount of time to complete if the service has a lot of data.
@@ -70,13 +69,6 @@ Read-Only:
 - `route` (String)
 - `ssl` (Boolean)
 - `usage` (String)
-
-
-<a id="nestedatt--mysql"></a>
-### Nested Schema for `mysql`
-
-Read-Only:
-
 
 
 <a id="nestedatt--mysql_user_config"></a>

--- a/docs/data-sources/redis.md
+++ b/docs/data-sources/redis.md
@@ -42,7 +42,6 @@ data "aiven_redis" "redis1" {
 - `maintenance_window_time` (String) Time of day when maintenance operations should be performed. UTC time in HH:mm:ss format.
 - `plan` (String) Defines what kind of computing resources are allocated for the service. It can be changed after creation, though there are some restrictions when going to a smaller plan such as the new plan must have sufficient amount of disk space to store all current data and switching to a plan with fewer nodes might not be supported. The basic plan names are `hobbyist`, `startup-x`, `business-x` and `premium-x` where `x` is (roughly) the amount of memory on each node (also other attributes like number of CPUs and amount of disk space varies but naming is based on memory). The available options can be seem from the [Aiven pricing page](https://aiven.io/pricing).
 - `project_vpc_id` (String) Specifies the VPC the service should run in. If the value is not set the service is not run inside a VPC. When set, the value should be given as a reference to set up dependencies correctly and the VPC must be in the same cloud and region as the service itself. Project can be freely moved to and from VPC after creation but doing so triggers migration to new servers so the operation can take significant amount of time to complete if the service has a lot of data.
-- `redis` (List of Object) Redis server provided values (see [below for nested schema](#nestedatt--redis))
 - `redis_user_config` (List of Object) Redis user configurable settings (see [below for nested schema](#nestedatt--redis_user_config))
 - `service_host` (String) The hostname of the service.
 - `service_integrations` (List of Object) Service integrations to specify when creating a service. Not applied after initial service creation (see [below for nested schema](#nestedatt--service_integrations))
@@ -70,13 +69,6 @@ Read-Only:
 - `route` (String)
 - `ssl` (Boolean)
 - `usage` (String)
-
-
-<a id="nestedatt--redis"></a>
-### Nested Schema for `redis`
-
-Read-Only:
-
 
 
 <a id="nestedatt--redis_user_config"></a>

--- a/docs/resources/cassandra.md
+++ b/docs/resources/cassandra.md
@@ -58,7 +58,6 @@ resource "aiven_cassandra" "bar" {
 
 ### Read-Only
 
-- `cassandra` (List of Object) Cassandra server provided values (see [below for nested schema](#nestedatt--cassandra))
 - `components` (List of Object) Service component information objects (see [below for nested schema](#nestedatt--components))
 - `disk_space_cap` (String) The maximum disk space of the service, possible values depend on the service type, the cloud provider and the project.
 - `disk_space_default` (String) The default disk space of the service, possible values depend on the service type, the cloud provider and the project. Its also the minimum value for `disk_space`
@@ -170,13 +169,6 @@ Optional:
 - `delete` (String)
 - `read` (String)
 - `update` (String)
-
-
-<a id="nestedatt--cassandra"></a>
-### Nested Schema for `cassandra`
-
-Read-Only:
-
 
 
 <a id="nestedatt--components"></a>

--- a/docs/resources/clickhouse.md
+++ b/docs/resources/clickhouse.md
@@ -50,7 +50,6 @@ resource "aiven_clickhouse" "clickhouse" {
 
 ### Read-Only
 
-- `clickhouse` (List of Object, Sensitive) Clickhouse server provided values (see [below for nested schema](#nestedatt--clickhouse))
 - `components` (List of Object) Service component information objects (see [below for nested schema](#nestedatt--components))
 - `disk_space_cap` (String) The maximum disk space of the service, possible values depend on the service type, the cloud provider and the project.
 - `disk_space_default` (String) The default disk space of the service, possible values depend on the service type, the cloud provider and the project. Its also the minimum value for `disk_space`
@@ -164,13 +163,6 @@ Optional:
 - `delete` (String)
 - `read` (String)
 - `update` (String)
-
-
-<a id="nestedatt--clickhouse"></a>
-### Nested Schema for `clickhouse`
-
-Read-Only:
-
 
 
 <a id="nestedatt--components"></a>

--- a/docs/resources/dragonfly.md
+++ b/docs/resources/dragonfly.md
@@ -57,7 +57,6 @@ resource "aiven_dragonfly" "example_dragonfly" {
 - `disk_space_default` (String) The default disk space of the service, possible values depend on the service type, the cloud provider and the project. Its also the minimum value for `disk_space`
 - `disk_space_step` (String) The default disk space step of the service, possible values depend on the service type, the cloud provider and the project. `disk_space` needs to increment from `disk_space_default` by increments of this size.
 - `disk_space_used` (String) Disk space that service is currently using
-- `dragonfly` (List of Object, Sensitive) Dragonfly server provided values (see [below for nested schema](#nestedatt--dragonfly))
 - `id` (String) The ID of this resource.
 - `service_host` (String) The hostname of the service.
 - `service_password` (String, Sensitive) Password used for connecting to the service, if applicable
@@ -197,12 +196,6 @@ Read-Only:
 - `route` (String)
 - `ssl` (Boolean)
 - `usage` (String)
-
-
-<a id="nestedatt--dragonfly"></a>
-### Nested Schema for `dragonfly`
-
-Read-Only:
 
 ## Import
 

--- a/docs/resources/grafana.md
+++ b/docs/resources/grafana.md
@@ -63,7 +63,6 @@ resource "aiven_grafana" "gr1" {
 - `disk_space_default` (String) The default disk space of the service, possible values depend on the service type, the cloud provider and the project. Its also the minimum value for `disk_space`
 - `disk_space_step` (String) The default disk space step of the service, possible values depend on the service type, the cloud provider and the project. `disk_space` needs to increment from `disk_space_default` by increments of this size.
 - `disk_space_used` (String) Disk space that service is currently using
-- `grafana` (List of Object) Grafana server provided values (see [below for nested schema](#nestedatt--grafana))
 - `id` (String) The ID of this resource.
 - `service_host` (String) The hostname of the service.
 - `service_password` (String, Sensitive) Password used for connecting to the service, if applicable
@@ -339,12 +338,6 @@ Read-Only:
 - `route` (String)
 - `ssl` (Boolean)
 - `usage` (String)
-
-
-<a id="nestedatt--grafana"></a>
-### Nested Schema for `grafana`
-
-Read-Only:
 
 ## Import
 

--- a/docs/resources/kafka_connect.md
+++ b/docs/resources/kafka_connect.md
@@ -66,7 +66,6 @@ resource "aiven_kafka_connect" "kc1" {
 - `disk_space_step` (String) The default disk space step of the service, possible values depend on the service type, the cloud provider and the project. `disk_space` needs to increment from `disk_space_default` by increments of this size.
 - `disk_space_used` (String) Disk space that service is currently using
 - `id` (String) The ID of this resource.
-- `kafka_connect` (List of Object) Kafka Connect server provided values (see [below for nested schema](#nestedatt--kafka_connect))
 - `service_host` (String) The hostname of the service.
 - `service_password` (String, Sensitive) Password used for connecting to the service, if applicable
 - `service_port` (Number) The port of the service
@@ -206,12 +205,6 @@ Read-Only:
 - `route` (String)
 - `ssl` (Boolean)
 - `usage` (String)
-
-
-<a id="nestedatt--kafka_connect"></a>
-### Nested Schema for `kafka_connect`
-
-Read-Only:
 
 ## Import
 

--- a/docs/resources/kafka_mirrormaker.md
+++ b/docs/resources/kafka_mirrormaker.md
@@ -64,7 +64,6 @@ resource "aiven_kafka_mirrormaker" "mm1" {
 - `disk_space_step` (String) The default disk space step of the service, possible values depend on the service type, the cloud provider and the project. `disk_space` needs to increment from `disk_space_default` by increments of this size.
 - `disk_space_used` (String) Disk space that service is currently using
 - `id` (String) The ID of this resource.
-- `kafka_mirrormaker` (List of Object) Kafka MirrorMaker 2 server provided values (see [below for nested schema](#nestedatt--kafka_mirrormaker))
 - `service_host` (String) The hostname of the service.
 - `service_password` (String, Sensitive) Password used for connecting to the service, if applicable
 - `service_port` (Number) The port of the service
@@ -170,12 +169,6 @@ Read-Only:
 - `route` (String)
 - `ssl` (Boolean)
 - `usage` (String)
-
-
-<a id="nestedatt--kafka_mirrormaker"></a>
-### Nested Schema for `kafka_mirrormaker`
-
-Read-Only:
 
 ## Import
 

--- a/docs/resources/m3aggregator.md
+++ b/docs/resources/m3aggregator.md
@@ -60,7 +60,6 @@ resource "aiven_m3aggregator" "m3a" {
 - `disk_space_step` (String) The default disk space step of the service, possible values depend on the service type, the cloud provider and the project. `disk_space` needs to increment from `disk_space_default` by increments of this size.
 - `disk_space_used` (String) Disk space that service is currently using
 - `id` (String) The ID of this resource.
-- `m3aggregator` (List of Object) M3 aggregator specific server provided values (see [below for nested schema](#nestedatt--m3aggregator))
 - `service_host` (String) The hostname of the service.
 - `service_password` (String, Sensitive) Password used for connecting to the service, if applicable
 - `service_port` (Number) The port of the service
@@ -147,12 +146,6 @@ Read-Only:
 - `route` (String)
 - `ssl` (Boolean)
 - `usage` (String)
-
-
-<a id="nestedatt--m3aggregator"></a>
-### Nested Schema for `m3aggregator`
-
-Read-Only:
 
 ## Import
 

--- a/docs/resources/m3db.md
+++ b/docs/resources/m3db.md
@@ -65,7 +65,6 @@ resource "aiven_m3db" "m3" {
 - `disk_space_step` (String) The default disk space step of the service, possible values depend on the service type, the cloud provider and the project. `disk_space` needs to increment from `disk_space_default` by increments of this size.
 - `disk_space_used` (String) Disk space that service is currently using
 - `id` (String) The ID of this resource.
-- `m3db` (List of Object) M3 specific server provided values (see [below for nested schema](#nestedatt--m3db))
 - `service_host` (String) The hostname of the service.
 - `service_password` (String, Sensitive) Password used for connecting to the service, if applicable
 - `service_port` (Number) The port of the service
@@ -294,12 +293,6 @@ Read-Only:
 - `route` (String)
 - `ssl` (Boolean)
 - `usage` (String)
-
-
-<a id="nestedatt--m3db"></a>
-### Nested Schema for `m3db`
-
-Read-Only:
 
 ## Import
 

--- a/docs/resources/mysql.md
+++ b/docs/resources/mysql.md
@@ -69,7 +69,6 @@ resource "aiven_mysql" "mysql1" {
 - `disk_space_step` (String) The default disk space step of the service, possible values depend on the service type, the cloud provider and the project. `disk_space` needs to increment from `disk_space_default` by increments of this size.
 - `disk_space_used` (String) Disk space that service is currently using
 - `id` (String) The ID of this resource.
-- `mysql` (List of Object) MySQL specific server provided values (see [below for nested schema](#nestedatt--mysql))
 - `service_host` (String) The hostname of the service.
 - `service_password` (String, Sensitive) Password used for connecting to the service, if applicable
 - `service_port` (Number) The port of the service
@@ -253,12 +252,6 @@ Read-Only:
 - `route` (String)
 - `ssl` (Boolean)
 - `usage` (String)
-
-
-<a id="nestedatt--mysql"></a>
-### Nested Schema for `mysql`
-
-Read-Only:
 
 ## Import
 

--- a/docs/resources/redis.md
+++ b/docs/resources/redis.md
@@ -64,7 +64,6 @@ resource "aiven_redis" "redis1" {
 - `disk_space_step` (String) The default disk space step of the service, possible values depend on the service type, the cloud provider and the project. `disk_space` needs to increment from `disk_space_default` by increments of this size.
 - `disk_space_used` (String) Disk space that service is currently using
 - `id` (String) The ID of this resource.
-- `redis` (List of Object) Redis server provided values (see [below for nested schema](#nestedatt--redis))
 - `service_host` (String) The hostname of the service.
 - `service_password` (String, Sensitive) Password used for connecting to the service, if applicable
 - `service_port` (Number) The port of the service
@@ -213,12 +212,6 @@ Read-Only:
 - `route` (String)
 - `ssl` (Boolean)
 - `usage` (String)
-
-
-<a id="nestedatt--redis"></a>
-### Nested Schema for `redis`
-
-Read-Only:
 
 ## Import
 

--- a/internal/schemautil/service.go
+++ b/internal/schemautil/service.go
@@ -746,17 +746,17 @@ func copyConnectionInfoFromAPIResponseToTerraform(
 	props := make(map[string]interface{})
 
 	switch serviceType {
-	case "opensearch":
+	case ServiceTypeOpenSearch:
 		props["opensearch_dashboards_uri"] = connectionInfo.OpensearchDashboardsURI
-	case "influxdb":
+	case ServiceTypeInfluxDB:
 		props["database_name"] = connectionInfo.InfluxDBDatabaseName
-	case "kafka":
+	case ServiceTypeKafka:
 		props["access_cert"] = connectionInfo.KafkaAccessCert
 		props["access_key"] = connectionInfo.KafkaAccessKey
 		props["connect_uri"] = connectionInfo.KafkaConnectURI
 		props["rest_uri"] = connectionInfo.KafkaRestURI
 		props["schema_registry_uri"] = connectionInfo.SchemaRegistryURI
-	case "pg":
+	case ServiceTypePG:
 		if connectionInfo.PostgresURIs != nil && len(connectionInfo.PostgresURIs) > 0 {
 			props["uri"] = connectionInfo.PostgresURIs[0]
 		}
@@ -774,8 +774,11 @@ func copyConnectionInfoFromAPIResponseToTerraform(
 		}
 		props["replica_uri"] = connectionInfo.PostgresReplicaURI
 		props["max_connections"] = metadata.(map[string]interface{})["max_connections"]
-	case "flink":
+	case ServiceTypeFlink:
 		props["host_ports"] = connectionInfo.FlinkHostPorts
+	default:
+		// Doesn't have connection info
+		return nil
 	}
 
 	return d.Set(serviceType, []map[string]interface{}{props})

--- a/internal/schemautil/service.go
+++ b/internal/schemautil/service.go
@@ -306,10 +306,6 @@ func ResourceServiceCreateWrapper(serviceType string) schema.CreateContextFunc {
 		if err := d.Set("service_type", serviceType); err != nil {
 			return diag.Errorf("error setting service_type: %s", err)
 		}
-		if err := d.Set(serviceType, []map[string]interface{}{}); err != nil {
-			return diag.Errorf("error setting an empty %s field: %s", serviceType, err)
-		}
-
 		return resourceServiceCreate(ctx, d, m)
 	}
 }

--- a/internal/sdkprovider/service/cassandra/cassandra.go
+++ b/internal/sdkprovider/service/cassandra/cassandra.go
@@ -9,16 +9,7 @@ import (
 )
 
 func cassandraSchema() map[string]*schema.Schema {
-	s := schemautil.ServiceCommonSchemaWithUserConfig(schemautil.ServiceTypeCassandra)
-	s[schemautil.ServiceTypeCassandra] = &schema.Schema{
-		Type:        schema.TypeList,
-		Computed:    true,
-		Description: "Cassandra server provided values",
-		Elem: &schema.Resource{
-			Schema: map[string]*schema.Schema{},
-		},
-	}
-	return s
+	return schemautil.ServiceCommonSchemaWithUserConfig(schemautil.ServiceTypeCassandra)
 }
 
 func ResourceCassandra() *schema.Resource {

--- a/internal/sdkprovider/service/clickhouse/clickhouse.go
+++ b/internal/sdkprovider/service/clickhouse/clickhouse.go
@@ -9,15 +9,6 @@ import (
 
 func clickhouseSchema() map[string]*schema.Schema {
 	s := schemautil.ServiceCommonSchemaWithUserConfig(schemautil.ServiceTypeClickhouse)
-	s[schemautil.ServiceTypeClickhouse] = &schema.Schema{
-		Type:        schema.TypeList,
-		Computed:    true,
-		Sensitive:   true,
-		Description: "Clickhouse server provided values",
-		Elem: &schema.Resource{
-			Schema: map[string]*schema.Schema{},
-		},
-	}
 	s["service_integrations"] = &schema.Schema{
 		Type:        schema.TypeList,
 		Optional:    true,

--- a/internal/sdkprovider/service/dragonfly/dragonfly.go
+++ b/internal/sdkprovider/service/dragonfly/dragonfly.go
@@ -8,17 +8,7 @@ import (
 )
 
 func dragonflySchema() map[string]*schema.Schema {
-	s := schemautil.ServiceCommonSchemaWithUserConfig(schemautil.ServiceTypeDragonfly)
-	s[schemautil.ServiceTypeDragonfly] = &schema.Schema{
-		Type:        schema.TypeList,
-		Computed:    true,
-		Sensitive:   true,
-		Description: "Dragonfly server provided values",
-		Elem: &schema.Resource{
-			Schema: map[string]*schema.Schema{},
-		},
-	}
-	return s
+	return schemautil.ServiceCommonSchemaWithUserConfig(schemautil.ServiceTypeDragonfly)
 }
 
 func ResourceDragonfly() *schema.Resource {

--- a/internal/sdkprovider/service/grafana/grafana.go
+++ b/internal/sdkprovider/service/grafana/grafana.go
@@ -9,16 +9,7 @@ import (
 )
 
 func grafanaSchema() map[string]*schema.Schema {
-	s := schemautil.ServiceCommonSchemaWithUserConfig(schemautil.ServiceTypeGrafana)
-	s[schemautil.ServiceTypeGrafana] = &schema.Schema{
-		Type:        schema.TypeList,
-		Computed:    true,
-		Description: "Grafana server provided values",
-		Elem: &schema.Resource{
-			Schema: map[string]*schema.Schema{},
-		},
-	}
-	return s
+	return schemautil.ServiceCommonSchemaWithUserConfig(schemautil.ServiceTypeGrafana)
 }
 
 func ResourceGrafana() *schema.Resource {

--- a/internal/sdkprovider/service/kafka/kafka_connect.go
+++ b/internal/sdkprovider/service/kafka/kafka_connect.go
@@ -9,16 +9,7 @@ import (
 )
 
 func aivenKafkaConnectSchema() map[string]*schema.Schema {
-	s := schemautil.ServiceCommonSchemaWithUserConfig(schemautil.ServiceTypeKafkaConnect)
-	s[schemautil.ServiceTypeKafkaConnect] = &schema.Schema{
-		Type:        schema.TypeList,
-		Computed:    true,
-		Description: "Kafka Connect server provided values",
-		Elem: &schema.Resource{
-			Schema: map[string]*schema.Schema{},
-		},
-	}
-	return s
+	return schemautil.ServiceCommonSchemaWithUserConfig(schemautil.ServiceTypeKafkaConnect)
 }
 
 func ResourceKafkaConnect() *schema.Resource {

--- a/internal/sdkprovider/service/kafka/kafka_mirrormaker.go
+++ b/internal/sdkprovider/service/kafka/kafka_mirrormaker.go
@@ -9,16 +9,7 @@ import (
 )
 
 func aivenKafkaMirrormakerSchema() map[string]*schema.Schema {
-	s := schemautil.ServiceCommonSchemaWithUserConfig(schemautil.ServiceTypeKafkaMirrormaker)
-	s[schemautil.ServiceTypeKafkaMirrormaker] = &schema.Schema{
-		Type:        schema.TypeList,
-		Computed:    true,
-		Description: "Kafka MirrorMaker 2 server provided values",
-		Elem: &schema.Resource{
-			Schema: map[string]*schema.Schema{},
-		},
-	}
-	return s
+	return schemautil.ServiceCommonSchemaWithUserConfig(schemautil.ServiceTypeKafkaMirrormaker)
 }
 func ResourceKafkaMirrormaker() *schema.Resource {
 	return &schema.Resource{

--- a/internal/sdkprovider/service/m3db/m3aggregator.go
+++ b/internal/sdkprovider/service/m3db/m3aggregator.go
@@ -9,16 +9,7 @@ import (
 )
 
 func aivenM3AggregatorSchema() map[string]*schema.Schema {
-	s := schemautil.ServiceCommonSchemaWithUserConfig(schemautil.ServiceTypeM3Aggregator)
-	s[schemautil.ServiceTypeM3Aggregator] = &schema.Schema{
-		Type:        schema.TypeList,
-		Computed:    true,
-		Description: "M3 aggregator specific server provided values",
-		Elem: &schema.Resource{
-			Schema: map[string]*schema.Schema{},
-		},
-	}
-	return s
+	return schemautil.ServiceCommonSchemaWithUserConfig(schemautil.ServiceTypeM3Aggregator)
 }
 func ResourceM3Aggregator() *schema.Resource {
 	return &schema.Resource{

--- a/internal/sdkprovider/service/m3db/m3db.go
+++ b/internal/sdkprovider/service/m3db/m3db.go
@@ -9,16 +9,7 @@ import (
 )
 
 func aivenM3DBSchema() map[string]*schema.Schema {
-	schemaM3 := schemautil.ServiceCommonSchemaWithUserConfig(schemautil.ServiceTypeM3)
-	schemaM3[schemautil.ServiceTypeM3] = &schema.Schema{
-		Type:        schema.TypeList,
-		Computed:    true,
-		Description: "M3 specific server provided values",
-		Elem: &schema.Resource{
-			Schema: map[string]*schema.Schema{},
-		},
-	}
-	return schemaM3
+	return schemautil.ServiceCommonSchemaWithUserConfig(schemautil.ServiceTypeM3)
 }
 func ResourceM3DB() *schema.Resource {
 	return &schema.Resource{

--- a/internal/sdkprovider/service/mysql/mysql.go
+++ b/internal/sdkprovider/service/mysql/mysql.go
@@ -9,16 +9,7 @@ import (
 )
 
 func aivenMySQLSchema() map[string]*schema.Schema {
-	schemaMySQL := schemautil.ServiceCommonSchemaWithUserConfig(schemautil.ServiceTypeMySQL)
-	schemaMySQL[schemautil.ServiceTypeMySQL] = &schema.Schema{
-		Type:        schema.TypeList,
-		Computed:    true,
-		Description: "MySQL specific server provided values",
-		Elem: &schema.Resource{
-			Schema: map[string]*schema.Schema{},
-		},
-	}
-	return schemaMySQL
+	return schemautil.ServiceCommonSchemaWithUserConfig(schemautil.ServiceTypeMySQL)
 }
 func ResourceMySQL() *schema.Resource {
 	return &schema.Resource{

--- a/internal/sdkprovider/service/redis/redis.go
+++ b/internal/sdkprovider/service/redis/redis.go
@@ -9,16 +9,7 @@ import (
 )
 
 func redisSchema() map[string]*schema.Schema {
-	s := schemautil.ServiceCommonSchemaWithUserConfig(schemautil.ServiceTypeRedis)
-	s[schemautil.ServiceTypeRedis] = &schema.Schema{
-		Type:        schema.TypeList,
-		Computed:    true,
-		Description: "Redis server provided values",
-		Elem: &schema.Resource{
-			Schema: map[string]*schema.Schema{},
-		},
-	}
-	return s
+	return schemautil.ServiceCommonSchemaWithUserConfig(schemautil.ServiceTypeRedis)
 }
 
 func ResourceRedis() *schema.Resource {


### PR DESCRIPTION
Removes redundant connection info fields that are have no fields and rendered as empty blocks.