### PR TITLE
Read only is a valid member type for project user

### DIFF
--- a/internal/sdkprovider/service/project/project_user.go
+++ b/internal/sdkprovider/service/project/project_user.go
@@ -26,7 +26,7 @@ var aivenProjectUserSchema = map[string]*schema.Schema{
 	"member_type": {
 		Required:    true,
 		Type:        schema.TypeString,
-		Description: userconfig.Desc("Project membership type.").PossibleValues("admin", "developer", "operator").Build(),
+		Description: userconfig.Desc("Project membership type.").PossibleValues("admin", "developer", "operator", "read_only").Build(),
 	},
 	"accepted": {
 		Computed:    true,


### PR DESCRIPTION
<!-- All contributors, please complete these sections, including maintainers. -->

## About this change—what it does

<!-- Provide a small sentence that summarizes the change. -->

In the GUI and through the Terraform provider you can use `read only` as a valid member type, so the documentation should reflect that.

https://aiven.io/docs/platform/reference/project-member-privileges


<!-- Provide the issue number below, if it exists. -->

## Why this way

<!-- Provide a small explanation on why this is the approach you took for solving this problem. -->
It looks like the documentation is generated from this Go-file, so hopefully it will populate where it is supposed to be.
