### PR TITLE
fix: add version to .goreleaser.yml

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,3 +1,6 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/goreleaser/goreleaser/v2.3.2/www/docs/static/schema.json
+version: 2
+
 builds:
   - env:
       - CGO_ENABLED=0


### PR DESCRIPTION
## About this change—what it does

* Adds `version` field to goreleaser config file
* Adds `yaml-language-server` as instructed in https://goreleaser.com/customization/

Fixes the following warning printed on the release GHA:

![image](https://github.com/user-attachments/assets/65c939c5-1791-4e24-a0dd-304c6ed1174a)

