### PR TITLE
test: fix aiven_service_component race

### DIFF
--- a/internal/sdkprovider/service/servicecomponent/service_component_data_source_test.go
+++ b/internal/sdkprovider/service/servicecomponent/service_component_data_source_test.go
@@ -24,10 +24,6 @@ func TestAccAivenServiceComponentDataSource_basic(t *testing.T) {
 		PreCheck:                 func() { acc.TestAccPreCheck(t) },
 		ProtoV6ProviderFactories: acc.TestProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
-			//{
-			//	Config:      testAccServiceComponentKafkaAuthMethodMissingErrorMessages(rName),
-			//	ExpectError: regexp.MustCompile("please try specifying 'kafka_authentication_method' to filter the results"),
-			//},
 			{
 				Config:      testAccServiceComponentKafkaAuthMethodNotMatchErrorMessages(rName),
 				ExpectError: regexp.MustCompile("cannot find component"),
@@ -171,11 +167,13 @@ data "aiven_project" "foo" {
   project = "%s"
 }
 
-resource "aiven_kafka" "kafka" {
-  project      = data.aiven_project.foo.project
-  service_name = "test-acc-sr-%s"
-  cloud_name   = "google-europe-west3"
-  plan         = "startup-2"
+resource "aiven_kafka" "bar" {
+  project                 = data.aiven_project.foo.project
+  cloud_name              = "google-europe-west1"
+  plan                    = "business-4"
+  service_name            = "test-acc-sr-%s"
+  maintenance_window_dow  = "monday"
+  maintenance_window_time = "10:00:00"
 
   kafka_user_config {
     public_access {
@@ -183,13 +181,14 @@ resource "aiven_kafka" "kafka" {
     }
   }
 }
+
 data "aiven_service_component" "kafka" {
-  project                     = aiven_kafka.kafka.project
-  service_name                = aiven_kafka.kafka.service_name
+  project                     = aiven_kafka.bar.project
+  service_name                = aiven_kafka.bar.service_name
   component                   = "kafka"
   route                       = "dynamic"
   kafka_authentication_method = "sasl"
 
-  depends_on = [aiven_kafka.kafka]
+  depends_on = [aiven_kafka.bar]
 }`, os.Getenv("AIVEN_PROJECT_NAME"), name)
 }


### PR DESCRIPTION
The test flow:

1. It creates a kafka service, runs checks
2. Destroys it, the code makes sure `ServiceGet` returns `NotFound` to prove it is destroyed
3. Creates another kafka with the very same name, but gets `[409 ServiceCreate]: Service name is already in use in this project`

Looks like it takes a bit longer now to destroy a service for real.
The fix reuses kafka from the step 1) updating it in 3).