### PR TITLE
docs: add VPC error info to private_access field fields

### DIFF
--- a/docs/resources/cassandra.md
+++ b/docs/resources/cassandra.md
@@ -86,7 +86,7 @@ Optional:
 - `ip_filter_object` (Block Set, Max: 1024) Allow incoming connections from CIDR address block, e.g. '10.20.0.0/16' (see [below for nested schema](#nestedblock--cassandra_user_config--ip_filter_object))
 - `ip_filter_string` (Set of String) Allow incoming connections from CIDR address block, e.g. '10.20.0.0/16'.
 - `migrate_sstableloader` (Boolean) Sets the service into migration mode enabling the sstableloader utility to be used to upload Cassandra data files. Available only on service create.
-- `private_access` (Block List, Max: 1) Allow access to selected service ports from private networks (see [below for nested schema](#nestedblock--cassandra_user_config--private_access))
+- `private_access` (Block List, Max: 1) Allow access to selected service ports from private networks. Projects that are in a VPC are private by default, so setting this for services in a project VPC will cause an error. (see [below for nested schema](#nestedblock--cassandra_user_config--private_access))
 - `project_to_fork_from` (String) Name of another project to fork a service from. This has effect only when a new service is being created.
 - `public_access` (Block List, Max: 1) Allow access to selected service ports from the public Internet (see [below for nested schema](#nestedblock--cassandra_user_config--public_access))
 - `service_log` (Boolean) Store logs for the service so that they are available in the HTTP API and console.

--- a/docs/resources/clickhouse.md
+++ b/docs/resources/clickhouse.md
@@ -73,7 +73,7 @@ Optional:
 - `ip_filter` (Set of String, Deprecated) Allow incoming connections from CIDR address block, e.g. '10.20.0.0/16'.
 - `ip_filter_object` (Block Set, Max: 1024) Allow incoming connections from CIDR address block, e.g. '10.20.0.0/16' (see [below for nested schema](#nestedblock--clickhouse_user_config--ip_filter_object))
 - `ip_filter_string` (Set of String) Allow incoming connections from CIDR address block, e.g. '10.20.0.0/16'.
-- `private_access` (Block List, Max: 1) Allow access to selected service ports from private networks (see [below for nested schema](#nestedblock--clickhouse_user_config--private_access))
+- `private_access` (Block List, Max: 1) Allow access to selected service ports from private networks. Projects that are in a VPC are private by default, so setting this for services in a project VPC will cause an error. (see [below for nested schema](#nestedblock--clickhouse_user_config--private_access))
 - `privatelink_access` (Block List, Max: 1) Allow access to selected service components through Privatelink (see [below for nested schema](#nestedblock--clickhouse_user_config--privatelink_access))
 - `project_to_fork_from` (String) Name of another project to fork a service from. This has effect only when a new service is being created.
 - `public_access` (Block List, Max: 1) Allow access to selected service ports from the public Internet (see [below for nested schema](#nestedblock--clickhouse_user_config--public_access))

--- a/docs/resources/dragonfly.md
+++ b/docs/resources/dragonfly.md
@@ -78,7 +78,7 @@ Optional:
 - `ip_filter_object` (Block Set, Max: 1024) Allow incoming connections from CIDR address block, e.g. '10.20.0.0/16' (see [below for nested schema](#nestedblock--dragonfly_user_config--ip_filter_object))
 - `ip_filter_string` (Set of String) Allow incoming connections from CIDR address block, e.g. '10.20.0.0/16'.
 - `migration` (Block List, Max: 1) Migrate data from existing server (see [below for nested schema](#nestedblock--dragonfly_user_config--migration))
-- `private_access` (Block List, Max: 1) Allow access to selected service ports from private networks (see [below for nested schema](#nestedblock--dragonfly_user_config--private_access))
+- `private_access` (Block List, Max: 1) Allow access to selected service ports from private networks. Projects that are in a VPC are private by default, so setting this for services in a project VPC will cause an error. (see [below for nested schema](#nestedblock--dragonfly_user_config--private_access))
 - `privatelink_access` (Block List, Max: 1) Allow access to selected service components through Privatelink (see [below for nested schema](#nestedblock--dragonfly_user_config--privatelink_access))
 - `project_to_fork_from` (String) Name of another project to fork a service from. This has effect only when a new service is being created.
 - `public_access` (Block List, Max: 1) Allow access to selected service ports from the public Internet (see [below for nested schema](#nestedblock--dragonfly_user_config--public_access))

--- a/docs/resources/grafana.md
+++ b/docs/resources/grafana.md
@@ -106,7 +106,7 @@ Optional:
 - `ip_filter_string` (Set of String) Allow incoming connections from CIDR address block, e.g. '10.20.0.0/16'.
 - `metrics_enabled` (Boolean) Enable Grafana /metrics endpoint.
 - `oauth_allow_insecure_email_lookup` (Boolean) Enforce user lookup based on email instead of the unique ID provided by the IdP.
-- `private_access` (Block List, Max: 1) Allow access to selected service ports from private networks (see [below for nested schema](#nestedblock--grafana_user_config--private_access))
+- `private_access` (Block List, Max: 1) Allow access to selected service ports from private networks. Projects that are in a VPC are private by default, so setting this for services in a project VPC will cause an error. (see [below for nested schema](#nestedblock--grafana_user_config--private_access))
 - `privatelink_access` (Block List, Max: 1) Allow access to selected service components through Privatelink (see [below for nested schema](#nestedblock--grafana_user_config--privatelink_access))
 - `project_to_fork_from` (String) Name of another project to fork a service from. This has effect only when a new service is being created.
 - `public_access` (Block List, Max: 1) Allow access to selected service ports from the public Internet (see [below for nested schema](#nestedblock--grafana_user_config--public_access))

--- a/docs/resources/kafka.md
+++ b/docs/resources/kafka.md
@@ -103,7 +103,7 @@ Optional:
 - `kafka_rest_authorization` (Boolean) Enable authorization in Kafka-REST service.
 - `kafka_rest_config` (Block List, Max: 1) Kafka REST configuration (see [below for nested schema](#nestedblock--kafka_user_config--kafka_rest_config))
 - `kafka_version` (String) Kafka major version.
-- `private_access` (Block List, Max: 1) Allow access to selected service ports from private networks (see [below for nested schema](#nestedblock--kafka_user_config--private_access))
+- `private_access` (Block List, Max: 1) Allow access to selected service ports from private networks. Projects that are in a VPC are private by default, so setting this for services in a project VPC will cause an error. (see [below for nested schema](#nestedblock--kafka_user_config--private_access))
 - `privatelink_access` (Block List, Max: 1) Allow access to selected service components through Privatelink (see [below for nested schema](#nestedblock--kafka_user_config--privatelink_access))
 - `public_access` (Block List, Max: 1) Allow access to selected service ports from the public Internet (see [below for nested schema](#nestedblock--kafka_user_config--public_access))
 - `schema_registry` (Boolean) Enable Schema-Registry service. The default value is `false`.

--- a/docs/resources/kafka_connect.md
+++ b/docs/resources/kafka_connect.md
@@ -84,7 +84,7 @@ Optional:
 - `ip_filter_object` (Block Set, Max: 1024) Allow incoming connections from CIDR address block, e.g. '10.20.0.0/16' (see [below for nested schema](#nestedblock--kafka_connect_user_config--ip_filter_object))
 - `ip_filter_string` (Set of String) Allow incoming connections from CIDR address block, e.g. '10.20.0.0/16'.
 - `kafka_connect` (Block List, Max: 1) Kafka Connect configuration values (see [below for nested schema](#nestedblock--kafka_connect_user_config--kafka_connect))
-- `private_access` (Block List, Max: 1) Allow access to selected service ports from private networks (see [below for nested schema](#nestedblock--kafka_connect_user_config--private_access))
+- `private_access` (Block List, Max: 1) Allow access to selected service ports from private networks. Projects that are in a VPC are private by default, so setting this for services in a project VPC will cause an error. (see [below for nested schema](#nestedblock--kafka_connect_user_config--private_access))
 - `privatelink_access` (Block List, Max: 1) Allow access to selected service components through Privatelink (see [below for nested schema](#nestedblock--kafka_connect_user_config--privatelink_access))
 - `public_access` (Block List, Max: 1) Allow access to selected service ports from the public Internet (see [below for nested schema](#nestedblock--kafka_connect_user_config--public_access))
 - `service_log` (Boolean) Store logs for the service so that they are available in the HTTP API and console.

--- a/docs/resources/m3db.md
+++ b/docs/resources/m3db.md
@@ -89,7 +89,7 @@ Optional:
 - `m3coordinator_enable_graphite_carbon_ingest` (Boolean) Enables access to Graphite Carbon plaintext metrics ingestion. It can be enabled only for services inside VPCs. The metrics are written to aggregated namespaces only.
 - `m3db_version` (String) M3 major version (the minimum compatible version).
 - `namespaces` (Block List, Max: 2147483647) List of M3 namespaces (see [below for nested schema](#nestedblock--m3db_user_config--namespaces))
-- `private_access` (Block List, Max: 1) Allow access to selected service ports from private networks (see [below for nested schema](#nestedblock--m3db_user_config--private_access))
+- `private_access` (Block List, Max: 1) Allow access to selected service ports from private networks. Projects that are in a VPC are private by default, so setting this for services in a project VPC will cause an error. (see [below for nested schema](#nestedblock--m3db_user_config--private_access))
 - `project_to_fork_from` (String) Name of another project to fork a service from. This has effect only when a new service is being created.
 - `public_access` (Block List, Max: 1) Allow access to selected service ports from the public Internet (see [below for nested schema](#nestedblock--m3db_user_config--public_access))
 - `rules` (Block List, Max: 1) M3 rules (see [below for nested schema](#nestedblock--m3db_user_config--rules))

--- a/docs/resources/mysql.md
+++ b/docs/resources/mysql.md
@@ -94,7 +94,7 @@ Optional:
 - `migration` (Block List, Max: 1) Migrate data from existing server (see [below for nested schema](#nestedblock--mysql_user_config--migration))
 - `mysql` (Block List, Max: 1) mysql.conf configuration values (see [below for nested schema](#nestedblock--mysql_user_config--mysql))
 - `mysql_version` (String) MySQL major version.
-- `private_access` (Block List, Max: 1) Allow access to selected service ports from private networks (see [below for nested schema](#nestedblock--mysql_user_config--private_access))
+- `private_access` (Block List, Max: 1) Allow access to selected service ports from private networks. Projects that are in a VPC are private by default, so setting this for services in a project VPC will cause an error. (see [below for nested schema](#nestedblock--mysql_user_config--private_access))
 - `privatelink_access` (Block List, Max: 1) Allow access to selected service components through Privatelink (see [below for nested schema](#nestedblock--mysql_user_config--privatelink_access))
 - `project_to_fork_from` (String) Name of another project to fork a service from. This has effect only when a new service is being created.
 - `public_access` (Block List, Max: 1) Allow access to selected service ports from the public Internet (see [below for nested schema](#nestedblock--mysql_user_config--public_access))

--- a/docs/resources/opensearch.md
+++ b/docs/resources/opensearch.md
@@ -98,7 +98,7 @@ Optional:
 - `opensearch` (Block List, Max: 1) OpenSearch settings (see [below for nested schema](#nestedblock--opensearch_user_config--opensearch))
 - `opensearch_dashboards` (Block List, Max: 1) OpenSearch Dashboards settings (see [below for nested schema](#nestedblock--opensearch_user_config--opensearch_dashboards))
 - `opensearch_version` (String) OpenSearch major version.
-- `private_access` (Block List, Max: 1) Allow access to selected service ports from private networks (see [below for nested schema](#nestedblock--opensearch_user_config--private_access))
+- `private_access` (Block List, Max: 1) Allow access to selected service ports from private networks. Projects that are in a VPC are private by default, so setting this for services in a project VPC will cause an error. (see [below for nested schema](#nestedblock--opensearch_user_config--private_access))
 - `privatelink_access` (Block List, Max: 1) Allow access to selected service components through Privatelink (see [below for nested schema](#nestedblock--opensearch_user_config--privatelink_access))
 - `project_to_fork_from` (String) Name of another project to fork a service from. This has effect only when a new service is being created.
 - `public_access` (Block List, Max: 1) Allow access to selected service ports from the public Internet (see [below for nested schema](#nestedblock--opensearch_user_config--public_access))

--- a/docs/resources/pg.md
+++ b/docs/resources/pg.md
@@ -135,7 +135,7 @@ Optional:
 - `pgaudit` (Block List, Max: 1) System-wide settings for the pgaudit extension (see [below for nested schema](#nestedblock--pg_user_config--pgaudit))
 - `pgbouncer` (Block List, Max: 1) PGBouncer connection pooling settings (see [below for nested schema](#nestedblock--pg_user_config--pgbouncer))
 - `pglookout` (Block List, Max: 1) System-wide settings for pglookout (see [below for nested schema](#nestedblock--pg_user_config--pglookout))
-- `private_access` (Block List, Max: 1) Allow access to selected service ports from private networks (see [below for nested schema](#nestedblock--pg_user_config--private_access))
+- `private_access` (Block List, Max: 1) Allow access to selected service ports from private networks. Projects that are in a VPC are private by default, so setting this for services in a project VPC will cause an error. (see [below for nested schema](#nestedblock--pg_user_config--private_access))
 - `privatelink_access` (Block List, Max: 1) Allow access to selected service components through Privatelink (see [below for nested schema](#nestedblock--pg_user_config--privatelink_access))
 - `project_to_fork_from` (String) Name of another project to fork a service from. This has effect only when a new service is being created.
 - `public_access` (Block List, Max: 1) Allow access to selected service ports from the public Internet (see [below for nested schema](#nestedblock--pg_user_config--public_access))

--- a/docs/resources/redis.md
+++ b/docs/resources/redis.md
@@ -82,7 +82,7 @@ Optional:
 - `ip_filter_object` (Block Set, Max: 1024) Allow incoming connections from CIDR address block, e.g. '10.20.0.0/16' (see [below for nested schema](#nestedblock--redis_user_config--ip_filter_object))
 - `ip_filter_string` (Set of String) Allow incoming connections from CIDR address block, e.g. '10.20.0.0/16'.
 - `migration` (Block List, Max: 1) Migrate data from existing server (see [below for nested schema](#nestedblock--redis_user_config--migration))
-- `private_access` (Block List, Max: 1) Allow access to selected service ports from private networks (see [below for nested schema](#nestedblock--redis_user_config--private_access))
+- `private_access` (Block List, Max: 1) Allow access to selected service ports from private networks. Projects that are in a VPC are private by default, so setting this for services in a project VPC will cause an error. (see [below for nested schema](#nestedblock--redis_user_config--private_access))
 - `privatelink_access` (Block List, Max: 1) Allow access to selected service components through Privatelink (see [below for nested schema](#nestedblock--redis_user_config--privatelink_access))
 - `project_to_fork_from` (String) Name of another project to fork a service from. This has effect only when a new service is being created.
 - `public_access` (Block List, Max: 1) Allow access to selected service ports from the public Internet (see [below for nested schema](#nestedblock--redis_user_config--public_access))

--- a/internal/sdkprovider/userconfig/service/cassandra.go
+++ b/internal/sdkprovider/userconfig/service/cassandra.go
@@ -109,7 +109,7 @@ func cassandraUserConfig() *schema.Schema {
 				Type:        schema.TypeBool,
 			},
 			"private_access": {
-				Description: "Allow access to selected service ports from private networks",
+				Description: "Allow access to selected service ports from private networks. Projects that are in a VPC are private by default, so setting this for services in a project VPC will cause an error.",
 				Elem: &schema.Resource{Schema: map[string]*schema.Schema{"prometheus": {
 					Description: "Allow clients to connect to prometheus with a DNS name that always resolves to the service's private IP addresses. Only available in certain network locations.",
 					Optional:    true,

--- a/internal/sdkprovider/userconfig/service/clickhouse.go
+++ b/internal/sdkprovider/userconfig/service/clickhouse.go
@@ -64,7 +64,7 @@ func clickhouseUserConfig() *schema.Schema {
 				Type:     schema.TypeSet,
 			},
 			"private_access": {
-				Description: "Allow access to selected service ports from private networks",
+				Description: "Allow access to selected service ports from private networks. Projects that are in a VPC are private by default, so setting this for services in a project VPC will cause an error.",
 				Elem: &schema.Resource{Schema: map[string]*schema.Schema{
 					"clickhouse": {
 						Description: "Allow clients to connect to clickhouse with a DNS name that always resolves to the service's private IP addresses. Only available in certain network locations.",

--- a/internal/sdkprovider/userconfig/service/dragonfly.go
+++ b/internal/sdkprovider/userconfig/service/dragonfly.go
@@ -120,7 +120,7 @@ func dragonflyUserConfig() *schema.Schema {
 				Type:     schema.TypeList,
 			},
 			"private_access": {
-				Description: "Allow access to selected service ports from private networks",
+				Description: "Allow access to selected service ports from private networks. Projects that are in a VPC are private by default, so setting this for services in a project VPC will cause an error.",
 				Elem: &schema.Resource{Schema: map[string]*schema.Schema{
 					"dragonfly": {
 						Description: "Allow clients to connect to dragonfly with a DNS name that always resolves to the service's private IP addresses. Only available in certain network locations.",

--- a/internal/sdkprovider/userconfig/service/grafana.go
+++ b/internal/sdkprovider/userconfig/service/grafana.go
@@ -499,7 +499,7 @@ func grafanaUserConfig() *schema.Schema {
 				Type:        schema.TypeBool,
 			},
 			"private_access": {
-				Description: "Allow access to selected service ports from private networks",
+				Description: "Allow access to selected service ports from private networks. Projects that are in a VPC are private by default, so setting this for services in a project VPC will cause an error.",
 				Elem: &schema.Resource{Schema: map[string]*schema.Schema{"grafana": {
 					Description: "Allow clients to connect to grafana with a DNS name that always resolves to the service's private IP addresses. Only available in certain network locations.",
 					Optional:    true,

--- a/internal/sdkprovider/userconfig/service/kafka.go
+++ b/internal/sdkprovider/userconfig/service/kafka.go
@@ -509,7 +509,7 @@ func kafkaUserConfig() *schema.Schema {
 				ValidateFunc: validation.StringInSlice([]string{"3.2", "3.3", "3.1", "3.4", "3.5", "3.6", "3.7"}, false),
 			},
 			"private_access": {
-				Description: "Allow access to selected service ports from private networks",
+				Description: "Allow access to selected service ports from private networks. Projects that are in a VPC are private by default, so setting this for services in a project VPC will cause an error.",
 				Elem: &schema.Resource{Schema: map[string]*schema.Schema{
 					"kafka": {
 						Description: "Allow clients to connect to kafka with a DNS name that always resolves to the service's private IP addresses. Only available in certain network locations.",

--- a/internal/sdkprovider/userconfig/service/kafka_connect.go
+++ b/internal/sdkprovider/userconfig/service/kafka_connect.go
@@ -157,7 +157,7 @@ func kafkaConnectUserConfig() *schema.Schema {
 				Type:     schema.TypeList,
 			},
 			"private_access": {
-				Description: "Allow access to selected service ports from private networks",
+				Description: "Allow access to selected service ports from private networks. Projects that are in a VPC are private by default, so setting this for services in a project VPC will cause an error.",
 				Elem: &schema.Resource{Schema: map[string]*schema.Schema{
 					"kafka_connect": {
 						Description: "Allow clients to connect to kafka_connect with a DNS name that always resolves to the service's private IP addresses. Only available in certain network locations.",

--- a/internal/sdkprovider/userconfig/service/m3db.go
+++ b/internal/sdkprovider/userconfig/service/m3db.go
@@ -223,7 +223,7 @@ func m3dbUserConfig() *schema.Schema {
 				Type:     schema.TypeList,
 			},
 			"private_access": {
-				Description: "Allow access to selected service ports from private networks",
+				Description: "Allow access to selected service ports from private networks. Projects that are in a VPC are private by default, so setting this for services in a project VPC will cause an error.",
 				Elem: &schema.Resource{Schema: map[string]*schema.Schema{"m3coordinator": {
 					Description: "Allow clients to connect to m3coordinator with a DNS name that always resolves to the service's private IP addresses. Only available in certain network locations.",
 					Optional:    true,

--- a/internal/sdkprovider/userconfig/service/mysql.go
+++ b/internal/sdkprovider/userconfig/service/mysql.go
@@ -307,7 +307,7 @@ func mysqlUserConfig() *schema.Schema {
 				ValidateFunc: validation.StringInSlice([]string{"8"}, false),
 			},
 			"private_access": {
-				Description: "Allow access to selected service ports from private networks",
+				Description: "Allow access to selected service ports from private networks. Projects that are in a VPC are private by default, so setting this for services in a project VPC will cause an error.",
 				Elem: &schema.Resource{Schema: map[string]*schema.Schema{
 					"mysql": {
 						Description: "Allow clients to connect to mysql with a DNS name that always resolves to the service's private IP addresses. Only available in certain network locations.",

--- a/internal/sdkprovider/userconfig/service/opensearch.go
+++ b/internal/sdkprovider/userconfig/service/opensearch.go
@@ -538,7 +538,7 @@ func opensearchUserConfig() *schema.Schema {
 				ValidateFunc: validation.StringInSlice([]string{"1", "2"}, false),
 			},
 			"private_access": {
-				Description: "Allow access to selected service ports from private networks",
+				Description: "Allow access to selected service ports from private networks. Projects that are in a VPC are private by default, so setting this for services in a project VPC will cause an error.",
 				Elem: &schema.Resource{Schema: map[string]*schema.Schema{
 					"opensearch": {
 						Description: "Allow clients to connect to opensearch with a DNS name that always resolves to the service's private IP addresses. Only available in certain network locations.",

--- a/internal/sdkprovider/userconfig/service/pg.go
+++ b/internal/sdkprovider/userconfig/service/pg.go
@@ -616,7 +616,7 @@ func pgUserConfig() *schema.Schema {
 				Type:     schema.TypeList,
 			},
 			"private_access": {
-				Description: "Allow access to selected service ports from private networks",
+				Description: "Allow access to selected service ports from private networks. Projects that are in a VPC are private by default, so setting this for services in a project VPC will cause an error.",
 				Elem: &schema.Resource{Schema: map[string]*schema.Schema{
 					"pg": {
 						Description: "Allow clients to connect to pg with a DNS name that always resolves to the service's private IP addresses. Only available in certain network locations.",

--- a/internal/sdkprovider/userconfig/service/redis.go
+++ b/internal/sdkprovider/userconfig/service/redis.go
@@ -114,7 +114,7 @@ func redisUserConfig() *schema.Schema {
 				Type:     schema.TypeList,
 			},
 			"private_access": {
-				Description: "Allow access to selected service ports from private networks",
+				Description: "Allow access to selected service ports from private networks. Projects that are in a VPC are private by default, so setting this for services in a project VPC will cause an error.",
 				Elem: &schema.Resource{Schema: map[string]*schema.Schema{
 					"prometheus": {
 						Description: "Allow clients to connect to prometheus with a DNS name that always resolves to the service's private IP addresses. Only available in certain network locations.",


### PR DESCRIPTION
## About this change—what it does

Setting private_access for services results in an error when those services are in a project that is in a VPC. This change informs users to not set this field for these types of services.


