### PR TITLE
fix(organization_user_group): make name field required

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ nav_order: 1
 ## [MAJOR.MINOR.PATCH] - YYYY-MM-DD
 
 - Fix aiven-go-client dependency version
+- Fix `aiven_organization_user_group` resource - `name` field is required
 
 ## [4.19.1] - 2024-05-05
 

--- a/docs/resources/organization_user_group.md
+++ b/docs/resources/organization_user_group.md
@@ -26,11 +26,11 @@ resource "aiven_organization_user_group" "example" {
 ### Required
 
 - `description` (String) The description of the user group. Changing this property forces recreation of the resource.
+- `name` (String) The name of the user group. Changing this property forces recreation of the resource.
 - `organization_id` (String) The ID of the organization. Changing this property forces recreation of the resource.
 
 ### Optional
 
-- `name` (String) The name of the user group. Changing this property forces recreation of the resource.
 - `timeouts` (Block, Optional) (see [below for nested schema](#nestedblock--timeouts))
 
 ### Read-Only

--- a/internal/sdkprovider/service/organization/organization_user_group.go
+++ b/internal/sdkprovider/service/organization/organization_user_group.go
@@ -20,7 +20,7 @@ var aivenOrganizationUserGroupSchema = map[string]*schema.Schema{
 	},
 	"name": {
 		Type:        schema.TypeString,
-		Optional:    true,
+		Required:    true,
 		ForceNew:    true,
 		Description: userconfig.Desc("The name of the user group.").ForceNew().Build(),
 	},


### PR DESCRIPTION
## About this change—what it does

Marks the `name` field as required for the user group resource.