### PR TITLE
chore(ci): remove deprecated gorelease args and options

### DIFF
--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -26,7 +26,7 @@ jobs:
     - uses: goreleaser/goreleaser-action@v5
       with:
         version: latest
-        args: release --rm-dist
+        args: release --clean
       env:
         GPG_FINGERPRINT: ${{ steps.import_gpg.outputs.fingerprint }}
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -39,4 +39,4 @@ signs:
 release:
   draft: true
 changelog:
-  skip: true
+  disable: true


### PR DESCRIPTION
The release workflow printed deprecation warnings.

* --rm-dist: https://goreleaser.com/deprecations/#__tabbed_17_1
* changelog.skip: https://goreleaser.com/deprecations/#changelogskip

Example: https://github.com/aiven/terraform-provider-aiven/actions/runs/9268626143/job/25497661979