### PR TITLE
fix: make fmt-imports

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -140,8 +140,11 @@ fmt-test: $(TERRAFMT)
 # macOS requires to install GNU sed first. Use `brew install gnu-sed` to install it.
 # It has to be added to PATH as `sed` command, to replace default BSD sed.
 # See `brew info gnu-sed` for more details on how to add it to PATH.
+# /^import ($$/: starts with "import ("
+# /^)/: ends with ")"
+# /^[[:space:]]*$$/: empty lines
 fmt-imports:
-	find . -type f -name '*.go' -exec sed -zi 's/"[\r\n\t]\+"/"\n"/g' {} +
+	find . -type f -name '*.go' -exec sed -i '/^import ($$/,/^)/ {/^[[:space:]]*$$/d}' {} +
 	goimports -local "github.com/aiven/terraform-provider-aiven" -w .
 
 #################################################

--- a/internal/sdkprovider/service/organization/organization_user_group_data_source.go
+++ b/internal/sdkprovider/service/organization/organization_user_group_data_source.go
@@ -4,11 +4,10 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/aiven/terraform-provider-aiven/internal/common"
-
 	avngen "github.com/aiven/go-client-codegen"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
+	"github.com/aiven/terraform-provider-aiven/internal/common"
 	"github.com/aiven/terraform-provider-aiven/internal/schemautil"
 )
 


### PR DESCRIPTION
The current command looks for `'s/"[\r\n\t]\+"/"\n"/g'`— newlines and tabs before `"`.
Hence, fails to sort lines with aliases: `\n\tmymodule"`.