### PR TITLE
fix: mark `aiven_external_identity` data source as beta in docs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -181,6 +181,7 @@ gen-go:
 
 
 docs: $(TFPLUGINDOCS)
+	rm -f docs/.DS_Store
 	PROVIDER_AIVEN_ENABLE_BETA=1 $(TFPLUGINDOCS) generate
 	rm -f docs/data-sources/influxdb*.md
 	rm -f docs/resources/influxdb*.md

--- a/docs/data-sources/external_identity.md
+++ b/docs/data-sources/external_identity.md
@@ -4,11 +4,16 @@ page_title: "aiven_external_identity Data Source - terraform-provider-aiven"
 subcategory: ""
 description: |-
   Maps an external service user to an Aiven user.
+  This resource is in the beta stage and may change without notice. Set
+  the PROVIDER_AIVEN_ENABLE_BETA environment variable to use the resource.
 ---
 
 # aiven_external_identity (Data Source)
 
-Maps an external service user to an Aiven user.
+Maps an external service user to an Aiven user. 
+
+**This resource is in the beta stage and may change without notice.** Set
+the `PROVIDER_AIVEN_ENABLE_BETA` environment variable to use the resource.
 
 
 

--- a/internal/plugin/service/externalidentity/external_identity_data_source.go
+++ b/internal/plugin/service/externalidentity/external_identity_data_source.go
@@ -5,12 +5,12 @@ import (
 	"fmt"
 
 	"github.com/aiven/aiven-go-client/v2"
-	"github.com/aiven/terraform-provider-aiven/internal/schemautil/userconfig"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
 	"github.com/aiven/terraform-provider-aiven/internal/plugin/util"
+	"github.com/aiven/terraform-provider-aiven/internal/schemautil/userconfig"
 )
 
 var (
@@ -58,7 +58,7 @@ func (r *externalIdentityDataSource) Schema(
 	resp *datasource.SchemaResponse,
 ) {
 	resp.Schema = schema.Schema{
-		Description: "Maps an external service user to an Aiven user.",
+		Description: userconfig.Desc("Maps an external service user to an Aiven user.").AvailabilityType(userconfig.Beta).Build(),
 		Attributes: map[string]schema.Attribute{
 			"organization_id": schema.StringAttribute{
 				Description: "The ID of the Aiven organization that the user is part of.",


### PR DESCRIPTION
## About this change—what it does

Marks `aiven_external_identity` as beta in docs
