### PR TITLE
chore: check description deprecation

### DIFF
--- a/internal/sdkprovider/provider/provider_test.go
+++ b/internal/sdkprovider/provider/provider_test.go
@@ -1,8 +1,10 @@
 package provider
 
 import (
+	"strings"
 	"testing"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -16,6 +18,21 @@ func TestProvider(t *testing.T) {
 
 	err = p.InternalValidate()
 	assert.NoError(t, err)
+
+	// Validates deprecations
+	sources := []map[string]*schema.Resource{p.ResourcesMap, p.DataSourcesMap}
+	for _, s := range sources {
+		for k, r := range s {
+			if r.DeprecationMessage == "" {
+				continue
+			}
+
+			assert.Contains(
+				t, strings.ToLower(r.Description), "deprecate",
+				"%q must have deprecation message and migration instructions in the description", k,
+			)
+		}
+	}
 }
 
 func TestProviderImpl(t *testing.T) {


### PR DESCRIPTION
Terraform doesn't add deprecation message to the docs site until it's not in the description.
Adds a test that looks for deprecation message in resource description.