### PR TITLE
chore: remove dead code

### DIFF
--- a/internal/plugin/errmsg/errmsg.go
+++ b/internal/plugin/errmsg/errmsg.go
@@ -43,9 +43,6 @@ const (
 	// SummaryErrorDeletingResource is the error summary for when a resource cannot be deleted.
 	SummaryErrorDeletingResource = "Error Deleting Resource"
 
-	// SummaryErrorImportingResource is the error summary for when a resource cannot be imported.
-	SummaryErrorImportingResource = "Error Importing Resource"
-
 	// SummaryDuplicateFoundByName is the error summary for when a duplicate resource is found by name.
 	SummaryDuplicateFoundByName = "Duplicate Found By Name"
 

--- a/internal/plugin/util/diag.go
+++ b/internal/plugin/util/diag.go
@@ -75,17 +75,6 @@ func DiagErrorDeletingResource(diagnostics diag.Diagnostics, typenameable TypeNa
 	return diagnostics
 }
 
-// DiagErrorImportingResourceNotSupported is a function that adds a resource importing not supported error to the
-// diagnostics and returns it. It is used in the ImportState method of the resource structs.
-func DiagErrorImportingResourceNotSupported(diagnostics diag.Diagnostics, typenameable TypeNameable) diag.Diagnostics {
-	diagnostics.AddError(
-		errmsg.SummaryErrorImportingResource,
-		fmt.Sprintf(errmsg.DetailErrorImportingResourceNotSupported, typenameable.TypeName()),
-	)
-
-	return diagnostics
-}
-
 // DiagErrorReadingDataSource is a function that adds a data source reading error to the diagnostics and returns it.
 // It is used in the Read method of the data source structs.
 func DiagErrorReadingDataSource(diagnostics diag.Diagnostics, typenameable TypeNameable, err error) diag.Diagnostics {

--- a/internal/plugin/util/helpers.go
+++ b/internal/plugin/util/helpers.go
@@ -1,11 +1,5 @@
 package util
 
-import (
-	"math/big"
-
-	"golang.org/x/exp/constraints"
-)
-
 // This file contains helper functions that are more generic and can be used in multiple places.
 // These functions are not specific to the Aiven plugin. If you are looking for Aiven plugin specific helpers,
 // please see the pluginhelpers.go file instead.
@@ -23,14 +17,4 @@ func NilIfZero[T comparable](v T) *T {
 	}
 
 	return &v
-}
-
-// First is a helper function that returns the first argument passed in out of two.
-func First[T any, U any](a T, _ U) T {
-	return a
-}
-
-// ToBigFloat is a helper function that converts any integer or float type to a big.Float.
-func ToBigFloat[T constraints.Integer | constraints.Float](v T) *big.Float {
-	return big.NewFloat(float64(v))
 }

--- a/internal/schemautil/userconfig/desc.go
+++ b/internal/schemautil/userconfig/desc.go
@@ -39,8 +39,6 @@ type DescriptionBuilder struct {
 	base string
 	// availabilityType is the availability type of the entity that the description is for.
 	availabilityType AvailabilityType
-	// withForcedFirstLetterCapitalization is a flag that indicates if the first letter should be capitalized.
-	withForcedFirstLetterCapitalization bool
 	// withPossibleValues is a flag that indicates if the possible values should be included.
 	withPossibleValues []string
 	// withRequiredWith is a flag that indicates if the required with should be included.
@@ -74,12 +72,6 @@ func (db *DescriptionBuilder) MarkAsDataSource() *DescriptionBuilder {
 // AvailabilityType is a function that sets the availabilityType field.
 func (db *DescriptionBuilder) AvailabilityType(t AvailabilityType) *DescriptionBuilder {
 	db.availabilityType = t
-	return db
-}
-
-// ForceFirstLetterCapitalization is a function that sets the withForcedFirstLetterCapitalization flag.
-func (db *DescriptionBuilder) ForceFirstLetterCapitalization() *DescriptionBuilder {
-	db.withForcedFirstLetterCapitalization = true
 	return db
 }
 
@@ -122,13 +114,7 @@ func (db *DescriptionBuilder) ForceNew() *DescriptionBuilder {
 func (db *DescriptionBuilder) Build() string {
 	builder := new(strings.Builder)
 
-	// Capitalize the first letter, if needed.
-	if db.withForcedFirstLetterCapitalization {
-		builder.WriteRune(rune(strings.ToUpper(string(db.base[0]))[0]))
-		builder.WriteString(db.base[1:])
-	} else {
-		builder.WriteString(db.base)
-	}
+	builder.WriteString(db.base)
 
 	// Add a trailing dot if it's missing.
 	if !strings.HasSuffix(db.base, ".") {


### PR DESCRIPTION
<!-- All contributors, please complete these sections, including maintainers. -->

## About this change—what it does

Removes dead code using https://pkg.go.dev/golang.org/x/tools/internal/cmd/deadcode.

```bash
$ deadcode -f='{{range .Funcs}}{{println .Position}}{{end}}' -test ./internal/...
internal/acctest/acctest.go:272:6
internal/acctest/template.go:103:28
internal/acctest/template.go:111:28
internal/acctest/template.go:117:28
internal/acctest/template.go:162:30
internal/acctest/template.go:179:30
internal/plugin/util/diag.go:80:6
internal/plugin/util/helpers.go:29:6
internal/plugin/util/helpers.go:34:6
internal/schemautil/userconfig/desc.go:81:31
```

Code in `template.go` is left as-is.
