### PR TITLE
feat: check user config for redacted creds

### DIFF
--- a/internal/schemautil/service_test.go
+++ b/internal/schemautil/service_test.go
@@ -1,0 +1,38 @@
+package schemautil
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestContainsRedactedCreds(t *testing.T) {
+	cases := []struct {
+		name     string
+		hash     map[string]any
+		expected error
+	}{
+		{
+			name:     "contains redacted",
+			hash:     map[string]any{"password": "<redacted>"},
+			expected: errContainsRedactedCreds,
+		},
+		{
+			name:     "contains invalid redacted",
+			hash:     map[string]any{"password": "<REDACTED>"},
+			expected: nil,
+		},
+		{
+			name:     "does not contain redacted",
+			hash:     map[string]any{"password": "123"},
+			expected: nil,
+		},
+	}
+
+	for _, opt := range cases {
+		t.Run(opt.name, func(t *testing.T) {
+			err := ContainsRedactedCreds(opt.hash)
+			assert.Equal(t, err, opt.expected)
+		})
+	}
+}

--- a/internal/sdkprovider/service/serviceintegration/service_integration_endpoint.go
+++ b/internal/sdkprovider/service/serviceintegration/service_integration_endpoint.go
@@ -116,6 +116,12 @@ func resourceServiceIntegrationEndpointRead(ctx context.Context, d *schema.Resou
 		return schemautil.ResourceReadHandleNotFound(err, d)
 	}
 
+	// The GET with include_secrets=true must not return redacted creds
+	err = schemautil.ContainsRedactedCreds(endpoint.EndpointConfig)
+	if err != nil {
+		return err
+	}
+
 	err = copyServiceIntegrationEndpointPropertiesFromAPIResponseToTerraform(d, endpoint, projectName)
 	if err != nil {
 		return err


### PR DESCRIPTION
Checks GET response doesn't contain `<redacted>` substring.