### PR TITLE
refactor: validate ForceNew fields in ResourceDataSet

### DIFF
--- a/internal/schemautil/schemautil.go
+++ b/internal/schemautil/schemautil.go
@@ -13,6 +13,7 @@ import (
 	"github.com/aiven/go-client-codegen/handler/service"
 	"github.com/docker/go-units"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/samber/lo"
 )
 
 // OptionalStringPointer retrieves a string pointer to a field, empty string
@@ -344,7 +345,7 @@ func CopyServiceUserGenPropertiesFromAPIResponseToTerraform(
 //
 // Warning: doesn't support nested sets.
 // Warning: not tested with nested objects.
-func ResourceDataGet(d ResourceData, dto any, fns ...KVModifier) error {
+func ResourceDataGet(d ResourceData, dto any, fns ...MapModifier) error {
 	rawConfig := d.GetRawConfig()
 	if rawConfig.IsNull() {
 		return nil
@@ -364,11 +365,13 @@ func ResourceDataGet(d ResourceData, dto any, fns ...KVModifier) error {
 			value = set.List()
 		}
 
-		for _, f := range fns {
-			k, value = f(k, value)
-		}
-
 		m[k] = serializeGet(value)
+	}
+
+	for _, f := range fns {
+		if err := f(m); err != nil {
+			return err
+		}
 	}
 
 	return Remarshal(&m, dto)
@@ -391,8 +394,13 @@ func serializeGet(value any) any {
 	return value
 }
 
-// KVModifier modifier for key/value pair
-type KVModifier func(k string, v any) (string, any)
+// MapModifier modifier for key/value pair
+type MapModifier func(m map[string]any) error
+
+// errMissingForceNew `terraform import` requires all ForceNew fields to be set
+// otherwise it will output "replace" plan.
+// All ForceNew fields must be set.
+var errMissingForceNew = fmt.Errorf("missing required ForceNew field")
 
 // ResourceDataSet Sets the given dto values to schema.ResourceData
 // Instead of setting every field individually and dealing with pointers,
@@ -408,8 +416,8 @@ type KVModifier func(k string, v any) (string, any)
 //
 // Use:
 //
-//	err := ResourceDataSet(s, d, dto)
-func ResourceDataSet(s map[string]*schema.Schema, d ResourceData, dto any, fns ...KVModifier) error {
+//	err := ResourceDataSet(d, dto, s)
+func ResourceDataSet(d ResourceData, dto any, s map[string]*schema.Schema, fns ...MapModifier) error {
 	var m map[string]any
 	err := Remarshal(dto, &m)
 	if err != nil {
@@ -417,28 +425,41 @@ func ResourceDataSet(s map[string]*schema.Schema, d ResourceData, dto any, fns .
 	}
 
 	for _, f := range fns {
-		for k, v := range m {
-			delete(m, k) // remove the old key in case it is replaced
-			k, v = f(k, v)
-			m[k] = v
+		if err := f(m); err != nil {
+			return err
 		}
 	}
 
-	m = serializeSet(s, m)
-	for k := range s {
-		if v, ok := m[k]; ok {
-			if err = d.Set(k, v); err != nil {
-				return err
-			}
+	if err = serializeSet(s, m); err != nil {
+		return err
+	}
+
+	for k, v := range m {
+		if err := d.Set(k, v); err != nil {
+			return err
 		}
 	}
+
 	return nil
 }
 
-func serializeSet(s map[string]*schema.Schema, m map[string]any) map[string]any {
-	for k, prop := range s {
+func serializeSet(s map[string]*schema.Schema, m map[string]any) error {
+	keys := lo.Uniq(append(lo.Keys(m), lo.Keys(s)...))
+	for _, k := range keys {
+		prop, ok := s[k]
+		if !ok {
+			// The field not in the schema, removes it.
+			delete(m, k)
+			continue
+		}
+
 		value, ok := m[k]
 		if !ok {
+			if prop.ForceNew && prop.Required {
+				return fmt.Errorf("%w: %q", errMissingForceNew, k)
+			}
+
+			// The field is not in the dto, moves on.
 			continue
 		}
 
@@ -449,25 +470,32 @@ func serializeSet(s map[string]*schema.Schema, m map[string]any) map[string]any 
 
 		// When we have an object, we need to convert it to a list.
 		// So there is no difference between a single object and a list of objects.
-		var items []any
-		switch element := value.(type) {
-		case map[string]any:
-			items = append(items, serializeSet(res.Schema, element))
-		case []any:
-			for _, v := range element {
-				items = append(items, serializeSet(res.Schema, v.(map[string]any)))
-			}
+		var list []any
+		if v, ok := value.([]any); ok {
+			list = v
+		} else {
+			list = append(list, value)
 		}
 
-		m[k] = items
+		m[k] = list
+		for _, v := range list {
+			o, ok := v.(map[string]any)
+			if !ok {
+				return fmt.Errorf("expected object for field %q, got type %T", k, v)
+			}
+
+			if err := serializeSet(res.Schema, o); err != nil {
+				return fmt.Errorf("failed to serialize object %q: %w", k, err)
+			}
+		}
 	}
 
-	return m
+	return nil
 }
 
 // RenameAlias renames field names terraform name -> dto name
 // Example: RenameAlias("hasFoo", "wantBar", "hasBaz", "wantEgg")
-func RenameAlias(keys ...string) KVModifier {
+func RenameAlias(keys ...string) MapModifier {
 	m := make(map[string]string, len(keys)/2)
 	for i := 0; i < len(keys); i += 2 {
 		m[keys[i]] = keys[i+1]
@@ -476,23 +504,39 @@ func RenameAlias(keys ...string) KVModifier {
 }
 
 // RenameAliases renames field names terraform name -> dto name
-func RenameAliases(aliases map[string]string) KVModifier {
-	return func(k string, v any) (string, any) {
-		alias, ok := aliases[k]
-		if ok {
-			return alias, v
+func RenameAliases(aliases map[string]string) MapModifier {
+	return func(m map[string]any) error {
+		for k, v := range m {
+			alias, ok := aliases[k]
+			if ok {
+				m[alias] = v
+				delete(m, k)
+			}
 		}
-		return k, v
+		return nil
 	}
 }
 
 // RenameAliasesReverse reverse version of RenameAliases
-func RenameAliasesReverse(aliases map[string]string) KVModifier {
+func RenameAliasesReverse(aliases map[string]string) MapModifier {
 	m := make(map[string]string, len(aliases))
 	for k, v := range aliases {
 		m[v] = k
 	}
 	return RenameAliases(m)
+}
+
+// AddForceNew adds extra key/value pair to the dto
+// Use it to set ForceNew fields when they are not in the dto
+func AddForceNew(k string, v string) MapModifier {
+	return func(dto map[string]any) error {
+		exist, ok := dto[k]
+		if ok {
+			return fmt.Errorf("field %q already exists: %v", k, exist)
+		}
+		dto[k] = v
+		return nil
+	}
 }
 
 // Remarshal marshals "in" object to "out" through json

--- a/internal/schemautil/schemautil_test.go
+++ b/internal/schemautil/schemautil_test.go
@@ -115,6 +115,7 @@ func TestResourceDataSetAddForceNew(t *testing.T) {
 	require.Error(t, err, fmt.Errorf("%w: %q", errMissingForceNew, "force_new"))
 
 	// Expects to set all fields
+	d.EXPECT().Id().Return("hey!")
 	d.EXPECT().Set("set", fieldSet).Return(nil)
 	d.EXPECT().Set("object", []any{fieldObject}).Return(nil)        // is wrapped into a list
 	d.EXPECT().Set("set_of_objects", fieldSetOfObjects).Return(nil) // renamed
@@ -122,7 +123,7 @@ func TestResourceDataSetAddForceNew(t *testing.T) {
 
 	err = ResourceDataSet(
 		d, dto, s,
-		AddForceNew("force_new", "hey!"),
+		ResourceIDKeys("force_new"),
 		RenameAlias("to_rename", "set_of_objects"),
 	)
 	require.NoError(t, err)

--- a/internal/schemautil/schemautil_test.go
+++ b/internal/schemautil/schemautil_test.go
@@ -2,10 +2,15 @@ package schemautil
 
 import (
 	"errors"
+	"fmt"
 	"reflect"
 	"testing"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/aiven/terraform-provider-aiven/mocks"
 )
 
 func Test_splitResourceID(t *testing.T) {
@@ -57,4 +62,68 @@ func Test_PointerValueOrDefault(t *testing.T) {
 	bar := "bar"
 	assert.Equal(t, PointerValueOrDefault(foo, "default"), "default")
 	assert.Equal(t, PointerValueOrDefault(&bar, "default"), "bar")
+}
+
+func TestResourceDataSetAddForceNew(t *testing.T) {
+	s := map[string]*schema.Schema{
+		"set": {
+			Elem:     &schema.Schema{Type: schema.TypeString},
+			Optional: true,
+			Type:     schema.TypeSet,
+		},
+		"object": {
+			Elem: &schema.Resource{Schema: map[string]*schema.Schema{
+				"string": {Optional: true, Type: schema.TypeString},
+			}},
+			Optional: true,
+			Type:     schema.TypeList,
+		},
+		"set_of_objects": {
+			Elem: &schema.Resource{Schema: map[string]*schema.Schema{
+				"description": {Optional: true, Type: schema.TypeString},
+			}},
+			Optional: true,
+			Type:     schema.TypeSet,
+		},
+		"optional_force_new": {
+			Type:     schema.TypeString,
+			ForceNew: true,
+			Optional: true, // ignored
+		},
+		"force_new": {
+			Type:     schema.TypeString,
+			ForceNew: true,
+			Required: true,
+		},
+	}
+
+	fieldSet := []any{"a", "b"}
+	fieldObject := map[string]any{"string": "a"}
+	fieldSetOfObjects := []any{
+		map[string]any{"description": "a"},
+	}
+	dto := map[string]any{
+		"set":       fieldSet,
+		"object":    fieldObject,
+		"to_rename": fieldSetOfObjects, // has different name in schema
+		"to_ignore": "will be ignored", // not in schema
+	}
+
+	// Missing force_new field
+	d := mocks.NewMockResourceData(t)
+	err := ResourceDataSet(d, dto, s)
+	require.Error(t, err, fmt.Errorf("%w: %q", errMissingForceNew, "force_new"))
+
+	// Expects to set all fields
+	d.EXPECT().Set("set", fieldSet).Return(nil)
+	d.EXPECT().Set("object", []any{fieldObject}).Return(nil)        // is wrapped into a list
+	d.EXPECT().Set("set_of_objects", fieldSetOfObjects).Return(nil) // renamed
+	d.EXPECT().Set("force_new", "hey!").Return(nil)                 // set force_new
+
+	err = ResourceDataSet(
+		d, dto, s,
+		AddForceNew("force_new", "hey!"),
+		RenameAlias("to_rename", "set_of_objects"),
+	)
+	require.NoError(t, err)
 }

--- a/internal/sdkprovider/service/account/account.go
+++ b/internal/sdkprovider/service/account/account.go
@@ -111,9 +111,7 @@ func resourceAccountRead(ctx context.Context, d *schema.ResourceData, client avn
 	}
 
 	if err = schemautil.ResourceDataSet(
-		aivenAccountSchema,
-		d,
-		resp,
+		d, resp, aivenAccountSchema,
 		schemautil.RenameAliases(map[string]string{
 			"account_name":          "name",
 			"account_owner_team_id": "owner_team_id",

--- a/internal/sdkprovider/service/account/account_team.go
+++ b/internal/sdkprovider/service/account/account_team.go
@@ -106,7 +106,7 @@ func resourceAccountTeamRead(ctx context.Context, d *schema.ResourceData, client
 	if err = schemautil.ResourceDataSet(
 		d, resp, aivenAccountTeamSchema,
 		schemautil.RenameAlias("team_name", "name"),
-		schemautil.AddForceNew("account_id", accountID),
+		schemautil.ResourceIDKeys("account_id"),
 	); err != nil {
 		return err
 	}

--- a/internal/sdkprovider/service/account/account_team.go
+++ b/internal/sdkprovider/service/account/account_team.go
@@ -104,10 +104,9 @@ func resourceAccountTeamRead(ctx context.Context, d *schema.ResourceData, client
 	}
 
 	if err = schemautil.ResourceDataSet(
-		aivenAccountTeamSchema,
-		d,
-		resp,
+		d, resp, aivenAccountTeamSchema,
 		schemautil.RenameAlias("team_name", "name"),
+		schemautil.AddForceNew("account_id", accountID),
 	); err != nil {
 		return err
 	}

--- a/internal/sdkprovider/service/account/account_team_member.go
+++ b/internal/sdkprovider/service/account/account_team_member.go
@@ -110,15 +110,9 @@ func resourceAccountTeamMemberRead(ctx context.Context, d *schema.ResourceData, 
 	for _, invite := range resp {
 		if invite.UserEmail == userEmail {
 			if err = schemautil.ResourceDataSet(
-				aivenAccountTeamMemberSchema,
-				d,
-				invite,
-				schemautil.RenameAliases(map[string]string{}),
+				d, invite, aivenAccountTeamMemberSchema,
+				schemautil.AddForceNew("account_id", accountID),
 			); err != nil {
-				return err
-			}
-
-			if err = d.Set("account_id", accountID); err != nil {
 				return err
 			}
 
@@ -139,14 +133,9 @@ func resourceAccountTeamMemberRead(ctx context.Context, d *schema.ResourceData, 
 	for _, member := range respTI {
 		if member.UserEmail == userEmail {
 			if err = schemautil.ResourceDataSet(
-				aivenAccountTeamMemberSchema,
-				d,
-				member,
+				d, member, aivenAccountTeamMemberSchema,
+				schemautil.AddForceNew("account_id", accountID),
 			); err != nil {
-				return err
-			}
-
-			if err = d.Set("account_id", accountID); err != nil {
 				return err
 			}
 

--- a/internal/sdkprovider/service/account/account_team_member.go
+++ b/internal/sdkprovider/service/account/account_team_member.go
@@ -111,7 +111,7 @@ func resourceAccountTeamMemberRead(ctx context.Context, d *schema.ResourceData, 
 		if invite.UserEmail == userEmail {
 			if err = schemautil.ResourceDataSet(
 				d, invite, aivenAccountTeamMemberSchema,
-				schemautil.AddForceNew("account_id", accountID),
+				schemautil.ResourceIDKeys("account_id"),
 			); err != nil {
 				return err
 			}
@@ -134,7 +134,7 @@ func resourceAccountTeamMemberRead(ctx context.Context, d *schema.ResourceData, 
 		if member.UserEmail == userEmail {
 			if err = schemautil.ResourceDataSet(
 				d, member, aivenAccountTeamMemberSchema,
-				schemautil.AddForceNew("account_id", accountID),
+				schemautil.ResourceIDKeys("account_id"),
 			); err != nil {
 				return err
 			}

--- a/internal/sdkprovider/service/alloydbomni/alloydbomni_database.go
+++ b/internal/sdkprovider/service/alloydbomni/alloydbomni_database.go
@@ -91,7 +91,11 @@ func resourceAlloyDBOmniDatabaseRead(ctx context.Context, d *schema.ResourceData
 		return err
 	}
 
-	return schemautil.ResourceDataSet(aivenAlloyDBOmniDatabaseSchema, d, db)
+	return schemautil.ResourceDataSet(
+		d, db, aivenAlloyDBOmniDatabaseSchema,
+		schemautil.AddForceNew("project", projectName),
+		schemautil.AddForceNew("service_name", serviceName),
+	)
 }
 
 func resourceAlloyDBOmniDatabaseDelete(ctx context.Context, d *schema.ResourceData, client avngen.Client) error {

--- a/internal/sdkprovider/service/alloydbomni/alloydbomni_database.go
+++ b/internal/sdkprovider/service/alloydbomni/alloydbomni_database.go
@@ -93,8 +93,7 @@ func resourceAlloyDBOmniDatabaseRead(ctx context.Context, d *schema.ResourceData
 
 	return schemautil.ResourceDataSet(
 		d, db, aivenAlloyDBOmniDatabaseSchema,
-		schemautil.AddForceNew("project", projectName),
-		schemautil.AddForceNew("service_name", serviceName),
+		schemautil.ResourceIDKeys("project", "service_name"),
 	)
 }
 

--- a/internal/sdkprovider/service/flink/flink_jar_application.go
+++ b/internal/sdkprovider/service/flink/flink_jar_application.go
@@ -65,8 +65,7 @@ func flinkJarApplicationRead(ctx context.Context, d *schema.ResourceData, client
 	return schemautil.ResourceDataSet(
 		d, rsp, flinkJarApplicationSchema(),
 		schemautil.RenameAliasesReverse(flinkJarApplicationRename()),
-		schemautil.AddForceNew("project", projectName),
-		schemautil.AddForceNew("service_name", serviceName),
+		schemautil.ResourceIDKeys("project", "service_name"),
 	)
 }
 

--- a/internal/sdkprovider/service/flink/flink_jar_application.go
+++ b/internal/sdkprovider/service/flink/flink_jar_application.go
@@ -45,12 +45,12 @@ func flinkJarApplicationCreate(ctx context.Context, d *schema.ResourceData, clie
 }
 
 func flinkJarApplicationRead(ctx context.Context, d *schema.ResourceData, client avngen.Client) error {
-	project, serviceName, applicationID, err := schemautil.SplitResourceID3(d.Id())
+	projectName, serviceName, applicationID, err := schemautil.SplitResourceID3(d.Id())
 	if err != nil {
 		return err
 	}
 
-	rsp, err := client.ServiceFlinkGetJarApplication(ctx, project, serviceName, applicationID)
+	rsp, err := client.ServiceFlinkGetJarApplication(ctx, projectName, serviceName, applicationID)
 	if err != nil {
 		return schemautil.ResourceReadHandleNotFound(err, d)
 	}
@@ -63,8 +63,10 @@ func flinkJarApplicationRead(ctx context.Context, d *schema.ResourceData, client
 	}
 
 	return schemautil.ResourceDataSet(
-		flinkJarApplicationSchema(), d, rsp,
+		d, rsp, flinkJarApplicationSchema(),
 		schemautil.RenameAliasesReverse(flinkJarApplicationRename()),
+		schemautil.AddForceNew("project", projectName),
+		schemautil.AddForceNew("service_name", serviceName),
 	)
 }
 

--- a/internal/sdkprovider/service/flink/flink_jar_application_deployment.go
+++ b/internal/sdkprovider/service/flink/flink_jar_application_deployment.go
@@ -84,18 +84,21 @@ func flinkApplicationDeploymentDelete(ctx context.Context, d *schema.ResourceDat
 }
 
 func flinkApplicationDeploymentRead(ctx context.Context, d *schema.ResourceData, client avngen.Client) error {
-	project, serviceName, applicationID, deploymentID, err := schemautil.SplitResourceID4(d.Id())
+	projectName, serviceName, applicationID, deploymentID, err := schemautil.SplitResourceID4(d.Id())
 	if err != nil {
 		return err
 	}
 
-	rsp, err := client.ServiceFlinkGetJarApplicationDeployment(ctx, project, serviceName, applicationID, deploymentID)
+	rsp, err := client.ServiceFlinkGetJarApplicationDeployment(ctx, projectName, serviceName, applicationID, deploymentID)
 	if err != nil {
 		return err
 	}
 
 	return schemautil.ResourceDataSet(
-		flinkJarApplicationDeploymentSchema(), d, rsp,
+		d, rsp, flinkJarApplicationDeploymentSchema(),
 		schemautil.RenameAliasesReverse(flinkJarApplicationDeploymentRename()),
+		schemautil.AddForceNew("project", projectName),
+		schemautil.AddForceNew("service_name", serviceName),
+		schemautil.AddForceNew("application_id", applicationID),
 	)
 }

--- a/internal/sdkprovider/service/flink/flink_jar_application_deployment.go
+++ b/internal/sdkprovider/service/flink/flink_jar_application_deployment.go
@@ -97,8 +97,6 @@ func flinkApplicationDeploymentRead(ctx context.Context, d *schema.ResourceData,
 	return schemautil.ResourceDataSet(
 		d, rsp, flinkJarApplicationDeploymentSchema(),
 		schemautil.RenameAliasesReverse(flinkJarApplicationDeploymentRename()),
-		schemautil.AddForceNew("project", projectName),
-		schemautil.AddForceNew("service_name", serviceName),
-		schemautil.AddForceNew("application_id", applicationID),
+		schemautil.ResourceIDKeys("project", "service_name", "application_id"),
 	)
 }

--- a/internal/sdkprovider/service/flink/flink_jar_application_version.go
+++ b/internal/sdkprovider/service/flink/flink_jar_application_version.go
@@ -136,9 +136,7 @@ func flinkJarApplicationVersionRead(ctx context.Context, d *schema.ResourceData,
 	return schemautil.ResourceDataSet(
 		d, rsp, flinkJarApplicationVersionSchema(),
 		schemautil.RenameAliasesReverse(flinkJarApplicationVersionRename()),
-		schemautil.AddForceNew("project", projectName),
-		schemautil.AddForceNew("service_name", serviceName),
-		schemautil.AddForceNew("application_id", applicationID),
+		schemautil.ResourceIDKeys("project", "service_name", "application_id"),
 	)
 }
 

--- a/internal/sdkprovider/service/flink/flink_jar_application_version.go
+++ b/internal/sdkprovider/service/flink/flink_jar_application_version.go
@@ -117,12 +117,12 @@ func flinkJarApplicationVersionCreate(ctx context.Context, d *schema.ResourceDat
 }
 
 func flinkJarApplicationVersionRead(ctx context.Context, d *schema.ResourceData, client avngen.Client) error {
-	project, serviceName, applicationID, version, err := schemautil.SplitResourceID4(d.Id())
+	projectName, serviceName, applicationID, version, err := schemautil.SplitResourceID4(d.Id())
 	if err != nil {
 		return err
 	}
 
-	rsp, err := client.ServiceFlinkGetJarApplicationVersion(ctx, project, serviceName, applicationID, version)
+	rsp, err := client.ServiceFlinkGetJarApplicationVersion(ctx, projectName, serviceName, applicationID, version)
 	if err != nil {
 		return schemautil.ResourceReadHandleNotFound(err, d)
 	}
@@ -134,8 +134,11 @@ func flinkJarApplicationVersionRead(ctx context.Context, d *schema.ResourceData,
 	}
 
 	return schemautil.ResourceDataSet(
-		flinkJarApplicationVersionSchema(), d, rsp,
+		d, rsp, flinkJarApplicationVersionSchema(),
 		schemautil.RenameAliasesReverse(flinkJarApplicationVersionRename()),
+		schemautil.AddForceNew("project", projectName),
+		schemautil.AddForceNew("service_name", serviceName),
+		schemautil.AddForceNew("application_id", applicationID),
 	)
 }
 

--- a/internal/sdkprovider/service/kafka/kafka_native_acl.go
+++ b/internal/sdkprovider/service/kafka/kafka_native_acl.go
@@ -91,12 +91,12 @@ func resourceKafkaNativeACLCreate(ctx context.Context, d *schema.ResourceData, c
 		return err
 	}
 
-	project := d.Get("project").(string)
+	projectName := d.Get("project").(string)
 	serviceName := d.Get("service_name").(string)
 
 	acl, err := client.ServiceKafkaNativeAclAdd(
 		ctx,
-		project,
+		projectName,
 		serviceName,
 		&req,
 	)
@@ -104,24 +104,28 @@ func resourceKafkaNativeACLCreate(ctx context.Context, d *schema.ResourceData, c
 		return err
 	}
 
-	err = schemautil.ResourceDataSet(aivenKafkaNativeACLSchema, d, acl)
+	err = schemautil.ResourceDataSet(
+		d, acl, aivenKafkaNativeACLSchema,
+		schemautil.AddForceNew("project", projectName),
+		schemautil.AddForceNew("service_name", serviceName),
+	)
 	if err != nil {
 		return err
 	}
 
-	d.SetId(schemautil.BuildResourceID(project, serviceName, acl.Id))
+	d.SetId(schemautil.BuildResourceID(projectName, serviceName, acl.Id))
 	return resourceKafkaNativeACLRead(ctx, d, client)
 }
 
 func resourceKafkaNativeACLRead(ctx context.Context, d *schema.ResourceData, client avngen.Client) error {
-	project, serviceName, aclID, err := schemautil.SplitResourceID3(d.Id())
+	projectName, serviceName, aclID, err := schemautil.SplitResourceID3(d.Id())
 	if err != nil {
 		return err
 	}
 
 	acl, err := client.ServiceKafkaNativeAclGet(
 		ctx,
-		project,
+		projectName,
 		serviceName,
 		aclID,
 	)
@@ -129,7 +133,11 @@ func resourceKafkaNativeACLRead(ctx context.Context, d *schema.ResourceData, cli
 		return err
 	}
 
-	err = schemautil.ResourceDataSet(aivenKafkaNativeACLSchema, d, acl)
+	err = schemautil.ResourceDataSet(
+		d, acl, aivenKafkaNativeACLSchema,
+		schemautil.AddForceNew("project", projectName),
+		schemautil.AddForceNew("service_name", serviceName),
+	)
 	return err
 }
 

--- a/internal/sdkprovider/service/kafka/kafka_native_acl.go
+++ b/internal/sdkprovider/service/kafka/kafka_native_acl.go
@@ -106,8 +106,7 @@ func resourceKafkaNativeACLCreate(ctx context.Context, d *schema.ResourceData, c
 
 	err = schemautil.ResourceDataSet(
 		d, acl, aivenKafkaNativeACLSchema,
-		schemautil.AddForceNew("project", projectName),
-		schemautil.AddForceNew("service_name", serviceName),
+		schemautil.ResourceIDKeys("project", "service_name"),
 	)
 	if err != nil {
 		return err
@@ -135,8 +134,7 @@ func resourceKafkaNativeACLRead(ctx context.Context, d *schema.ResourceData, cli
 
 	err = schemautil.ResourceDataSet(
 		d, acl, aivenKafkaNativeACLSchema,
-		schemautil.AddForceNew("project", projectName),
-		schemautil.AddForceNew("service_name", serviceName),
+		schemautil.ResourceIDKeys("project", "service_name"),
 	)
 	return err
 }

--- a/internal/sdkprovider/service/kafka/kafka_quota.go
+++ b/internal/sdkprovider/service/kafka/kafka_quota.go
@@ -182,8 +182,7 @@ func resourceKafkaQuotaRead(ctx context.Context, d *schema.ResourceData, client 
 	return schemautil.ResourceDataSet(
 		d, resp, aivenKafkaQuotaSchema,
 		schemautil.RenameAliasesReverse(quotaFieldsAliases),
-		schemautil.AddForceNew("project", projectName),
-		schemautil.AddForceNew("service_name", serviceName),
+		schemautil.ResourceIDKeys("project", "service_name"),
 	)
 }
 

--- a/internal/sdkprovider/service/kafka/kafka_quota.go
+++ b/internal/sdkprovider/service/kafka/kafka_quota.go
@@ -151,7 +151,7 @@ func resourceKafkaQuotaUpdate(ctx context.Context, d *schema.ResourceData, clien
 }
 
 func resourceKafkaQuotaRead(ctx context.Context, d *schema.ResourceData, client avngen.Client) error {
-	project, serviceName, clientID, user, err := schemautil.SplitResourceID4(d.Id())
+	projectName, serviceName, clientID, user, err := schemautil.SplitResourceID4(d.Id())
 	if err != nil {
 		return err
 	}
@@ -171,7 +171,7 @@ func resourceKafkaQuotaRead(ctx context.Context, d *schema.ResourceData, client 
 
 	resp, err := client.ServiceKafkaQuotaDescribe(
 		ctx,
-		project,
+		projectName,
 		serviceName,
 		params...,
 	)
@@ -180,10 +180,10 @@ func resourceKafkaQuotaRead(ctx context.Context, d *schema.ResourceData, client 
 	}
 
 	return schemautil.ResourceDataSet(
-		aivenKafkaQuotaSchema,
-		d,
-		resp,
+		d, resp, aivenKafkaQuotaSchema,
 		schemautil.RenameAliasesReverse(quotaFieldsAliases),
+		schemautil.AddForceNew("project", projectName),
+		schemautil.AddForceNew("service_name", serviceName),
 	)
 }
 

--- a/internal/sdkprovider/service/kafka/mirrormaker_replication_flow.go
+++ b/internal/sdkprovider/service/kafka/mirrormaker_replication_flow.go
@@ -184,10 +184,9 @@ func resourceMirrorMakerReplicationFlowRead(ctx context.Context, d *schema.Resou
 
 	err = schemautil.ResourceDataSet(
 		d, dto, aivenMirrorMakerReplicationFlowSchema,
-		schemautil.AddForceNew("project", project),
-		schemautil.AddForceNew("service_name", serviceName),
+		schemautil.ResourceIDKeys("project", "service_name"),
 		schemautil.RenameAliasesReverse(dtoFieldsAliases),
-		func(m map[string]any) error {
+		func(_ schemautil.ResourceData, m map[string]any) error {
 			if v, ok := m[configPropsKey]; ok {
 				// This field is received as a string
 				s, ok := v.(string)
@@ -241,7 +240,7 @@ func resourceMirrorMakerReplicationFlowDelete(ctx context.Context, d *schema.Res
 func marshalFlow(d *schema.ResourceData, dto any) error {
 	return schemautil.ResourceDataGet(
 		d, dto, schemautil.RenameAliases(dtoFieldsAliases),
-		func(m map[string]any) error {
+		func(_ schemautil.ResourceData, m map[string]any) error {
 			// This field is sent as a string
 			if v, ok := m[configPropsKey]; ok {
 				m[configPropsKey] = strings.Join(schemautil.FlattenToString(v.([]any)), ",")

--- a/internal/sdkprovider/service/organization/organization_application_user.go
+++ b/internal/sdkprovider/service/organization/organization_application_user.go
@@ -110,7 +110,7 @@ func resourceOrganizationApplicationUserRead(ctx context.Context, d *schema.Reso
 	err = schemautil.ResourceDataSet(
 		d, user, aivenOrganizationApplicationUserSchema,
 		schemautil.RenameAlias("user_email", "email"),
-		schemautil.AddForceNew("organization_id", orgID),
+		schemautil.ResourceIDKeys("organization_id"),
 	)
 	if err != nil {
 		return err

--- a/internal/sdkprovider/service/organization/organization_application_user.go
+++ b/internal/sdkprovider/service/organization/organization_application_user.go
@@ -107,18 +107,12 @@ func resourceOrganizationApplicationUserRead(ctx context.Context, d *schema.Reso
 	}
 
 	// Sets name and user_id
-	err = schemautil.ResourceDataSet(aivenOrganizationApplicationUserSchema, d, user)
+	err = schemautil.ResourceDataSet(
+		d, user, aivenOrganizationApplicationUserSchema,
+		schemautil.RenameAlias("user_email", "email"),
+		schemautil.AddForceNew("organization_id", orgID),
+	)
 	if err != nil {
-		return err
-	}
-
-	// This field has "email" in the schema and "user_email" in the request
-	if err = d.Set("email", user.UserEmail); err != nil {
-		return err
-	}
-
-	// This is for import command
-	if err = d.Set("organization_id", orgID); err != nil {
 		return err
 	}
 

--- a/internal/sdkprovider/service/organization/organization_application_user_token.go
+++ b/internal/sdkprovider/service/organization/organization_application_user_token.go
@@ -143,8 +143,7 @@ func resourceOrganizationApplicationUserTokenCreate(ctx context.Context, d *sche
 
 	err = schemautil.ResourceDataSet(
 		d, token, aivenOrganizationApplicationUserTokenSchema,
-		schemautil.AddForceNew("organization_id", orgID),
-		schemautil.AddForceNew("user_id", userID),
+		schemautil.ResourceIDKeys("organization_id", "user_id"),
 	)
 	if err != nil {
 		return err
@@ -179,8 +178,7 @@ func resourceOrganizationApplicationUserTokenRead(ctx context.Context, d *schema
 
 	err = schemautil.ResourceDataSet(
 		d, token, aivenOrganizationApplicationUserTokenSchema,
-		schemautil.AddForceNew("organization_id", orgID),
-		schemautil.AddForceNew("user_id", userID),
+		schemautil.ResourceIDKeys("organization_id", "user_id"),
 	)
 	if err != nil {
 		return err

--- a/internal/sdkprovider/service/organization/organization_application_user_token.go
+++ b/internal/sdkprovider/service/organization/organization_application_user_token.go
@@ -141,7 +141,11 @@ func resourceOrganizationApplicationUserTokenCreate(ctx context.Context, d *sche
 		return err
 	}
 
-	err = schemautil.ResourceDataSet(aivenOrganizationApplicationUserTokenSchema, d, token)
+	err = schemautil.ResourceDataSet(
+		d, token, aivenOrganizationApplicationUserTokenSchema,
+		schemautil.AddForceNew("organization_id", orgID),
+		schemautil.AddForceNew("user_id", userID),
+	)
 	if err != nil {
 		return err
 	}
@@ -173,7 +177,11 @@ func resourceOrganizationApplicationUserTokenRead(ctx context.Context, d *schema
 		return fmt.Errorf("application user token not found")
 	}
 
-	err = schemautil.ResourceDataSet(aivenOrganizationApplicationUserTokenSchema, d, token)
+	err = schemautil.ResourceDataSet(
+		d, token, aivenOrganizationApplicationUserTokenSchema,
+		schemautil.AddForceNew("organization_id", orgID),
+		schemautil.AddForceNew("user_id", userID),
+	)
 	if err != nil {
 		return err
 	}

--- a/internal/sdkprovider/service/organization/organization_user_group.go
+++ b/internal/sdkprovider/service/organization/organization_user_group.go
@@ -103,7 +103,7 @@ func resourceOrganizationUserGroupRead(ctx context.Context, d *schema.ResourceDa
 		d, resp, aivenOrganizationUserGroupSchema,
 		schemautil.RenameAlias("user_group_name", "name"),
 		schemautil.RenameAlias("user_group_id", "group_id"),
-		schemautil.AddForceNew("organization_id", orgID),
+		schemautil.ResourceIDKeys("organization_id"),
 	); err != nil {
 		return err
 	}

--- a/internal/sdkprovider/service/organization/organization_user_group.go
+++ b/internal/sdkprovider/service/organization/organization_user_group.go
@@ -100,19 +100,11 @@ func resourceOrganizationUserGroupRead(ctx context.Context, d *schema.ResourceDa
 	}
 
 	if err = schemautil.ResourceDataSet(
-		aivenOrganizationUserGroupSchema,
-		d,
-		resp,
-		schemautil.RenameAliases(map[string]string{
-			"user_group_name": "name",
-			"user_group_id":   "group_id",
-		}),
+		d, resp, aivenOrganizationUserGroupSchema,
+		schemautil.RenameAlias("user_group_name", "name"),
+		schemautil.RenameAlias("user_group_id", "group_id"),
+		schemautil.AddForceNew("organization_id", orgID),
 	); err != nil {
-		return err
-	}
-
-	// set the organization_id directly as it is not returned by the API and may not be set in case of import
-	if err = d.Set("organization_id", orgID); err != nil {
 		return err
 	}
 

--- a/internal/sdkprovider/service/organization/organization_user_list_data_source.go
+++ b/internal/sdkprovider/service/organization/organization_user_list_data_source.go
@@ -151,7 +151,7 @@ func datasourceOrganizationUserListRead(ctx context.Context, d *schema.ResourceD
 
 	d.SetId(organizationID)
 	users := map[string]any{"users": list}
-	return schemautil.ResourceDataSet(datasourceOrganizationUserListSchema(), d, users)
+	return schemautil.ResourceDataSet(d, users, datasourceOrganizationUserListSchema())
 }
 
 func GetOrganizationByName(ctx context.Context, client avngen.Client, name string) (string, error) {

--- a/internal/sdkprovider/service/organization/organizational_unit.go
+++ b/internal/sdkprovider/service/organization/organizational_unit.go
@@ -109,11 +109,7 @@ func resourceOrganizationalUnitRead(ctx context.Context, d *schema.ResourceData,
 		}
 	}
 
-	if err = schemautil.ResourceDataSet(
-		aivenOrganizationalUnitSchema,
-		d,
-		resp,
-	); err != nil {
+	if err = schemautil.ResourceDataSet(d, resp, aivenOrganizationalUnitSchema); err != nil {
 		return err
 	}
 

--- a/internal/sdkprovider/service/pg/pg_user.go
+++ b/internal/sdkprovider/service/pg/pg_user.go
@@ -192,8 +192,7 @@ func ResourcePGUserRead(ctx context.Context, d schemautil.ResourceData, client a
 
 	err = schemautil.ResourceDataSet(
 		d, user, ResourcePGUserSchema,
-		schemautil.AddForceNew("project", projectName),
-		schemautil.AddForceNew("service_name", serviceName),
+		schemautil.ResourceIDKeys("project", "service_name", "username"),
 	)
 	if err != nil {
 		return err

--- a/internal/sdkprovider/service/pg/pg_user.go
+++ b/internal/sdkprovider/service/pg/pg_user.go
@@ -190,7 +190,11 @@ func ResourcePGUserRead(ctx context.Context, d schemautil.ResourceData, client a
 		return schemautil.ResourceReadHandleNotFound(err, d)
 	}
 
-	err = schemautil.ResourceDataSet(ResourcePGUserSchema, d, user)
+	err = schemautil.ResourceDataSet(
+		d, user, ResourcePGUserSchema,
+		schemautil.AddForceNew("project", projectName),
+		schemautil.AddForceNew("service_name", serviceName),
+	)
 	if err != nil {
 		return err
 	}

--- a/internal/sdkprovider/service/pg/pg_user_retries_test.go
+++ b/internal/sdkprovider/service/pg/pg_user_retries_test.go
@@ -104,6 +104,8 @@ func TestReadDoesNotRetryEmptyPassword(t *testing.T) {
 		ServiceUserGet(ctx, projectName, serviceName, username).
 		Return(&service.ServiceUserGetOut{Username: username, Type: "normal"}, nil)
 
+	d.EXPECT().Set("project", projectName).Return(nil)
+	d.EXPECT().Set("service_name", serviceName).Return(nil)
 	d.EXPECT().Set("username", username).Return(nil)
 	d.EXPECT().Set("type", "normal").Return(nil)
 	d.EXPECT().Set("password", "").Return(nil) // Empty password!


### PR DESCRIPTION
Terraform doesn't read the config on `import` command.
If a `ForceNew` field is not set during the `ReadContext`,
terraform then compares "empty" value with the value from the config,
and outputs "replace" plan.

`ResourceDataSet` must set all the `ForceNew` field values.

- Adds the validation
- Improves types conversions
- Makes `ResourceDataSet` more similar to `ResourceDataGet`