### PR TITLE
fix(aiven_kafka_schema): create missing schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ nav_order: 1
 <!-- Always keep the following header in place: -->
 <!-- ## [MAJOR.MINOR.PATCH] - YYYY-MM-DD -->
 
+## [MAJOR.MINOR.PATCH] - YYYY-MM-DD
+
+- Show "create" plan for missing `aiven_kafka_schema`
+
 ## [4.21.0] - 2024-07-23
 
 - Fix `aiven_transit_gateway_vpc_attachment`: remove `peer_region` deprecation, mark the field as create only.

--- a/internal/sdkprovider/service/kafkaschema/kafka_schema.go
+++ b/internal/sdkprovider/service/kafkaschema/kafka_schema.go
@@ -233,7 +233,7 @@ func resourceKafkaSchemaRead(ctx context.Context, d *schema.ResourceData, m inte
 
 	s, err := client.KafkaSubjectSchemas.Get(ctx, project, serviceName, subjectName, version)
 	if err != nil {
-		return diag.FromErr(err)
+		return diag.FromErr(schemautil.ResourceReadHandleNotFound(err, d))
 	}
 
 	if err := d.Set("schema", s.Version.Schema); err != nil {


### PR DESCRIPTION
Doesn't throw "not found"; instead, acts like the source never existed.