### PR TITLE
docs(clickhouse): fix grant example

### DIFF
--- a/docs/resources/clickhouse_grant.md
+++ b/docs/resources/clickhouse_grant.md
@@ -92,7 +92,7 @@ Required:
 Optional:
 
 - `column` (String) The column to grant access to. Changing this property forces recreation of the resource.
-- `privilege` (String) The privileges to grant. For example: 'INSERT', 'SELECT', `CREATE`. A complete list is available in the [ClickHouse documentation](https://clickhouse.com/docs/en/sql-reference/statements/grant). Changing this property forces recreation of the resource.
+- `privilege` (String) The privileges to grant. For example: `INSERT`, `SELECT`, `CREATE TABLE`. A complete list is available in the [ClickHouse documentation](https://clickhouse.com/docs/en/sql-reference/statements/grant). Changing this property forces recreation of the resource.
 - `table` (String) The table to grant access to. Changing this property forces recreation of the resource.
 - `with_grant` (Boolean) Allow grantees to grant their privileges to other grantees. Changing this property forces recreation of the resource.
 

--- a/internal/sdkprovider/service/clickhouse/clickhouse_grant.go
+++ b/internal/sdkprovider/service/clickhouse/clickhouse_grant.go
@@ -41,7 +41,7 @@ var aivenClickhouseGrantSchema = map[string]*schema.Schema{
 		Elem: &schema.Resource{
 			Schema: map[string]*schema.Schema{
 				"privilege": {
-					Description:  userconfig.Desc("The privileges to grant. For example: 'INSERT', 'SELECT', `CREATE`. A complete list is available in the [ClickHouse documentation](https://clickhouse.com/docs/en/sql-reference/statements/grant).").ForceNew().Build(),
+					Description:  userconfig.Desc("The privileges to grant. For example: `INSERT`, `SELECT`, `CREATE TABLE`. A complete list is available in the [ClickHouse documentation](https://clickhouse.com/docs/en/sql-reference/statements/grant).").ForceNew().Build(),
 					Type:         schema.TypeString,
 					Optional:     true,
 					ForceNew:     true,


### PR DESCRIPTION
## About this change—what it does

CREATE is not a valid option for ClickHouse grants. This replaces that
example in the docs with CREATE TABLE and fixes
formatting of the other example values.