### PR TITLE
feat: MM2 exactly-once delivery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ nav_order: 1
   Defaults to aiven.
 - Add `aiven_service_integration_endpoint` datasource field `datadog_user_config.extra_tags_prefix`: Extra tags prefix.
   Defaults to aiven.
+- Add `exactly_once_delivery_enabled` field to `aiven_mirrormaker_replication_flow`: Whether to enable exactly-once message delivery for Mirrormaker replication flow
 
 ## [4.29.0] - 2024-11-14
 

--- a/docs/data-sources/mirrormaker_replication_flow.md
+++ b/docs/data-sources/mirrormaker_replication_flow.md
@@ -37,6 +37,7 @@ data "aiven_mirrormaker_replication_flow" "f1" {
 - `emit_backward_heartbeats_enabled` (Boolean) Whether to emit heartbeats to the direction opposite to the flow, i.e. to the source cluster. The default value is `false`.
 - `emit_heartbeats_enabled` (Boolean) Whether to emit heartbeats to the target cluster. The default value is `false`.
 - `enable` (Boolean) Enable of disable replication flows for a service.
+- `exactly_once_delivery_enabled` (Boolean) Whether to enable exactly-once message delivery. We recommend you set this to `enabled` for new replications. The default value is `false`.
 - `id` (String) The ID of this resource.
 - `offset_syncs_topic_location` (String) Offset syncs topic location. The possible values are `source` and `target`.
 - `replication_factor` (Number) Replication factor, `>= 1`.

--- a/docs/resources/mirrormaker_replication_flow.md
+++ b/docs/resources/mirrormaker_replication_flow.md
@@ -59,6 +59,7 @@ resource "aiven_mirrormaker_replication_flow" "f1" {
 - `config_properties_exclude` (Set of String) List of topic configuration properties and/or regular expressions to not replicate. The properties that are not replicated by default are: `follower.replication.throttled.replicas`, `leader.replication.throttled.replicas`, `message.timestamp.difference.max.ms`, `message.timestamp.type`, `unclean.leader.election.enable`, and `min.insync.replicas`. Setting this overrides the defaults. For example, to enable replication for 'min.insync.replicas' and 'unclean.leader.election.enable' set this to: ["follower\\\\.replication\\\\.throttled\\\\.replicas", "leader\\\\.replication\\\\.throttled\\\\.replicas", "message\\\\.timestamp\\\\.difference\\\\.max\\\\.ms",  "message\\\\.timestamp\\\\.type"]
 - `emit_backward_heartbeats_enabled` (Boolean) Whether to emit heartbeats to the direction opposite to the flow, i.e. to the source cluster. The default value is `false`.
 - `emit_heartbeats_enabled` (Boolean) Whether to emit heartbeats to the target cluster. The default value is `false`.
+- `exactly_once_delivery_enabled` (Boolean) Whether to enable exactly-once message delivery. We recommend you set this to `enabled` for new replications. The default value is `false`.
 - `replication_factor` (Number) Replication factor, `>= 1`.
 - `sync_group_offsets_enabled` (Boolean) Sync consumer group offsets. The default value is `false`.
 - `sync_group_offsets_interval_seconds` (Number) Frequency of consumer group offset sync. The default value is `1`.

--- a/internal/sdkprovider/service/kafka/mirrormaker_replication_flow.go
+++ b/internal/sdkprovider/service/kafka/mirrormaker_replication_flow.go
@@ -122,6 +122,14 @@ var aivenMirrorMakerReplicationFlowSchema = map[string]*schema.Schema{
 		ValidateFunc: validation.IntAtLeast(1),
 		Description:  "Replication factor, `>= 1`.",
 	},
+	"exactly_once_delivery_enabled": {
+		Type:     schema.TypeBool,
+		Optional: true,
+		Default:  false,
+		Description: userconfig.Desc(
+			"Whether to enable exactly-once message delivery. We recommend you set this to `enabled` for new replications.",
+		).DefaultValue(false).Build(),
+	},
 }
 
 func ResourceMirrorMakerReplicationFlow() *schema.Resource {

--- a/internal/sdkprovider/service/kafka/mirrormaker_replication_flow_test.go
+++ b/internal/sdkprovider/service/kafka/mirrormaker_replication_flow_test.go
@@ -43,10 +43,11 @@ func TestAccAivenMirrorMakerReplicationFlow_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "topics_blacklist.1", ".*\\.replica"),
 					resource.TestCheckResourceAttr(resourceName, "topics_blacklist.2", "__.*"),
 					resource.TestCheckResourceAttr(resourceName, "config_properties_exclude.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "exactly_once_delivery_enabled", "true"),
 				),
 			},
 			{
-				Config: testAccMirrorMakerReplicationFlowResource(rName, `	
+				Config: testAccMirrorMakerReplicationFlowResource(rName, `
 				config_properties_exclude = [
 					"follower\\.replication\\.throttled\\.replicas",
 					"leader\\.replication\\.throttled\\.replicas",
@@ -226,6 +227,7 @@ resource "aiven_mirrormaker_replication_flow" "foo" {
   emit_heartbeats_enabled             = true
   emit_backward_heartbeats_enabled    = true
   offset_syncs_topic_location         = "source"
+  exactly_once_delivery_enabled       = true
 
   topics = [
     ".*",


### PR DESCRIPTION
## About this change—what it does
We update the `aivenMirrorMakerReplicationFlowSchema` with `exactly_once_delivery_enabled` config flag so users can toggle the exactly once message delivery semantics.
