### PR TITLE
docs(kafka): update description for topic owner group

### DIFF
--- a/docs/data-sources/kafka_topic.md
+++ b/docs/data-sources/kafka_topic.md
@@ -33,7 +33,7 @@ data "aiven_kafka_topic" "example_topic" {
 
 - `config` (List of Object) [Advanced parameters](https://aiven.io/docs/products/kafka/reference/advanced-params) to configure topics. (see [below for nested schema](#nestedatt--config))
 - `id` (String) The ID of this resource.
-- `owner_user_group_id` (String) The user group that is the owner of the topic
+- `owner_user_group_id` (String) The ID of the user group that owns the topic. Assigning ownership to decentralize topic management is part of [Aiven for Apache Kafka® governance](https://aiven.io/docs/products/kafka/concepts/governance-overview).
 - `partitions` (Number) The number of partitions to create in the topic.
 - `replication` (Number) The replication factor for the topic.
 - `tag` (Set of Object) Tags for the topic. (see [below for nested schema](#nestedatt--tag))

--- a/docs/resources/kafka_topic.md
+++ b/docs/resources/kafka_topic.md
@@ -26,6 +26,8 @@ resource "aiven_kafka_topic" "example_topic" {
     cleanup_policy = "compact,delete"
   }
 
+  owner_user_group_id = aiven_organization_user_group.example.group_id
+
   timeouts {
     create = "1m"
     read   = "5m"
@@ -47,7 +49,7 @@ resource "aiven_kafka_topic" "example_topic" {
 ### Optional
 
 - `config` (Block List, Max: 1) [Advanced parameters](https://aiven.io/docs/products/kafka/reference/advanced-params) to configure topics. (see [below for nested schema](#nestedblock--config))
-- `owner_user_group_id` (String) The user group that is the owner of the topic
+- `owner_user_group_id` (String) The ID of the user group that owns the topic. Assigning ownership to decentralize topic management is part of [Aiven for Apache Kafka® governance](https://aiven.io/docs/products/kafka/concepts/governance-overview).
 - `tag` (Block Set) Tags for the topic. (see [below for nested schema](#nestedblock--tag))
 - `termination_protection` (Boolean) Prevents topics from being deleted by Terraform. It's recommended for topics containing critical data. **Topics can still be deleted in the Aiven Console.**
 - `timeouts` (Block, Optional) (see [below for nested schema](#nestedblock--timeouts))

--- a/examples/resources/aiven_kafka_topic/resource.tf
+++ b/examples/resources/aiven_kafka_topic/resource.tf
@@ -11,6 +11,8 @@ resource "aiven_kafka_topic" "example_topic" {
     cleanup_policy = "compact,delete"
   }
 
+  owner_user_group_id = aiven_organization_user_group.example.group_id
+
   timeouts {
     create = "1m"
     read   = "5m"

--- a/internal/sdkprovider/service/kafkatopic/kafka_topic.go
+++ b/internal/sdkprovider/service/kafkatopic/kafka_topic.go
@@ -194,7 +194,7 @@ var aivenKafkaTopicSchema = map[string]*schema.Schema{
 	"owner_user_group_id": {
 		Type:        schema.TypeString,
 		Optional:    true,
-		Description: "The user group that is the owner of the topic",
+		Description: "The ID of the user group that owns the topic. Assigning ownership to decentralize topic management is part of [Aiven for Apache Kafka® governance](https://aiven.io/docs/products/kafka/concepts/governance-overview).",
 	},
 	"termination_protection": {
 		Type:        schema.TypeBool,


### PR DESCRIPTION
## About this change—what it does

Updates the description of for the `owner_user_group_id` field to provide more information and link to governance conceptual docs.