### PR TITLE
feat: add support for topic description and ownership

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ nav_order: 1
 - Use `ServiceGet` from the code-generated client
 - Use the code-generated client to manage `aiven_service_integration` and `aiven_service_integration_endpoint`
 - Use Go 1.23
+- Add capability to set description and owner group per topic.
 
 ## [4.24.0] - 2024-08-21
 

--- a/docs/data-sources/kafka_topic.md
+++ b/docs/data-sources/kafka_topic.md
@@ -33,10 +33,12 @@ data "aiven_kafka_topic" "example_topic" {
 
 - `config` (List of Object) [Advanced parameters](https://aiven.io/docs/products/kafka/reference/advanced-params) to configure topics. (see [below for nested schema](#nestedatt--config))
 - `id` (String) The ID of this resource.
+- `owner_user_group_id` (String) The user group that is the owner of the topic
 - `partitions` (Number) The number of partitions to create in the topic.
 - `replication` (Number) The replication factor for the topic.
 - `tag` (Set of Object) Tags for the topic. (see [below for nested schema](#nestedatt--tag))
 - `termination_protection` (Boolean) Prevents topics from being deleted by Terraform. It's recommended for topics containing critical data. **Topics can still be deleted in the Aiven Console.**
+- `topic_description` (String) The description of the topic
 
 <a id="nestedatt--config"></a>
 ### Nested Schema for `config`

--- a/docs/resources/kafka_topic.md
+++ b/docs/resources/kafka_topic.md
@@ -47,9 +47,11 @@ resource "aiven_kafka_topic" "example_topic" {
 ### Optional
 
 - `config` (Block List, Max: 1) [Advanced parameters](https://aiven.io/docs/products/kafka/reference/advanced-params) to configure topics. (see [below for nested schema](#nestedblock--config))
+- `owner_user_group_id` (String) The user group that is the owner of the topic
 - `tag` (Block Set) Tags for the topic. (see [below for nested schema](#nestedblock--tag))
 - `termination_protection` (Boolean) Prevents topics from being deleted by Terraform. It's recommended for topics containing critical data. **Topics can still be deleted in the Aiven Console.**
 - `timeouts` (Block, Optional) (see [below for nested schema](#nestedblock--timeouts))
+- `topic_description` (String) The description of the topic
 
 ### Read-Only
 


### PR DESCRIPTION
<!-- All contributors, please complete these sections, including maintainers. -->

## About this change—what it does

Add capability to set description and owner group per topic.

<!-- Provide the issue number below, if it exists. -->

## Why this way

topic description and owner user group are now supported per topic in aiven API's. Both fields are optional. Especially the owner group field will provide basic governing functionality by being able to mark owner to a topic. 

Worth mentioning is that due to how the Aiven topic update endpoint works (fields are reset by sending the field as null to the endpoint) it is not possible to remove the field from config to unset it. In order to unset one of these fields, `terraform destroy` and `terraform apply` must be done in order to completely unset these fields.
