### PR TITLE
fix(user_config): plus suppresses false values [NEX-1314]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ nav_order: 1
 
 ## [MAJOR.MINOR.PATCH] - YYYY-MM-DD
 
+- Fix user config plan suppresses `false` values 
 - Fix `terraform import` for various resources
 - Fix `aiven_organization_application_user`: improve delete operation
 - Improve `aiven_organiztion_permission`: use `PermissionsSet` endpoint to set permissions


### PR DESCRIPTION
Fixes `false` values suppression in the plan in the user config block.

Resolves #2087 