### PR TITLE
docs: fix typo in guide

### DIFF
--- a/docs/guides/update-deprecated-resources.md
+++ b/docs/guides/update-deprecated-resources.md
@@ -424,7 +424,7 @@ resource "aiven_account_team_project" "main" {
 ## Update `aiven_redis` resources after Valkey upgrade
 
 After you [upgrade from Aiven for Caching to Aiven for Valkey™](https://aiven.io/docs/products/caching/howto/upgrade-aiven-for-caching-to-valkey), update your
-Terraform configraution to use the `aiven_valkey` resource. Aiven for Caching can only be upgraded to Valkey using the Aiven Console or the Aiven API.
+Terraform configuration to use the `aiven_valkey` resource. Aiven for Caching can only be upgraded to Valkey using the Aiven Console or the Aiven API.
 
 The following steps show you how to update your Terraform files using this example file with an Aiven for Caching service:
 

--- a/templates/guides/update-deprecated-resources.md
+++ b/templates/guides/update-deprecated-resources.md
@@ -424,7 +424,7 @@ resource "aiven_account_team_project" "main" {
 ## Update `aiven_redis` resources after Valkey upgrade
 
 After you [upgrade from Aiven for Caching to Aiven for Valkey™](https://aiven.io/docs/products/caching/howto/upgrade-aiven-for-caching-to-valkey), update your
-Terraform configraution to use the `aiven_valkey` resource. Aiven for Caching can only be upgraded to Valkey using the Aiven Console or the Aiven API.
+Terraform configuration to use the `aiven_valkey` resource. Aiven for Caching can only be upgraded to Valkey using the Aiven Console or the Aiven API.
 
 The following steps show you how to update your Terraform files using this example file with an Aiven for Caching service:
 


### PR DESCRIPTION
## About this change—what it does

Fixes a misspelling in the guide for updating deprecated resources.