### PR TITLE
chore(release): v4.21.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ nav_order: 1
 <!-- Always keep the following header in place: -->
 <!-- ## [MAJOR.MINOR.PATCH] - YYYY-MM-DD -->
 
-## [MAJOR.MINOR.PATCH] - YYYY-MM-DD
+## [4.21.0] - 2024-07-23
 
 - Fix `aiven_transit_gateway_vpc_attachment`: remove `peer_region` deprecation, mark the field as create only.
 - Add `aiven_valkey` resource as a beta resource


### PR DESCRIPTION
Release v4.21.0

- Fix `aiven_transit_gateway_vpc_attachment`: remove `peer_region` deprecation, mark the field as create only.
- Add `aiven_valkey` resource as a beta resource
- Add `aiven_valkey_user` resource as a beta resource
- Temporarily remove the `aiven_project_user` deprecation until we find a suitable alternative.