### PR TITLE
fix(aiven_organization_project): fixed test

### DIFF
--- a/internal/sdkprovider/service/project/organization_project_test.go
+++ b/internal/sdkprovider/service/project/organization_project_test.go
@@ -39,6 +39,7 @@ resource "aiven_organization" "foo" {
 
 resource "aiven_billing_group" "foo" {
   name = "test-acc-bg-%[1]s"
+  parent_id = aiven_organization.foo.id
 }
 
 resource "aiven_organizational_unit" "foo" {


### PR DESCRIPTION
<!-- All contributors, please complete these sections, including maintainers. -->

## About this change—what it does

<!-- Provide a small sentence that summarizes the change. -->

<!-- Provide the issue number below, if it exists. -->
- fixed a test for `aiven_organization_project`. The backend does not accept the `billing_group_id` which does not belong directly to this organization

<!-- Provide a small explanation on why this is the approach you took for solving this problem. -->
