### PR TITLE
docs(mirromaker): added valid options for config

### DIFF
--- a/docs/data-sources/mirrormaker_replication_flow.md
+++ b/docs/data-sources/mirrormaker_replication_flow.md
@@ -37,7 +37,7 @@ data "aiven_mirrormaker_replication_flow" "f1" {
 - `emit_heartbeats_enabled` (Boolean) Whether to emit heartbeats to the target cluster. The default value is `false`.
 - `enable` (Boolean) Enable of disable replication flows for a service.
 - `id` (String) The ID of this resource.
-- `offset_syncs_topic_location` (String) Offset syncs topic location.
+- `offset_syncs_topic_location` (String) Offset syncs topic location. Possible values are `source` & `target`. There is no default value. 
 - `replication_policy_class` (String) Replication policy class. The possible values are `org.apache.kafka.connect.mirror.DefaultReplicationPolicy` and `org.apache.kafka.connect.mirror.IdentityReplicationPolicy`. The default value is `org.apache.kafka.connect.mirror.DefaultReplicationPolicy`.
 - `sync_group_offsets_enabled` (Boolean) Sync consumer group offsets. The default value is `false`.
 - `sync_group_offsets_interval_seconds` (Number) Frequency of consumer group offset sync. The default value is `1`.

--- a/docs/data-sources/mirrormaker_replication_flow.md
+++ b/docs/data-sources/mirrormaker_replication_flow.md
@@ -37,7 +37,7 @@ data "aiven_mirrormaker_replication_flow" "f1" {
 - `emit_heartbeats_enabled` (Boolean) Whether to emit heartbeats to the target cluster. The default value is `false`.
 - `enable` (Boolean) Enable of disable replication flows for a service.
 - `id` (String) The ID of this resource.
-- `offset_syncs_topic_location` (String) Offset syncs topic location. Possible values are `source` & `target`. There is no default value. 
+- `offset_syncs_topic_location` (String) Offset syncs topic location. Possible values are `source` & `target`. There is no default value.
 - `replication_policy_class` (String) Replication policy class. The possible values are `org.apache.kafka.connect.mirror.DefaultReplicationPolicy` and `org.apache.kafka.connect.mirror.IdentityReplicationPolicy`. The default value is `org.apache.kafka.connect.mirror.DefaultReplicationPolicy`.
 - `sync_group_offsets_enabled` (Boolean) Sync consumer group offsets. The default value is `false`.
 - `sync_group_offsets_interval_seconds` (Number) Frequency of consumer group offset sync. The default value is `1`.

--- a/docs/resources/mirrormaker_replication_flow.md
+++ b/docs/resources/mirrormaker_replication_flow.md
@@ -38,7 +38,7 @@ resource "aiven_mirrormaker_replication_flow" "f1" {
 ### Required
 
 - `enable` (Boolean) Enable of disable replication flows for a service.
-- `offset_syncs_topic_location` (String) Offset syncs topic location. Possible values are `source` & `target`. There is no default value. 
+- `offset_syncs_topic_location` (String) Offset syncs topic location. Possible values are `source` & `target`. There is no default value.
 - `project` (String) The name of the project this resource belongs to. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
 - `replication_policy_class` (String) Replication policy class. The possible values are `org.apache.kafka.connect.mirror.DefaultReplicationPolicy` and `org.apache.kafka.connect.mirror.IdentityReplicationPolicy`. The default value is `org.apache.kafka.connect.mirror.DefaultReplicationPolicy`.
 - `service_name` (String) The name of the project this resource belongs to. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.

--- a/docs/resources/mirrormaker_replication_flow.md
+++ b/docs/resources/mirrormaker_replication_flow.md
@@ -38,7 +38,7 @@ resource "aiven_mirrormaker_replication_flow" "f1" {
 ### Required
 
 - `enable` (Boolean) Enable of disable replication flows for a service.
-- `offset_syncs_topic_location` (String) Offset syncs topic location.
+- `offset_syncs_topic_location` (String) Offset syncs topic location. Possible values are `source` & `target`. There is no default value. 
 - `project` (String) The name of the project this resource belongs to. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.
 - `replication_policy_class` (String) Replication policy class. The possible values are `org.apache.kafka.connect.mirror.DefaultReplicationPolicy` and `org.apache.kafka.connect.mirror.IdentityReplicationPolicy`. The default value is `org.apache.kafka.connect.mirror.DefaultReplicationPolicy`.
 - `service_name` (String) The name of the project this resource belongs to. To set up proper dependencies please refer to this variable as a reference. Changing this property forces recreation of the resource.

--- a/internal/sdkprovider/service/kafka/mirrormaker_replication_flow.go
+++ b/internal/sdkprovider/service/kafka/mirrormaker_replication_flow.go
@@ -104,7 +104,7 @@ var aivenMirrorMakerReplicationFlowSchema = map[string]*schema.Schema{
 	"offset_syncs_topic_location": {
 		Type:         schema.TypeString,
 		Required:     true,
-		Description:  "Offset syncs topic location.",
+		Description:  "Offset syncs topic location. Possible values are `source` & `target`. There is no default value.",
 		ValidateFunc: validation.StringInSlice([]string{"source", "target"}, false),
 	},
 }


### PR DESCRIPTION
offset_syncs_topic_location takes a string of "source" or "target" but the docs did not reflect that. The config also lacks a default and that was not captured. This adds the valid options and the lack of a default

<!-- All contributors, please complete these sections, including maintainers. -->

## About this change—what it does
offset_syncs_topic_location takes a string of "source" or "target" but the docs did not reflect that. The config also lacks a default and that was not captured. This adds the valid options and the lack of a default
<!-- Provide a small sentence that summarizes the change. -->

## Why this way
Based on the other configs, this is the approach that is used to document. 
<!-- Provide a small explanation on why this is the approach you took for solving this problem. -->
