### PR TITLE
fix: formatting for deprecation callouts

### DIFF
--- a/docs/data-sources/account.md
+++ b/docs/data-sources/account.md
@@ -4,7 +4,7 @@ page_title: "aiven_account Data Source - terraform-provider-aiven"
 subcategory: ""
 description: |-
   The Account data source provides information about the existing Aiven Account.
-  ~> This resource is deprecated.
+  ~> This resource is deprecated
   This resource will be removed in v5.0.0. Use aiven_organization instead.
 ---
 
@@ -12,8 +12,7 @@ description: |-
 
 The Account data source provides information about the existing Aiven Account.
 
-~> **This resource is deprecated**.
-
+~> **This resource is deprecated**
 This resource will be removed in v5.0.0. Use `aiven_organization` instead.
 
 ## Example Usage

--- a/docs/data-sources/account_authentication.md
+++ b/docs/data-sources/account_authentication.md
@@ -4,7 +4,7 @@ page_title: "aiven_account_authentication Data Source - terraform-provider-aiven
 subcategory: ""
 description: |-
   The Account Authentication data source provides information about the existing Aiven Account Authentication.
-  ~> This resource is deprecated.
+  ~> This resource is deprecated
   This resource is deprecated
 ---
 
@@ -12,8 +12,7 @@ description: |-
 
 The Account Authentication data source provides information about the existing Aiven Account Authentication.
 
-~> **This resource is deprecated**.
-
+~> **This resource is deprecated**
 This resource is deprecated
 
 ## Example Usage

--- a/docs/data-sources/organization_user.md
+++ b/docs/data-sources/organization_user.md
@@ -4,10 +4,10 @@ page_title: "aiven_organization_user Data Source - terraform-provider-aiven"
 subcategory: ""
 description: |-
   The Organization User data source provides information about the existing Aiven Organization User.
-  ~> This resource is deprecated.
+  ~> This resource is deprecated
   Users cannot be invited to an organization using Terraform.
-  Use the Aiven Console to invite users to your organization. After the user accepts the invite
-  you can get their information using the aiven_organization_user data source. You can manage
+  Use the Aiven Console to invite users to your organization https://aiven.io/docs/platform/howto/manage-org-users.
+  After the user accepts the invite you can get their information using the aiven_organization_user data source. You can manage
   user access to projects with the aiven_organization_user_group, aiven_organization_user_group_member,
   and aiven_organization_permission resources.
 ---
@@ -16,11 +16,10 @@ description: |-
 
 The Organization User data source provides information about the existing Aiven Organization User.
 
-~> **This resource is deprecated**.
-
+~> **This resource is deprecated**
 Users cannot be invited to an organization using Terraform.
-Use the Aiven Console to invite users to your organization. After the user accepts the invite
-you can get their information using the `aiven_organization_user` data source. You can manage
+Use the Aiven Console to [invite users to your organization](https://aiven.io/docs/platform/howto/manage-org-users).
+After the user accepts the invite you can get their information using the `aiven_organization_user` data source. You can manage
 user access to projects with the `aiven_organization_user_group`, `aiven_organization_user_group_member`,
 and `aiven_organization_permission` resources.
 

--- a/docs/data-sources/project_user.md
+++ b/docs/data-sources/project_user.md
@@ -4,17 +4,20 @@ page_title: "aiven_project_user Data Source - terraform-provider-aiven"
 subcategory: ""
 description: |-
   The Project User data source provides information about the existing Aiven Project User.
-  ~> This resource is deprecated.
-  Use aiven_organization_permission instead.
+  ~> This resource is deprecated
+  Use aiven_organization_permission instead and
+  migrate existing aiven_project_user resources https://registry.terraform.io/providers/aiven/aiven/latest/docs/guides/update-deprecated-resources
+  to the new resource.
 ---
 
 # aiven_project_user (Data Source)
 
 The Project User data source provides information about the existing Aiven Project User.
 
-~> **This resource is deprecated**.
-
-Use `aiven_organization_permission` instead.
+~> **This resource is deprecated**
+Use `aiven_organization_permission` instead and
+[migrate existing `aiven_project_user` resources](https://registry.terraform.io/providers/aiven/aiven/latest/docs/guides/update-deprecated-resources) 
+to the new resource.
 
 ## Example Usage
 

--- a/docs/resources/account.md
+++ b/docs/resources/account.md
@@ -4,7 +4,7 @@ page_title: "aiven_account Resource - terraform-provider-aiven"
 subcategory: ""
 description: |-
   Creates and manages an Aiven account.
-  ~> This resource is deprecated.
+  ~> This resource is deprecated
   This resource will be removed in v5.0.0. Use aiven_organization instead.
 ---
 
@@ -12,8 +12,7 @@ description: |-
 
 Creates and manages an Aiven account.
 
-~> **This resource is deprecated**.
-
+~> **This resource is deprecated**
 This resource will be removed in v5.0.0. Use `aiven_organization` instead.
 
 ## Example Usage

--- a/docs/resources/account_authentication.md
+++ b/docs/resources/account_authentication.md
@@ -4,7 +4,7 @@ page_title: "aiven_account_authentication Resource - terraform-provider-aiven"
 subcategory: ""
 description: |-
   Creates and manages an authentication method.
-  ~> This resource is deprecated.
+  ~> This resource is deprecated
   To set up an identity provider as an authentication method for your organization,
   use the Aiven Console https://aiven.io/docs/platform/howto/saml/add-identity-providers.
   It guides you through the steps and explains the settings.
@@ -14,8 +14,7 @@ description: |-
 
 Creates and manages an authentication method.
 
-~> **This resource is deprecated**.
-
+~> **This resource is deprecated**
 To set up an identity provider as an authentication method for your organization,
 [use the Aiven Console](https://aiven.io/docs/platform/howto/saml/add-identity-providers).
 It guides you through the steps and explains the settings.

--- a/docs/resources/organization_user.md
+++ b/docs/resources/organization_user.md
@@ -3,37 +3,23 @@
 page_title: "aiven_organization_user Resource - terraform-provider-aiven"
 subcategory: ""
 description: |-
-  **This resource is deprecated**. Users cannot be invited to an organization using Terraform.
-  	Use the [Aiven Console](https://console.aiven.io/) to [invite users](https://aiven.io/docs/platform/howto/manage-org-users)
-  	to your organization. 
-  
-  After the user accepts the invite you can get their information using the aiven_organization_user
-  data source. You can manage user access to projects with the aiven_organization_user_group,
-  aiven_organization_user_group_member, and aiven_organization_permission resources.
-  ~> This resource is deprecated.
+  Creates and manages an Aiven Organization user.
+  ~> This resource is deprecated
   Users cannot be invited to an organization using Terraform.
-  Use the Aiven Console to invite users to your organization. After the user accepts the invite
-  you can get their information using the aiven_organization_user data source. You can manage
+  Use the Aiven Console to invite users to your organization https://aiven.io/docs/platform/howto/manage-org-users.
+  After the user accepts the invite you can get their information using the aiven_organization_user data source. You can manage
   user access to projects with the aiven_organization_user_group, aiven_organization_user_group_member,
   and aiven_organization_permission resources.
 ---
 
 # aiven_organization_user (Resource)
 
-**This resource is deprecated**. Users cannot be invited to an organization using Terraform.
-		Use the [Aiven Console](https://console.aiven.io/) to [invite users](https://aiven.io/docs/platform/howto/manage-org-users)
-		to your organization. 
-		
-After the user accepts the invite you can get their information using the `aiven_organization_user`
-data source. You can manage user access to projects with the `aiven_organization_user_group`, 
-`aiven_organization_user_group_member`, and `aiven_organization_permission` resources.
+Creates and manages an Aiven Organization user. 
 
-
-~> **This resource is deprecated**.
-
+~> **This resource is deprecated**
 Users cannot be invited to an organization using Terraform.
-Use the Aiven Console to invite users to your organization. After the user accepts the invite
-you can get their information using the `aiven_organization_user` data source. You can manage
+Use the Aiven Console to [invite users to your organization](https://aiven.io/docs/platform/howto/manage-org-users).
+After the user accepts the invite you can get their information using the `aiven_organization_user` data source. You can manage
 user access to projects with the `aiven_organization_user_group`, `aiven_organization_user_group_member`,
 and `aiven_organization_permission` resources.
 

--- a/docs/resources/project_user.md
+++ b/docs/resources/project_user.md
@@ -4,25 +4,20 @@ page_title: "aiven_project_user Resource - terraform-provider-aiven"
 subcategory: ""
 description: |-
   Creates and manages an Aiven project member.
-  This resource is deprecated. Use aiven_organization_permission and
+  ~> This resource is deprecated
+  Use aiven_organization_permission instead and
   migrate existing aiven_project_user resources https://registry.terraform.io/providers/aiven/aiven/latest/docs/guides/update-deprecated-resources
   to the new resource.
-  ~> This resource is deprecated.
-  Use aiven_organization_permission instead.
 ---
 
 # aiven_project_user (Resource)
 
 Creates and manages an Aiven project member.
 
-**This resource is deprecated.** Use `aiven_organization_permission` and
-[migrate existing aiven_project_user resources](https://registry.terraform.io/providers/aiven/aiven/latest/docs/guides/update-deprecated-resources) 
+~> **This resource is deprecated**
+Use `aiven_organization_permission` instead and
+[migrate existing `aiven_project_user` resources](https://registry.terraform.io/providers/aiven/aiven/latest/docs/guides/update-deprecated-resources) 
 to the new resource.
-		
-
-~> **This resource is deprecated**.
-
-Use `aiven_organization_permission` instead.
 
 ## Example Usage
 

--- a/internal/sdkprovider/provider/provider.go
+++ b/internal/sdkprovider/provider/provider.go
@@ -446,5 +446,5 @@ func formatDeprecation(s string) string {
 		// Doesn't turn the deprecation into a callout if it already is one
 		return msg
 	}
-	return "~> **This resource is deprecated**.\n\n" + msg
+	return "~> **This resource is deprecated**\n" + msg
 }

--- a/internal/sdkprovider/service/organization/organization_user.go
+++ b/internal/sdkprovider/service/organization/organization_user.go
@@ -57,15 +57,7 @@ var aivenOrganizationUserSchema = map[string]*schema.Schema{
 
 func ResourceOrganizationUser() *schema.Resource {
 	return &schema.Resource{
-		Description: `
-		**This resource is deprecated**. Users cannot be invited to an organization using Terraform.
-		Use the [Aiven Console](https://console.aiven.io/) to [invite users](https://aiven.io/docs/platform/howto/manage-org-users)
-		to your organization. 
-		
-After the user accepts the invite you can get their information using the ` + "`aiven_organization_user`" + `
-data source. You can manage user access to projects with the ` + "`aiven_organization_user_group`" + `, 
-` + "`aiven_organization_user_group_member`" + `, and ` + "`aiven_organization_permission`" + ` resources.
-`,
+		Description:   "Creates and manages an Aiven Organization user. ",
 		CreateContext: resourceOrganizationUserCreate,
 		ReadContext:   common.WithGenClient(resourceOrganizationUserRead),
 		DeleteContext: common.WithGenClient(resourceOrganizationUserDelete),
@@ -76,8 +68,8 @@ data source. You can manage user access to projects with the ` + "`aiven_organiz
 		Schema:   aivenOrganizationUserSchema,
 		DeprecationMessage: `
 Users cannot be invited to an organization using Terraform.
-Use the Aiven Console to invite users to your organization. After the user accepts the invite
-you can get their information using the aiven_organization_user data source. You can manage
+Use the Aiven Console to [invite users to your organization](https://aiven.io/docs/platform/howto/manage-org-users).
+After the user accepts the invite you can get their information using the aiven_organization_user data source. You can manage
 user access to projects with the aiven_organization_user_group, aiven_organization_user_group_member,
 and aiven_organization_permission resources.
 		`,

--- a/internal/sdkprovider/service/project/project_user.go
+++ b/internal/sdkprovider/service/project/project_user.go
@@ -38,12 +38,7 @@ var aivenProjectUserSchema = map[string]*schema.Schema{
 
 func ResourceProjectUser() *schema.Resource {
 	return &schema.Resource{
-		Description: `Creates and manages an Aiven project member.
-
-**This resource is deprecated.** Use ` + "`aiven_organization_permission`" + ` and
-[migrate existing aiven_project_user resources](https://registry.terraform.io/providers/aiven/aiven/latest/docs/guides/update-deprecated-resources) 
-to the new resource.
-		`,
+		Description:   "Creates and manages an Aiven project member.",
 		CreateContext: common.WithGenClient(resourceProjectUserCreate),
 		ReadContext:   common.WithGenClient(resourceProjectUserRead),
 		UpdateContext: common.WithGenClient(resourceProjectUserUpdate),
@@ -53,8 +48,10 @@ to the new resource.
 		},
 		Timeouts: schemautil.DefaultResourceTimeouts(),
 
-		Schema:             aivenProjectUserSchema,
-		DeprecationMessage: "Use aiven_organization_permission instead.",
+		Schema: aivenProjectUserSchema,
+		DeprecationMessage: `Use aiven_organization_permission instead and
+[migrate existing aiven_project_user resources](https://registry.terraform.io/providers/aiven/aiven/latest/docs/guides/update-deprecated-resources) 
+to the new resource.`,
 	}
 }
 


### PR DESCRIPTION
<!-- All contributors, please complete these sections, including maintainers. -->

## About this change—what it does

Removes one line break to fix the formatting since callouts don't support multiple paragraphs. 

![{A935F0A7-75F4-47FA-B85F-9003898CDBA4}](https://github.com/user-attachments/assets/456ecfd6-2071-4925-a412-8721e1ab1f3a)

With just one line break:
![{D5FEDA47-BCD3-4339-AD54-DEACDA2ABA90}](https://github.com/user-attachments/assets/79a3e63f-9fa9-44a7-9d46-2ae2756e298a)

Also removes a couple of duplicate deprecation notices.
