### PR TITLE
fix(aiven_transit_gateway_vpc_attachment): remove peer_region deprecation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ nav_order: 1
 <!-- Always keep the following header in place: -->
 <!-- ## [MAJOR.MINOR.PATCH] - YYYY-MM-DD -->
 
+## [MAJOR.MINOR.PATCH] - YYYY-MM-DD
+
+- Fix `aiven_transit_gateway_vpc_attachment`: remove `peer_region` deprecation, mark the field as create only.
+
 ## [4.20.0] - 2024-06-26
 
 - Mark several sensitive user config fields as "sensitive"

--- a/docs/data-sources/transit_gateway_vpc_attachment.md
+++ b/docs/data-sources/transit_gateway_vpc_attachment.md
@@ -32,7 +32,7 @@ data "aiven_transit_gateway_vpc_attachment" "attachment" {
 ### Read-Only
 
 - `id` (String) The ID of this resource.
-- `peer_region` (String) AWS region of the peered VPC (if not in the same region as Aiven VPC)
+- `peer_region` (String) AWS region of the peered VPC (if not in the same region as Aiven VPC). This value can't be changed.
 - `peering_connection_id` (String) Cloud provider identifier for the peering connection if available
 - `state` (String) State of the peering connection
 - `state_info` (Map of String) State-specific help or error information

--- a/docs/resources/transit_gateway_vpc_attachment.md
+++ b/docs/resources/transit_gateway_vpc_attachment.md
@@ -36,7 +36,7 @@ resource "aiven_transit_gateway_vpc_attachment" "attachment" {
 
 ### Optional
 
-- `peer_region` (String, Deprecated) AWS region of the peered VPC (if not in the same region as Aiven VPC)
+- `peer_region` (String) AWS region of the peered VPC (if not in the same region as Aiven VPC). This value can't be changed.
 - `timeouts` (Block, Optional) (see [below for nested schema](#nestedblock--timeouts))
 
 ### Read-Only

--- a/internal/sdkprovider/service/vpc/transit_gateway_vpc_attachment.go
+++ b/internal/sdkprovider/service/vpc/transit_gateway_vpc_attachment.go
@@ -43,8 +43,8 @@ var aivenTransitGatewayVPCAttachmentSchema = map[string]*schema.Schema{
 	"peer_region": {
 		Optional:    true,
 		Type:        schema.TypeString,
-		Description: "AWS region of the peered VPC (if not in the same region as Aiven VPC)",
-		Deprecated:  "This field is deprecated and will be removed in the next major release.",
+		ForceNew:    true,
+		Description: "AWS region of the peered VPC (if not in the same region as Aiven VPC). This value can't be changed.",
 	},
 	"state": {
 		Computed:    true,


### PR DESCRIPTION
The field has been mistakenly deprecated in #1204.
Marks `peer_region` as create only, removes deprecation.

Resolves #1751 