### PR TITLE
fix(service_integration): remove v2 client checks

### DIFF
--- a/internal/sdkprovider/service/serviceintegration/service_integration.go
+++ b/internal/sdkprovider/service/serviceintegration/service_integration.go
@@ -7,7 +7,6 @@ import (
 	"regexp"
 	"time"
 
-	"github.com/aiven/aiven-go-client/v2"
 	avngen "github.com/aiven/go-client-codegen"
 	"github.com/aiven/go-client-codegen/handler/service"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
@@ -272,7 +271,7 @@ func resourceServiceIntegrationWaitUntilActive(ctx context.Context, d *schema.Re
 			ii, err := client.ServiceIntegrationGet(ctx, projectName, integrationID)
 			if err != nil {
 				// Sometimes Aiven API retrieves 404 error even when a successful service integration is created
-				if aiven.IsNotFound(err) {
+				if avngen.IsNotFound(err) {
 					log.Println("[DEBUG] Service Integration: not yet found")
 					return nil, notActive, nil
 				}

--- a/internal/sdkprovider/service/serviceintegration/service_integration_endpoint_test.go
+++ b/internal/sdkprovider/service/serviceintegration/service_integration_endpoint_test.go
@@ -2,17 +2,16 @@ package serviceintegration_test
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"os"
 	"testing"
 
-	"github.com/aiven/aiven-go-client/v2"
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 
 	acc "github.com/aiven/terraform-provider-aiven/internal/acctest"
+	"github.com/aiven/terraform-provider-aiven/internal/common"
 	"github.com/aiven/terraform-provider-aiven/internal/schemautil"
 )
 
@@ -248,11 +247,8 @@ func testAccCheckAivenServiceIntegraitonEndpointResourceDestroy(s *terraform.Sta
 		}
 
 		i, err := c.ServiceIntegrationEndpoints.Get(ctx, projectName, endpointID)
-		if err != nil {
-			var e aiven.Error
-			if errors.As(err, &e) && e.Status != 404 {
-				return err
-			}
+		if common.IsCritical(err) {
+			return err
 		}
 
 		if i != nil {

--- a/internal/sdkprovider/service/serviceintegration/sweep.go
+++ b/internal/sdkprovider/service/serviceintegration/sweep.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/aiven/aiven-go-client/v2"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 
 	"github.com/aiven/terraform-provider-aiven/internal/common"
@@ -48,19 +47,15 @@ func sweepServiceIntegrations(ctx context.Context) func(region string) error {
 			if err != nil {
 				return fmt.Errorf("error retrieving a list of service integration for service `%s`: %w", service.Name, err)
 			}
+
 			for _, serviceIntegration := range serviceIntegrations {
-				if err := client.ServiceIntegrations.Delete(
-					ctx,
-					projectName,
-					serviceIntegration.ServiceIntegrationID,
-				); err != nil {
-					if !aiven.IsNotFound(err) {
-						return fmt.Errorf(
-							"unable to delete service integration `%s`: %w",
-							serviceIntegration.ServiceIntegrationID,
-							err,
-						)
-					}
+				err = client.ServiceIntegrations.Delete(ctx, projectName, serviceIntegration.ServiceIntegrationID)
+				if common.IsCritical(err) {
+					return fmt.Errorf(
+						"unable to delete service integration `%s`: %w",
+						serviceIntegration.ServiceIntegrationID,
+						err,
+					)
 				}
 			}
 		}


### PR DESCRIPTION
There was `IsNotFound` usage from v2 client, which doesn't work with gen client errors.