### PR TITLE
docs: add warning to project user and group project resources

### DIFF
--- a/docs/data-sources/project_user.md
+++ b/docs/data-sources/project_user.md
@@ -7,7 +7,7 @@ description: |-
   ~> This resource is deprecated
   Use aiven_organization_permission instead and
   migrate existing aiven_project_user resources https://registry.terraform.io/providers/aiven/aiven/latest/docs/guides/update-deprecated-resources
-  to the new resource.
+  to the new resource. Do not use the aiven_project_user and aiven_organization_permission resources together.
 ---
 
 # aiven_project_user (Data Source)
@@ -17,7 +17,7 @@ The Project User data source provides information about the existing Aiven Proje
 ~> **This resource is deprecated**
 Use `aiven_organization_permission` instead and
 [migrate existing `aiven_project_user` resources](https://registry.terraform.io/providers/aiven/aiven/latest/docs/guides/update-deprecated-resources) 
-to the new resource.
+to the new resource. **Do not use the `aiven_project_user` and `aiven_organization_permission` resources together**.
 
 ## Example Usage
 

--- a/docs/resources/organization_group_project.md
+++ b/docs/resources/organization_group_project.md
@@ -6,7 +6,7 @@ description: |-
   Adds and manages a group of users as members of a project.
   This resource is deprecated. Use aiven_organization_permission and
   migrate existing aiven_organization_group_project resources https://registry.terraform.io/providers/aiven/aiven/latest/docs/guides/update-deprecated-resources
-  to the new resource.
+  to the new resource. Do not use the aiven_organization_group_project and aiven_organization_permission resources together.
 ---
 
 # aiven_organization_group_project (Resource)
@@ -15,7 +15,7 @@ Adds and manages a group of users as members of a project.
 
 **This resource is deprecated.** Use `aiven_organization_permission` and
 [migrate existing aiven_organization_group_project resources](https://registry.terraform.io/providers/aiven/aiven/latest/docs/guides/update-deprecated-resources) 
-to the new resource.
+to the new resource. **Do not use the aiven_organization_group_project and aiven_organization_permission resources together**.
 
 ## Example Usage
 

--- a/docs/resources/organization_permission.md
+++ b/docs/resources/organization_permission.md
@@ -3,12 +3,19 @@
 page_title: "aiven_organization_permission Resource - terraform-provider-aiven"
 subcategory: ""
 description: |-
-  Grants roles and permissions https://aiven.io/docs/platform/concepts/permissions to a principal for a resource. Permissions can be granted at the organization, organizational unit, and project level. Unit-level permissions aren't shown in the Aiven Console.
+  Grants roles and permissions https://aiven.io/docs/platform/concepts/permissions
+  to a principal for a resource. Permissions can be granted at the organization, organizational unit, and project level.
+  Unit-level permissions aren't shown in the Aiven Console.
+  Do not use the aiven_project_user or aiven_organization_group_project resources with this resource.
 ---
 
 # aiven_organization_permission (Resource)
 
-Grants [roles and permissions](https://aiven.io/docs/platform/concepts/permissions) to a principal for a resource. Permissions can be granted at the organization, organizational unit, and project level. Unit-level permissions aren't shown in the Aiven Console.
+Grants [roles and permissions](https://aiven.io/docs/platform/concepts/permissions)
+to a principal for a resource. Permissions can be granted at the organization, organizational unit, and project level. 
+Unit-level permissions aren't shown in the Aiven Console.
+
+**Do not use the `aiven_project_user` or `aiven_organization_group_project` resources with this resource**.
 
 ## Example Usage
 

--- a/docs/resources/project_user.md
+++ b/docs/resources/project_user.md
@@ -7,7 +7,7 @@ description: |-
   ~> This resource is deprecated
   Use aiven_organization_permission instead and
   migrate existing aiven_project_user resources https://registry.terraform.io/providers/aiven/aiven/latest/docs/guides/update-deprecated-resources
-  to the new resource.
+  to the new resource. Do not use the aiven_project_user and aiven_organization_permission resources together.
 ---
 
 # aiven_project_user (Resource)
@@ -17,7 +17,7 @@ Creates and manages an Aiven project member.
 ~> **This resource is deprecated**
 Use `aiven_organization_permission` instead and
 [migrate existing `aiven_project_user` resources](https://registry.terraform.io/providers/aiven/aiven/latest/docs/guides/update-deprecated-resources) 
-to the new resource.
+to the new resource. **Do not use the `aiven_project_user` and `aiven_organization_permission` resources together**.
 
 ## Example Usage
 

--- a/internal/plugin/service/organization/organization_group_project.go
+++ b/internal/plugin/service/organization/organization_group_project.go
@@ -83,7 +83,7 @@ func (r *organizationGroupProjectResource) Schema(
 
 **This resource is deprecated.** Use ` + "`aiven_organization_permission`" + ` and
 [migrate existing aiven_organization_group_project resources](https://registry.terraform.io/providers/aiven/aiven/latest/docs/guides/update-deprecated-resources) 
-to the new resource.
+to the new resource. **Do not use the aiven_organization_group_project and aiven_organization_permission resources together**.
 			`,
 		DeprecationMessage: "This resource is deprecated. Use aiven_organization_permission instead.",
 		Attributes: map[string]schema.Attribute{

--- a/internal/sdkprovider/service/organization/organization_permission.go
+++ b/internal/sdkprovider/service/organization/organization_permission.go
@@ -72,7 +72,12 @@ var permissionFields = map[string]*schema.Schema{
 
 func ResourceOrganizationalPermission() *schema.Resource {
 	return &schema.Resource{
-		Description:   "Grants [roles and permissions](https://aiven.io/docs/platform/concepts/permissions) to a principal for a resource. Permissions can be granted at the organization, organizational unit, and project level. Unit-level permissions aren't shown in the Aiven Console.",
+		Description: `Grants [roles and permissions](https://aiven.io/docs/platform/concepts/permissions)
+to a principal for a resource. Permissions can be granted at the organization, organizational unit, and project level. 
+Unit-level permissions aren't shown in the Aiven Console.
+
+**Do not use the ` + "`aiven_project_user`" + ` or ` + "`aiven_organization_group_project`" + ` resources with this resource**.
+`,
 		CreateContext: common.WithGenClient(resourceOrganizationalPermissionUpsert),
 		ReadContext:   common.WithGenClient(resourceOrganizationalPermissionRead),
 		UpdateContext: common.WithGenClient(resourceOrganizationalPermissionUpsert),

--- a/internal/sdkprovider/service/project/project_user.go
+++ b/internal/sdkprovider/service/project/project_user.go
@@ -51,7 +51,7 @@ func ResourceProjectUser() *schema.Resource {
 		Schema: aivenProjectUserSchema,
 		DeprecationMessage: `Use aiven_organization_permission instead and
 [migrate existing aiven_project_user resources](https://registry.terraform.io/providers/aiven/aiven/latest/docs/guides/update-deprecated-resources) 
-to the new resource.`,
+to the new resource. **Do not use the aiven_project_user and aiven_organization_permission resources together**.`,
 	}
 }
 


### PR DESCRIPTION
<!-- All contributors, please complete these sections, including maintainers. -->

## About this change—what it does

Adds a warning to not use the `aiven_project_user` and `aiven_organization_group_project` resources together with the `aiven_organization_permission` resource.