### PR TITLE
refactor: return plain error

### DIFF
--- a/internal/common/client.go
+++ b/internal/common/client.go
@@ -73,11 +73,11 @@ func CacheGenAivenClient(token, tfVersion, buildVersion string) error {
 	return nil
 }
 
-type crudHandler func(context.Context, *schema.ResourceData, avngen.Client) diag.Diagnostics
+type crudHandler func(context.Context, *schema.ResourceData, avngen.Client) error
 
 // WithGenClient wraps CRUD handlers and runs with avngen.Client
 func WithGenClient(handler crudHandler) func(context.Context, *schema.ResourceData, any) diag.Diagnostics {
 	return func(ctx context.Context, d *schema.ResourceData, _ any) diag.Diagnostics {
-		return handler(ctx, d, clientCache)
+		return diag.FromErr(handler(ctx, d, clientCache))
 	}
 }

--- a/internal/sdkprovider/service/kafka/kafka_mirrormaker_replication_flow_data_source.go
+++ b/internal/sdkprovider/service/kafka/kafka_mirrormaker_replication_flow_data_source.go
@@ -4,7 +4,6 @@ import (
 	"context"
 
 	avngen "github.com/aiven/go-client-codegen"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
 	"github.com/aiven/terraform-provider-aiven/internal/common"
@@ -21,7 +20,7 @@ func DatasourceMirrorMakerReplicationFlowTopic() *schema.Resource {
 	}
 }
 
-func datasourceMirrorMakerReplicationFlowRead(ctx context.Context, d *schema.ResourceData, client avngen.Client) diag.Diagnostics {
+func datasourceMirrorMakerReplicationFlowRead(ctx context.Context, d *schema.ResourceData, client avngen.Client) error {
 	projectName := d.Get("project").(string)
 	serviceName := d.Get("service_name").(string)
 	sourceCluster := d.Get("source_cluster").(string)

--- a/internal/sdkprovider/service/kafka/mirrormaker_replication_flow.go
+++ b/internal/sdkprovider/service/kafka/mirrormaker_replication_flow.go
@@ -6,7 +6,6 @@ import (
 
 	avngen "github.com/aiven/go-client-codegen"
 	"github.com/aiven/go-client-codegen/handler/kafkamirrormaker"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 
@@ -141,7 +140,7 @@ func ResourceMirrorMakerReplicationFlow() *schema.Resource {
 	}
 }
 
-func resourceMirrorMakerReplicationFlowCreate(ctx context.Context, d *schema.ResourceData, client avngen.Client) diag.Diagnostics {
+func resourceMirrorMakerReplicationFlowCreate(ctx context.Context, d *schema.ResourceData, client avngen.Client) error {
 	project := d.Get("project").(string)
 	serviceName := d.Get("service_name").(string)
 	sourceCluster := d.Get("source_cluster").(string)
@@ -150,12 +149,12 @@ func resourceMirrorMakerReplicationFlowCreate(ctx context.Context, d *schema.Res
 	dto := new(kafkamirrormaker.ServiceKafkaMirrorMakerCreateReplicationFlowIn)
 	err := marshalFlow(d, dto)
 	if err != nil {
-		return diag.FromErr(err)
+		return err
 	}
 
 	err = client.ServiceKafkaMirrorMakerCreateReplicationFlow(ctx, project, serviceName, dto)
 	if err != nil {
-		return diag.FromErr(err)
+		return err
 	}
 
 	d.SetId(schemautil.BuildResourceID(project, serviceName, sourceCluster, targetCluster))
@@ -163,22 +162,22 @@ func resourceMirrorMakerReplicationFlowCreate(ctx context.Context, d *schema.Res
 	return resourceMirrorMakerReplicationFlowRead(ctx, d, client)
 }
 
-func resourceMirrorMakerReplicationFlowRead(ctx context.Context, d *schema.ResourceData, client avngen.Client) diag.Diagnostics {
+func resourceMirrorMakerReplicationFlowRead(ctx context.Context, d *schema.ResourceData, client avngen.Client) error {
 	project, serviceName, sourceCluster, targetCluster, err := schemautil.SplitResourceID4(d.Id())
 	if err != nil {
-		return diag.FromErr(err)
+		return err
 	}
 
 	dto, err := client.ServiceKafkaMirrorMakerGetReplicationFlow(ctx, project, serviceName, sourceCluster, targetCluster)
 	if err != nil {
-		return diag.FromErr(schemautil.ResourceReadHandleNotFound(err, d))
+		return schemautil.ResourceReadHandleNotFound(err, d)
 	}
 
 	if err := d.Set("project", project); err != nil {
-		return diag.FromErr(err)
+		return err
 	}
 	if err := d.Set("service_name", serviceName); err != nil {
-		return diag.FromErr(err)
+		return err
 	}
 
 	err = schemautil.ResourceDataSet(
@@ -196,37 +195,37 @@ func resourceMirrorMakerReplicationFlowRead(ctx context.Context, d *schema.Resou
 		},
 	)
 
-	return diag.FromErr(err)
+	return err
 }
 
-func resourceMirrorMakerReplicationFlowUpdate(ctx context.Context, d *schema.ResourceData, client avngen.Client) diag.Diagnostics {
+func resourceMirrorMakerReplicationFlowUpdate(ctx context.Context, d *schema.ResourceData, client avngen.Client) error {
 	project, serviceName, sourceCluster, targetCluster, err := schemautil.SplitResourceID4(d.Id())
 	if err != nil {
-		return diag.FromErr(err)
+		return err
 	}
 
 	dto := new(kafkamirrormaker.ServiceKafkaMirrorMakerPatchReplicationFlowIn)
 	err = marshalFlow(d, dto)
 	if err != nil {
-		return diag.FromErr(err)
+		return err
 	}
 
 	_, err = client.ServiceKafkaMirrorMakerPatchReplicationFlow(ctx, project, serviceName, sourceCluster, targetCluster, dto)
 	if err != nil {
-		return diag.FromErr(err)
+		return err
 	}
 
 	return resourceMirrorMakerReplicationFlowRead(ctx, d, client)
 }
 
-func resourceMirrorMakerReplicationFlowDelete(ctx context.Context, d *schema.ResourceData, client avngen.Client) diag.Diagnostics {
+func resourceMirrorMakerReplicationFlowDelete(ctx context.Context, d *schema.ResourceData, client avngen.Client) error {
 	project, serviceName, sourceCluster, targetCluster, err := schemautil.SplitResourceID4(d.Id())
 	if err != nil {
-		return diag.FromErr(err)
+		return err
 	}
 
 	err = client.ServiceKafkaMirrorMakerDeleteReplicationFlow(ctx, project, serviceName, sourceCluster, targetCluster)
-	return diag.FromErr(err)
+	return err
 }
 
 func marshalFlow(d *schema.ResourceData, dto any) error {

--- a/internal/sdkprovider/service/organization/organization_application_user_data_source.go
+++ b/internal/sdkprovider/service/organization/organization_application_user_data_source.go
@@ -4,7 +4,6 @@ import (
 	"context"
 
 	avngen "github.com/aiven/go-client-codegen"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
 	"github.com/aiven/terraform-provider-aiven/internal/common"
@@ -19,7 +18,7 @@ func DatasourceOrganizationApplicationUser() *schema.Resource {
 	}
 }
 
-func datasourceOrganizationApplicationUserRead(ctx context.Context, d *schema.ResourceData, client avngen.Client) diag.Diagnostics {
+func datasourceOrganizationApplicationUserRead(ctx context.Context, d *schema.ResourceData, client avngen.Client) error {
 	// The id used to read the resource
 	d.SetId(schemautil.BuildResourceID(d.Get("organization_id").(string), d.Get("user_id").(string)))
 	return resourceOrganizationApplicationUserRead(ctx, d, client)

--- a/internal/sdkprovider/service/valkey/valkey_user_data_source.go
+++ b/internal/sdkprovider/service/valkey/valkey_user_data_source.go
@@ -4,7 +4,6 @@ import (
 	"context"
 
 	avngen "github.com/aiven/go-client-codegen"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
 	"github.com/aiven/terraform-provider-aiven/internal/common"
@@ -20,7 +19,7 @@ func DatasourceValkeyUser() *schema.Resource {
 	}
 }
 
-func datasourceValkeyUserRead(ctx context.Context, d *schema.ResourceData, client avngen.Client) diag.Diagnostics {
+func datasourceValkeyUserRead(ctx context.Context, d *schema.ResourceData, client avngen.Client) error {
 	projectName := d.Get("project").(string)
 	serviceName := d.Get("service_name").(string)
 	userName := d.Get("username").(string)


### PR DESCRIPTION
Returns a plain error in functions wrapped with `WithGenClient`.
This way it is cleaner and easier to code.