### PR TITLE
fix: changelog doesn't show diff for user config enums

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,29 +15,23 @@ nav_order: 1
 - Add `aiven_alloydbomni_user` BETA resource and datasource
 - Add `aiven_alloydbomni_database` BETA resource and datasource
 - Fix `terraform plan`: new resources don't display zero values for user configuration options
-- Add `aiven_service_integration` resource field `destination_service_project`: Destination service project name
-- Add `aiven_service_integration` resource field `source_service_project`: Source service project name
-- Add `aiven_service_integration` datasource field `destination_service_project`: Destination service project name
-- Add `aiven_service_integration` datasource field `source_service_project`: Source service project name
-- Add `aiven_opensearch` resource field `opensearch_user_config.opensearch_dashboards.multiple_data_source_enabled`:
-  Enable or disable multiple data sources in OpenSearch Dashboards
-- Add `aiven_opensearch` datasource field `opensearch_user_config.opensearch_dashboards.multiple_data_source_enabled`:
-  Enable or disable multiple data sources in OpenSearch Dashboards
-- Change `aiven_account_team_project` resource field `team_type`: remove `organization:billing:read`,
-  `organization:billing:write`, `organization:network:read`, `organization:network:write`,
+- Add `aiven_service_integration` resource and datasource field `destination_service_project`: Destination service project name
+- Add `aiven_service_integration` resource and datasource field `source_service_project`: Source service project name
+- Change `aiven_account_team_project` resource and datasource field `team_type` (enum): remove
+  `organization:billing:read`, `organization:billing:write`, `organization:network:read`, `organization:network:write`,
   `organization:permissions:read`, `organization:permissions:write`, `organization:projects:read`, `organization:projects:write`
-- Change `aiven_organization_permission` resource field `permissions.permissions`: remove `organization:billing:read`,
-  `organization:billing:write`, `organization:network:read`, `organization:network:write`,
+- Add `aiven_alloydbomni` resource and datasource field `alloydbomni_user_config.pg.password_encryption` (enum)
+- Change `aiven_flink` resource and datasource field `flink_user_config.flink_version` (enum): add `1.20`
+- Add `aiven_opensearch` resource and datasource field
+  `opensearch_user_config.opensearch_dashboards.multiple_data_source_enabled`: Enable or disable multiple data sources
+  in OpenSearch Dashboards
+- Change `aiven_organization_permission` resource field `permissions.permissions` (enum): remove
+  `organization:billing:read`, `organization:billing:write`, `organization:network:read`, `organization:network:write`,
   `organization:permissions:read`, `organization:permissions:write`, `organization:projects:read`, `organization:projects:write`
-- Change `aiven_pg` resource field `pg_user_config.additional_backup_regions`: remove deprecation
-- Change `aiven_project_user` resource field `member_type`: remove `organization:billing:read`,
-  `organization:billing:write`, `organization:network:read`, `organization:network:write`,
-  `organization:permissions:read`, `organization:permissions:write`, `organization:projects:read`, `organization:projects:write`
-- Change `aiven_account_team_project` datasource field `team_type`: remove `organization:billing:read`,
-  `organization:billing:write`, `organization:network:read`, `organization:network:write`,
-  `organization:permissions:read`, `organization:permissions:write`, `organization:projects:read`, `organization:projects:write`
-- Change `aiven_pg` datasource field `pg_user_config.additional_backup_regions`: remove deprecation
-- Change `aiven_project_user` datasource field `member_type`: remove `organization:billing:read`,
+- Add `aiven_pg` resource and datasource field `pg_user_config.pg.password_encryption` (enum)
+- Change `aiven_pg` resource and datasource field `pg_user_config.additional_backup_regions`: remove deprecation
+- Change `aiven_pg` resource and datasource field `pg_user_config.pg_version` (enum): add `17`
+- Change `aiven_project_user` resource and datasource field `member_type` (enum): remove `organization:billing:read`,
   `organization:billing:write`, `organization:network:read`, `organization:network:write`,
   `organization:permissions:read`, `organization:permissions:write`, `organization:projects:read`, `organization:projects:write`
 

--- a/changelog/differ_test.go
+++ b/changelog/differ_test.go
@@ -12,102 +12,116 @@ func TestCompare(t *testing.T) {
 	tests := []struct {
 		name     string
 		expect   string
-		kind     RootType
 		old, new *Item
 	}{
 		{
 			name:   "change enums",
-			expect: "Change `foo` resource field `bar`: add `foo`, remove `bar`",
-			kind:   ResourceRootType,
+			expect: "Change `foo` resource field `bar` (enum): add `foo`, remove `bar`",
 			old: &Item{
+				Kind:        ResourceRootKind,
 				Type:        schema.TypeString,
 				Path:        "foo.bar",
+				Root:        "foo",
 				Description: "Foo. The possible values are `bar`, `baz`.",
 			},
 			new: &Item{
+				Kind:        ResourceRootKind,
 				Type:        schema.TypeString,
 				Path:        "foo.bar",
+				Root:        "foo",
 				Description: "Foo. The possible values are `foo`, `baz`.",
 			},
 		},
 		{
 			name:   "change enum",
-			expect: "Change `foo` resource field `bar`: add `foo`",
-			kind:   ResourceRootType,
+			expect: "Change `foo` resource field `bar` (enum): add `foo`",
 			old: &Item{
+				Kind:        ResourceRootKind,
 				Type:        schema.TypeString,
 				Path:        "foo.bar",
+				Root:        "foo",
 				Description: "Foo. The possible values is `bar`",
 			},
 			new: &Item{
+				Kind:        ResourceRootKind,
 				Type:        schema.TypeString,
 				Path:        "foo.bar",
+				Root:        "foo",
 				Description: "Foo. The possible values are `foo`, `bar`.",
 			},
 		},
 		{
 			name:   "add resource field",
 			expect: "Add `foo` resource field `bar`: Foo",
-			kind:   ResourceRootType,
 			new: &Item{
+				Kind:        ResourceRootKind,
 				Type:        schema.TypeString,
 				Path:        "foo.bar",
+				Root:        "foo",
 				Description: "Foo",
 			},
 		},
 		{
 			name:   "remove resource field",
 			expect: "Remove `foo` resource field `bar`: Foo",
-			kind:   ResourceRootType,
 			old: &Item{
+				Kind:        ResourceRootKind,
 				Type:        schema.TypeString,
 				Path:        "foo.bar",
+				Root:        "foo",
 				Description: "Foo",
 			},
 		},
 		{
 			name:   "remove beta from the field",
 			expect: "Change `foo` resource field `bar`: no longer beta",
-			kind:   ResourceRootType,
 			old: &Item{
+				Kind:        ResourceRootKind,
 				Type:        schema.TypeString,
 				Path:        "foo.bar",
+				Root:        "foo",
 				Description: "PROVIDER_AIVEN_ENABLE_BETA",
 			},
 			new: &Item{
+				Kind:        ResourceRootKind,
 				Type:        schema.TypeString,
 				Path:        "foo.bar",
+				Root:        "foo",
 				Description: "Foo",
 			},
 		},
 		{
 			name:   "add beta resource",
 			expect: "Add `foo` resource _(beta)_: does stuff, PROVIDER_AIVEN_ENABLE_BETA",
-			kind:   ResourceRootType,
 			new: &Item{
+				Kind:        ResourceRootKind,
 				Type:        schema.TypeString,
 				Path:        "foo",
+				Root:        "foo",
 				Description: "does stuff, PROVIDER_AIVEN_ENABLE_BETA",
 			},
 		},
 		{
 			name:   "change type",
 			expect: "Change `foo` resource field `bar`: type ~~`list`~~ → `set`",
-			kind:   ResourceRootType,
 			old: &Item{
+				Kind: ResourceRootKind,
 				Type: schema.TypeList,
 				Path: "foo.bar",
+				Root: "foo",
 			},
 			new: &Item{
+				Kind: ResourceRootKind,
 				Type: schema.TypeSet,
 				Path: "foo.bar",
+				Root: "foo",
 			},
 		},
 	}
 
 	for _, opt := range tests {
 		t.Run(opt.name, func(t *testing.T) {
-			got, err := diffItems(opt.kind, opt.old, opt.new)
+			got, err := diffItems(opt.old, opt.new)
 			assert.NoError(t, err)
 			assert.Equal(t, opt.expect, got.String())
 		})
@@ -116,19 +130,19 @@ func TestCompare(t *testing.T) {
 
 func TestSerializeDiff(t *testing.T) {
 	list := []*Diff{
-		{Action: AddDiffAction, RootType: ResourceRootType, Description: "foo", Item: &Item{Path: "aiven_opensearch.opensearch_user_config.azure_migration.include_aliases"}},
-		{Action: ChangeDiffAction, RootType: DataSourceRootType, Description: "remove deprecation", Item: &Item{Path: "aiven_cassandra.cassandra_user_config.additional_backup_regions"}},
-		{Action: ChangeDiffAction, RootType: ResourceRootType, Description: "remove deprecation", Item: &Item{Path: "aiven_cassandra.cassandra_user_config.additional_backup_regions"}},
-		{Action: AddDiffAction, RootType: ResourceRootType, Description: "foo", Item: &Item{Path: "aiven_opensearch.opensearch_user_config.s3_migration.include_aliases"}},
-		{Action: AddDiffAction, RootType: ResourceRootType, Description: "foo", Item: &Item{Path: "aiven_opensearch.opensearch_user_config.gcs_migration.include_aliases"}},
+		{Action: AddDiffAction, Description: "foo", Item: &Item{Kind: ResourceRootKind, Root: "aiven_opensearch", Path: "aiven_opensearch.opensearch_user_config.azure_migration.include_aliases"}},
+		{Action: ChangeDiffAction, Description: "remove deprecation", Item: &Item{Kind: DataSourceRootKind, Root: "aiven_cassandra", Path: "aiven_cassandra.cassandra_user_config.additional_backup_regions"}},
+		{Action: ChangeDiffAction, Description: "remove deprecation", Item: &Item{Kind: ResourceRootKind, Root: "aiven_cassandra", Path: "aiven_cassandra.cassandra_user_config.additional_backup_regions"}},
+		{Action: AddDiffAction, Description: "foo", Item: &Item{Kind: ResourceRootKind, Root: "aiven_opensearch", Path: "aiven_opensearch.opensearch_user_config.s3_migration.include_aliases"}},
+		{Action: AddDiffAction, Description: "foo", Item: &Item{Kind: DataSourceRootKind, Root: "aiven_opensearch", Path: "aiven_opensearch.opensearch_user_config.s3_migration.include_aliases"}},
+		{Action: AddDiffAction, Description: "foo", Item: &Item{Kind: ResourceRootKind, Root: "aiven_opensearch", Path: "aiven_opensearch.opensearch_user_config.gcs_migration.include_aliases"}},
 	}
 
 	expect := []string{
+		"Change `aiven_cassandra` resource and datasource field `cassandra_user_config.additional_backup_regions`: remove deprecation",
 		"Add `aiven_opensearch` resource field `opensearch_user_config.azure_migration.include_aliases`: foo",
 		"Add `aiven_opensearch` resource field `opensearch_user_config.gcs_migration.include_aliases`: foo",
-		"Add `aiven_opensearch` resource field `opensearch_user_config.s3_migration.include_aliases`: foo",
-		"Change `aiven_cassandra` resource field `cassandra_user_config.additional_backup_regions`: remove deprecation",
-		"Change `aiven_cassandra` datasource field `cassandra_user_config.additional_backup_regions`: remove deprecation",
+		"Add `aiven_opensearch` resource and datasource field `opensearch_user_config.s3_migration.include_aliases`: foo",
 	}
 
 	actual := serializeDiff(list)

--- a/changelog/main.go
+++ b/changelog/main.go
@@ -162,9 +162,9 @@ func writeChangelog(filePath string, reformat bool, entries []string) error {
 func fromProvider(p *schema.Provider) (ItemMap, error) {
 	// Item names might clash between resources and data sources
 	// Splits into separate maps
-	sourceMaps := map[RootType]map[string]*schema.Resource{
-		ResourceRootType:   p.ResourcesMap,
-		DataSourceRootType: p.DataSourcesMap,
+	sourceMaps := map[RootKind]map[string]*schema.Resource{
+		ResourceRootKind:   p.ResourcesMap,
+		DataSourceRootKind: p.DataSourcesMap,
 	}
 
 	items := make(ItemMap)
@@ -173,7 +173,9 @@ func fromProvider(p *schema.Provider) (ItemMap, error) {
 		for name, r := range m {
 			res := &Item{
 				Name:        name,
+				Root:        name,
 				Path:        name,
+				Kind:        kind,
 				Description: r.Description,
 				Type:        schema.TypeList,
 			}
@@ -192,7 +194,9 @@ func fromProvider(p *schema.Provider) (ItemMap, error) {
 func walkSchema(name string, this *schema.Schema, parent *Item) []*Item {
 	item := &Item{
 		Name:        name,
+		Root:        parent.Root,
 		Path:        fmt.Sprintf("%s.%s", parent.Path, name),
+		Kind:        parent.Kind,
 		ForceNew:    this.ForceNew,
 		Optional:    this.Optional,
 		Sensitive:   this.Sensitive,

--- a/changelog/text.go
+++ b/changelog/text.go
@@ -25,11 +25,21 @@ func removeEnum(text string) string {
 var reCode = regexp.MustCompile("`([^`]+)`")
 
 func findEnums(description string) []string {
-	parts := strings.Split(description, userconfig.PossibleValuesPrefix)
-	if len(parts) != 2 {
-		return nil
+	var values []string
+	switch {
+	case strings.Contains(description, userconfig.PossibleValuesPrefix):
+		// userconfig.PossibleValuesPrefix is used within "internal" package,
+		// see userconfig.DescriptionBuilder.PossibleValuesString()
+		parts := strings.Split(description, userconfig.PossibleValuesPrefix)
+		if len(parts) != 2 {
+			return nil
+		}
+		values = reCode.FindAllString(parts[1], -1)
+	case strings.Contains(strings.ToLower(description), "enum"):
+		// "enum" is used in the user config generator
+		values = reCode.FindAllString(description, -1)
 	}
-	values := reCode.FindAllString(parts[1], -1)
+
 	if len(values) == 0 {
 		return nil
 	}

--- a/docs/data-sources/alloydbomni.md
+++ b/docs/data-sources/alloydbomni.md
@@ -176,6 +176,7 @@ Read-Only:
 - `max_standby_streaming_delay` (Number)
 - `max_wal_senders` (Number)
 - `max_worker_processes` (Number)
+- `password_encryption` (String)
 - `pg_partman_bgw__dot__interval` (Number)
 - `pg_partman_bgw__dot__role` (String)
 - `pg_stat_statements__dot__track` (String)

--- a/docs/data-sources/pg.md
+++ b/docs/data-sources/pg.md
@@ -210,6 +210,7 @@ Read-Only:
 - `max_standby_streaming_delay` (Number)
 - `max_wal_senders` (Number)
 - `max_worker_processes` (Number)
+- `password_encryption` (String)
 - `pg_partman_bgw__dot__interval` (Number)
 - `pg_partman_bgw__dot__role` (String)
 - `pg_stat_monitor__dot__pgsm_enable_query_plan` (Boolean)

--- a/docs/resources/alloydbomni.md
+++ b/docs/resources/alloydbomni.md
@@ -186,6 +186,7 @@ Optional:
 - `max_standby_streaming_delay` (Number) Max standby streaming delay in milliseconds.
 - `max_wal_senders` (Number) PostgreSQL maximum WAL senders.
 - `max_worker_processes` (Number) Sets the maximum number of background processes that the system can support.
+- `password_encryption` (String) Enum: `md5`, `scram-sha-256`. Chooses the algorithm for encrypting passwords. Default: `md5`.
 - `pg_partman_bgw__dot__interval` (Number) Sets the time interval to run pg_partman's scheduled tasks. Example: `3600`.
 - `pg_partman_bgw__dot__role` (String) Controls which role to use for pg_partman's scheduled background tasks. Example: `myrolename`.
 - `pg_stat_statements__dot__track` (String) Enum: `all`, `none`, `top`. Controls which statements are counted. Specify top to track top-level statements (those issued directly by clients), all to also track nested statements (such as statements invoked within functions), or none to disable statement statistics collection. The default value is top.

--- a/docs/resources/pg.md
+++ b/docs/resources/pg.md
@@ -238,6 +238,7 @@ Optional:
 - `max_standby_streaming_delay` (Number) Max standby streaming delay in milliseconds.
 - `max_wal_senders` (Number) PostgreSQL maximum WAL senders.
 - `max_worker_processes` (Number) Sets the maximum number of background processes that the system can support.
+- `password_encryption` (String) Enum: `md5`, `scram-sha-256`. Chooses the algorithm for encrypting passwords. Default: `md5`.
 - `pg_partman_bgw__dot__interval` (Number) Sets the time interval to run pg_partman's scheduled tasks. Example: `3600`.
 - `pg_partman_bgw__dot__role` (String) Controls which role to use for pg_partman's scheduled background tasks. Example: `myrolename`.
 - `pg_stat_monitor__dot__pgsm_enable_query_plan` (Boolean) Enables or disables query plan monitoring.

--- a/go.mod
+++ b/go.mod
@@ -63,7 +63,7 @@ require (
 	cloud.google.com/go v0.112.0 // indirect
 	cloud.google.com/go/storage v1.36.0 // indirect
 	github.com/agext/levenshtein v1.2.3 // indirect
-	github.com/aiven/go-api-schemas v1.105.0
+	github.com/aiven/go-api-schemas v1.106.0
 	github.com/aws/aws-sdk-go v1.44.122 // indirect
 	github.com/bgentry/go-netrc v0.0.0-20140422174119-9fd32a8b3d3d // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -197,8 +197,8 @@ github.com/agext/levenshtein v1.2.3 h1:YB2fHEn0UJagG8T1rrWknE3ZQzWM06O8AMAatNn7l
 github.com/agext/levenshtein v1.2.3/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=
 github.com/aiven/aiven-go-client/v2 v2.33.0 h1:7hsM3/2lVog/P9ls/gLeba5feNVQjK8rIL+lbxD2GB4=
 github.com/aiven/aiven-go-client/v2 v2.33.0/go.mod h1:qXBgER0dtjJa1V3l7kzpizuAGjFCkgahhHL5OpoM2ZM=
-github.com/aiven/go-api-schemas v1.105.0 h1:AEG3GMDuu/9kJIGpAQlNNmw6IG18tnIfZ/hyqHlx27c=
-github.com/aiven/go-api-schemas v1.105.0/go.mod h1:z7dGvufm6If4gOdVr7dWTuFZmll9FOZr5Z5CSxGpebA=
+github.com/aiven/go-api-schemas v1.106.0 h1:qncRsbiaGnU9JE9fmTFHclTCBem+t+6EPMXGXM35w2c=
+github.com/aiven/go-api-schemas v1.106.0/go.mod h1:z7dGvufm6If4gOdVr7dWTuFZmll9FOZr5Z5CSxGpebA=
 github.com/aiven/go-client-codegen v0.68.0 h1:LeQC5MpbTqNxnMqtjKf0vB70VaUews+cub6gSGO2JUw=
 github.com/aiven/go-client-codegen v0.68.0/go.mod h1:QKN/GgLMGWd6+gPEucXlZPi5vC3C6RpD3UeBRQOLI1Y=
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=

--- a/internal/sdkprovider/userconfig/service/alloydbomni.go
+++ b/internal/sdkprovider/userconfig/service/alloydbomni.go
@@ -292,6 +292,12 @@ func alloydbomniUserConfig() *schema.Schema {
 						Optional:    true,
 						Type:        schema.TypeInt,
 					},
+					"password_encryption": {
+						Description:  "Enum: `md5`, `scram-sha-256`. Chooses the algorithm for encrypting passwords. Default: `md5`.",
+						Optional:     true,
+						Type:         schema.TypeString,
+						ValidateFunc: validation.StringInSlice([]string{"md5", "scram-sha-256"}, false),
+					},
 					"pg_partman_bgw__dot__interval": {
 						Description: "Sets the time interval to run pg_partman's scheduled tasks. Example: `3600`.",
 						Optional:    true,

--- a/internal/sdkprovider/userconfig/service/pg.go
+++ b/internal/sdkprovider/userconfig/service/pg.go
@@ -332,6 +332,12 @@ func pgUserConfig() *schema.Schema {
 						Optional:    true,
 						Type:        schema.TypeInt,
 					},
+					"password_encryption": {
+						Description:  "Enum: `md5`, `scram-sha-256`. Chooses the algorithm for encrypting passwords. Default: `md5`.",
+						Optional:     true,
+						Type:         schema.TypeString,
+						ValidateFunc: validation.StringInSlice([]string{"md5", "scram-sha-256"}, false),
+					},
 					"pg_partman_bgw__dot__interval": {
 						Description: "Sets the time interval to run pg_partman's scheduled tasks. Example: `3600`.",
 						Optional:    true,


### PR DESCRIPTION
- Fixes enums in the changlog for user config fields
- Groups similar changes for resources and datasources
- Updates schemas and the client (the most of the diff)