### PR TITLE
feat: Support Datadog user-config for mirrormaker_custom_metrics

### DIFF
--- a/docs/data-sources/service_integration.md
+++ b/docs/data-sources/service_integration.md
@@ -126,6 +126,7 @@ Read-Only:
 - `include_consumer_groups` (List of String)
 - `include_topics` (List of String)
 - `kafka_custom_metrics` (List of String)
+- `mirrormaker_custom_metrics` (List of String)
 - `max_jmx_metrics` (Number)
 - `opensearch` (List of Object) (see [below for nested schema](#nestedobjatt--datadog_user_config--opensearch))
 - `redis` (List of Object) (see [below for nested schema](#nestedobjatt--datadog_user_config--redis))

--- a/docs/resources/service_integration.md
+++ b/docs/resources/service_integration.md
@@ -135,6 +135,7 @@ Optional:
 - `include_consumer_groups` (List of String) List of custom metrics.
 - `include_topics` (List of String) List of topics to include.
 - `kafka_custom_metrics` (List of String) List of custom metrics.
+- `mirrormaker_custom_metrics` (List of String) List of custom metrics.
 - `max_jmx_metrics` (Number) Maximum number of JMX metrics to send.
 - `opensearch` (Block List, Max: 1) Datadog Opensearch Options (see [below for nested schema](#nestedblock--datadog_user_config--opensearch))
 - `redis` (Block List, Max: 1) Datadog Redis Options (see [below for nested schema](#nestedblock--datadog_user_config--redis))


### PR DESCRIPTION
# About this change
Support for new Datadog integration user-config key `mirromaker_custom_metrics`.

# Contributes to resolving
https://aiven.atlassian.net/browse/EC-252

# Why this way
The new feature works as `kafka_custom_metrics` and so the changes were done based on https://github.com/search?q=repo%3Aaiven%2Fterraform-provider-aiven+_custom_metrics&type=code