### PR TITLE
docs: fix example usage for billing group data source

### DIFF
--- a/docs/data-sources/billing_group.md
+++ b/docs/data-sources/billing_group.md
@@ -14,7 +14,7 @@ Gets information about a billing group.
 
 ```terraform
 data "aiven_billing_group" "example_billing_group" {
-  name = "example-billing-group"
+  billing_group_id = "1a2b3c4d-5e6f-7a8b-9c0d-1e2f3a4b5c6d"
 }
 ```
 
@@ -23,7 +23,7 @@ data "aiven_billing_group" "example_billing_group" {
 
 ### Required
 
-- `billing_group_id` (String) The ID of the billing group. To set up proper dependencies please refer to this variable as a reference.
+- `billing_group_id` (String) The [ID of the billing group](https://aiven.io/docs/platform/reference/get-resource-IDs#get-a-billing-group-id). To set up proper dependencies please refer to this variable as a reference.
 
 ### Read-Only
 

--- a/examples/data-sources/aiven_billing_group/data-source.tf
+++ b/examples/data-sources/aiven_billing_group/data-source.tf
@@ -1,3 +1,3 @@
 data "aiven_billing_group" "example_billing_group" {
-  name = "example-billing-group"
+  billing_group_id = "1a2b3c4d-5e6f-7a8b-9c0d-1e2f3a4b5c6d"
 }

--- a/internal/sdkprovider/service/project/billing_group_data_source.go
+++ b/internal/sdkprovider/service/project/billing_group_data_source.go
@@ -17,7 +17,7 @@ func DatasourceBillingGroup() *schema.Resource {
 		"billing_group_id": {
 			Type:        schema.TypeString,
 			Required:    true,
-			Description: userconfig.Desc("The ID of the billing group.").Referenced().Build(),
+			Description: userconfig.Desc("The [ID of the billing group](https://aiven.io/docs/platform/reference/get-resource-IDs#get-a-billing-group-id).").Referenced().Build(),
 		},
 	})
 


### PR DESCRIPTION
<!-- All contributors, please complete these sections, including maintainers. -->

## About this change—what it does

Fixes the example usage for billing group data sources to use the ID instead of the name. Adds a link to instructions on how to get the billing group ID from the Console. 