### PR TITLE
Add ClickHouse managed credentials examples

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,4 @@ dist/
 
 # Editors
 .vscode
+.idea

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ nav_order: 1
 <!-- Always keep the following header in place: -->
 <!-- ## [MAJOR.MINOR.PATCH] - YYYY-MM-DD -->
 
+## [MAJOR.MINOR.PATCH] - YYYY-MM-DD
+
+- Add ClickHouse examples for managed credentials integrations with an S3 bucket and remote Postgres, MySQL & ClickHouse clusters
+
 ## [4.25.0] - 2024-09-17
 
 - Fix `aiven_kafka_connector`: increase create polling timeout

--- a/examples/clickhouse_integrations/credentials/README.md
+++ b/examples/clickhouse_integrations/credentials/README.md
@@ -1,0 +1,109 @@
+# ClickHouse managed credentials
+
+This example creates a ClickHouse cluster and integrates it with credentials stored as service integration endpoints.
+
+An S3 bucket is defined by Terraform variables and creates an service integration endpoint resource. 
+The endpoint is made available to the ClickHouse cluster through a managed credentials integration.
+
+Example PostgreSQL, MySQL and ClickHouse services are created to show how remote databases would be integrated. 
+Managed credentials allow ClickHouse users to access them with the PostgreSQL & MySQL table engines, and the `remoteSecure` function.
+
+## Prerequisites
+
+* [Install Terraform](https://www.terraform.io/downloads)
+* [Sign up for Aiven](https://console.aiven.io/signup?utm_source=github&utm_medium=organic&utm_campaign=devportal&utm_content=repo)
+* [Create an authentication token](https://docs.aiven.io/docs/platform/howto/create_authentication_token.html)
+
+## Create the example resources
+
+1. Ensure that you have Terraform v0.13.0 or higher installed. To check the version, run:
+
+    ```sh
+    $ terraform --version 
+    ```
+
+    The output is similar to the following:
+
+    ```sh
+    Terraform version: 1.9.5
+    + provider registry.terraform.io/aiven/aiven v4.9.2
+    ```
+
+2. Clone this repository.
+
+3. Replace the placeholders in the `get-started.tf` file. It's recommended to use your organization name as a prefix for the project name.
+
+4. Initialize Terraform:
+
+```sh
+$ terraform init
+```
+
+The output is similar to the following:
+
+```sh
+
+Initializing the backend...
+
+Initializing provider plugins...
+- Finding aiven/aiven versions matching ">= 4.0.0, < 5.0.0"...
+- Installing aiven/aiven v4.25.0...
+- Installed aiven/aiven v4.25.0
+...
+Terraform has been successfully initialized!
+...
+```
+
+5. To create an execution plan and preview the changes that will be made, run:
+
+```sh
+$ terraform plan
+
+```
+
+6. To deploy your changes, run the following and enter yes to confirm:
+
+```sh
+$ terraform apply 
+```
+
+## Verify the changes in the Aiven Console
+
+You can see the services, integration endpoints and managed credentials integrations in the [Aiven Console](https://console.aiven.io/):
+
+1. In the project services list, you can see the ClickHouse, PostgreSQL, and MySQL services.
+
+2. In the Integration endpoints list, you can see the S3 endpoint and the external ClickHouse, PostgreSQL, and MySQL endpoints.
+
+3. In the overview page for the `clickhouse-gcp-eu` service, the managed credentials are show in the Data Integrations section and the Data pipeline view shows the four integrations as active.
+
+## Clean up
+
+To delete the example resources: 
+
+1. To preview the changes first, run:
+
+```sh
+$ terraform plan -destroy 
+```
+
+The output shows what changes will be made when you run the `destroy` command.
+
+2. To delete all resources, run:
+
+```sh
+$ terraform destroy 
+```
+
+3. Enter yes to confirm the changes:
+
+```sh
+Plan: 0 to add, 0 to change, 13 to destroy
+...
+
+Do you really want to destroy all resources?
+  Terraform will destroy all your managed infrastructure, as shown above.
+  There is no undo. Only 'yes' will be accepted to confirm.
+
+  Enter a value: yes
+```

--- a/examples/clickhouse_integrations/credentials/clickhouse.tf
+++ b/examples/clickhouse_integrations/credentials/clickhouse.tf
@@ -1,0 +1,28 @@
+resource "aiven_clickhouse" "clickhouse" {
+  project      = var.aiven_project_name
+  cloud_name   = "google-europe-west1"
+  plan         = "startup-16"
+  service_name = "clickhouse-gcp-eu"
+}
+
+# Second ClickHouse service, used to showcase integrating with an external cluster
+
+resource "aiven_clickhouse" "external_clickhouse" {
+  project      = var.aiven_project_name
+  cloud_name   = "google-europe-west1"
+  plan         = "startup-16"
+  service_name = "external-clickhouse-gcp-eu"
+}
+
+resource "aiven_service_integration_endpoint" "external_clickhouse" {
+  project       = var.aiven_project_name
+  endpoint_name = "external-clickhouse"
+  endpoint_type = "external_clickhouse"
+
+  external_clickhouse_user_config {
+    host     = aiven_clickhouse.external_clickhouse.service_host
+    port     = aiven_clickhouse.external_clickhouse.service_port
+    username = aiven_clickhouse.external_clickhouse.service_username
+    password = aiven_clickhouse.external_clickhouse.service_password
+  }
+}

--- a/examples/clickhouse_integrations/credentials/credentials-integrations.tf
+++ b/examples/clickhouse_integrations/credentials/credentials-integrations.tf
@@ -1,0 +1,32 @@
+# ClickHouse credentials integrations with endpoints defined in clickhouse.tf, mysql.tf and postgres.tf
+# Each integration will result in a new named collection being created in the ClickHouse service.
+
+resource "aiven_service_integration" "s3_managed_credentials" {
+  project                  = var.aiven_project_name
+  integration_type         = "clickhouse_credentials"
+  source_endpoint_id       = aiven_service_integration_endpoint.s3_bucket.id
+  destination_service_name = aiven_clickhouse.clickhouse.service_name
+}
+
+resource "aiven_service_integration" "external_postgres_managed_credentials" {
+  project                  = var.aiven_project_name
+  integration_type         = "clickhouse_credentials"
+  source_endpoint_id       = aiven_service_integration_endpoint.external_postgres.id
+  destination_service_name = aiven_clickhouse.clickhouse.service_name
+}
+
+resource "aiven_service_integration" "external_mysql_managed_credentials" {
+  project                  = var.aiven_project_name
+  integration_type         = "clickhouse_credentials"
+  source_endpoint_id       = aiven_service_integration_endpoint.external_mysql.id
+  destination_service_name = aiven_clickhouse.clickhouse.service_name
+}
+
+
+resource "aiven_service_integration" "external_clickhouse_managed_credentials" {
+  project                  = var.aiven_project_name
+  integration_type         = "clickhouse_credentials"
+  source_endpoint_id       = aiven_service_integration_endpoint.external_clickhouse.id
+  destination_service_name = aiven_clickhouse.clickhouse.service_name
+}
+

--- a/examples/clickhouse_integrations/credentials/mysql.tf
+++ b/examples/clickhouse_integrations/credentials/mysql.tf
@@ -1,0 +1,21 @@
+# MySQL service based in GCP US East
+resource "aiven_mysql" "external_mysql" {
+  project      = var.aiven_project_name
+  service_name = "external-mysql-gcp-us"
+  cloud_name   = "google-us-east4"
+  plan         = "business-8"
+}
+
+resource "aiven_service_integration_endpoint" "external_mysql" {
+  project       = var.aiven_project_name
+  endpoint_name = "external-mysql"
+  endpoint_type = "external_mysql"
+
+  external_mysql_user_config {
+    host     = aiven_mysql.external_mysql.service_host
+    port     = aiven_mysql.external_mysql.service_port
+    username = aiven_mysql.external_mysql.service_username
+    password = aiven_mysql.external_mysql.service_password
+  }
+}
+

--- a/examples/clickhouse_integrations/credentials/postgres.tf
+++ b/examples/clickhouse_integrations/credentials/postgres.tf
@@ -1,0 +1,21 @@
+# Postgres service based in GCP US East
+resource "aiven_pg" "external_postgres" {
+  project      = var.aiven_project_name
+  service_name = "external-postgres-gcp-us"
+  cloud_name   = "google-us-east4"
+  plan         = "business-8" # Primary and read replica
+}
+
+resource "aiven_service_integration_endpoint" "external_postgres" {
+  project       = var.aiven_project_name
+  endpoint_name = "external-postgresql"
+  endpoint_type = "external_postgresql"
+
+  external_postgresql {
+    host     = aiven_pg.external_postgres.service_host
+    port     = aiven_pg.external_postgres.service_port
+    username = aiven_pg.external_postgres.service_username
+    password = aiven_pg.external_postgres.service_password
+  }
+}
+

--- a/examples/clickhouse_integrations/credentials/project.tf
+++ b/examples/clickhouse_integrations/credentials/project.tf
@@ -1,0 +1,3 @@
+resource "aiven_project" "clickhouse_managed_credentials" {
+  project = var.aiven_project_name
+}

--- a/examples/clickhouse_integrations/credentials/provider.tf
+++ b/examples/clickhouse_integrations/credentials/provider.tf
@@ -1,0 +1,15 @@
+# Initialize the provider
+
+terraform {
+  required_version = ">=0.13"
+  required_providers {
+    aiven = {
+      source  = "aiven/aiven"
+      version = ">=4.25.0, <5.0.0"
+    }
+  }
+}
+
+provider "aiven" {
+  api_token = var.aiven_api_token
+}

--- a/examples/clickhouse_integrations/credentials/s3.tf
+++ b/examples/clickhouse_integrations/credentials/s3.tf
@@ -1,0 +1,13 @@
+# S3 bucket that can hold data in formats that ClickHouse can read from,
+# eg. CSV, Parquet, ORC, JSON, Avro
+resource "aiven_service_integration_endpoint" "s3_bucket" {
+  project       = var.aiven_project_name
+  endpoint_name = "s3-bucket"
+  endpoint_type = "external_aws_s3"
+
+  external_aws_s3_user_config {
+    access_key_id     = var.s3_bucket_access_key
+    secret_access_key = var.s3_bucket_secret_key
+    url               = var.s3_bucket_url
+  }
+}

--- a/examples/clickhouse_integrations/credentials/variables.tf
+++ b/examples/clickhouse_integrations/credentials/variables.tf
@@ -1,0 +1,28 @@
+variable "aiven_api_token" {
+  description = "Aiven API token"
+  type        = string
+  sensitive = true
+}
+
+# Pre-existing Aiven project
+variable "aiven_project_name" {
+  description = "Aiven project name"
+  type        = string
+}
+
+
+variable "s3_bucket_access_key" {
+  default = "AAAAAAAAAAAAAAAAAAA"
+  type        = string
+}
+
+variable "s3_bucket_secret_key" {
+  default = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+  type        = string
+  sensitive = true
+}
+
+variable "s3_bucket_url" {
+  default = "https://mybucket.s3-myregion.amazonaws.com/mydataset/"
+  type        = string
+}


### PR DESCRIPTION
<!-- All contributors, please complete these sections, including maintainers. -->

## About this change—what it does

<!-- Provide a small sentence that summarizes the change. -->

<!-- Provide the issue number below, if it exists. -->
Adds examples using the newly released Managed Credentials integration, which allows connecting a ClickHouse cluster with S3 buckets and remote Postgres, MySQL & ClickHouse services.

## Why this way

<!-- Provide a small explanation on why this is the approach you took for solving this problem. -->

Chose to define the `aiven_service_integration_endpoint` close to each service, and the `clickhouse_credentials` of type `aiven_service_integration` in a single file. Let me know if the resource organization is not intuitive or could be improved!
