### PR TITLE
docs: fix deprecation info for teams resources

### DIFF
--- a/docs/resources/account_team.md
+++ b/docs/resources/account_team.md
@@ -12,12 +12,15 @@ Creates and manages a team.
 
 
 ~> **Teams have been deprecated and are being migrated to groups**
-**On 2 September 2024** the Account Owners team will transition to super admin. Super admin have full access to the organization. 
-The Account Owners and super admin are synced, so the removal of the Account Owners team will have no impact on your day to day operations.
+**On 30 September 2024** the Account Owners team will transition to super admin. Super admin have full access to the organization.
+The Account Owners and super admin are synced, so the removal of the Account Owners team will have no impact on existing permissions.
 **From 4 November 2024** you won't be able to create new teams or update existing ones. Existing teams will be migrated to groups after
 this date. **On 2 December 2024** all teams will be deleted and the teams feature will be completely removed. [View the 
 migration guide](https://aiven.io/docs/tools/terraform/howto/migrate-from-teams-to-groups) for more information on the changes and migrating to groups.
 
+~> **Important**
+You can't delete the Account Owners team. **Deleting all other teams in your organization will disable the teams feature.**
+You won't be able to create new teams or access your Account Owners team.
 
 ## Example Usage
 ```terraform

--- a/docs/resources/account_team_member.md
+++ b/docs/resources/account_team_member.md
@@ -18,8 +18,8 @@ The user is added to the team after they accept the invite. Deleting `aiven_acco
 deletes the pending invite if not accepted or removes the user from the team if they already accepted the invite.
 
 ~> **Teams have been deprecated and are being migrated to groups**
-**On 2 September 2024** the Account Owners team will transition to super admin. Super admin have full access to the organization. 
-The Account Owners and super admin are synced, so the removal of the Account Owners team will have no impact on your day to day operations.
+**On 30 September 2024** the Account Owners team will transition to super admin. Super admin have full access to the organization.
+The Account Owners and super admin are synced, so the removal of the Account Owners team will have no impact on existing permissions.
 **From 4 November 2024** you won't be able to create new teams or update existing ones. Existing teams will be migrated to groups after
 this date. **On 2 December 2024** all teams will be deleted and the teams feature will be completely removed. [View the 
 migration guide](https://aiven.io/docs/tools/terraform/howto/migrate-from-teams-to-groups) for more information on the changes and migrating to groups.

--- a/docs/resources/account_team_project.md
+++ b/docs/resources/account_team_project.md
@@ -11,8 +11,8 @@ description: |-
 Links an existing project to an existing team. Both the project and team should have the same `account_id`.
 
 ~> **Teams have been deprecated and are being migrated to groups**
-**On 2 September 2024** the Account Owners team will transition to super admin. Super admin have full access to the organization. 
-The Account Owners and super admin are synced, so the removal of the Account Owners team will have no impact on your day to day operations.
+**On 30 September 2024** the Account Owners team will transition to super admin. Super admin have full access to the organization.
+The Account Owners and super admin are synced, so the removal of the Account Owners team will have no impact on existing permissions.
 **From 4 November 2024** you won't be able to create new teams or update existing ones. Existing teams will be migrated to groups after
 this date. **On 2 December 2024** all teams will be deleted and the teams feature will be completely removed. [View the 
 migration guide](https://aiven.io/docs/tools/terraform/howto/migrate-from-teams-to-groups) for more information on the changes and migrating to groups.

--- a/internal/sdkprovider/service/account/account_team.go
+++ b/internal/sdkprovider/service/account/account_team.go
@@ -51,8 +51,15 @@ func ResourceAccountTeam() *schema.Resource {
 		},
 		Timeouts: schemautil.DefaultResourceTimeouts(),
 
-		Schema:             aivenAccountTeamSchema,
-		DeprecationMessage: "This resource is deprecated. Use aiven_organization_user_group instead.",
+		Schema: aivenAccountTeamSchema,
+		DeprecationMessage: `
+This resource is deprecated. Use aiven_organization_user_group instead.
+
+You can't delete the Account Owners team. Deleting all other teams in your organization will disable the teams feature. You won't be able to create new teams or access your Account Owners team.
+
+On 2 December 2024 all teams will be deleted and the teams feature will be completely removed. View the
+migration guide for more information: https://aiven.io/docs/tools/terraform/howto/migrate-from-teams-to-groups.
+`,
 	}
 }
 

--- a/internal/sdkprovider/service/account/account_team_member.go
+++ b/internal/sdkprovider/service/account/account_team_member.go
@@ -70,8 +70,15 @@ deletes the pending invite if not accepted or removes the user from the team if 
 		},
 		Timeouts: schemautil.DefaultResourceTimeouts(),
 
-		Schema:             aivenAccountTeamMemberSchema,
-		DeprecationMessage: "This resource is deprecated. Use aiven_organization_user_group_member instead.",
+		Schema: aivenAccountTeamMemberSchema,
+		DeprecationMessage: `
+This resource is deprecated. Use aiven_organization_user_group instead.
+
+You can't delete the Account Owners team. Deleting all other teams in your organization will disable the teams feature. You won't be able to create new teams or access your Account Owners team.
+
+On 2 December 2024 all teams will be deleted and the teams feature will be completely removed. View the
+migration guide for more information: https://aiven.io/docs/tools/terraform/howto/migrate-from-teams-to-groups.
+`,
 	}
 }
 

--- a/internal/sdkprovider/service/account/account_team_project.go
+++ b/internal/sdkprovider/service/account/account_team_project.go
@@ -53,7 +53,12 @@ Links an existing project to an existing team. Both the project and team should 
 
 		Schema: aivenAccountTeamProjectSchema,
 		DeprecationMessage: `
-This resource is deprecated. Use aiven_organization_group_project instead.
+This resource is deprecated. Use aiven_organization_user_group instead.
+
+You can't delete the Account Owners team. Deleting all other teams in your organization will disable the teams feature. You won't be able to create new teams or access your Account Owners team.
+
+On 2 December 2024 all teams will be deleted and the teams feature will be completely removed. View the
+migration guide for more information: https://aiven.io/docs/tools/terraform/howto/migrate-from-teams-to-groups.
 `,
 	}
 }

--- a/templates/resources/account_team.md.tmpl
+++ b/templates/resources/account_team.md.tmpl
@@ -12,12 +12,15 @@ description: |-
 
 
 ~> **Teams have been deprecated and are being migrated to groups**
-**On 2 September 2024** the Account Owners team will transition to super admin. Super admin have full access to the organization. 
-The Account Owners and super admin are synced, so the removal of the Account Owners team will have no impact on your day to day operations.
+**On 30 September 2024** the Account Owners team will transition to super admin. Super admin have full access to the organization.
+The Account Owners and super admin are synced, so the removal of the Account Owners team will have no impact on existing permissions.
 **From 4 November 2024** you won't be able to create new teams or update existing ones. Existing teams will be migrated to groups after
 this date. **On 2 December 2024** all teams will be deleted and the teams feature will be completely removed. [View the 
 migration guide](https://aiven.io/docs/tools/terraform/howto/migrate-from-teams-to-groups) for more information on the changes and migrating to groups.
 
+~> **Important**
+You can't delete the Account Owners team. **Deleting all other teams in your organization will disable the teams feature.**
+You won't be able to create new teams or access your Account Owners team.
 
 {{ if .HasExample -}}
 ## Example Usage

--- a/templates/resources/account_team_member.md.tmpl
+++ b/templates/resources/account_team_member.md.tmpl
@@ -11,8 +11,8 @@ description: |-
 {{ .Description | trimspace }}
 
 ~> **Teams have been deprecated and are being migrated to groups**
-**On 2 September 2024** the Account Owners team will transition to super admin. Super admin have full access to the organization. 
-The Account Owners and super admin are synced, so the removal of the Account Owners team will have no impact on your day to day operations.
+**On 30 September 2024** the Account Owners team will transition to super admin. Super admin have full access to the organization.
+The Account Owners and super admin are synced, so the removal of the Account Owners team will have no impact on existing permissions.
 **From 4 November 2024** you won't be able to create new teams or update existing ones. Existing teams will be migrated to groups after
 this date. **On 2 December 2024** all teams will be deleted and the teams feature will be completely removed. [View the 
 migration guide](https://aiven.io/docs/tools/terraform/howto/migrate-from-teams-to-groups) for more information on the changes and migrating to groups.

--- a/templates/resources/account_team_project.md.tmpl
+++ b/templates/resources/account_team_project.md.tmpl
@@ -11,8 +11,8 @@ description: |-
 {{ .Description | trimspace }}
 
 ~> **Teams have been deprecated and are being migrated to groups**
-**On 2 September 2024** the Account Owners team will transition to super admin. Super admin have full access to the organization. 
-The Account Owners and super admin are synced, so the removal of the Account Owners team will have no impact on your day to day operations.
+**On 30 September 2024** the Account Owners team will transition to super admin. Super admin have full access to the organization.
+The Account Owners and super admin are synced, so the removal of the Account Owners team will have no impact on existing permissions.
 **From 4 November 2024** you won't be able to create new teams or update existing ones. Existing teams will be migrated to groups after
 this date. **On 2 December 2024** all teams will be deleted and the teams feature will be completely removed. [View the 
 migration guide](https://aiven.io/docs/tools/terraform/howto/migrate-from-teams-to-groups) for more information on the changes and migrating to groups.


### PR DESCRIPTION
## About this change—what it does
Changes the date for the Account Owners team removal and updates the deprecation notice for the teams resources.

Adds warning about the effects of deleting all teams. 
![image](https://github.com/aiven/terraform-provider-aiven/assets/111294980/839feae7-218e-4fa0-9f04-7ca3b67dec33)



