### PR TITLE
fix: services always created in the default VPC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ nav_order: 1
 
 - Add `disaster_recovery` service integration type support
 - Add `aiven_flink_jar_application`, `aiven_flink_jar_application_version` and `aiven_flink_jar_application_deployment` BETA resources
+- Fix: services always created in the default VPC of the same cloud, when `project_vpc_id` wasn't set
 - Change `aiven_account_team_project` field `team_type` (enum): add `organization:networking:read`, `organization:networking:write`
 - Change `aiven_organization_permission` resource field `permissions.permissions` (enum):
   add `organization:networking:read`, `organization:networking:write`


### PR DESCRIPTION
Fix: services always created in the default VPC of the same cloud, 
when `project_vpc_id` wasn't set.

1. Uses [updated client](https://github.com/aiven/go-client-codegen/pull/227) that can send `nil` value in `project_vpc_id` (the client updated in this [PR](https://github.com/aiven/terraform-provider-aiven/pull/2009))
1. Adds a test
 
**Doesn't fix:** resetting `project_vpc_id` was never possible.