### PR TITLE
fix(ip_filter): suppress ipv6 default value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,12 @@ nav_order: 1
 <!-- Always keep the following header in place: -->
 <!--## [MAJOR.MINOR.PATCH] - YYYY-MM-DD -->
 
+## [MAJOR.MINOR.PATCH] - YYYY-MM-DD
+
+- Fix `ip_filter`, suppress plan for the new `ip_filter` default value (`::/0`) when a new service is created
+
 ## [4.34.1] - 2025-02-07
+
 - Fix `organization_user_group` import
 
 ## [4.34.0] - 2025-01-29

--- a/internal/schemautil/helpers.go
+++ b/internal/schemautil/helpers.go
@@ -2,7 +2,6 @@ package schemautil
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"strings"
 
@@ -11,7 +10,6 @@ import (
 	"github.com/aiven/go-client-codegen/handler/service"
 	"github.com/docker/go-units"
 	"github.com/hashicorp/go-cty/cty"
-	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
@@ -191,16 +189,4 @@ func StringToDiagWarning(msg string) diag.Diagnostics {
 // ErrorToDiagWarning is a function that converts an error to a diag warning.
 func ErrorToDiagWarning(err error) diag.Diagnostics {
 	return StringToDiagWarning(err.Error())
-}
-
-// ErrorFromDiagnostics converts diag.Diagnostics to error.
-// Warning: ignores diag.Warning level diagnostics.
-func ErrorFromDiagnostics(diags diag.Diagnostics) error {
-	var err error
-	for _, v := range diags {
-		if v.Severity == diag.Error {
-			err = multierror.Append(err, errors.New(v.Summary))
-		}
-	}
-	return err
 }

--- a/internal/sdkprovider/service/kafka/kafka_test.go
+++ b/internal/sdkprovider/service/kafka/kafka_test.go
@@ -323,7 +323,7 @@ func testAccCheckAivenServiceKafkaAttributes(n string) resource.TestCheckFunc {
 			return fmt.Errorf("expected to get a correct public_access.prometheus from Aiven")
 		}
 
-		if a["kafka_user_config.0.ip_filter.0"] != "0.0.0.0/0" {
+		if a["kafka_user_config.0.ip_filter.0"] != "0.0.0.0/0" || a["kafka_user_config.0.ip_filter.1"] != "::/0" {
 			return fmt.Errorf("expected to get a correct ip_filter from Aiven")
 		}
 

--- a/internal/sdkprovider/service/kafka/mirrormaker_replication_flow_test.go
+++ b/internal/sdkprovider/service/kafka/mirrormaker_replication_flow_test.go
@@ -182,7 +182,7 @@ resource "aiven_kafka_mirrormaker" "mm" {
   service_name = "test-acc-sr-mm-%[2]s"
 
   kafka_mirrormaker_user_config {
-    ip_filter = ["0.0.0.0/0"]
+    ip_filter = ["0.0.0.0/0", "::/0"]
 
     kafka_mirrormaker {
       refresh_groups_interval_seconds = 600

--- a/internal/sdkprovider/service/kafka/mirrormaker_test.go
+++ b/internal/sdkprovider/service/kafka/mirrormaker_test.go
@@ -52,7 +52,7 @@ resource "aiven_kafka_mirrormaker" "bar" {
   service_name = "test-acc-sr-%s"
 
   kafka_mirrormaker_user_config {
-    ip_filter = ["0.0.0.0/0"]
+    ip_filter = ["0.0.0.0/0", "::/0"]
 
     kafka_mirrormaker {
       refresh_groups_interval_seconds = 600

--- a/internal/sdkprovider/service/m3db/m3db_test.go
+++ b/internal/sdkprovider/service/m3db/m3db_test.go
@@ -227,7 +227,7 @@ resource "aiven_grafana" "grafana1" {
   service_name = "test-acc-sr-g-%s"
 
   grafana_user_config {
-    ip_filter        = ["0.0.0.0/0"]
+    ip_filter        = ["0.0.0.0/0", "::/0"]
     alerting_enabled = true
 
     public_access {
@@ -303,7 +303,7 @@ resource "aiven_grafana" "grafana1" {
   service_name = "test-acc-sr-g-%s"
 
   grafana_user_config {
-    ip_filter        = ["0.0.0.0/0"]
+    ip_filter        = ["0.0.0.0/0", "::/0"]
     alerting_enabled = true
 
     public_access {

--- a/internal/sdkprovider/service/organization/organization_user_group_test.go
+++ b/internal/sdkprovider/service/organization/organization_user_group_test.go
@@ -196,14 +196,14 @@ func TestAccAivenOrganizationUserGroup_Import(t *testing.T) {
 func testAccOrganizationUserGroupImportConfig(orgID, name, groupID string) string {
 	return fmt.Sprintf(`
 resource "aiven_organization_user_group" "import_group" {
-    organization_id = "%s"
-    name            = "%s"
-    description     = "Imported group"
+  organization_id = "%s"
+  name            = "%s"
+  description     = "Imported group"
 }
 
 import {
-    id = "%s/%s"
-    to = aiven_organization_user_group.import_group
+  id = "%s/%s"
+  to = aiven_organization_user_group.import_group
 }
 `, orgID, name, orgID, groupID)
 }

--- a/internal/sdkprovider/userconfig/converters/utils_test.go
+++ b/internal/sdkprovider/userconfig/converters/utils_test.go
@@ -20,32 +20,32 @@ func TestRenameAliasesToDto(t *testing.T) {
 		{
 			serviceType: "kafka",
 			name:        "keeps original key",
-			src:         `{"ip_filter": ["0.0.0.0/0"]}`,
-			expected:    `{"ip_filter": ["0.0.0.0/0"]}`,
+			src:         `{"ip_filter": ["0.0.0.0/0", "::/0"]}`,
+			expected:    `{"ip_filter": ["0.0.0.0/0", "::/0"]}`,
 		},
 		{
 			serviceType: "kafka",
 			name:        "chooses original out if 3",
-			src:         `{"ip_filter": ["0.0.0.0/0"], "ip_filter_string": [], "ip_filter_object": []}`,
-			expected:    `{"ip_filter": ["0.0.0.0/0"]}`,
+			src:         `{"ip_filter": ["0.0.0.0/0", "::/0"], "ip_filter_string": [], "ip_filter_object": []}`,
+			expected:    `{"ip_filter": ["0.0.0.0/0", "::/0"]}`,
 		},
 		{
 			serviceType: "kafka",
 			name:        "chooses string out if 3",
-			src:         `{"ip_filter": [], "ip_filter_string": ["0.0.0.0/0"], "ip_filter_object": []}`,
-			expected:    `{"ip_filter": ["0.0.0.0/0"]}`,
+			src:         `{"ip_filter": [], "ip_filter_string": ["0.0.0.0/0", "::/0"], "ip_filter_object": []}`,
+			expected:    `{"ip_filter": ["0.0.0.0/0", "::/0"]}`,
 		},
 		{
 			serviceType: "kafka",
 			name:        "ignores unknown key",
-			src:         `{"whatever": ["0.0.0.0/0"]}`,
-			expected:    `{"whatever": ["0.0.0.0/0"]}`,
+			src:         `{"whatever": ["0.0.0.0/0", "::/0"]}`,
+			expected:    `{"whatever": ["0.0.0.0/0", "::/0"]}`,
 		},
 		{
 			serviceType: `kafka`,
 			name:        `renames "_string" prefix`,
-			src:         `{"ip_filter_string": ["0.0.0.0/0"]}`,
-			expected:    `{"ip_filter": ["0.0.0.0/0"]}`,
+			src:         `{"ip_filter_string": ["0.0.0.0/0", "::/0"]}`,
+			expected:    `{"ip_filter": ["0.0.0.0/0", "::/0"]}`,
 		},
 		{
 			serviceType: `kafka`,
@@ -117,28 +117,34 @@ func TestRenameAliasesToTfo(t *testing.T) {
 		{
 			serviceType: "kafka",
 			name:        "keeps original key",
-			expected:    `{"ip_filter": ["0.0.0.0/0"]}`,
-			dto:         `{"ip_filter": ["0.0.0.0/0"]}`,
+			expected:    `{"ip_filter": ["0.0.0.0/0", "::/0"]}`,
+			dto:         `{"ip_filter": ["0.0.0.0/0", "::/0"]}`,
 			tfo: newResourceDataMock(
-				newResourceDataKV("kafka_user_config.0.ip_filter", []string{"0.0.0.0/0"}),
+				newResourceDataKV("kafka_user_config.0.ip_filter", []string{"0.0.0.0/0", "::/0"}),
 			),
 		},
 		{
 			serviceType: "kafka",
 			name:        "uses ip_filter_string",
-			expected:    `{"ip_filter_string": ["0.0.0.0/0"]}`,
-			dto:         `{"ip_filter": ["0.0.0.0/0"]}`,
+			expected:    `{"ip_filter_string": ["0.0.0.0/0", "::/0"]}`,
+			dto:         `{"ip_filter": ["0.0.0.0/0", "::/0"]}`,
 			tfo: newResourceDataMock(
-				newResourceDataKV("kafka_user_config.0.ip_filter_string", []string{"0.0.0.0/0"}),
+				newResourceDataKV("kafka_user_config.0.ip_filter_string", []string{"0.0.0.0/0", "::/0"}),
 			),
 		},
 		{
 			serviceType: "kafka",
 			name:        "uses ip_filter_object",
-			expected:    `{"ip_filter_object": [{"network": "0.0.0.0/0"}]}`,
-			dto:         `{"ip_filter": [{"network": "0.0.0.0/0"}]}`,
+			expected:    `{"ip_filter_object": [{"network": "0.0.0.0/0"},{"network": "::/0"}]}`,
+			dto:         `{"ip_filter": [{"network": "0.0.0.0/0"},{"network": "::/0"}]}`,
 			tfo: newResourceDataMock(
-				newResourceDataKV("kafka_user_config.0.ip_filter_object", []map[string]string{{"network": "0.0.0.0/0"}}),
+				newResourceDataKV(
+					"kafka_user_config.0.ip_filter_object",
+					[]map[string]string{
+						{"network": "0.0.0.0/0"},
+						{"network": "::/0"},
+					},
+				),
 			),
 		},
 		{
@@ -176,28 +182,34 @@ func TestRenameAliasesToTfo(t *testing.T) {
 		{
 			serviceType: "thanos",
 			name:        "ip_filter gets a list of objects",
-			expected:    `{"ip_filter": ["0.0.0.0/0"]}`,
-			dto:         `{"ip_filter": [{"network": "0.0.0.0/0"}]}`,
+			expected:    `{"ip_filter": ["0.0.0.0/0", "::/0"]}`,
+			dto:         `{"ip_filter": [{"network": "0.0.0.0/0"},{"network": "::/0"}]}`,
 			tfo: newResourceDataMock(
-				newResourceDataKV("thanos_user_config.0.ip_filter", []string{"0.0.0.0/0"}),
+				newResourceDataKV("thanos_user_config.0.ip_filter", []string{"0.0.0.0/0", "::/0"}),
 			),
 		},
 		{
 			serviceType: "thanos",
 			name:        "ip_filter_string gets a list of objects",
-			expected:    `{"ip_filter_string": ["0.0.0.0/0"]}`,
-			dto:         `{"ip_filter": [{"network": "0.0.0.0/0"}]}`,
+			expected:    `{"ip_filter_string": ["0.0.0.0/0", "::/0"]}`,
+			dto:         `{"ip_filter": [{"network": "0.0.0.0/0"},{"network": "::/0"}]}`,
 			tfo: newResourceDataMock(
-				newResourceDataKV("thanos_user_config.0.ip_filter_string", []string{"0.0.0.0/0"}),
+				newResourceDataKV("thanos_user_config.0.ip_filter_string", []string{"0.0.0.0/0", "::/0"}),
 			),
 		},
 		{
 			serviceType: "thanos",
 			name:        "ip_filter_object gets a list of strings",
-			expected:    `{"ip_filter_object": [{"network": "0.0.0.0/0"}]}`,
-			dto:         `{"ip_filter": ["0.0.0.0/0"]}`,
+			expected:    `{"ip_filter_object": [{"network": "0.0.0.0/0"},{"network": "::/0"}]}`,
+			dto:         `{"ip_filter": ["0.0.0.0/0", "::/0"]}`,
 			tfo: newResourceDataMock(
-				newResourceDataKV("thanos_user_config.0.ip_filter_object", []map[string]string{{"network": "0.0.0.0/0"}}),
+				newResourceDataKV(
+					"thanos_user_config.0.ip_filter_object",
+					[]map[string]string{
+						{"network": "0.0.0.0/0"},
+						{"network": "::/0"},
+					},
+				),
 			),
 		},
 		{

--- a/internal/sdkprovider/userconfig/diff/diff_test.go
+++ b/internal/sdkprovider/userconfig/diff/diff_test.go
@@ -1,0 +1,237 @@
+package diff
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/samber/lo"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIsDefaultIPFilterList(t *testing.T) {
+	type testCase struct {
+		name     string
+		networks []any
+		expected bool
+	}
+
+	cases := []testCase{
+		// Positive cases
+		{
+			name:     `old efault value`,
+			networks: []any{"0.0.0.0/0"},
+			expected: true,
+		},
+		{
+			name:     `new default ip_filter list`,
+			networks: []any{"0.0.0.0/0", "::/0"},
+			expected: true,
+		},
+		{
+			name:     "new ip_filter list reordered",
+			networks: []any{"::/0", "0.0.0.0/0"},
+			expected: true,
+		},
+		{
+			name:     `["::/0"] is not default value`,
+			networks: []any{"::/0"},
+			expected: false,
+		},
+		{
+			name:     `default value with extra network`,
+			networks: []any{"0.0.0.0/0", "127.0.0.1/32", "::/0"},
+			expected: false,
+		},
+		{
+			name:     `a random network`,
+			networks: []any{"127.0.0.1/32"},
+			expected: false,
+		},
+	}
+
+	// Copies cases for ip_filter_object
+	j := len(cases)
+	for i := 0; i < j; i++ {
+		cases = append(cases, testCase{
+			name:     "ip_filter_object " + cases[i].name,
+			expected: cases[i].expected,
+			networks: lo.Map(cases[i].networks, func(item any, _ int) any {
+				return map[string]any{"network": item}
+			}),
+		})
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			actual := IsDefaultIPFilterList(c.networks)
+			assert.Equal(t, c.expected, actual)
+		})
+	}
+}
+
+func TestSuppressIPFilterSet(t *testing.T) {
+	t.Parallel()
+
+	resourceSchema := map[string]*schema.Schema{
+		"foo_user_config": {
+			Type:     schema.TypeList,
+			MaxItems: 1,
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"ip_filter": {
+						Type:     schema.TypeSet,
+						Optional: true,
+						Elem: &schema.Schema{
+							Type: schema.TypeString,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	tests := []struct {
+		name           string
+		key            string
+		oldValue       interface{}
+		newValue       interface{}
+		shouldSuppress bool
+	}{
+		{
+			name:           "identical default IPv4 values",
+			key:            "foo_user_config.0.ip_filter",
+			oldValue:       []interface{}{"0.0.0.0/0"},
+			newValue:       []interface{}{"0.0.0.0/0"},
+			shouldSuppress: false,
+		},
+		{
+			name:           "identical default IPv4 and IPv6",
+			key:            "foo_user_config.0.ip_filter",
+			oldValue:       []interface{}{"0.0.0.0/0", "::/0"},
+			newValue:       []interface{}{"0.0.0.0/0", "::/0"},
+			shouldSuppress: false,
+		},
+		{
+			name:           "default values in different order",
+			key:            "foo_user_config.0.ip_filter",
+			oldValue:       []interface{}{"::/0", "0.0.0.0/0"},
+			newValue:       []interface{}{"0.0.0.0/0", "::/0"},
+			shouldSuppress: false,
+		},
+		{
+			name:           "custom IP filter change",
+			key:            "foo_user_config.0.ip_filter",
+			oldValue:       []interface{}{"192.168.1.0/24"},
+			newValue:       []interface{}{"10.0.0.0/24"},
+			shouldSuppress: false,
+		},
+		{
+			name:           "change from default to custom",
+			key:            "foo_user_config.0.ip_filter",
+			oldValue:       []interface{}{"0.0.0.0/0"},
+			newValue:       []interface{}{"192.168.1.0/24"},
+			shouldSuppress: false,
+		},
+		{
+			name:           "default IPv4",
+			key:            "foo_user_config.0.ip_filter",
+			oldValue:       []interface{}{"0.0.0.0/0"},
+			newValue:       []interface{}{"0.0.0.0/0"},
+			shouldSuppress: false,
+		},
+		{
+			name:           "default IPv4 and IPv6",
+			key:            "foo_user_config.0.ip_filter",
+			oldValue:       []interface{}{"0.0.0.0/0", "::/0"},
+			newValue:       []interface{}{"0.0.0.0/0", "::/0"},
+			shouldSuppress: false,
+		},
+		{
+			name:           "default values in different order",
+			key:            "foo_user_config.0.ip_filter",
+			oldValue:       []interface{}{"::/0", "0.0.0.0/0"},
+			newValue:       []interface{}{"0.0.0.0/0", "::/0"},
+			shouldSuppress: false,
+		},
+		{
+			name:           "private network change",
+			key:            "foo_user_config.0.ip_filter",
+			oldValue:       []interface{}{"192.168.1.0/24"},
+			newValue:       []interface{}{"192.168.2.0/24"},
+			shouldSuppress: false,
+		},
+		{
+			name:           "private to public network",
+			key:            "foo_user_config.0.ip_filter",
+			oldValue:       []interface{}{"10.0.0.0/8"},
+			newValue:       []interface{}{"203.0.113.0/24"},
+			shouldSuppress: false,
+		},
+		{
+			name:           "multiple networks",
+			key:            "foo_user_config.0.ip_filter",
+			oldValue:       []interface{}{"192.168.1.0/24", "10.0.0.0/8", "172.16.0.0/12"},
+			newValue:       []interface{}{"192.168.1.0/24", "10.0.0.0/8", "172.16.0.0/12"},
+			shouldSuppress: false,
+		},
+		{
+			name:           "IPv6 networks",
+			key:            "foo_user_config.0.ip_filter",
+			oldValue:       []interface{}{"2001:db8::/32", "2001:db8:1234::/48"},
+			newValue:       []interface{}{"2001:db8::/32", "2001:db8:5678::/48"},
+			shouldSuppress: false,
+		},
+		{
+			name:           "mixed IPv4 and IPv6",
+			key:            "foo_user_config.0.ip_filter",
+			oldValue:       []interface{}{"192.168.1.0/24", "2001:db8::/32"},
+			newValue:       []interface{}{"192.168.1.0/24", "2001:db8::/32"},
+			shouldSuppress: false,
+		},
+		{
+			name:           "mixed default changes to mix with custom",
+			key:            "foo_user_config.0.ip_filter",
+			oldValue:       []interface{}{"::/0", "0.0.0.0/0"},
+			newValue:       []interface{}{"::/0", "0.0.0.0/0", "192.168.1.0/24"},
+			shouldSuppress: false,
+		},
+		{
+			name:           "mixed custom changes to default",
+			key:            "foo_user_config.0.ip_filter",
+			oldValue:       []interface{}{"::/0", "0.0.0.0/0", "192.168.1.0/24"},
+			newValue:       []interface{}{"::/0", "0.0.0.0/0"},
+			shouldSuppress: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			// Create a new resource data with old value
+			d := schema.TestResourceDataRaw(t, resourceSchema, map[string]interface{}{
+				"foo_user_config": []interface{}{
+					map[string]interface{}{
+						"ip_filter": tc.oldValue,
+					},
+				},
+			})
+
+			// Set the new value
+			newConfig := map[string]interface{}{
+				"foo_user_config": []interface{}{
+					map[string]interface{}{
+						"ip_filter": tc.newValue,
+					},
+				},
+			}
+			require.NoError(t, d.Set("foo_user_config", newConfig["foo_user_config"]))
+
+			result := suppressIPFilterSet(tc.key, "", "", d)
+			if result != tc.shouldSuppress {
+				t.Errorf("Test %q: expected result to be %v but got %v", tc.name, tc.shouldSuppress, result)
+			}
+		})
+	}
+}


### PR DESCRIPTION
New services get new default value for the `ip_filter` field: `["0.0.0.0/0", "::/0"]`.

- Suppresses `"::/0"` for the new services.
- Remove redundant (skipped) test
- Adds more `ip_filter` tests
- Improves Grafana waiter. Adds `ip_filter` object type support.