### PR TITLE
fix: service user update lag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ nav_order: 1
 - Replaced `aiven-go-client/v2` with `aiven/go-client-codegen` in `aiven_pg_user` resource/data source
 - Fix `aiven_pg_user` creating in bulk occasionally results in a 404 error
 - Use `aiven_pg_user` handlers and schema in `aiven_alloydbomni_user` resource
+- Ensure the service user's password is updated correctly
 
 ## [4.31.1] - 2024-12-23
 

--- a/internal/common/client.go
+++ b/internal/common/client.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/aiven/aiven-go-client/v2"
 	avngen "github.com/aiven/go-client-codegen"
-	"github.com/avast/retry-go"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
@@ -118,19 +117,5 @@ func BuildVersionOpt(v string) ClientOpt {
 func TokenOpt(v string) ClientOpt {
 	return func(o *clientOpts) {
 		o.token = v
-	}
-}
-
-// RetryCrudNotFound retries the handler if the error is NotFound
-// This happens when GET called right after CREATE, and the resource is not yet available
-func RetryCrudNotFound(f CrudHandler) CrudHandler {
-	return func(ctx context.Context, d *schema.ResourceData, client avngen.Client) error {
-		return retry.Do(
-			func() error {
-				return f(ctx, d, client)
-			},
-			retry.Context(ctx),
-			retry.RetryIf(avngen.IsNotFound),
-		)
 	}
 }

--- a/internal/schemautil/helpers.go
+++ b/internal/schemautil/helpers.go
@@ -2,6 +2,7 @@ package schemautil
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 
@@ -10,6 +11,7 @@ import (
 	"github.com/aiven/go-client-codegen/handler/service"
 	"github.com/docker/go-units"
 	"github.com/hashicorp/go-cty/cty"
+	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
@@ -189,4 +191,16 @@ func StringToDiagWarning(msg string) diag.Diagnostics {
 // ErrorToDiagWarning is a function that converts an error to a diag warning.
 func ErrorToDiagWarning(err error) diag.Diagnostics {
 	return StringToDiagWarning(err.Error())
+}
+
+// ErrorFromDiagnostics converts diag.Diagnostics to error.
+// Warning: ignores diag.Warning level diagnostics.
+func ErrorFromDiagnostics(diags diag.Diagnostics) error {
+	var err error
+	for _, v := range diags {
+		if v.Severity == diag.Error {
+			err = multierror.Append(err, errors.New(v.Summary))
+		}
+	}
+	return err
 }

--- a/internal/schemautil/wait.go
+++ b/internal/schemautil/wait.go
@@ -374,3 +374,16 @@ func WaitUntilNotFound(ctx context.Context, retryableFunc retryGo.RetryableFunc)
 		retryGo.Delay(common.DefaultStateChangeDelay),
 	)
 }
+
+// retryNotFoundAttempts just a random number
+const retryNotFoundAttempts = 10
+
+func RetryNotFound(ctx context.Context, retryableFunc retryGo.RetryableFunc) error {
+	return retryGo.Do(
+		retryableFunc,
+		retryGo.Context(ctx),
+		retryGo.Delay(time.Second),
+		retryGo.Attempts(retryNotFoundAttempts),
+		retryGo.RetryIf(IsNotFound),
+	)
+}


### PR DESCRIPTION
There is a lag between `ServiceUserCreate` and `ServiceUserCredentialsModify` changes take affect, and `ServiceUserGet` might get the outdated state.
Adds a waiter to make sure certain fields are updated.