### PR TITLE
chore(redis): skip redis tests

### DIFF
--- a/internal/sdkprovider/service/redis/redis_test.go
+++ b/internal/sdkprovider/service/redis/redis_test.go
@@ -13,7 +13,11 @@ import (
 	acc "github.com/aiven/terraform-provider-aiven/internal/acctest"
 )
 
+const redisDeprecated = "This resource is deprecated. Can't run tests"
+
 func TestAccAiven_redis(t *testing.T) {
+	t.Skip(redisDeprecated)
+
 	resourceName := "aiven_redis.bar"
 	rName := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
 

--- a/internal/sdkprovider/service/redis/redis_user_test.go
+++ b/internal/sdkprovider/service/redis/redis_user_test.go
@@ -17,6 +17,8 @@ import (
 )
 
 func TestAccAivenRedisUser_basic(t *testing.T) {
+	t.Skip(redisDeprecated)
+
 	resourceName := "aiven_redis_user.foo"
 	rName := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
 


### PR DESCRIPTION
<!-- All contributors, please complete these sections, including maintainers. -->

## About this change—what it does
- skip tests for `redis` resource due to the deprecation

<!-- Provide a small sentence that summarizes the change. -->

<!-- Provide the issue number below, if it exists. -->

<!-- Provide a small explanation on why this is the approach you took for solving this problem. -->
