### PR TITLE
docs: update links to permissions docs

### DIFF
--- a/docs/guides/update-deprecated-resources.md
+++ b/docs/guides/update-deprecated-resources.md
@@ -217,8 +217,7 @@ Teams have been deprecated and are being migrated to groups. Groups are an easie
 
   The Account Owners and super admin are synced, so the removal of the
   Account Owners team will have no impact on existing permissions.
-  [Super admin](/docs/platform/concepts/orgs-units-projects#users-and-roles)
-  have full access to organizations.
+  Super admin have full access to organizations.
 
 * **From November 4, 2024 you won't be able to create new teams or update existing ones.**
 

--- a/docs/resources/organization_permission.md
+++ b/docs/resources/organization_permission.md
@@ -3,12 +3,12 @@
 page_title: "aiven_organization_permission Resource - terraform-provider-aiven"
 subcategory: ""
 description: |-
-  Grants permissions to a principal for a resource.
+  Grants permissions https://aiven.io/docs/platform/concepts/permissions to a principal for a resource.
 ---
 
 # aiven_organization_permission (Resource)
 
-Grants permissions to a principal for a resource.
+Grants [permissions](https://aiven.io/docs/platform/concepts/permissions) to a principal for a resource.
 
 ## Example Usage
 

--- a/internal/sdkprovider/service/organization/organization_permission.go
+++ b/internal/sdkprovider/service/organization/organization_permission.go
@@ -70,7 +70,7 @@ var permissionFields = map[string]*schema.Schema{
 
 func ResourceOrganizationalPermission() *schema.Resource {
 	return &schema.Resource{
-		Description:   "Grants permissions to a principal for a resource.",
+		Description:   "Grants [permissions](https://aiven.io/docs/platform/concepts/permissions) to a principal for a resource.",
 		CreateContext: common.WithGenClient(resourceOrganizationalPermissionUpsert),
 		ReadContext:   common.WithGenClient(resourceOrganizationalPermissionRead),
 		UpdateContext: common.WithGenClient(resourceOrganizationalPermissionUpsert),

--- a/templates/guides/update-deprecated-resources.md
+++ b/templates/guides/update-deprecated-resources.md
@@ -217,8 +217,7 @@ Teams have been deprecated and are being migrated to groups. Groups are an easie
 
   The Account Owners and super admin are synced, so the removal of the
   Account Owners team will have no impact on existing permissions.
-  [Super admin](/docs/platform/concepts/orgs-units-projects#users-and-roles)
-  have full access to organizations.
+  Super admin have full access to organizations.
 
 * **From November 4, 2024 you won't be able to create new teams or update existing ones.**
 


### PR DESCRIPTION
## About this change—what it does

Removes links to a section of Aiven docs that will be deleted soon and adds a link to the new permissions page with details about roles and permissions in the platform.