### PR TITLE
refactor: unify clients configuration

### DIFF
--- a/examples_tests/base.go
+++ b/examples_tests/base.go
@@ -50,7 +50,7 @@ func (s *BaseTestSuite) setupSuite() error {
 	s.tfConfigPath = tfConfigPath
 
 	// Uses client to validates resources
-	client, err := newClient(s.config.Token)
+	client, err := common.NewAivenClient(common.TokenOpt(s.config.Token))
 	if err != nil {
 		return err
 	}
@@ -108,14 +108,6 @@ func examplesRandPrefix() func(string) string {
 	return func(s string) string {
 		return exampleTestsPrefix + format(s)
 	}
-}
-
-func newClient(token string) (*aiven.Client, error) {
-	client, err := common.NewAivenClientWithToken(token)
-	if err != nil {
-		return nil, err
-	}
-	return client, nil
 }
 
 // configTemplate forces terraform use dev build

--- a/internal/acctest/acctest.go
+++ b/internal/acctest/acctest.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	"github.com/aiven/aiven-go-client/v2"
+	avngen "github.com/aiven/go-client-codegen"
 	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
@@ -47,11 +48,19 @@ func GetTestAivenClient() *aiven.Client {
 	testAivenClientOnce.Do(func() {
 		client, err := common.NewAivenClient()
 		if err != nil {
-			log.Fatal(err)
+			log.Panicf("test client error: %s", err)
 		}
 		testAivenClient = client
 	})
 	return testAivenClient
+}
+
+func GetTestGenAivenClient() avngen.Client {
+	client, err := common.NewAivenGenClient()
+	if err != nil {
+		log.Panicf("test generated client error: %s", err)
+	}
+	return client
 }
 
 // commonTestDependencies is a struct that contains common dependencies that are used by acceptance tests.

--- a/internal/common/client_test.go
+++ b/internal/common/client_test.go
@@ -1,0 +1,93 @@
+package common
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewClientOpts(t *testing.T) {
+	cases := []struct {
+		name      string
+		opts      []ClientOpt
+		envToken  string
+		expectErr error
+		expect    *clientOpts
+	}{
+		{
+			name:      "empty options",
+			expectErr: errTokenRequired,
+		},
+		{
+			name:     "env token",
+			envToken: "foo",
+			expect: &clientOpts{
+				token:        "foo",
+				tfVersion:    "0.11+compatible",
+				buildVersion: "dev",
+				userAgent:    "terraform-provider-aiven/0.11+compatible/dev",
+			},
+		},
+		{
+			name: "custom token",
+			opts: []ClientOpt{
+				TokenOpt("opt token"),
+			},
+			expect: &clientOpts{
+				token:        "opt token",
+				tfVersion:    "0.11+compatible",
+				buildVersion: "dev",
+				userAgent:    "terraform-provider-aiven/0.11+compatible/dev",
+			},
+		},
+		{
+			name:     "custom version number",
+			envToken: "foo",
+			opts: []ClientOpt{
+				TFVersionOpt("bar"),
+			},
+			expect: &clientOpts{
+				token:        "foo",
+				tfVersion:    "bar",
+				buildVersion: "dev",
+				userAgent:    "terraform-provider-aiven/bar/dev",
+			},
+		},
+		{
+			name:     "custom build number",
+			envToken: "bar",
+			opts: []ClientOpt{
+				BuildVersionOpt("baz"),
+			},
+			expect: &clientOpts{
+				token:        "bar",
+				tfVersion:    "0.11+compatible",
+				buildVersion: "baz",
+				userAgent:    "terraform-provider-aiven/0.11+compatible/baz",
+			},
+		},
+		{
+			name: "custom all",
+			opts: []ClientOpt{
+				BuildVersionOpt("baz"),
+				TFVersionOpt("bar"),
+				TokenOpt("foo"),
+			},
+			expect: &clientOpts{
+				token:        "foo",
+				tfVersion:    "bar",
+				buildVersion: "baz",
+				userAgent:    "terraform-provider-aiven/bar/baz",
+			},
+		},
+	}
+
+	for _, o := range cases {
+		t.Run(o.name, func(t *testing.T) {
+			t.Setenv("AIVEN_TOKEN", o.envToken) // must not expose a real token in logs
+			actual, err := newClientOpts(o.opts...)
+			assert.Equal(t, o.expectErr, err)
+			assert.Equal(t, o.expect, actual)
+		})
+	}
+}

--- a/internal/plugin/provider.go
+++ b/internal/plugin/provider.go
@@ -95,7 +95,11 @@ func (p *AivenProvider) Configure(
 		data.APIToken = types.StringValue(token)
 	}
 
-	client, err := common.NewCustomAivenClient(data.APIToken.ValueString(), req.TerraformVersion, p.version)
+	client, err := common.NewAivenClient(
+		common.TokenOpt(data.APIToken.ValueString()),
+		common.TFVersionOpt(req.TerraformVersion),
+		common.BuildVersionOpt(p.version),
+	)
 	if err != nil {
 		resp.Diagnostics.AddError(errmsg.SummaryConstructingClient, err.Error())
 

--- a/internal/schemautil/common.go
+++ b/internal/schemautil/common.go
@@ -42,14 +42,6 @@ var (
 	}
 )
 
-func StringSliceToInterfaceSlice(s []string) []interface{} {
-	res := make([]interface{}, len(s))
-	for i := range s {
-		res[i] = s[i]
-	}
-	return res
-}
-
 func SetTagsTerraformProperties(t map[string]string) []map[string]interface{} {
 	tags := make([]map[string]interface{}, len(t))
 	var i int

--- a/internal/sdkprovider/provider/provider.go
+++ b/internal/sdkprovider/provider/provider.go
@@ -306,13 +306,19 @@ func Provider(version string) (*schema.Provider, error) {
 			token = os.Getenv("AIVEN_TOKEN")
 		}
 
-		client, err := common.NewCustomAivenClient(token, p.TerraformVersion, version)
+		opts := []common.ClientOpt{
+			common.TokenOpt(token),
+			common.TFVersionOpt(p.TerraformVersion),
+			common.BuildVersionOpt(version),
+		}
+
+		client, err := common.NewAivenClient(opts...)
 		if err != nil {
 			return nil, diag.FromErr(err)
 		}
 
-		// fixme: temporary solution
-		err = common.CacheGenAivenClient(token, p.TerraformVersion, version)
+		// fixme: temporary solution, uses a singleton
+		err = common.CachedGenAivenClient(opts...)
 		if err != nil {
 			return nil, diag.FromErr(err)
 		}


### PR DESCRIPTION
There are multiple places where we use old client (plugin, sdkv2, tests), and multiple constructors to build it. That adds unnecessary complexity, and complicates the new client integration.

- Replaces multiple client constructors with a single approach
- Unifies old and new client configuration