### PR TITLE
ci: remove caching action

### DIFF
--- a/.github/workflows/acceptance-tests.yml
+++ b/.github/workflows/acceptance-tests.yml
@@ -35,6 +35,8 @@ jobs:
   acceptance_tests:
     needs: setup_aiven_project_suffix
     runs-on: ubuntu-latest
+    env:
+      ACC_TEST_PARALLELISM: 5
     strategy:
       max-parallel: 5
       fail-fast: false
@@ -82,15 +84,6 @@ jobs:
         with:
           go-version-file: go.mod
 
-      - uses: actions/cache@v4
-        with:
-          path: |
-            ~/.cache/go-build
-            ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-
-
       - run: make test-acc
         env:
           AIVEN_TOKEN: ${{ secrets.AIVEN_TOKEN }}
@@ -117,15 +110,6 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
-
-      - uses: actions/cache@v4
-        with:
-          path: |
-            ~/.cache/go-build
-            ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-
 
       - uses: nick-invision/retry@v3
         if: always()


### PR DESCRIPTION
Fixes `Cannot open: File exists` error in [acceptance tests](https://github.com/aiven/terraform-provider-aiven/actions/runs/13000813509/job/36258930620#step:5:27).

Caching action is already used by [`actions/setup.go`](https://github.com/actions/setup-go/blob/5a083d0e9a84784eb32078397cf5459adecb4c40/package.json#L28).
So we don't need to use [`actions/cache`](https://github.com/orgs/community/discussions/58174#discussioncomment-7627691).

Additionally, sets `ACC_TEST_PARALLELISM=5` to reduce concurrency errors.