### PR TITLE
refactor(organization_project): move to organization module

### DIFF
--- a/internal/sdkprovider/provider/provider.go
+++ b/internal/sdkprovider/provider/provider.go
@@ -101,12 +101,12 @@ func Provider(version string) (*schema.Provider, error) {
 			"aiven_organization_user_list":        organization.DatasourceOrganizationUserList(),
 			"aiven_organization_user_group":       organization.DatasourceOrganizationUserGroup(),
 			"aiven_organization_application_user": organization.DatasourceOrganizationApplicationUser(),
+			"aiven_organization_project":          organization.DatasourceOrganizationProject(),
 
 			// project
-			"aiven_project":              project.DatasourceProject(),
-			"aiven_project_user":         project.DatasourceProjectUser(),
-			"aiven_billing_group":        project.DatasourceBillingGroup(),
-			"aiven_organization_project": project.DatasourceOrganizationProject(),
+			"aiven_project":       project.DatasourceProject(),
+			"aiven_project_user":  project.DatasourceProjectUser(),
+			"aiven_billing_group": project.DatasourceBillingGroup(),
 
 			// vpc
 			"aiven_aws_privatelink":                  vpc.DatasourceAWSPrivatelink(),
@@ -221,12 +221,12 @@ func Provider(version string) (*schema.Provider, error) {
 			"aiven_organization_application_user":       organization.ResourceOrganizationApplicationUser(),
 			"aiven_organization_application_user_token": organization.ResourceOrganizationApplicationUserToken(),
 			"aiven_organization_permission":             organization.ResourceOrganizationalPermission(),
+			"aiven_organization_project":                organization.ResourceOrganizationProject(),
 
 			// project
-			"aiven_project":              project.ResourceProject(),
-			"aiven_project_user":         project.ResourceProjectUser(),
-			"aiven_billing_group":        project.ResourceBillingGroup(),
-			"aiven_organization_project": project.ResourceOrganizationProject(),
+			"aiven_project":       project.ResourceProject(),
+			"aiven_project_user":  project.ResourceProjectUser(),
+			"aiven_billing_group": project.ResourceBillingGroup(),
 
 			// vpc
 			"aiven_aws_privatelink":                       vpc.ResourceAWSPrivatelink(),

--- a/internal/sdkprovider/service/organization/organization_project.go
+++ b/internal/sdkprovider/service/organization/organization_project.go
@@ -1,4 +1,4 @@
-package project
+package organization
 
 import (
 	"context"

--- a/internal/sdkprovider/service/organization/organization_project_data_source.go
+++ b/internal/sdkprovider/service/organization/organization_project_data_source.go
@@ -1,4 +1,4 @@
-package project
+package organization
 
 import (
 	"context"

--- a/internal/sdkprovider/service/organization/organization_project_test.go
+++ b/internal/sdkprovider/service/organization/organization_project_test.go
@@ -1,4 +1,4 @@
-package project_test
+package organization_test
 
 import (
 	"context"
@@ -14,7 +14,7 @@ import (
 	acc "github.com/aiven/terraform-provider-aiven/internal/acctest"
 	"github.com/aiven/terraform-provider-aiven/internal/common"
 	"github.com/aiven/terraform-provider-aiven/internal/schemautil"
-	"github.com/aiven/terraform-provider-aiven/internal/sdkprovider/service/project"
+	"github.com/aiven/terraform-provider-aiven/internal/sdkprovider/service/organization"
 )
 
 var aivenOrganizationProjectResource = "aiven_organization_project"
@@ -246,7 +246,7 @@ func TestAccAivenOrganizationProjectUpdateStages(t *testing.T) {
 						"ref_bg":     "foo",
 						"ref_par":    "bar", // trying to change parent_id group only
 					}).MustRender(t),
-				ExpectError: regexp.MustCompile(project.ErrProjectStructureChangeNotSupported.Error()),
+				ExpectError: regexp.MustCompile(organization.ErrProjectStructureChangeNotSupported.Error()),
 			},
 			{
 				// try to change only billing_group_id - should fail
@@ -258,7 +258,7 @@ func TestAccAivenOrganizationProjectUpdateStages(t *testing.T) {
 						"ref_bg":     "bar", // trying to change billing group only
 						"ref_par":    "foo",
 					}).MustRender(t),
-				ExpectError: regexp.MustCompile(project.ErrProjectStructureChangeNotSupported.Error()),
+				ExpectError: regexp.MustCompile(organization.ErrProjectStructureChangeNotSupported.Error()),
 			},
 			{
 				// update project_id


### PR DESCRIPTION
Moves `aiven_organization_project` to the organization module where it belongs to.