### PR TITLE
fix: missing mockery tool

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -207,7 +207,7 @@ load-schemas:
 	go get github.com/aiven/go-client-codegen@latest github.com/aiven/go-api-schemas@latest
 	go mod tidy
 
-mockery:
+mockery: $(MOCKERY)
 	$(MOCKERY) --config=./.mockery.yml
 
 update-schemas: dump-schemas load-schemas generate diff-schemas mockery


### PR DESCRIPTION
Resolves the [dependency](https://github.com/aiven/terraform-provider-aiven/actions/runs/12901573049/job/35973859503#step:5:459).