### PR TITLE
docs(aiven_kafka_schema_registry_acl): fix import

### DIFF
--- a/docs/resources/kafka_schema_registry_acl.md
+++ b/docs/resources/kafka_schema_registry_acl.md
@@ -58,5 +58,5 @@ Optional:
 Import is supported using the following syntax:
 
 ```shell
-terraform import aiven_kafka_schema_registry_acl.foo PROJECT/SERVICE_NAME
+terraform import aiven_kafka_schema_registry_acl.foo PROJECT/SERVICE_NAME/ACL_ID
 ```

--- a/examples/resources/aiven_kafka_schema_registry_acl/import.sh
+++ b/examples/resources/aiven_kafka_schema_registry_acl/import.sh
@@ -1,1 +1,1 @@
-terraform import aiven_kafka_schema_registry_acl.foo PROJECT/SERVICE_NAME
+terraform import aiven_kafka_schema_registry_acl.foo PROJECT/SERVICE_NAME/ACL_ID


### PR DESCRIPTION
The import command required ACL id [kafka_schema_registry_acl.go](https://github.com/aiven/terraform-provider-aiven/blob/0f362d6e368f07b65c5abdfa34b3c64bb61192bb/internal/sdkprovider/service/kafkaschema/kafka_schema_registry_acl.go#L91-L91)