### PR TITLE
chore: refactor acctest env var handling

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -25,17 +25,18 @@ jobs:
         with:
           fetch-depth: 0
       - uses: wagoid/commitlint-github-action@v6
-      
+
   semgrep:
     runs-on: ubuntu-latest
     if: (github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'skip workflows')) || github.event_name == 'push'
     container:
-      image: returntocorp/semgrep
+      image: semgrep/semgrep
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - run: semgrep ci --config auto --no-suppress-errors
+      # Keep in sync with Makefile
+      - run: semgrep --config "p/auto" --config ".semgrep.yml" --include="**" --error
 
   make_lint:
     runs-on: ubuntu-latest
@@ -63,7 +64,7 @@ jobs:
 
       - run: make docs
       - run: git diff --exit-code
-  
+
   sweep_check:
     runs-on: ubuntu-latest
     if: (github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'skip workflows')) || github.event_name == 'push'
@@ -74,5 +75,5 @@ jobs:
     - uses: actions/setup-go@v5
       with:
         go-version-file: go.mod
-        
+
     - run: make sweep-check

--- a/.semgrep.yml
+++ b/.semgrep.yml
@@ -59,7 +59,32 @@ rules:
 
 # Rules to select small service plans in tests:
 
-# TODO: we can maybe use startup-2 for most kafka needs
+# Rule for Kafka with Kafka Connect
+- id: large-plan-in-test-kafka-connect
+  languages: [generic]
+  paths:
+    include:
+    - "*_test.go"
+  patterns:
+  - pattern-inside:
+      plan = "..."
+  - pattern-inside: |
+      resource "aiven_kafka" ... {
+        ...
+        kafka_user_config {
+          ...
+          kafka_connect = true
+          ...
+        }
+        ...
+      }
+  - pattern-not-regex: business-4|%s
+  fix: plan = "business-4"
+  message: |
+    Kafka with kafka_connect enabled requires at least business-4 plan
+  severity: ERROR
+
+# Rule for Kafka without Kafka Connect
 - id: large-plan-in-test-kafka
   languages: [generic]
   paths:
@@ -68,17 +93,65 @@ rules:
   patterns:
   - pattern-inside:
       plan = "..."
-  - pattern-inside:
+  - pattern-inside: |
       resource "aiven_kafka" ... {
         ...
       }
-  - pattern-not-regex: business-4
-  fix: |
-    plan = "business-4"
+  - pattern-not-inside: |
+      resource "aiven_kafka" ... {
+        ...
+        kafka_user_config {
+          ...
+          kafka_connect = true
+          ...
+        }
+        ...
+      }
+  - pattern-not-regex: startup-2|%s
+  fix: plan = "startup-2"
   message: |
-    Tests should use the smallest kafka plan to save costs
+    Tests should use startup-2 for Kafka without kafka_connect
   severity: ERROR
 
+# Rule for Flink
+- id: large-plan-in-test-flink
+  languages: [generic]
+  paths:
+    include:
+    - "*_test.go"
+  patterns:
+  - pattern-inside:
+      plan = "..."
+  - pattern-inside: |
+      resource "aiven_flink" ... {
+        ...
+      }
+  - pattern-not-regex: business-4|%s
+  fix: plan = "business-4"
+  message: |
+    Flink requires at least business-4 plan
+  severity: ERROR
+
+# Rule for Grafana
+- id: large-plan-in-test-grafana
+  languages: [generic]
+  paths:
+    include:
+    - "*_test.go"
+  patterns:
+  - pattern-inside:
+      plan = "..."
+  - pattern-inside: |
+      resource "aiven_grafana" ... {
+        ...
+      }
+  - pattern-not-regex: startup-1|%s
+  fix: plan = "startup-1"
+  message: |
+    Grafana should use the smallest plan (startup-1) to save costs
+  severity: ERROR
+
+# Rule for M3 Aggregator
 - id: large-plan-in-test-m3aggregator
   languages: [generic]
   paths:
@@ -87,17 +160,17 @@ rules:
   patterns:
   - pattern-inside:
       plan = "..."
-  - pattern-inside:
+  - pattern-inside: |
       resource "aiven_m3aggregator" ... {
         ...
       }
-  - pattern-not-regex: business-8
-  fix: |
-    plan = "business-8"
+  - pattern-not-regex: business-8|%s
+  fix: plan = "business-8"
   message: |
-    Tests should use the smallest m3aggregator plan to save costs
+    M3Aggregator requires at least business-8 plan
   severity: ERROR
 
+# Rule for ClickHouse
 - id: large-plan-in-test-clickhouse
   languages: [generic]
   paths:
@@ -106,17 +179,17 @@ rules:
   patterns:
   - pattern-inside:
       plan = "..."
-  - pattern-inside:
+  - pattern-inside: |
       resource "aiven_clickhouse" ... {
         ...
       }
-  - pattern-not-regex: startup-16
-  fix: |
-    plan = "startup-16"
+  - pattern-not-regex: startup-16|%s
+  fix: plan = "startup-16"
   message: |
-    Tests should use the smallest clickhouse plan to save costs
+    Clickhouse requires at least startup-16 plan
   severity: ERROR
 
+# Rule for all other services
 - id: large-plan-in-test-other
   languages: [generic]
   paths:
@@ -125,25 +198,36 @@ rules:
   patterns:
   - pattern-inside:
       plan = "..."
-  - pattern-inside:
+  - pattern-inside: |
       resource ... ... {
         ...
       }
-  - pattern-not-inside:
+  - pattern-not-inside: |
       resource "aiven_kafka" ... {
         ...
       }
-  - pattern-not-inside:
+  - pattern-not-inside: |
+      resource "aiven_flink" ... {
+        ...
+      }
+  - pattern-not-inside: |
       resource "aiven_m3aggregator" ... {
         ...
       }
-  - pattern-not-inside:
+  - pattern-not-inside: |
+      resource "aiven_m3db" ... {
+        ...
+      }
+  - pattern-not-inside: |
       resource "aiven_clickhouse" ... {
         ...
       }
-  - pattern-not-regex: (startup-(1|2|4|8)|%s)
-  fix: |
-    plan = "startup-4"
+  - pattern-not-inside: |
+      resource "aiven_grafana" ... {
+        ...
+      }
+  - pattern-not-regex: startup-4|%s
+  fix: plan = "startup-4"
   message: |
     Tests should use the smallest service plan to save costs
   severity: ERROR

--- a/.semgrep.yml
+++ b/.semgrep.yml
@@ -36,6 +36,27 @@ rules:
     Each schema field should have a description
   severity: WARNING
 
+# Rules to enforce using acctest helpers instead of direct environment variable access:
+- id: direct-env-var-access-in-tests
+  languages: [go]
+  paths:
+    include:
+    - "*_test.go"
+  patterns:
+    - pattern-either:
+      - pattern: os.Getenv("AIVEN_PROJECT_NAME")
+      - pattern: os.Getenv("AIVEN_ORGANIZATION_NAME")
+      - pattern: os.Getenv("AIVEN_ACCOUNT_NAME")
+      - pattern: os.LookupEnv("AIVEN_PROJECT_NAME")
+      - pattern: os.LookupEnv("AIVEN_ORGANIZATION_NAME")
+      - pattern: os.LookupEnv("AIVEN_ACCOUNT_NAME")
+  message: |
+    Do not use os.Getenv/LookupEnv directly in tests for Aiven environment variables.
+    Instead use the helper functions from internal/acctest:
+    - Use acc.ProjectName() for AIVEN_PROJECT_NAME
+    - Use acc.OrganizationName() for AIVEN_ORGANIZATION_NAME
+  severity: ERROR
+
 # Rules to select small service plans in tests:
 
 # TODO: we can maybe use startup-2 for most kafka needs

--- a/.semgrep.yml
+++ b/.semgrep.yml
@@ -10,14 +10,14 @@ rules:
     - "datasource_*"
   patterns:
   - pattern: |
-      &schema.Resource{ ... } 
+      &schema.Resource{ ... }
   - pattern-not: |
       &schema.Resource{ ..., Description: ..., ... }
   - pattern-inside: |
       func $F() *schema.Resource { ... }
   message: |
     Each schema resource should have a description
-  severity: WARNING
+  severity: ERROR
 
 - id: schema-element-without-description
   languages: [go]
@@ -34,7 +34,7 @@ rules:
       { ..., Description: ..., ... }
   message: |
     Each schema field should have a description
-  severity: WARNING
+  severity: ERROR
 
 # Rules to enforce using acctest helpers instead of direct environment variable access:
 - id: direct-env-var-access-in-tests
@@ -77,7 +77,7 @@ rules:
     plan = "business-4"
   message: |
     Tests should use the smallest kafka plan to save costs
-  severity: WARNING
+  severity: ERROR
 
 - id: large-plan-in-test-m3aggregator
   languages: [generic]
@@ -96,7 +96,7 @@ rules:
     plan = "business-8"
   message: |
     Tests should use the smallest m3aggregator plan to save costs
-  severity: WARNING
+  severity: ERROR
 
 - id: large-plan-in-test-clickhouse
   languages: [generic]
@@ -110,12 +110,12 @@ rules:
       resource "aiven_clickhouse" ... {
         ...
       }
-  - pattern-not-regex: startup-beta-8
+  - pattern-not-regex: startup-16
   fix: |
-    plan = "startup-beta-8"
+    plan = "startup-16"
   message: |
     Tests should use the smallest clickhouse plan to save costs
-  severity: WARNING
+  severity: ERROR
 
 - id: large-plan-in-test-other
   languages: [generic]
@@ -146,4 +146,4 @@ rules:
     plan = "startup-4"
   message: |
     Tests should use the smallest service plan to save costs
-  severity: WARNING
+  severity: ERROR

--- a/.semgrepignore
+++ b/.semgrepignore
@@ -1,0 +1,3 @@
+# See https://semgrep.dev/docs/ignoring-files-folders-code#understand-semgrep-defaults to understand why this is needed...
+# Remove when https://github.com/semgrep/semgrep/issues/4524 is resolved
+!*_test.go

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@
 #################################################
 
 GO := CGO_ENABLED=0 go
+CONTAINER_TOOL ?= podman
 
 TOOLS_DIR ?= tools
 TOOLS_BIN_DIR ?= $(TOOLS_DIR)/bin
@@ -113,7 +114,7 @@ test-examples: build-dev clean-examples
 # Lint
 #################################################
 
-lint: lint-go lint-test lint-docs
+lint: lint-go lint-test lint-docs semgrep
 
 
 lint-go: $(GOLANGCILINT)
@@ -134,6 +135,14 @@ lint-docs: $(TFPLUGINDOCS)
 	PROVIDER_AIVEN_ENABLE_BETA=1 $(TFPLUGINDOCS) validate --provider-name aiven
 	rm -f docs/data-sources/influxdb*.md
 	rm -f docs/resources/influxdb*.md
+
+semgrep:
+	$(CONTAINER_TOOL) run --rm -v "${PWD}:/src" semgrep/semgrep semgrep \
+		--config="p/auto" \
+		--config=".semgrep.yml" \
+		--include="**" \
+		--metrics=off \
+		--error
 
 #################################################
 # Format

--- a/internal/acctest/acctest.go
+++ b/internal/acctest/acctest.go
@@ -30,6 +30,7 @@ const (
 	envBetaFeatures     = "PROVIDER_AIVEN_ENABLE_BETA"
 	envUserID           = "AIVEN_ORGANIZATION_USER_ID"
 	envAccountID        = "AIVEN_ORGANIZATION_ACCOUNT_ID"
+	envAccountName      = "AIVEN_ACCOUNT_NAME"
 )
 
 var TestProtoV6ProviderFactories = map[string]func() (tfprotov6.ProviderServer, error){
@@ -96,6 +97,11 @@ func UserID() string {
 // AccountID returns the Aiven organization account ID
 func AccountID() string {
 	return getEnvVar(envAccountID)
+}
+
+// AccountName returns the Aiven account name
+func AccountName() string {
+	return getEnvVar(envAccountName)
 }
 
 // TestAccPreCheck validates the necessary test API keys exist in the testing environment

--- a/internal/acctest/acctest.go
+++ b/internal/acctest/acctest.go
@@ -18,146 +18,105 @@ import (
 
 	"github.com/aiven/terraform-provider-aiven/internal/common"
 	"github.com/aiven/terraform-provider-aiven/internal/plugin/errmsg"
-	"github.com/aiven/terraform-provider-aiven/internal/plugin/util"
 	"github.com/aiven/terraform-provider-aiven/internal/schemautil"
 	"github.com/aiven/terraform-provider-aiven/internal/server"
 )
 
-var (
-	testAivenClient              *aiven.Client
-	testAivenClientOnce          sync.Once
-	TestProtoV6ProviderFactories = map[string]func() (tfprotov6.ProviderServer, error){
-		"aiven": func() (tfprotov6.ProviderServer, error) {
-			return server.NewMuxServer(context.Background(), "test")
-		},
-	}
-)
-
-var (
-	// ErrMustSetBetaEnvVar is an error that is returned when the PROVIDER_AIVEN_ENABLE_BETA environment variable is not
-	// set, but it is required for the concrete acceptance test to run.
-	ErrMustSetBetaEnvVar = "PROVIDER_AIVEN_ENABLE_BETA must be set for this test to run"
-
-	// ErrMustSetOrganizationUserIDEnvVar is an error that is returned when the AIVEN_ORGANIZATION_USER_ID environment
-	// variable is not set, but it is required for the concrete acceptance test to run.
-	ErrMustSetOrganizationUserIDEnvVar = "AIVEN_ORGANIZATION_USER_ID must be set for this test to run"
-)
-
-// GetTestAivenClient returns a new Aiven client that can be used for acceptance tests.
-func GetTestAivenClient() *aiven.Client {
-	testAivenClientOnce.Do(func() {
-		client, err := common.NewAivenClient()
-		if err != nil {
-			log.Panicf("test client error: %s", err)
-		}
-		testAivenClient = client
-	})
-	return testAivenClient
-}
-
-func GetTestGenAivenClient() (avngen.Client, error) {
-	client, err := common.NewAivenGenClient()
-	if err != nil {
-		return nil, fmt.Errorf("test generated client error: %w", err)
-	}
-	return client, nil
-}
-
-// commonTestDependencies is a struct that contains common dependencies that are used by acceptance tests.
-type commonTestDependencies struct {
-	// t is the testing.T instance that is used for acceptance tests.
-	t *testing.T
-
-	// isBeta is a flag that indicates whether the provider is in beta mode.
-	isBeta bool
-	// organizationName is the name of the organization that is used for acceptance tests.
-	organizationName string
-	// organizationUserID is the ID of the organization user that is used for acceptance tests.
-	organizationUserID *string
-}
-
-// IsBeta returns a flag that indicates whether the provider is in beta mode.
-// If skip is true, then this function will skip the test if the provider is not in beta mode.
-func (d *commonTestDependencies) IsBeta(skip bool) bool {
-	if skip && !d.isBeta {
-		d.t.Skip(ErrMustSetBetaEnvVar)
-	}
-
-	return d.isBeta
-}
-
-// OrganizationName returns the name of the organization that is used for acceptance tests.
-func (d *commonTestDependencies) OrganizationName() string {
-	return d.organizationName
-}
-
-// OrganizationUserID returns the ID of the organization user that is used for acceptance tests.
-// If skip is true, then this function will skip the test if the organization user ID is not set.
-func (d *commonTestDependencies) OrganizationUserID(skip bool) *string {
-	if skip && d.organizationUserID == nil {
-		d.t.Skip(ErrMustSetOrganizationUserIDEnvVar)
-	}
-
-	return d.organizationUserID
-}
-
-// CommonTestDependencies returns a new commonTestDependencies struct that contains common dependencies that are
-// used by acceptance tests.
-// nolint:revive // Ignore unexported type error because this type is not meant to be used outside of this package.
-func CommonTestDependencies(t *testing.T) *commonTestDependencies {
-	// We mimic the real error message that is returned by Terraform when the acceptance tests are skipped.
-	//
-	// This is done because the tests that use this function are running it before the real Terraform check takes
-	// place, and we want to avoid false positively running this function when the acceptance tests are not actually
-	// ran, e.g. if unit tests are ran instead.
-	//
-	// See https://github.com/hashicorp/terraform-plugin-testing/blob/v1.6.0/helper/resource/testing.go#L849-L857 for
-	// more details on the real check.
-	if _, ok := os.LookupEnv("TF_ACC"); !ok {
-		t.Skip("Acceptance tests skipped unless env 'TF_ACC' set")
-	}
-
-	deps := &commonTestDependencies{
-		t: t,
-
-		isBeta: util.IsBeta(),
-	}
-
-	organizationName, ok := os.LookupEnv("AIVEN_ORGANIZATION_NAME")
-	if !ok {
-		t.Fatal("AIVEN_ORGANIZATION_NAME environment variable must be set for acceptance tests")
-	}
-	deps.organizationName = organizationName
-
-	organizationUserID, ok := os.LookupEnv("AIVEN_ORGANIZATION_USER_ID")
-	if ok {
-		deps.organizationUserID = &organizationUserID
-	}
-
-	return deps
-}
-
 const (
-	// DefaultResourceNamePrefix is the default prefix used for resource names in acceptance tests.
-	DefaultResourceNamePrefix = "test-acc"
-
-	// DefaultRandomSuffixLength is the default length of the random suffix used in acceptance tests.
-	DefaultRandomSuffixLength = 6
+	// Environment variables used in tests
+	envToken            = "AIVEN_TOKEN"
+	envProjectName      = "AIVEN_PROJECT_NAME"
+	envOrganizationName = "AIVEN_ORGANIZATION_NAME"
+	envBetaFeatures     = "PROVIDER_AIVEN_ENABLE_BETA"
+	envUserID           = "AIVEN_ORGANIZATION_USER_ID"
+	envAccountID        = "AIVEN_ORGANIZATION_ACCOUNT_ID"
 )
 
-func RandStr() string {
-	return acctest.RandStringFromCharSet(DefaultRandomSuffixLength, acctest.CharSetAlphaNum)
+var TestProtoV6ProviderFactories = map[string]func() (tfprotov6.ProviderServer, error){
+	"aiven": func() (tfprotov6.ProviderServer, error) {
+		return server.NewMuxServer(context.Background(), "test")
+	},
 }
 
-// TestAccPreCheck is a helper function that is called by acceptance tests prior to any test case execution.
-// It is used to perform any pre-test setup, such as environment variable validation.
+// getEnvVar returns environment variable value or empty string if not set
+func getEnvVar(name string) string {
+	val, ok := os.LookupEnv(name)
+	if !ok {
+		return ""
+	}
+	return val
+}
+
+// RequireEnvVars checks that all specified environment variables are set.
+// It skips the test if any variable is missing.
+// Returns a map of environment variable names to their values.
+func RequireEnvVars(t *testing.T, vars ...string) map[string]string {
+	t.Helper()
+
+	result := make(map[string]string, len(vars))
+	for _, v := range vars {
+		val, ok := os.LookupEnv(v)
+		if !ok {
+			t.Skipf("environment variable %s not set", v)
+		}
+		result[v] = val
+	}
+	return result
+}
+
+// SkipIfNotBeta skips the test if beta features are not enabled
+func SkipIfNotBeta(t *testing.T) {
+	t.Helper()
+
+	if _, ok := os.LookupEnv(envBetaFeatures); !ok {
+		t.Skip("This test requires beta features to be enabled. Set PROVIDER_AIVEN_ENABLE_BETA environment variable.")
+	}
+}
+
+// Token returns the Aiven API token
+func Token() string {
+	return getEnvVar(envToken)
+}
+
+// ProjectName returns the Aiven project name
+func ProjectName() string {
+	return getEnvVar(envProjectName)
+}
+
+// OrganizationName returns the Aiven organization name
+func OrganizationName() string {
+	return getEnvVar(envOrganizationName)
+}
+
+// UserID returns the Aiven organization user ID
+func UserID() string {
+	return getEnvVar(envUserID)
+}
+
+// AccountID returns the Aiven organization account ID
+func AccountID() string {
+	return getEnvVar(envAccountID)
+}
+
+// TestAccPreCheck validates the necessary test API keys exist in the testing environment
 func TestAccPreCheck(t *testing.T) {
-	if _, ok := os.LookupEnv("AIVEN_TOKEN"); !ok {
-		t.Fatal("AIVEN_TOKEN environment variable must be set for acceptance tests")
+	t.Helper()
+
+	if err := os.Setenv("TF_ACC", "1"); err != nil {
+		t.Fatal("Error setting TF_ACC: ", err)
 	}
 
-	if _, ok := os.LookupEnv("AIVEN_PROJECT_NAME"); !ok {
-		t.Log("AIVEN_PROJECT_NAME environment variable is not set. Some acceptance tests will be skipped")
+	// These are required for all tests
+	vars := RequireEnvVars(t, envToken, envProjectName)
+	token := vars[envToken]
+	projectName := vars[envProjectName]
+
+	if err := os.Setenv(envToken, token); err != nil {
+		t.Fatal("Error setting AIVEN_TOKEN: ", err)
+	}
+
+	if err := os.Setenv(envProjectName, projectName); err != nil {
+		t.Fatal("Error setting AIVEN_PROJECT_NAME: ", err)
 	}
 }
 
@@ -231,48 +190,39 @@ func ResourceFromState(state *terraform.State, name string) (*terraform.Resource
 	return rs, nil
 }
 
-// EnvVarCheckMode determines how missing environment variables are handled
-type EnvVarCheckMode int
-
-const (
-	// MustBeSet fails the test if any required env vars are missing
-	MustBeSet EnvVarCheckMode = iota
-	// SkipIfMissing skips the test if any required env vars are missing
-	SkipIfMissing
+var (
+	testAivenClient     *aiven.Client
+	testAivenClientOnce sync.Once
 )
 
-func CheckEnvVars(t *testing.T, mode EnvVarCheckMode, vars ...string) map[string]string {
-	t.Helper()
-
-	values := make(map[string]string)
-	missingVars := make([]string, 0)
-
-	for _, v := range vars {
-		val, ok := os.LookupEnv(v)
-		if !ok {
-			missingVars = append(missingVars, v)
-			continue
+// GetTestAivenClient returns a new Aiven client that can be used for acceptance tests.
+func GetTestAivenClient() *aiven.Client {
+	testAivenClientOnce.Do(func() {
+		client, err := common.NewAivenClient()
+		if err != nil {
+			log.Panicf("test client error: %s", err)
 		}
-		values[v] = val
-	}
-
-	if len(missingVars) > 0 {
-		msg := fmt.Sprintf("required environment variables not set: %s", strings.Join(missingVars, ", "))
-		switch mode {
-		case MustBeSet:
-			t.Fatal(msg)
-		case SkipIfMissing:
-			t.Skip(msg)
-		}
-	}
-
-	return values
+		testAivenClient = client
+	})
+	return testAivenClient
 }
 
-func MustHaveEnvVars(t *testing.T, vars ...string) map[string]string {
-	return CheckEnvVars(t, MustBeSet, vars...)
+func GetTestGenAivenClient() (avngen.Client, error) {
+	client, err := common.NewAivenGenClient()
+	if err != nil {
+		return nil, fmt.Errorf("test generated client error: %w", err)
+	}
+	return client, nil
 }
 
-func SkipIfEnvVarsNotSet(t *testing.T, vars ...string) map[string]string {
-	return CheckEnvVars(t, SkipIfMissing, vars...)
+const (
+	// DefaultResourceNamePrefix is the default prefix used for resource names in acceptance tests.
+	DefaultResourceNamePrefix = "test-acc"
+
+	// DefaultRandomSuffixLength is the default length of the random suffix used in acceptance tests.
+	DefaultRandomSuffixLength = 6
+)
+
+func RandStr() string {
+	return acctest.RandStringFromCharSet(DefaultRandomSuffixLength, acctest.CharSetAlphaNum)
 }

--- a/internal/acctest/template/generator.go
+++ b/internal/acctest/template/generator.go
@@ -202,8 +202,6 @@ func (r *CommonTemplateRenderer) RenderField(builder *strings.Builder, field Tem
 		r.renderMap(builder, field, path, indent)
 	} else if field.FieldType == FieldTypeBool {
 		r.renderBool(builder, field, path, indent)
-	} else if field.FieldType == FieldTypeNumber {
-		r.renderSimple(builder, field, path, indent)
 	} else {
 		r.renderSimple(builder, field, path, indent)
 	}

--- a/internal/plugin/service/externalidentity/external_identity_data_source_test.go
+++ b/internal/plugin/service/externalidentity/external_identity_data_source_test.go
@@ -12,12 +12,10 @@ import (
 
 // TestExternalIdentityDataSource tests the external_identity datasource.
 func TestExternalIdentityDataSource(t *testing.T) {
-	deps := acc.CommonTestDependencies(t)
+	acc.SkipIfNotBeta(t)
 
-	_ = deps.IsBeta(true)
-
-	organizationName := deps.OrganizationName()
-	userID := deps.OrganizationUserID(true)
+	organizationName := acc.OrganizationName()
+	userID := acc.UserID()
 	prefix := acc.DefaultResourceNamePrefix
 	suffix := acctest.RandStringFromCharSet(acc.DefaultRandomSuffixLength, acctest.CharSetAlphaNum)
 	userGroupName := fmt.Sprintf("%s-usr-group-%s", prefix, suffix)
@@ -29,10 +27,10 @@ func TestExternalIdentityDataSource(t *testing.T) {
 		PreCheck:                 func() { acc.TestAccPreCheck(t) },
 		Steps: []resource.TestStep{
 			{
-				Config: testExternalIdentityDataSourceBasic(organizationName, userGroupName, *userID, externalUserID),
+				Config: testExternalIdentityDataSourceBasic(organizationName, userGroupName, userID, externalUserID),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "external_user_id", "alice"),
-					resource.TestCheckResourceAttr(resourceName, "internal_user_id", *userID),
+					resource.TestCheckResourceAttr(resourceName, "internal_user_id", userID),
 				),
 			},
 		},

--- a/internal/plugin/service/organization/address/organization_address_data_source_test.go
+++ b/internal/plugin/service/organization/address/organization_address_data_source_test.go
@@ -10,10 +10,8 @@ import (
 )
 
 func TestAccAivenOrganizationAddressDataSource(t *testing.T) {
-	deps := acc.CommonTestDependencies(t)
-
 	var (
-		organizationName = deps.OrganizationName()
+		organizationName = acc.OrganizationName()
 		dataSourceName   = "data.aiven_organization_address.ds"
 		resourceName     = "aiven_organization_address.address"
 		templBuilder     = template.InitializeTemplateStore(t).NewBuilder().

--- a/internal/plugin/service/organization/address/organization_address_resource_test.go
+++ b/internal/plugin/service/organization/address/organization_address_resource_test.go
@@ -10,11 +10,9 @@ import (
 )
 
 func TestAccAivenOrganizationAddress(t *testing.T) {
-	deps := acc.CommonTestDependencies(t)
-
 	var (
 		name             = "aiven_organization_address.address"
-		organizationName = deps.OrganizationName()
+		organizationName = acc.OrganizationName()
 		templateStore    = template.InitializeTemplateStore(t)
 	)
 
@@ -105,11 +103,9 @@ func TestAccAivenOrganizationAddress(t *testing.T) {
 // This test and the corresponding workaround in the code should be removed once the API is fixed
 // to properly handle null vs. empty string for company_name.
 func TestAccAivenOrganizationAddress_CompanyNameHandling(t *testing.T) {
-	deps := acc.CommonTestDependencies(t)
-
 	var (
 		name             = "aiven_organization_address.test_address"
-		organizationName = deps.OrganizationName()
+		organizationName = acc.OrganizationName()
 		templateStore    = template.InitializeTemplateStore(t)
 	)
 

--- a/internal/plugin/service/organization/organization_group_project_test.go
+++ b/internal/plugin/service/organization/organization_group_project_test.go
@@ -16,9 +16,7 @@ import (
 func TestAccOrganizationGroupProject(t *testing.T) {
 	t.Skip("Deprecated resource")
 
-	deps := acc.CommonTestDependencies(t)
-
-	_ = deps.IsBeta(true)
+	acc.SkipIfNotBeta(t)
 
 	name := "aiven_organization_group_project.foo"
 
@@ -50,7 +48,7 @@ resource "aiven_organization_group_project" "foo" {
   group_id = aiven_organization_user_group.foo.group_id
   role     = "admin"
 }
-`, acc.DefaultResourceNamePrefix, suffix, deps.OrganizationName()),
+`, acc.DefaultResourceNamePrefix, suffix, acc.OrganizationName()),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(
 						name,

--- a/internal/plugin/service/organization/organization_user_group_member_test.go
+++ b/internal/plugin/service/organization/organization_user_group_member_test.go
@@ -14,11 +14,8 @@ import (
 
 // TestAccOrganizationUserGroupMember tests the organization user group member resource.
 func TestAccOrganizationUserGroupMember(t *testing.T) {
-	deps := acc.CommonTestDependencies(t)
-
-	_ = deps.IsBeta(true)
-
-	userID := deps.OrganizationUserID(true)
+	acc.SkipIfNotBeta(t)
+	userID := acc.UserID()
 
 	name := "aiven_organization_user_group_member.foo"
 
@@ -45,7 +42,7 @@ resource "aiven_organization_user_group_member" "foo" {
   group_id        = aiven_organization_user_group.foo.group_id
   user_id         = "%[4]s"
 }
-	`, acc.DefaultResourceNamePrefix, suffix, deps.OrganizationName(), *userID),
+	`, acc.DefaultResourceNamePrefix, suffix, acc.OrganizationName(), userID),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet(name, "last_activity_time"),
 				),

--- a/internal/plugin/util/pluginhelpers.go
+++ b/internal/plugin/util/pluginhelpers.go
@@ -14,9 +14,9 @@ const (
 	AivenEnableBeta                 = "PROVIDER_AIVEN_ENABLE_BETA"
 )
 
-// IsBeta is a helper function that returns a flag that indicates whether the provider is in beta mode.
-// This SHOULD NOT be used anywhere else except in the provider and acceptance tests initialization.
-// In case this functionality is needed in tests, please use the acctest.CommonTestDependencies.IsBeta() function.
+// IsBeta returns true if beta features are enabled.
+// This is used in the provider schema to determine if beta features should be included.
+// In case this functionality is needed in tests, please use acc.SkipIfNotBeta(t) to skip tests when beta features are not enabled.
 func IsBeta() bool {
 	return os.Getenv(AivenEnableBeta) != ""
 }

--- a/internal/sdkprovider/service/account/account_team_data_source_test.go
+++ b/internal/sdkprovider/service/account/account_team_data_source_test.go
@@ -1,7 +1,6 @@
 package account_test
 
 import (
-	"os"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
@@ -12,10 +11,6 @@ import (
 
 func TestAccAivenAccountTeamDataSource_basic(t *testing.T) {
 	t.Skip(accountTeamDeprecated)
-
-	if _, ok := os.LookupEnv("AIVEN_ACCOUNT_NAME"); !ok {
-		t.Skip("AIVEN_ACCOUNT_NAME env variable is required to run this test")
-	}
 
 	datasourceName := "data.aiven_account_team.team"
 	resourceName := "aiven_account_team.foo"

--- a/internal/sdkprovider/service/account/account_team_member_data_source_test.go
+++ b/internal/sdkprovider/service/account/account_team_member_data_source_test.go
@@ -1,7 +1,6 @@
 package account_test
 
 import (
-	"os"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
@@ -12,10 +11,6 @@ import (
 
 func TestAccAivenAccountTeamMemberDataSource_basic(t *testing.T) {
 	t.Skip(accountTeamDeprecated)
-
-	if _, ok := os.LookupEnv("AIVEN_ACCOUNT_NAME"); !ok {
-		t.Skip("AIVEN_ACCOUNT_NAME env variable is required to run this test")
-	}
 
 	datasourceName := "data.aiven_account_team_member.member"
 	resourceName := "aiven_account_team_member.foo"

--- a/internal/sdkprovider/service/account/account_team_member_test.go
+++ b/internal/sdkprovider/service/account/account_team_member_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"log"
-	"os"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
@@ -18,10 +17,6 @@ import (
 
 func TestAccAivenAccountTeamMember_basic(t *testing.T) {
 	t.Skip(accountTeamDeprecated)
-
-	if _, ok := os.LookupEnv("AIVEN_ACCOUNT_NAME"); !ok {
-		t.Skip("AIVEN_ACCOUNT_NAME env variable is required to run this test")
-	}
 
 	resourceName := "aiven_account_team_member.foo"
 	rName := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
@@ -44,7 +39,7 @@ func TestAccAivenAccountTeamMember_basic(t *testing.T) {
 }
 
 func testAccAccountTeamMemberResource(name string) string {
-	orgName := os.Getenv("AIVEN_ACCOUNT_NAME")
+	accountName := acc.AccountName()
 
 	return fmt.Sprintf(`
 data "aiven_account" "foo" {
@@ -59,7 +54,7 @@ resource "aiven_account_team" "foo" {
 resource "aiven_account_team_member" "foo" {
   team_id    = aiven_account_team.foo.team_id
   account_id = aiven_account_team.foo.account_id
-  user_email = "ivan.savciuc+%[2]s@aiven.fi"
+  user_email = "ivan.savciuc+%s@aiven.fi"
 }
 
 data "aiven_account_team_member" "member" {
@@ -68,7 +63,7 @@ data "aiven_account_team_member" "member" {
   user_email = aiven_account_team_member.foo.user_email
 
   depends_on = [aiven_account_team_member.foo]
-}`, orgName, name)
+}`, accountName, name, name)
 }
 
 func testAccCheckAivenAccountTeamMemberResourceDestroy(s *terraform.State) error {

--- a/internal/sdkprovider/service/account/account_team_project_test.go
+++ b/internal/sdkprovider/service/account/account_team_project_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"log"
-	"os"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
@@ -18,10 +17,6 @@ import (
 
 func TestAccAivenAccountTeamProject_basic(t *testing.T) {
 	t.Skip(accountTeamDeprecated)
-
-	if _, ok := os.LookupEnv("AIVEN_ACCOUNT_NAME"); !ok {
-		t.Skip("AIVEN_ACCOUNT_NAME env variable is required to run this test")
-	}
 
 	resourceName := "aiven_account_team_project.foo"
 	rName := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
@@ -44,7 +39,7 @@ func TestAccAivenAccountTeamProject_basic(t *testing.T) {
 }
 
 func testAccAccountTeamProjectResource(name string) string {
-	orgName := os.Getenv("AIVEN_ACCOUNT_NAME")
+	accountName := acc.AccountName()
 
 	return fmt.Sprintf(`
 data "aiven_account" "foo" {
@@ -74,7 +69,7 @@ data "aiven_account_team_project" "project" {
   project_name = aiven_account_team_project.foo.project_name
 
   depends_on = [aiven_account_team_project.foo]
-}`, orgName, name)
+}`, accountName, name)
 }
 
 func testAccCheckAivenAccountTeamProjectResourceDestroy(s *terraform.State) error {

--- a/internal/sdkprovider/service/account/account_team_test.go
+++ b/internal/sdkprovider/service/account/account_team_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"log"
-	"os"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
@@ -20,10 +19,6 @@ const accountTeamDeprecated = "This resource is deprecated. Can't run tests"
 
 func TestAccAivenAccountTeam_basic(t *testing.T) {
 	t.Skip(accountTeamDeprecated)
-
-	if _, ok := os.LookupEnv("AIVEN_ACCOUNT_NAME"); !ok {
-		t.Skip("AIVEN_ACCOUNT_NAME env variable is required to run this test")
-	}
 
 	resourceName := "aiven_account_team.foo"
 	rName := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
@@ -45,8 +40,6 @@ func TestAccAivenAccountTeam_basic(t *testing.T) {
 }
 
 func testAccAccountTeamResource(name string) string {
-	orgName := os.Getenv("AIVEN_ACCOUNT_NAME")
-
 	return fmt.Sprintf(`
 data "aiven_account" "foo" {
   name = "%s"
@@ -62,7 +55,7 @@ data "aiven_account_team" "team" {
   account_id = aiven_account_team.foo.account_id
 
   depends_on = [aiven_account_team.foo]
-}`, orgName, name)
+}`, acc.AccountName(), name)
 }
 
 func testAccCheckAivenAccountTeamResourceDestroy(s *terraform.State) error {

--- a/internal/sdkprovider/service/alloydbomni/alloydbomni_database_test.go
+++ b/internal/sdkprovider/service/alloydbomni/alloydbomni_database_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"os"
 	"strings"
 	"testing"
 
@@ -19,7 +18,7 @@ import (
 
 func TestAccAivenAlloyDBOmniDatabase_basic(t *testing.T) {
 	resourceName := "aiven_alloydbomni_database.foo"
-	projectName := os.Getenv("AIVEN_PROJECT_NAME")
+	projectName := acc.ProjectName()
 	rName := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
 
 	resource.ParallelTest(t, resource.TestCase{

--- a/internal/sdkprovider/service/alloydbomni/alloydbomni_import_test.go
+++ b/internal/sdkprovider/service/alloydbomni/alloydbomni_import_test.go
@@ -2,7 +2,6 @@ package alloydbomni_test
 
 import (
 	"fmt"
-	"os"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
@@ -15,7 +14,7 @@ import (
 
 func TestAccAivenAlloyDBOmni_import(t *testing.T) {
 	resourceName := "aiven_alloydbomni.main"
-	projectName := os.Getenv("AIVEN_PROJECT_NAME")
+	projectName := acc.ProjectName()
 	rName := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
 
 	resource.ParallelTest(t, resource.TestCase{

--- a/internal/sdkprovider/service/alloydbomni/alloydbomni_test.go
+++ b/internal/sdkprovider/service/alloydbomni/alloydbomni_test.go
@@ -3,7 +3,6 @@ package alloydbomni_test
 import (
 	"context"
 	"fmt"
-	"os"
 	"regexp"
 	"strings"
 	"testing"
@@ -120,7 +119,7 @@ func TestAccAivenAlloyDBOmni_static_ips(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "service_name", fmt.Sprintf("test-acc-sr-%s", rName)),
 					resource.TestCheckResourceAttrSet(resourceName, "state"),
-					resource.TestCheckResourceAttr(resourceName, "project", os.Getenv("AIVEN_PROJECT_NAME")),
+					resource.TestCheckResourceAttr(resourceName, "project", acc.ProjectName()),
 					resource.TestCheckResourceAttr(resourceName, "service_type", "alloydbomni"),
 					resource.TestCheckResourceAttr(resourceName, "cloud_name", "google-europe-west1"),
 					resource.TestCheckResourceAttr(resourceName, "maintenance_window_dow", "monday"),
@@ -187,7 +186,7 @@ func TestAccAivenAlloyDBOmni_changing_plan(t *testing.T) {
 					testAccCheckAivenServiceAlloyDBOmniAttributes("data.aiven_alloydbomni.common"),
 					resource.TestCheckResourceAttr(resourceName, "service_name", fmt.Sprintf("test-acc-sr-%s", rName)),
 					resource.TestCheckResourceAttrSet(resourceName, "state"),
-					resource.TestCheckResourceAttr(resourceName, "project", os.Getenv("AIVEN_PROJECT_NAME")),
+					resource.TestCheckResourceAttr(resourceName, "project", acc.ProjectName()),
 					resource.TestCheckResourceAttr(resourceName, "service_type", "alloydbomni"),
 					resource.TestCheckResourceAttr(resourceName, "cloud_name", "google-europe-west1"),
 					resource.TestCheckResourceAttr(resourceName, "maintenance_window_dow", "monday"),
@@ -202,7 +201,7 @@ func TestAccAivenAlloyDBOmni_changing_plan(t *testing.T) {
 					testAccCheckAivenServiceAlloyDBOmniAttributes("data.aiven_alloydbomni.common"),
 					resource.TestCheckResourceAttr(resourceName, "service_name", fmt.Sprintf("test-acc-sr-%s", rName)),
 					resource.TestCheckResourceAttrSet(resourceName, "state"),
-					resource.TestCheckResourceAttr(resourceName, "project", os.Getenv("AIVEN_PROJECT_NAME")),
+					resource.TestCheckResourceAttr(resourceName, "project", acc.ProjectName()),
 					resource.TestCheckResourceAttr(resourceName, "service_type", "alloydbomni"),
 					resource.TestCheckResourceAttr(resourceName, "cloud_name", "google-europe-west1"),
 					resource.TestCheckResourceAttr(resourceName, "maintenance_window_dow", "monday"),
@@ -229,7 +228,7 @@ func TestAccAivenAlloyDBOmni_deleting_additional_disk_size(t *testing.T) {
 					testAccCheckAivenServiceAlloyDBOmniAttributes("data.aiven_alloydbomni.common"),
 					resource.TestCheckResourceAttr(resourceName, "service_name", fmt.Sprintf("test-acc-sr-%s", rName)),
 					resource.TestCheckResourceAttrSet(resourceName, "state"),
-					resource.TestCheckResourceAttr(resourceName, "project", os.Getenv("AIVEN_PROJECT_NAME")),
+					resource.TestCheckResourceAttr(resourceName, "project", acc.ProjectName()),
 					resource.TestCheckResourceAttr(resourceName, "service_type", "alloydbomni"),
 					resource.TestCheckResourceAttr(resourceName, "cloud_name", "google-europe-west1"),
 					resource.TestCheckResourceAttr(resourceName, "maintenance_window_dow", "monday"),
@@ -246,7 +245,7 @@ func TestAccAivenAlloyDBOmni_deleting_additional_disk_size(t *testing.T) {
 					testAccCheckAivenServiceAlloyDBOmniAttributes("data.aiven_alloydbomni.common"),
 					resource.TestCheckResourceAttr(resourceName, "service_name", fmt.Sprintf("test-acc-sr-%s", rName)),
 					resource.TestCheckResourceAttrSet(resourceName, "state"),
-					resource.TestCheckResourceAttr(resourceName, "project", os.Getenv("AIVEN_PROJECT_NAME")),
+					resource.TestCheckResourceAttr(resourceName, "project", acc.ProjectName()),
 					resource.TestCheckResourceAttr(resourceName, "service_type", "alloydbomni"),
 					resource.TestCheckResourceAttr(resourceName, "cloud_name", "google-europe-west1"),
 					resource.TestCheckResourceAttr(resourceName, "maintenance_window_dow", "monday"),
@@ -274,7 +273,7 @@ func TestAccAivenAlloyDBOmni_deleting_disk_size(t *testing.T) {
 					testAccCheckAivenServiceAlloyDBOmniAttributes("data.aiven_alloydbomni.common"),
 					resource.TestCheckResourceAttr(resourceName, "service_name", fmt.Sprintf("test-acc-sr-%s", rName)),
 					resource.TestCheckResourceAttrSet(resourceName, "state"),
-					resource.TestCheckResourceAttr(resourceName, "project", os.Getenv("AIVEN_PROJECT_NAME")),
+					resource.TestCheckResourceAttr(resourceName, "project", acc.ProjectName()),
 					resource.TestCheckResourceAttr(resourceName, "service_type", "alloydbomni"),
 					resource.TestCheckResourceAttr(resourceName, "cloud_name", "google-europe-west1"),
 					resource.TestCheckResourceAttr(resourceName, "maintenance_window_dow", "monday"),
@@ -290,7 +289,7 @@ func TestAccAivenAlloyDBOmni_deleting_disk_size(t *testing.T) {
 					testAccCheckAivenServiceAlloyDBOmniAttributes("data.aiven_alloydbomni.common"),
 					resource.TestCheckResourceAttr(resourceName, "service_name", fmt.Sprintf("test-acc-sr-%s", rName)),
 					resource.TestCheckResourceAttrSet(resourceName, "state"),
-					resource.TestCheckResourceAttr(resourceName, "project", os.Getenv("AIVEN_PROJECT_NAME")),
+					resource.TestCheckResourceAttr(resourceName, "project", acc.ProjectName()),
 					resource.TestCheckResourceAttr(resourceName, "service_type", "alloydbomni"),
 					resource.TestCheckResourceAttr(resourceName, "cloud_name", "google-europe-west1"),
 					resource.TestCheckResourceAttr(resourceName, "maintenance_window_dow", "monday"),
@@ -318,7 +317,7 @@ func TestAccAivenAlloyDBOmni_changing_disk_size(t *testing.T) {
 					testAccCheckAivenServiceAlloyDBOmniAttributes("data.aiven_alloydbomni.common"),
 					resource.TestCheckResourceAttr(resourceName, "service_name", fmt.Sprintf("test-acc-sr-%s", rName)),
 					resource.TestCheckResourceAttrSet(resourceName, "state"),
-					resource.TestCheckResourceAttr(resourceName, "project", os.Getenv("AIVEN_PROJECT_NAME")),
+					resource.TestCheckResourceAttr(resourceName, "project", acc.ProjectName()),
 					resource.TestCheckResourceAttr(resourceName, "service_type", "alloydbomni"),
 					resource.TestCheckResourceAttr(resourceName, "cloud_name", "google-europe-west1"),
 					resource.TestCheckResourceAttr(resourceName, "maintenance_window_dow", "monday"),
@@ -334,7 +333,7 @@ func TestAccAivenAlloyDBOmni_changing_disk_size(t *testing.T) {
 					testAccCheckAivenServiceAlloyDBOmniAttributes("data.aiven_alloydbomni.common"),
 					resource.TestCheckResourceAttr(resourceName, "service_name", fmt.Sprintf("test-acc-sr-%s", rName)),
 					resource.TestCheckResourceAttrSet(resourceName, "state"),
-					resource.TestCheckResourceAttr(resourceName, "project", os.Getenv("AIVEN_PROJECT_NAME")),
+					resource.TestCheckResourceAttr(resourceName, "project", acc.ProjectName()),
 					resource.TestCheckResourceAttr(resourceName, "service_type", "alloydbomni"),
 					resource.TestCheckResourceAttr(resourceName, "cloud_name", "google-europe-west1"),
 					resource.TestCheckResourceAttr(resourceName, "maintenance_window_dow", "monday"),
@@ -379,7 +378,7 @@ data "aiven_alloydbomni" "common" {
   project      = aiven_alloydbomni.bar.project
 
   depends_on = [aiven_alloydbomni.bar]
-}`, os.Getenv("AIVEN_PROJECT_NAME"), count, name)
+}`, acc.ProjectName(), count, name)
 }
 
 func testAccAlloyDBOmniResourceWithDiskSize(name, diskSize string) string {
@@ -415,7 +414,7 @@ data "aiven_alloydbomni" "common" {
   project      = aiven_alloydbomni.bar.project
 
   depends_on = [aiven_alloydbomni.bar]
-}`, os.Getenv("AIVEN_PROJECT_NAME"), name, diskSize)
+}`, acc.ProjectName(), name, diskSize)
 }
 
 func testAccAlloyDBOmniResourceWithAdditionalDiskSize(name, diskSize string) string {
@@ -451,7 +450,7 @@ data "aiven_alloydbomni" "common" {
   project      = aiven_alloydbomni.bar.project
 
   depends_on = [aiven_alloydbomni.bar]
-}`, os.Getenv("AIVEN_PROJECT_NAME"), name, diskSize)
+}`, acc.ProjectName(), name, diskSize)
 }
 
 func testAccAlloyDBOmniResourceWithoutDiskSize(name string) string {
@@ -491,7 +490,7 @@ data "aiven_alloydbomni" "common" {
   project      = aiven_alloydbomni.bar.project
 
   depends_on = [aiven_alloydbomni.bar]
-}`, os.Getenv("AIVEN_PROJECT_NAME"), name)
+}`, acc.ProjectName(), name)
 }
 
 func testAccAlloyDBOmniResourcePlanChange(name, plan string) string {
@@ -531,7 +530,7 @@ data "aiven_alloydbomni" "common" {
   project      = aiven_alloydbomni.bar.project
 
   depends_on = [aiven_alloydbomni.bar]
-}`, os.Getenv("AIVEN_PROJECT_NAME"), plan, name)
+}`, acc.ProjectName(), plan, name)
 }
 
 func testAccAlloyDBOmniDoubleTagResource(name string) string {
@@ -575,14 +574,14 @@ data "aiven_alloydbomni" "common" {
   project      = aiven_alloydbomni.bar.project
 
   depends_on = [aiven_alloydbomni.bar]
-}`, os.Getenv("AIVEN_PROJECT_NAME"), name)
+}`, acc.ProjectName(), name)
 }
 
 // TestAccAivenAlloyDBOmni_admin_creds tests admin creds in user_config
 func TestAccAivenAlloyDBOmni_admin_creds(t *testing.T) {
 	resourceName := "aiven_alloydbomni.alloydbomni"
 	prefix := "test-tf-acc-" + acctest.RandString(7)
-	project := os.Getenv("AIVEN_PROJECT_NAME")
+	project := acc.ProjectName()
 	expectedURLPrefix := fmt.Sprintf("postgres://root:%s-password", prefix)
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acc.TestAccPreCheck(t) },
@@ -638,7 +637,7 @@ func TestAccAivenServiceAlloyDBOmni_basic(t *testing.T) {
 					acc.TestAccCheckAivenServiceCommonAttributes("data.aiven_alloydbomni.common-alloydbomni"),
 					testAccCheckAivenServiceAlloyDBOmniAttributes("data.aiven_alloydbomni.common-alloydbomni"),
 					resource.TestCheckResourceAttr(resourceName, "service_name", fmt.Sprintf("test-acc-sr-%s", rName)),
-					resource.TestCheckResourceAttr(resourceName, "project", os.Getenv("AIVEN_PROJECT_NAME")),
+					resource.TestCheckResourceAttr(resourceName, "project", acc.ProjectName()),
 					resource.TestCheckResourceAttr(resourceName, "cloud_name", "google-europe-west1"),
 					resource.TestCheckResourceAttr(resourceName, "maintenance_window_dow", "monday"),
 					resource.TestCheckResourceAttr(resourceName, "maintenance_window_time", "10:00:00"),
@@ -665,7 +664,7 @@ func TestAccAivenServiceAlloyDBOmni_termination_protection(t *testing.T) {
 					acc.TestAccCheckAivenServiceCommonAttributes("data.aiven_alloydbomni.common-alloydbomni"),
 					testAccCheckAivenServiceAlloyDBOmniAttributes("data.aiven_alloydbomni.common-alloydbomni"),
 					resource.TestCheckResourceAttr(resourceName, "service_name", fmt.Sprintf("test-acc-sr-%s", rName)),
-					resource.TestCheckResourceAttr(resourceName, "project", os.Getenv("AIVEN_PROJECT_NAME")),
+					resource.TestCheckResourceAttr(resourceName, "project", acc.ProjectName()),
 					resource.TestCheckResourceAttr(resourceName, "cloud_name", "google-europe-west1"),
 					resource.TestCheckResourceAttr(resourceName, "maintenance_window_dow", "monday"),
 					resource.TestCheckResourceAttr(resourceName, "maintenance_window_time", "10:00:00"),
@@ -693,7 +692,7 @@ func TestAccAivenServiceAlloyDBOmni_read_replica(t *testing.T) {
 					acc.TestAccCheckAivenServiceCommonAttributes("data.aiven_alloydbomni.common-alloydbomni"),
 					testAccCheckAivenServiceAlloyDBOmniAttributes("data.aiven_alloydbomni.common-alloydbomni"),
 					resource.TestCheckResourceAttr(resourceName, "service_name", fmt.Sprintf("test-acc-sr-%s", rName)),
-					resource.TestCheckResourceAttr(resourceName, "project", os.Getenv("AIVEN_PROJECT_NAME")),
+					resource.TestCheckResourceAttr(resourceName, "project", acc.ProjectName()),
 					resource.TestCheckResourceAttr(resourceName, "cloud_name", "google-europe-west1"),
 					resource.TestCheckResourceAttr(resourceName, "maintenance_window_dow", "monday"),
 					resource.TestCheckResourceAttr(resourceName, "maintenance_window_time", "10:00:00"),
@@ -719,7 +718,7 @@ func TestAccAivenServiceAlloyDBOmni_custom_timeouts(t *testing.T) {
 					acc.TestAccCheckAivenServiceCommonAttributes("data.aiven_alloydbomni.common-alloydbomni"),
 					testAccCheckAivenServiceAlloyDBOmniAttributes("data.aiven_alloydbomni.common-alloydbomni"),
 					resource.TestCheckResourceAttr(resourceName, "service_name", fmt.Sprintf("test-acc-sr-%s", rName)),
-					resource.TestCheckResourceAttr(resourceName, "project", os.Getenv("AIVEN_PROJECT_NAME")),
+					resource.TestCheckResourceAttr(resourceName, "project", acc.ProjectName()),
 					resource.TestCheckResourceAttr(resourceName, "cloud_name", "google-europe-west1"),
 					resource.TestCheckResourceAttr(resourceName, "maintenance_window_dow", "monday"),
 					resource.TestCheckResourceAttr(resourceName, "maintenance_window_time", "10:00:00"),
@@ -762,7 +761,7 @@ data "aiven_alloydbomni" "common-alloydbomni" {
   project      = aiven_alloydbomni.bar-alloydbomni.project
 
   depends_on = [aiven_alloydbomni.bar-alloydbomni]
-}`, os.Getenv("AIVEN_PROJECT_NAME"), name)
+}`, acc.ProjectName(), name)
 }
 
 func testAccAlloyDBOmniServiceCustomTimeoutsResource(name string) string {
@@ -801,7 +800,7 @@ data "aiven_alloydbomni" "common-alloydbomni" {
   project      = aiven_alloydbomni.bar-alloydbomni.project
 
   depends_on = [aiven_alloydbomni.bar-alloydbomni]
-}`, os.Getenv("AIVEN_PROJECT_NAME"), name)
+}`, acc.ProjectName(), name)
 }
 
 func testAccAlloyDBOmniTerminationProtectionServiceResource(name string) string {
@@ -836,7 +835,7 @@ data "aiven_alloydbomni" "common-alloydbomni" {
   project      = aiven_alloydbomni.bar-alloydbomni.project
 
   depends_on = [aiven_alloydbomni.bar-alloydbomni]
-}`, os.Getenv("AIVEN_PROJECT_NAME"), name)
+}`, acc.ProjectName(), name)
 }
 
 func testAccAlloyDBOmniReadReplicaServiceResource(name string) string {
@@ -908,7 +907,7 @@ data "aiven_alloydbomni" "common-alloydbomni" {
   project      = aiven_alloydbomni.bar-alloydbomni.project
 
   depends_on = [aiven_alloydbomni.bar-alloydbomni]
-}`, os.Getenv("AIVEN_PROJECT_NAME"), name, name)
+}`, acc.ProjectName(), name, name)
 }
 
 func testAccCheckAivenServiceTerminationProtection(n string) resource.TestCheckFunc {
@@ -956,7 +955,6 @@ func testAccCheckAivenServiceTerminationProtection(n string) resource.TestCheckF
 				UserConfig:            service.UserConfig,
 			},
 		)
-
 		if err != nil {
 			return fmt.Errorf("unable to update Aiven service to set termination_protection=false err: %w", err)
 		}
@@ -1069,7 +1067,7 @@ func TestAccAivenServiceAlloyDBOmni_service_account_credentials(t *testing.T) {
 		t.Skipf("cannot get aiven client: %s", err)
 	}
 
-	project := os.Getenv("AIVEN_PROJECT_NAME")
+	project := acc.ProjectName()
 	resourceName := "aiven_alloydbomni.foo"
 	serviceName := fmt.Sprintf("test-acc-sr-%s", acc.RandStr())
 

--- a/internal/sdkprovider/service/alloydbomni/alloydbomni_user_test.go
+++ b/internal/sdkprovider/service/alloydbomni/alloydbomni_user_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"os"
 	"testing"
 
 	"github.com/aiven/aiven-go-client/v2"
@@ -29,7 +28,7 @@ func TestAccAivenAlloyDBOmniUser_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					schemautil.TestAccCheckAivenServiceUserAttributes("data.aiven_alloydbomni_user.user"),
 					resource.TestCheckResourceAttr(resourceName, "service_name", fmt.Sprintf("test-acc-sr-%s", rName)),
-					resource.TestCheckResourceAttr(resourceName, "project", os.Getenv("AIVEN_PROJECT_NAME")),
+					resource.TestCheckResourceAttr(resourceName, "project", acc.ProjectName()),
 					resource.TestCheckResourceAttr(resourceName, "username", fmt.Sprintf("user-%s", rName)),
 					resource.TestCheckResourceAttr(resourceName, "password", "Test$1234"),
 				),
@@ -52,7 +51,7 @@ func TestAccAivenAlloyDBOmniUser_alloydbomni_no_password(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					schemautil.TestAccCheckAivenServiceUserAttributes("data.aiven_alloydbomni_user.user"),
 					resource.TestCheckResourceAttr(resourceName, "service_name", fmt.Sprintf("test-acc-sr-%s", rName)),
-					resource.TestCheckResourceAttr(resourceName, "project", os.Getenv("AIVEN_PROJECT_NAME")),
+					resource.TestCheckResourceAttr(resourceName, "project", acc.ProjectName()),
 					resource.TestCheckResourceAttr(resourceName, "username", fmt.Sprintf("user-%s", rName)),
 				),
 			},
@@ -63,7 +62,7 @@ func TestAccAivenAlloyDBOmniUser_alloydbomni_no_password(t *testing.T) {
 func TestAccAivenAlloyDBOmniUser_alloydbomni_replica(t *testing.T) {
 	resourceName := "aiven_alloydbomni_user.foo"
 	rName := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
-	project := os.Getenv("AIVEN_PROJECT_NAME")
+	project := acc.ProjectName()
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acc.TestAccPreCheck(t) },
@@ -168,7 +167,7 @@ data "aiven_alloydbomni_user" "user" {
   username     = aiven_alloydbomni_user.foo.username
 
   depends_on = [aiven_alloydbomni_user.foo]
-}`, os.Getenv("AIVEN_PROJECT_NAME"), name, name)
+}`, acc.ProjectName(), name, name)
 }
 
 func testAccAlloyDBOmniUserPgReplicationDisableResource(name string) string {
@@ -200,7 +199,7 @@ data "aiven_alloydbomni_user" "user" {
   username     = aiven_alloydbomni_user.foo.username
 
   depends_on = [aiven_alloydbomni_user.foo]
-}`, os.Getenv("AIVEN_PROJECT_NAME"), name, name)
+}`, acc.ProjectName(), name, name)
 }
 
 func testAccAlloyDBOmniUserPgReplicationEnableResource(name string) string {
@@ -232,7 +231,7 @@ data "aiven_alloydbomni_user" "user" {
   username     = aiven_alloydbomni_user.foo.username
 
   depends_on = [aiven_alloydbomni_user.foo]
-}`, os.Getenv("AIVEN_PROJECT_NAME"), name, name)
+}`, acc.ProjectName(), name, name)
 }
 
 func testAccAlloyDBOmniUserNewPasswordResource(name string) string {
@@ -265,7 +264,7 @@ data "aiven_alloydbomni_user" "user" {
   username     = aiven_alloydbomni_user.foo.username
 
   depends_on = [aiven_alloydbomni_user.foo]
-}`, os.Getenv("AIVEN_PROJECT_NAME"), name, name)
+}`, acc.ProjectName(), name, name)
 }
 
 func testAccAlloyDBOmniUserNoPasswordResource(name string) string {
@@ -303,5 +302,5 @@ data "aiven_alloydbomni_user" "user" {
   username     = aiven_alloydbomni_user.foo.username
 
   depends_on = [aiven_alloydbomni_user.foo]
-}`, os.Getenv("AIVEN_PROJECT_NAME"), name, name)
+}`, acc.ProjectName(), name, name)
 }

--- a/internal/sdkprovider/service/cassandra/cassandra_test.go
+++ b/internal/sdkprovider/service/cassandra/cassandra_test.go
@@ -2,7 +2,6 @@ package cassandra_test
 
 import (
 	"fmt"
-	"os"
 	"regexp"
 	"testing"
 
@@ -29,7 +28,7 @@ func TestAccAiven_cassandra(t *testing.T) {
 					testAccCheckAivenServiceCassandraAttributes("data.aiven_cassandra.common"),
 					resource.TestCheckResourceAttr(resourceName, "service_name", fmt.Sprintf("test-acc-sr-%s", rName)),
 					resource.TestCheckResourceAttr(resourceName, "state", "RUNNING"),
-					resource.TestCheckResourceAttr(resourceName, "project", os.Getenv("AIVEN_PROJECT_NAME")),
+					resource.TestCheckResourceAttr(resourceName, "project", acc.ProjectName()),
 					resource.TestCheckResourceAttr(resourceName, "service_type", "cassandra"),
 					resource.TestCheckResourceAttr(resourceName, "cloud_name", "google-europe-west1"),
 					resource.TestCheckResourceAttr(resourceName, "maintenance_window_dow", "monday"),
@@ -86,7 +85,7 @@ data "aiven_cassandra" "common" {
   project      = data.aiven_project.foo.project
 
   depends_on = [aiven_cassandra.bar]
-}`, os.Getenv("AIVEN_PROJECT_NAME"), name)
+}`, acc.ProjectName(), name)
 }
 
 func testAccCassandraDoubleTagKeyResource(name string) string {
@@ -126,7 +125,7 @@ data "aiven_cassandra" "common" {
   project      = data.aiven_project.foo.project
 
   depends_on = [aiven_cassandra.bar]
-}`, os.Getenv("AIVEN_PROJECT_NAME"), name)
+}`, acc.ProjectName(), name)
 }
 
 func testAccCheckAivenServiceCassandraAttributes(n string) resource.TestCheckFunc {

--- a/internal/sdkprovider/service/cassandra/cassandra_user_test.go
+++ b/internal/sdkprovider/service/cassandra/cassandra_user_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"os"
 	"testing"
 
 	"github.com/aiven/aiven-go-client/v2"
@@ -30,7 +29,7 @@ func TestAccAivenCassandraUser_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					schemautil.TestAccCheckAivenServiceUserAttributes("data.aiven_cassandra_user.user"),
 					resource.TestCheckResourceAttr(resourceName, "service_name", fmt.Sprintf("test-acc-sr-%s", rName)),
-					resource.TestCheckResourceAttr(resourceName, "project", os.Getenv("AIVEN_PROJECT_NAME")),
+					resource.TestCheckResourceAttr(resourceName, "project", acc.ProjectName()),
 					resource.TestCheckResourceAttr(resourceName, "username", fmt.Sprintf("user-%s", rName)),
 					resource.TestCheckResourceAttr(resourceName, "password", "Test$1234"),
 				),
@@ -101,5 +100,5 @@ data "aiven_cassandra_user" "user" {
   username     = aiven_cassandra_user.foo.username
 
   depends_on = [aiven_cassandra_user.foo]
-}`, os.Getenv("AIVEN_PROJECT_NAME"), name, name)
+}`, acc.ProjectName(), name, name)
 }

--- a/internal/sdkprovider/service/clickhouse/clickhouse_database_test.go
+++ b/internal/sdkprovider/service/clickhouse/clickhouse_database_test.go
@@ -2,7 +2,6 @@ package clickhouse_test
 
 import (
 	"fmt"
-	"os"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
@@ -22,7 +21,7 @@ func TestAccAivenClickhouseDatabase_basic(t *testing.T) {
 			{
 				Config: testAccClickhouseDatabaseResource(rName),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(resourceName, "project", os.Getenv("AIVEN_PROJECT_NAME")),
+					resource.TestCheckResourceAttr(resourceName, "project", acc.ProjectName()),
 					resource.TestCheckResourceAttr(resourceName, "service_name", fmt.Sprintf("test-acc-sr-%s", rName)),
 					resource.TestCheckResourceAttr(resourceName, "name", fmt.Sprintf("test-acc-db-%s", rName)),
 					resource.TestCheckResourceAttr(resourceName, "termination_protection", "false"),
@@ -57,5 +56,5 @@ data "aiven_clickhouse_database" "database" {
   project      = aiven_clickhouse_database.foo.project
   service_name = aiven_clickhouse_database.foo.service_name
   name         = aiven_clickhouse_database.foo.name
-}`, os.Getenv("AIVEN_PROJECT_NAME"), name, name)
+}`, acc.ProjectName(), name, name)
 }

--- a/internal/sdkprovider/service/clickhouse/clickhouse_grant_test.go
+++ b/internal/sdkprovider/service/clickhouse/clickhouse_grant_test.go
@@ -3,7 +3,6 @@ package clickhouse_test
 import (
 	"context"
 	"fmt"
-	"os"
 	"testing"
 
 	"github.com/aiven/aiven-go-client/v2"
@@ -18,7 +17,7 @@ import (
 
 func TestAccAivenClickhouseGrant(t *testing.T) {
 	serviceName := fmt.Sprintf("test-acc-ch-%s", acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
-	projectName := os.Getenv("AIVEN_PROJECT_NAME")
+	projectName := acc.ProjectName()
 
 	manifest := fmt.Sprintf(`
 resource "aiven_clickhouse" "bar" {

--- a/internal/sdkprovider/service/clickhouse/clickhouse_role_test.go
+++ b/internal/sdkprovider/service/clickhouse/clickhouse_role_test.go
@@ -3,7 +3,6 @@ package clickhouse_test
 import (
 	"context"
 	"fmt"
-	"os"
 	"testing"
 
 	"github.com/aiven/aiven-go-client/v2"
@@ -18,7 +17,7 @@ import (
 
 func TestAccAivenClickhouseRole(t *testing.T) {
 	serviceName := fmt.Sprintf("test-acc-ch-%s", acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
-	projectName := os.Getenv("AIVEN_PROJECT_NAME")
+	projectName := acc.ProjectName()
 	resourceName := "aiven_clickhouse_role.foo"
 
 	manifest := fmt.Sprintf(`

--- a/internal/sdkprovider/service/clickhouse/clickhouse_test.go
+++ b/internal/sdkprovider/service/clickhouse/clickhouse_test.go
@@ -2,7 +2,6 @@ package clickhouse_test
 
 import (
 	"fmt"
-	"os"
 	"regexp"
 	"testing"
 
@@ -29,7 +28,7 @@ func TestAccAiven_clickhouse(t *testing.T) {
 					testAccCheckAivenServiceClickhouseAttributes("data.aiven_clickhouse.common"),
 					resource.TestCheckResourceAttr(resourceName, "service_name", fmt.Sprintf("test-acc-sr-%s", rName)),
 					resource.TestCheckResourceAttr(resourceName, "state", "RUNNING"),
-					resource.TestCheckResourceAttr(resourceName, "project", os.Getenv("AIVEN_PROJECT_NAME")),
+					resource.TestCheckResourceAttr(resourceName, "project", acc.ProjectName()),
 					resource.TestCheckResourceAttr(resourceName, "service_type", "clickhouse"),
 					resource.TestCheckResourceAttr(resourceName, "cloud_name", "google-europe-west1"),
 					resource.TestCheckResourceAttr(resourceName, "maintenance_window_dow", "monday"),
@@ -78,7 +77,7 @@ data "aiven_clickhouse" "common" {
   project      = data.aiven_project.foo.project
 
   depends_on = [aiven_clickhouse.bar]
-}`, os.Getenv("AIVEN_PROJECT_NAME"), name)
+}`, acc.ProjectName(), name)
 }
 
 func testAccClickhouseDubleTagKeyResource(name string) string {
@@ -110,7 +109,7 @@ data "aiven_clickhouse" "common" {
   project      = data.aiven_project.foo.project
 
   depends_on = [aiven_clickhouse.bar]
-}`, os.Getenv("AIVEN_PROJECT_NAME"), name)
+}`, acc.ProjectName(), name)
 }
 
 func testAccCheckAivenServiceClickhouseAttributes(n string) resource.TestCheckFunc {

--- a/internal/sdkprovider/service/clickhouse/clickhouse_user_test.go
+++ b/internal/sdkprovider/service/clickhouse/clickhouse_user_test.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"log"
-	"os"
 	"testing"
 
 	"github.com/aiven/aiven-go-client/v2"
@@ -31,7 +30,7 @@ func TestAccAivenClickhouseUser_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAivenClickhouseUserAttributes("data.aiven_clickhouse_user.user"),
 					resource.TestCheckResourceAttr(resourceName, "service_name", fmt.Sprintf("test-acc-sr-%s", rName)),
-					resource.TestCheckResourceAttr(resourceName, "project", os.Getenv("AIVEN_PROJECT_NAME")),
+					resource.TestCheckResourceAttr(resourceName, "project", acc.ProjectName()),
 					resource.TestCheckResourceAttr(resourceName, "username", fmt.Sprintf("user-%s", rName)),
 					resource.TestCheckResourceAttrSet(resourceName, "password"),
 					resource.TestCheckResourceAttrSet(resourceName, "uuid"),
@@ -99,7 +98,7 @@ data "aiven_clickhouse_user" "user" {
   service_name = aiven_clickhouse_user.foo.service_name
   project      = aiven_clickhouse_user.foo.project
   username     = aiven_clickhouse_user.foo.username
-}`, os.Getenv("AIVEN_PROJECT_NAME"), name, name)
+}`, acc.ProjectName(), name, name)
 }
 
 func testAccCheckAivenClickhouseUserAttributes(n string) resource.TestCheckFunc {

--- a/internal/sdkprovider/service/connectionpool/connection_pool_test.go
+++ b/internal/sdkprovider/service/connectionpool/connection_pool_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"os"
 	"testing"
 
 	"github.com/aiven/aiven-go-client/v2"
@@ -30,7 +29,7 @@ func TestAccAivenConnectionPool_basic(t *testing.T) {
 				Config: testAccConnectionPoolResource(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAivenConnectionPoolAttributes("data.aiven_connection_pool.pool"),
-					resource.TestCheckResourceAttr(resourceName, "project", os.Getenv("AIVEN_PROJECT_NAME")),
+					resource.TestCheckResourceAttr(resourceName, "project", acc.ProjectName()),
 					resource.TestCheckResourceAttr(resourceName, "service_name", fmt.Sprintf("test-acc-sr-%s", rName)),
 					resource.TestCheckResourceAttr(resourceName, "database_name", fmt.Sprintf("test-acc-db-%s", rName)),
 					resource.TestCheckResourceAttr(resourceName, "username", fmt.Sprintf("user-%s", rName)),
@@ -42,7 +41,7 @@ func TestAccAivenConnectionPool_basic(t *testing.T) {
 			{
 				Config: testAccConnectionPoolNoUserResource(rName2),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(resourceName, "project", os.Getenv("AIVEN_PROJECT_NAME")),
+					resource.TestCheckResourceAttr(resourceName, "project", acc.ProjectName()),
 					resource.TestCheckResourceAttr(resourceName, "service_name", fmt.Sprintf("test-acc-sr-%s", rName2)),
 					resource.TestCheckResourceAttr(resourceName, "database_name", fmt.Sprintf("test-acc-db-%s", rName2)),
 					resource.TestCheckResourceAttr(resourceName, "pool_name", fmt.Sprintf("test-acc-pool-%s", rName2)),
@@ -92,7 +91,7 @@ data "aiven_connection_pool" "pool" {
   pool_name    = aiven_connection_pool.foo.pool_name
 
   depends_on = [aiven_connection_pool.foo]
-}`, os.Getenv("AIVEN_PROJECT_NAME"), name, name, name)
+}`, acc.ProjectName(), name, name, name)
 }
 
 func testAccConnectionPoolResource(name string) string {
@@ -140,7 +139,7 @@ data "aiven_connection_pool" "pool" {
   pool_name    = aiven_connection_pool.foo.pool_name
 
   depends_on = [aiven_connection_pool.foo]
-}`, os.Getenv("AIVEN_PROJECT_NAME"), name, name, name, name)
+}`, acc.ProjectName(), name, name, name, name)
 }
 
 func testAccCheckAivenConnectionPoolAttributes(n string) resource.TestCheckFunc {

--- a/internal/sdkprovider/service/dragonfly/dragonfly_test.go
+++ b/internal/sdkprovider/service/dragonfly/dragonfly_test.go
@@ -2,7 +2,6 @@ package dragonfly_test
 
 import (
 	"fmt"
-	"os"
 	"regexp"
 	"testing"
 
@@ -32,7 +31,7 @@ func TestAccAiven_dragonfly(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "tech_emails.0.email", "techsupport@company.com"),
 					resource.TestCheckResourceAttr(resourceName, "service_name", fmt.Sprintf("test-acc-sr-%s", rName)),
 					resource.TestCheckResourceAttr(resourceName, "state", "RUNNING"),
-					resource.TestCheckResourceAttr(resourceName, "project", os.Getenv("AIVEN_PROJECT_NAME")),
+					resource.TestCheckResourceAttr(resourceName, "project", acc.ProjectName()),
 					resource.TestCheckResourceAttr(resourceName, "service_type", "dragonfly"),
 					resource.TestCheckResourceAttr(resourceName, "cloud_name", "google-europe-west1"),
 					resource.TestCheckResourceAttr(resourceName, "maintenance_window_dow", "monday"),
@@ -100,7 +99,7 @@ data "aiven_dragonfly" "common" {
   project      = data.aiven_project.foo.project
 
   depends_on = [aiven_dragonfly.bar]
-}`, os.Getenv("AIVEN_PROJECT_NAME"), name)
+}`, acc.ProjectName(), name)
 }
 
 func testAccDragonflyRemoveEmailsResource(name string) string {
@@ -134,7 +133,7 @@ data "aiven_dragonfly" "common" {
   project      = data.aiven_project.foo.project
 
   depends_on = [aiven_dragonfly.bar]
-}`, os.Getenv("AIVEN_PROJECT_NAME"), name)
+}`, acc.ProjectName(), name)
 }
 
 func testAccDragonflyDoubleTagResource(name string) string {
@@ -172,7 +171,7 @@ data "aiven_dragonfly" "common" {
   project      = data.aiven_project.foo.project
 
   depends_on = [aiven_dragonfly.bar]
-}`, os.Getenv("AIVEN_PROJECT_NAME"), name)
+}`, acc.ProjectName(), name)
 }
 
 // Dragonfly service tests
@@ -191,7 +190,7 @@ func TestAccAivenService_dragonfly(t *testing.T) {
 					acc.TestAccCheckAivenServiceCommonAttributes("data.aiven_dragonfly.common"),
 					testAccCheckAivenServiceDragonflyAttributes("data.aiven_dragonfly.common"),
 					resource.TestCheckResourceAttr(resourceName, "service_name", fmt.Sprintf("test-acc-sr-%s", rName)),
-					resource.TestCheckResourceAttr(resourceName, "project", os.Getenv("AIVEN_PROJECT_NAME")),
+					resource.TestCheckResourceAttr(resourceName, "project", acc.ProjectName()),
 					resource.TestCheckResourceAttr(resourceName, "service_type", "dragonfly"),
 					resource.TestCheckResourceAttr(resourceName, "cloud_name", "google-europe-west1"),
 					resource.TestCheckResourceAttr(resourceName, "maintenance_window_dow", "monday"),
@@ -206,7 +205,7 @@ func TestAccAivenService_dragonfly(t *testing.T) {
 					acc.TestAccCheckAivenServiceCommonAttributes("data.aiven_dragonfly.common"),
 					testAccCheckAivenServiceDragonflyAttributes("data.aiven_dragonfly.common"),
 					resource.TestCheckResourceAttr(resourceName, "service_name", fmt.Sprintf("test-acc-sr-%s", rName)),
-					resource.TestCheckResourceAttr(resourceName, "project", os.Getenv("AIVEN_PROJECT_NAME")),
+					resource.TestCheckResourceAttr(resourceName, "project", acc.ProjectName()),
 					resource.TestCheckResourceAttr(resourceName, "service_type", "dragonfly"),
 					resource.TestCheckResourceAttr(resourceName, "cloud_name", "google-europe-west1"),
 					resource.TestCheckResourceAttr(resourceName, "maintenance_window_dow", "monday"),
@@ -245,7 +244,7 @@ data "aiven_dragonfly" "common" {
   project      = aiven_dragonfly.bar.project
 
   depends_on = [aiven_dragonfly.bar]
-}`, os.Getenv("AIVEN_PROJECT_NAME"), name)
+}`, acc.ProjectName(), name)
 }
 
 func testAccDragonflyServiceResourceWithPersistenceOff(name string) string {
@@ -274,7 +273,7 @@ data "aiven_dragonfly" "common" {
   project      = aiven_dragonfly.bar.project
 
   depends_on = [aiven_dragonfly.bar]
-}`, os.Getenv("AIVEN_PROJECT_NAME"), name)
+}`, acc.ProjectName(), name)
 }
 
 func testAccCheckAivenServiceDragonflyAttributes(n string) resource.TestCheckFunc {

--- a/internal/sdkprovider/service/flink/flink_application_version_test.go
+++ b/internal/sdkprovider/service/flink/flink_application_version_test.go
@@ -95,7 +95,7 @@ resource "aiven_flink" "foo" {
 resource "aiven_kafka" "kafka" {
   project      = data.aiven_project.foo.project
   cloud_name   = "google-europe-west1"
-  plan         = "business-4"
+  plan         = "startup-2"
   service_name = "test-acc-kafka-%[2]s"
 }
 

--- a/internal/sdkprovider/service/flink/flink_application_version_test.go
+++ b/internal/sdkprovider/service/flink/flink_application_version_test.go
@@ -3,7 +3,6 @@ package flink_test
 import (
 	"context"
 	"fmt"
-	"os"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
@@ -28,7 +27,7 @@ func TestAccAivenFlinkApplicationVersion_basic(t *testing.T) {
 				Config: testAccFlinkApplicationVersionResource(rName),
 				Check: resource.ComposeTestCheckFunc(
 					checkAivenFlinkApplicationVersionAttributes("data.aiven_flink_application_version.bar"),
-					resource.TestCheckResourceAttr(resourceName, "project", os.Getenv("AIVEN_PROJECT_NAME")),
+					resource.TestCheckResourceAttr(resourceName, "project", acc.ProjectName()),
 					resource.TestCheckResourceAttr(
 						resourceName,
 						"service_name",
@@ -37,7 +36,7 @@ func TestAccAivenFlinkApplicationVersion_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "sink.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "source.#", "1"),
 					resource.TestCheckResourceAttr(
-						resourceNameDeployment, "project", os.Getenv("AIVEN_PROJECT_NAME"),
+						resourceNameDeployment, "project", acc.ProjectName(),
 					),
 					resource.TestCheckResourceAttr(
 						resourceNameDeployment,
@@ -181,7 +180,7 @@ data "aiven_flink_application_version" "bar" {
   application_id         = aiven_flink_application.foo.application_id
   application_version_id = aiven_flink_application_version.foo.application_version_id
 }
-`, os.Getenv("AIVEN_PROJECT_NAME"), r)
+`, acc.ProjectName(), r)
 }
 
 func checkAivenFlinkApplicationVersionAttributes(n string) resource.TestCheckFunc {

--- a/internal/sdkprovider/service/flink/flink_jar_application_version_test.go
+++ b/internal/sdkprovider/service/flink/flink_jar_application_version_test.go
@@ -21,8 +21,7 @@ import (
 // TestAccAivenFlinkJarApplicationVersion_basic
 // This test requires a jar file to run.
 func TestAccAivenFlinkJarApplicationVersion_basic(t *testing.T) {
-	deps := acc.CommonTestDependencies(t)
-	_ = deps.IsBeta(true)
+	acc.SkipIfNotBeta(t)
 
 	jarFile := os.Getenv("AIVEN_TEST_FLINK_JAR_FILE")
 	if jarFile == "" {
@@ -159,7 +158,7 @@ func createMinimalJar() (func(), string, error) {
 		Method:   zip.Store, // entries should use STORE
 		Modified: time.Now(),
 	}
-	dirHeader.SetMode(0755)
+	dirHeader.SetMode(0o755)
 	_, err = zw.CreateHeader(dirHeader)
 	if err != nil {
 		return nil, "", fmt.Errorf("failed to create META-INF directory: %w", err)
@@ -171,7 +170,7 @@ func createMinimalJar() (func(), string, error) {
 		Method:   zip.Deflate, // use compression for files
 		Modified: time.Now(),
 	}
-	manifestHeader.SetMode(0644)
+	manifestHeader.SetMode(0o644)
 
 	mf, err := zw.CreateHeader(manifestHeader)
 	if err != nil {

--- a/internal/sdkprovider/service/flink/flink_jar_application_version_test.go
+++ b/internal/sdkprovider/service/flink/flink_jar_application_version_test.go
@@ -31,7 +31,7 @@ func TestAccAivenFlinkJarApplicationVersion_basic(t *testing.T) {
 		defer remove()
 	}
 
-	project := os.Getenv("AIVEN_PROJECT_NAME")
+	project := acc.ProjectName()
 	resourceNameApp := "aiven_flink_jar_application.app"
 	resourceNameVersion := "aiven_flink_jar_application_version.version"
 	resourceNameDeployment := "aiven_flink_jar_application_deployment.deployment"

--- a/internal/sdkprovider/service/flink/flink_test.go
+++ b/internal/sdkprovider/service/flink/flink_test.go
@@ -2,7 +2,6 @@ package flink_test
 
 import (
 	"fmt"
-	"os"
 	"regexp"
 	"testing"
 
@@ -15,7 +14,7 @@ import (
 
 // TestAccAiven_flink tests Flink resource.
 func TestAccAiven_flink(t *testing.T) {
-	projectName := os.Getenv("AIVEN_PROJECT_NAME")
+	projectName := acc.ProjectName()
 
 	randString := func() string { return acctest.RandStringFromCharSet(10, acctest.CharSetAlpha) }
 

--- a/internal/sdkprovider/service/grafana/grafana_test.go
+++ b/internal/sdkprovider/service/grafana/grafana_test.go
@@ -37,7 +37,7 @@ func TestAccAiven_grafana(t *testing.T) {
 					testAccCheckAivenServiceGrafanaAttributes("data.aiven_grafana.common"),
 					resource.TestCheckResourceAttr(resourceName, "service_name", fmt.Sprintf("test-acc-sr-%s", rName)),
 					resource.TestCheckResourceAttr(resourceName, "state", "RUNNING"),
-					resource.TestCheckResourceAttr(resourceName, "project", os.Getenv("AIVEN_PROJECT_NAME")),
+					resource.TestCheckResourceAttr(resourceName, "project", acc.ProjectName()),
 					resource.TestCheckResourceAttr(resourceName, "service_type", "grafana"),
 					resource.TestCheckResourceAttr(resourceName, "cloud_name", "google-europe-west1"),
 					resource.TestCheckResourceAttr(resourceName, "maintenance_window_dow", "monday"),
@@ -186,7 +186,7 @@ data "aiven_grafana" "common" {
   project      = data.aiven_project.foo.project
 
   depends_on = [aiven_grafana.bar]
-}`, os.Getenv("AIVEN_PROJECT_NAME"), rName),
+}`, acc.ProjectName(), rName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "grafana_user_config.0.ip_filter.#", "2"),
 					resource.TestCheckResourceAttr(resourceName, "grafana_user_config.0.alerting_enabled", "true"),
@@ -224,7 +224,7 @@ data "aiven_grafana" "common" {
   project      = data.aiven_project.foo.project
 
   depends_on = [aiven_grafana.bar]
-}`, os.Getenv("AIVEN_PROJECT_NAME"), rName),
+}`, acc.ProjectName(), rName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "grafana_user_config.0.ip_filter.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "grafana_user_config.0.alerting_enabled", "true"),
@@ -260,7 +260,7 @@ data "aiven_grafana" "common" {
   project      = data.aiven_project.foo.project
 
   depends_on = [aiven_grafana.bar]
-}`, os.Getenv("AIVEN_PROJECT_NAME"), rName),
+}`, acc.ProjectName(), rName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "grafana_user_config.0.ip_filter.#", "2"),
 					resource.TestCheckResourceAttr(resourceName, "grafana_user_config.0.alerting_enabled", "true"),
@@ -292,7 +292,7 @@ data "aiven_grafana" "common" {
   project      = data.aiven_project.foo.project
 
   depends_on = [aiven_grafana.bar]
-}`, os.Getenv("AIVEN_PROJECT_NAME"), rName),
+}`, acc.ProjectName(), rName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "grafana_user_config.0.ip_filter.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "grafana_user_config.0.alerting_enabled", "true"),
@@ -337,8 +337,9 @@ data "aiven_grafana" "common" {
   project      = data.aiven_project.foo.project
 
   depends_on = [aiven_grafana.bar]
-}`, os.Getenv("AIVEN_PROJECT_NAME"), name, ipFilters)
+}`, acc.ProjectName(), name, ipFilters)
 }
+
 func testAccGrafanaDoubleTagResource(name string) string {
 	return fmt.Sprintf(`
 data "aiven_project" "foo" {
@@ -377,7 +378,7 @@ data "aiven_grafana" "common" {
   project      = data.aiven_project.foo.project
 
   depends_on = [aiven_grafana.bar]
-}`, os.Getenv("AIVEN_PROJECT_NAME"), name)
+}`, acc.ProjectName(), name)
 }
 
 // Grafana service tests
@@ -398,7 +399,7 @@ func TestAccAivenService_grafana(t *testing.T) {
 					testAccCheckAivenServiceGrafanaAttributes("data.aiven_grafana.common"),
 					resource.TestCheckResourceAttr(resourceName, "service_name", fmt.Sprintf("test-acc-sr-%s", rName)),
 					resource.TestCheckResourceAttr(resourceName, "state", "RUNNING"),
-					resource.TestCheckResourceAttr(resourceName, "project", os.Getenv("AIVEN_PROJECT_NAME")),
+					resource.TestCheckResourceAttr(resourceName, "project", acc.ProjectName()),
 					resource.TestCheckResourceAttr(resourceName, "service_type", "grafana"),
 					resource.TestCheckResourceAttr(resourceName, "cloud_name", "google-europe-west1"),
 					resource.TestCheckResourceAttr(resourceName, "maintenance_window_dow", "monday"),
@@ -414,7 +415,7 @@ func TestAccAivenService_grafana(t *testing.T) {
 					testAccCheckAivenServiceGrafanaAttributes("data.aiven_grafana.common"),
 					resource.TestCheckResourceAttr(resourceName, "service_name", fmt.Sprintf("test-acc-sr-%s", rName2)),
 					resource.TestCheckResourceAttr(resourceName, "state", "RUNNING"),
-					resource.TestCheckResourceAttr(resourceName, "project", os.Getenv("AIVEN_PROJECT_NAME")),
+					resource.TestCheckResourceAttr(resourceName, "project", acc.ProjectName()),
 					resource.TestCheckResourceAttr(resourceName, "service_type", "grafana"),
 					resource.TestCheckResourceAttr(resourceName, "cloud_name", "google-europe-west1"),
 					resource.TestCheckResourceAttr(resourceName, "maintenance_window_dow", "monday"),
@@ -456,7 +457,7 @@ data "aiven_grafana" "common" {
   project      = aiven_grafana.bar.project
 
   depends_on = [aiven_grafana.bar]
-}`, os.Getenv("AIVEN_PROJECT_NAME"), name)
+}`, acc.ProjectName(), name)
 }
 
 func testAccGrafanaServiceCustomIPFiltersResource(name string) string {
@@ -488,7 +489,7 @@ data "aiven_grafana" "common" {
   project      = aiven_grafana.bar.project
 
   depends_on = [aiven_grafana.bar]
-}`, os.Getenv("AIVEN_PROJECT_NAME"), name)
+}`, acc.ProjectName(), name)
 }
 
 func testAccCheckAivenServiceGrafanaAttributes(n string) resource.TestCheckFunc {
@@ -575,7 +576,7 @@ data "aiven_grafana" "common" {
   project      = data.aiven_project.foo.project
 
   depends_on = [aiven_grafana.bar]
-}`, os.Getenv("AIVEN_PROJECT_NAME"), name, teamIDs)
+}`, acc.ProjectName(), name, teamIDs)
 }
 
 func TestAccAiven_grafana_user_config_ip_filter_object(t *testing.T) {
@@ -702,7 +703,7 @@ resource "aiven_grafana" "bar" {
     }
   }
 }
-`, networks, os.Getenv("AIVEN_PROJECT_NAME"), name)
+`, networks, acc.ProjectName(), name)
 }
 
 // TestAccAiven_grafana_and_default_vpc
@@ -712,7 +713,7 @@ resource "aiven_grafana" "bar" {
 // Although this behavior affects all service types due to shared backend logic,
 // we use Grafana for testing as it has the fastest setup time.
 func TestAccAiven_grafana_and_default_vpc(t *testing.T) {
-	project := os.Getenv("AIVEN_PROJECT_NAME")
+	project := acc.ProjectName()
 	grafanaName := "test-acc-sr-" + acc.RandStr()
 	// Must be unique across all the tests,
 	// there can be only one VPC with the same name in the project

--- a/internal/sdkprovider/service/influxdb/influxdb_database_test.go
+++ b/internal/sdkprovider/service/influxdb/influxdb_database_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"os"
 	"strings"
 	"testing"
 
@@ -19,7 +18,7 @@ import (
 
 func TestAccAivenInfluxDBDatabase_basic(t *testing.T) {
 	resourceName := "aiven_influxdb_database.foo"
-	projectName := os.Getenv("AIVEN_PROJECT_NAME")
+	projectName := acc.ProjectName()
 	rName := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
 	rName2 := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
 

--- a/internal/sdkprovider/service/influxdb/influxdb_test.go
+++ b/internal/sdkprovider/service/influxdb/influxdb_test.go
@@ -2,7 +2,6 @@ package influxdb_test
 
 import (
 	"fmt"
-	"os"
 	"regexp"
 	"testing"
 
@@ -28,7 +27,7 @@ func TestAccAiven_influxdb(t *testing.T) {
 					testAccCheckAivenServiceInfluxdbAttributes("data.aiven_influxdb.common"),
 					resource.TestCheckResourceAttr(resourceName, "service_name", fmt.Sprintf("test-acc-sr-%s", rName)),
 					resource.TestCheckResourceAttr(resourceName, "state", "RUNNING"),
-					resource.TestCheckResourceAttr(resourceName, "project", os.Getenv("AIVEN_PROJECT_NAME")),
+					resource.TestCheckResourceAttr(resourceName, "project", acc.ProjectName()),
 					resource.TestCheckResourceAttr(resourceName, "service_type", "influxdb"),
 					resource.TestCheckResourceAttr(resourceName, "cloud_name", "google-europe-west1"),
 					resource.TestCheckResourceAttr(resourceName, "maintenance_window_dow", "monday"),
@@ -83,7 +82,7 @@ data "aiven_influxdb" "common" {
   project      = aiven_influxdb.bar.project
 
   depends_on = [aiven_influxdb.bar]
-}`, os.Getenv("AIVEN_PROJECT_NAME"), name)
+}`, acc.ProjectName(), name)
 }
 
 func testAccInfluxDBDoubleTagResource(name string) string {
@@ -121,5 +120,5 @@ data "aiven_influxdb" "common" {
   project      = aiven_influxdb.bar.project
 
   depends_on = [aiven_influxdb.bar]
-}`, os.Getenv("AIVEN_PROJECT_NAME"), name)
+}`, acc.ProjectName(), name)
 }

--- a/internal/sdkprovider/service/influxdb/influxdb_user_test.go
+++ b/internal/sdkprovider/service/influxdb/influxdb_user_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"os"
 	"testing"
 
 	"github.com/aiven/aiven-go-client/v2"
@@ -30,7 +29,7 @@ func TestAccAivenInfluxDBUser_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					schemautil.TestAccCheckAivenServiceUserAttributes("data.aiven_influxdb_user.user"),
 					resource.TestCheckResourceAttr(resourceName, "service_name", fmt.Sprintf("test-acc-sr-%s", rName)),
-					resource.TestCheckResourceAttr(resourceName, "project", os.Getenv("AIVEN_PROJECT_NAME")),
+					resource.TestCheckResourceAttr(resourceName, "project", acc.ProjectName()),
 					resource.TestCheckResourceAttr(resourceName, "username", fmt.Sprintf("user-%s", rName)),
 					resource.TestCheckResourceAttr(resourceName, "password", "Test$1234"),
 				),
@@ -97,7 +96,7 @@ data "aiven_influxdb_user" "user" {
   service_name = aiven_influxdb_user.foo.service_name
   project      = aiven_influxdb_user.foo.project
   username     = aiven_influxdb_user.foo.username
-}`, os.Getenv("AIVEN_PROJECT_NAME"), name, name)
+}`, acc.ProjectName(), name, name)
 }
 
 // InfluxDB service tests
@@ -117,7 +116,7 @@ func TestAccAivenService_influxdb(t *testing.T) {
 					testAccCheckAivenServiceInfluxdbAttributes("data.aiven_influxdb.common"),
 					resource.TestCheckResourceAttr(resourceName, "service_name", fmt.Sprintf("test-acc-sr-%s", rName)),
 					resource.TestCheckResourceAttr(resourceName, "state", "RUNNING"),
-					resource.TestCheckResourceAttr(resourceName, "project", os.Getenv("AIVEN_PROJECT_NAME")),
+					resource.TestCheckResourceAttr(resourceName, "project", acc.ProjectName()),
 					resource.TestCheckResourceAttr(resourceName, "service_type", "influxdb"),
 					resource.TestCheckResourceAttr(resourceName, "cloud_name", "google-europe-west1"),
 					resource.TestCheckResourceAttr(resourceName, "maintenance_window_dow", "monday"),
@@ -156,7 +155,7 @@ data "aiven_influxdb" "common" {
   project      = aiven_influxdb.bar.project
 
   depends_on = [aiven_influxdb.bar]
-}`, os.Getenv("AIVEN_PROJECT_NAME"), name)
+}`, acc.ProjectName(), name)
 }
 
 func testAccCheckAivenServiceInfluxdbAttributes(n string) resource.TestCheckFunc {

--- a/internal/sdkprovider/service/kafka/kafka_acl_test.go
+++ b/internal/sdkprovider/service/kafka/kafka_acl_test.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"log"
-	"os"
 	"regexp"
 	"testing"
 
@@ -66,7 +65,7 @@ func TestAccAivenKafkaACL_basic(t *testing.T) {
 				Config: testAccKafkaACLResource(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAivenKafkaACLAttributes("data.aiven_kafka_acl.acl"),
-					resource.TestCheckResourceAttr(resourceName, "project", os.Getenv("AIVEN_PROJECT_NAME")),
+					resource.TestCheckResourceAttr(resourceName, "project", acc.ProjectName()),
 					resource.TestCheckResourceAttr(resourceName, "service_name", fmt.Sprintf("test-acc-sr-%s", rName)),
 					resource.TestCheckResourceAttr(resourceName, "topic", fmt.Sprintf("test-acc-topic-%s", rName)),
 					resource.TestCheckResourceAttr(resourceName, "username", fmt.Sprintf("user-%s", rName)),
@@ -118,7 +117,6 @@ resource "aiven_kafka_acl" "foo" {
   username     = "user-1"
   permission   = "admin"
 }`
-
 }
 
 func testAccKafkaACLWrongServiceNameResource(_ string) string {
@@ -130,7 +128,6 @@ resource "aiven_kafka_acl" "foo" {
   username     = "user-1"
   permission   = "admin"
 }`
-
 }
 
 func testAccKafkaACLWrongPermisionResource(_ string) string {
@@ -142,7 +139,6 @@ resource "aiven_kafka_acl" "foo" {
   username     = "user-1"
   permission   = "wrong-permission"
 }`
-
 }
 
 func testAccKafkaACLWildcardResource(_ string) string {
@@ -154,7 +150,6 @@ resource "aiven_kafka_acl" "foo" {
   username     = "*"
   permission   = "admin"
 }`
-
 }
 
 func testAccKafkaACLPrefixWildcardResource(_ string) string {
@@ -166,7 +161,6 @@ resource "aiven_kafka_acl" "foo" {
   username     = "group-user-*"
   permission   = "admin"
 }`
-
 }
 
 func testAccKafkaACLWrongUsernameResource(_ string) string {
@@ -178,7 +172,6 @@ resource "aiven_kafka_acl" "foo" {
   username     = "#-user"
   permission   = "admin"
 }`
-
 }
 
 func testAccKafkaACLInvalidCharsResource(_ string) string {
@@ -190,7 +183,6 @@ resource "aiven_kafka_acl" "foo" {
   username     = "!./,£$^&*()_"
   permission   = "admin"
 }`
-
 }
 
 func testAccKafkaACLResource(name string) string {
@@ -239,7 +231,7 @@ data "aiven_kafka_acl" "acl" {
   permission   = aiven_kafka_acl.foo.permission
 
   depends_on = [aiven_kafka_acl.foo]
-}`, os.Getenv("AIVEN_PROJECT_NAME"), name, name, name)
+}`, acc.ProjectName(), name, name, name)
 }
 
 func testAccCheckAivenKafkaACLResourceDestroy(s *terraform.State) error {

--- a/internal/sdkprovider/service/kafka/kafka_connect_test.go
+++ b/internal/sdkprovider/service/kafka/kafka_connect_test.go
@@ -2,7 +2,6 @@ package kafka_test
 
 import (
 	"fmt"
-	"os"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
@@ -29,7 +28,7 @@ func TestAccAiven_kafkaconnect(t *testing.T) {
 					testAccCheckAivenServiceKafkaConnectAttributes("data.aiven_kafka_connect.common"),
 					resource.TestCheckResourceAttr(resourceName, "service_name", fmt.Sprintf("test-acc-sr-%s", rName)),
 					resource.TestCheckResourceAttr(resourceName, "state", "RUNNING"),
-					resource.TestCheckResourceAttr(resourceName, "project", os.Getenv("AIVEN_PROJECT_NAME")),
+					resource.TestCheckResourceAttr(resourceName, "project", acc.ProjectName()),
 					resource.TestCheckResourceAttr(resourceName, "service_type", "kafka_connect"),
 					resource.TestCheckResourceAttr(resourceName, "cloud_name", "google-europe-west1"),
 					resource.TestCheckResourceAttr(resourceName, "maintenance_window_dow", "monday"),
@@ -72,7 +71,7 @@ data "aiven_kafka_connect" "common" {
   project      = aiven_kafka_connect.bar.project
 
   depends_on = [aiven_kafka_connect.bar]
-}`, os.Getenv("AIVEN_PROJECT_NAME"), name)
+}`, acc.ProjectName(), name)
 }
 
 // Kafka Connect service tests
@@ -91,7 +90,7 @@ func TestAccAivenService_kafkaconnect(t *testing.T) {
 					acc.TestAccCheckAivenServiceCommonAttributes("data.aiven_kafka_connect.common"),
 					testAccCheckAivenServiceKafkaConnectAttributes("data.aiven_kafka_connect.common"),
 					resource.TestCheckResourceAttr(resourceName, "service_name", fmt.Sprintf("test-acc-sr-%s", rName)),
-					resource.TestCheckResourceAttr(resourceName, "project", os.Getenv("AIVEN_PROJECT_NAME")),
+					resource.TestCheckResourceAttr(resourceName, "project", acc.ProjectName()),
 					resource.TestCheckResourceAttr(resourceName, "service_type", "kafka_connect"),
 					resource.TestCheckResourceAttr(resourceName, "cloud_name", "google-europe-west1"),
 					resource.TestCheckResourceAttr(resourceName, "maintenance_window_dow", "monday"),
@@ -134,7 +133,7 @@ data "aiven_kafka_connect" "common" {
   project      = aiven_kafka_connect.bar.project
 
   depends_on = [aiven_kafka_connect.bar]
-}`, os.Getenv("AIVEN_PROJECT_NAME"), name)
+}`, acc.ProjectName(), name)
 }
 
 func testAccCheckAivenServiceKafkaConnectAttributes(n string) resource.TestCheckFunc {

--- a/internal/sdkprovider/service/kafka/kafka_connector_test.go
+++ b/internal/sdkprovider/service/kafka/kafka_connector_test.go
@@ -126,7 +126,6 @@ func testAccCheckAivenKafkaConnectorResourceDestroy(s *terraform.State) error {
 	return nil
 }
 
-// nosemgrep: kafka connectors need kafka with business plans
 func testAccKafkaConnectorResource(name string) string {
 	return fmt.Sprintf(`
 data "aiven_project" "foo" {
@@ -191,7 +190,6 @@ data "aiven_kafka_connector" "connector" {
 }`, acc.ProjectName(), name, name, name, name, name)
 }
 
-// nosemgrep: kafka connectors need kafka with business plans
 func testAccKafkaConnectorWrongConfigNameResource(name string) string {
 	return fmt.Sprintf(`
 data "aiven_project" "foo" {
@@ -265,7 +263,7 @@ data "aiven_project" "foo" {
 resource "aiven_kafka" "bar" {
   project                 = data.aiven_project.foo.project
   cloud_name              = "google-europe-west1"
-  plan                    = "startup-2"
+  plan                    = "business-4"
   service_name            = "test-acc-sr-%s"
   maintenance_window_dow  = "monday"
   maintenance_window_time = "10:00:00"

--- a/internal/sdkprovider/service/kafka/kafka_connector_test.go
+++ b/internal/sdkprovider/service/kafka/kafka_connector_test.go
@@ -30,7 +30,7 @@ func TestAccAivenKafkaConnector_basic(t *testing.T) {
 				Config: testAccKafkaConnectorResource(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAivenKafkaConnectorAttributes("data.aiven_kafka_connector.connector"),
-					resource.TestCheckResourceAttr(resourceName, "project", os.Getenv("AIVEN_PROJECT_NAME")),
+					resource.TestCheckResourceAttr(resourceName, "project", acc.ProjectName()),
 					resource.TestCheckResourceAttr(resourceName, "service_name", fmt.Sprintf("test-acc-sr-%s", rName)),
 					resource.TestCheckResourceAttr(resourceName, "connector_name", fmt.Sprintf("test-acc-con-%s", rName)),
 				),
@@ -60,7 +60,7 @@ func TestAccAivenKafkaConnector_mogosink(t *testing.T) {
 			{
 				Config: testAccKafkaConnectorMonoSinkResource(rName),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(resourceName, "project", os.Getenv("AIVEN_PROJECT_NAME")),
+					resource.TestCheckResourceAttr(resourceName, "project", acc.ProjectName()),
 					resource.TestCheckResourceAttr(resourceName, "service_name", fmt.Sprintf("test-acc-sr-%s", rName)),
 					resource.TestCheckResourceAttr(resourceName, "connector_name", fmt.Sprintf("test-acc-con-mongo-sink-%s", rName)),
 				),
@@ -188,7 +188,7 @@ data "aiven_kafka_connector" "connector" {
   connector_name = aiven_kafka_connector.foo.connector_name
 
   depends_on = [aiven_kafka_connector.foo]
-}`, os.Getenv("AIVEN_PROJECT_NAME"), name, name, name, name, name)
+}`, acc.ProjectName(), name, name, name, name, name)
 }
 
 // nosemgrep: kafka connectors need kafka with business plans
@@ -253,7 +253,7 @@ data "aiven_kafka_connector" "connector" {
   connector_name = aiven_kafka_connector.foo.connector_name
 
   depends_on = [aiven_kafka_connector.foo]
-}`, os.Getenv("AIVEN_PROJECT_NAME"), name, name, name, name, name)
+}`, acc.ProjectName(), name, name, name, name, name)
 }
 
 func testAccKafkaConnectorMonoSinkResource(name string) string {
@@ -314,7 +314,7 @@ data "aiven_kafka_connector" "connector" {
   connector_name = aiven_kafka_connector.foo.connector_name
 
   depends_on = [aiven_kafka_connector.foo]
-}`, os.Getenv("AIVEN_PROJECT_NAME"), name, name, name, name, os.Getenv("MONGO_URI"))
+}`, acc.ProjectName(), name, name, name, name, os.Getenv("MONGO_URI"))
 }
 
 func testAccCheckAivenKafkaConnectorAttributes(n string) resource.TestCheckFunc {

--- a/internal/sdkprovider/service/kafka/kafka_mirrormaker_test.go
+++ b/internal/sdkprovider/service/kafka/kafka_mirrormaker_test.go
@@ -2,7 +2,6 @@ package kafka_test
 
 import (
 	"fmt"
-	"os"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
@@ -26,7 +25,7 @@ func TestAccAiven_kafka_mirrormaker(t *testing.T) {
 					testAccCheckAivenServiceMirrorMakerAttributes("data.aiven_kafka_mirrormaker.common"),
 					resource.TestCheckResourceAttr(resourceName, "service_name", fmt.Sprintf("test-acc-sr-%s", rName)),
 					resource.TestCheckResourceAttr(resourceName, "state", "RUNNING"),
-					resource.TestCheckResourceAttr(resourceName, "project", os.Getenv("AIVEN_PROJECT_NAME")),
+					resource.TestCheckResourceAttr(resourceName, "project", acc.ProjectName()),
 					resource.TestCheckResourceAttr(resourceName, "service_type", "kafka_mirrormaker"),
 					resource.TestCheckResourceAttr(resourceName, "cloud_name", "google-europe-west1"),
 					resource.TestCheckResourceAttr(resourceName, "state", "RUNNING"),
@@ -65,5 +64,5 @@ data "aiven_kafka_mirrormaker" "common" {
   project      = aiven_kafka_mirrormaker.bar.project
 
   depends_on = [aiven_kafka_mirrormaker.bar]
-}`, os.Getenv("AIVEN_PROJECT_NAME"), name)
+}`, acc.ProjectName(), name)
 }

--- a/internal/sdkprovider/service/kafka/kafka_native_acl_test.go
+++ b/internal/sdkprovider/service/kafka/kafka_native_acl_test.go
@@ -2,7 +2,6 @@ package kafka_test
 
 import (
 	"fmt"
-	"os"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
@@ -13,7 +12,7 @@ import (
 
 // TestKafkaNativeAcl tests the kafka acl resource.
 func TestKafkaNativeAcl(t *testing.T) {
-	projectName := os.Getenv("AIVEN_PROJECT_NAME")
+	projectName := acc.ProjectName()
 	serviceName := fmt.Sprintf("test-acc-native-acl-%s", acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
 	resourceName := "aiven_kafka_native_acl.foo"
 

--- a/internal/sdkprovider/service/kafka/kafka_quota_test.go
+++ b/internal/sdkprovider/service/kafka/kafka_quota_test.go
@@ -3,7 +3,6 @@ package kafka_test
 import (
 	"context"
 	"fmt"
-	"os"
 	"regexp"
 	"testing"
 
@@ -25,7 +24,7 @@ func TestAccAivenKafkaQuota(t *testing.T) {
 	var (
 		randName    = acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
 		serviceName = fmt.Sprintf("test-acc-sr-%s", randName)
-		projectName = os.Getenv("AIVEN_PROJECT_NAME")
+		projectName = acc.ProjectName()
 
 		user     = fmt.Sprintf("acc_test_user_%s", randName)
 		clientID = fmt.Sprintf("acc_test_client_%s", randName)

--- a/internal/sdkprovider/service/kafka/kafka_test.go
+++ b/internal/sdkprovider/service/kafka/kafka_test.go
@@ -115,7 +115,7 @@ data "aiven_project" "foo" {
 resource "aiven_kafka" "bar" {
   project                 = data.aiven_project.foo.project
   cloud_name              = "google-europe-west1"
-  plan                    = "startup-2"
+  plan                    = "business-4"
   service_name            = "test-acc-sr-%s"
   maintenance_window_dow  = "monday"
   maintenance_window_time = "10:00:00"
@@ -355,7 +355,7 @@ func testAccKafkaResourceUserConfigKafkaOmitsNullFields(project, prefix string) 
 resource "aiven_kafka" "kafka" {
   project                 = "%s"
   cloud_name              = "google-europe-west1"
-  plan                    = "startup-2"
+  plan                    = "business-4"
   service_name            = "%s-kafka"
   maintenance_window_dow  = "monday"
   maintenance_window_time = "10:00:00"

--- a/internal/sdkprovider/service/kafka/kafka_test.go
+++ b/internal/sdkprovider/service/kafka/kafka_test.go
@@ -3,7 +3,6 @@ package kafka_test
 import (
 	"context"
 	"fmt"
-	"os"
 	"regexp"
 	"testing"
 
@@ -38,7 +37,7 @@ func TestAccAiven_kafka(t *testing.T) {
 					testAccCheckAivenServiceKafkaAttributes("data.aiven_kafka.common"),
 					resource.TestCheckResourceAttr(resourceName, "service_name", fmt.Sprintf("test-acc-sr-%s", rName)),
 					resource.TestCheckResourceAttr(resourceName, "state", "RUNNING"),
-					resource.TestCheckResourceAttr(resourceName, "project", os.Getenv("AIVEN_PROJECT_NAME")),
+					resource.TestCheckResourceAttr(resourceName, "project", acc.ProjectName()),
 					resource.TestCheckResourceAttr(resourceName, "service_type", "kafka"),
 					resource.TestCheckResourceAttr(resourceName, "cloud_name", "google-europe-west1"),
 					resource.TestCheckResourceAttr(resourceName, "maintenance_window_dow", "monday"),
@@ -60,7 +59,7 @@ func TestAccAiven_kafka(t *testing.T) {
 					testAccCheckAivenServiceKafkaAttributes("data.aiven_kafka.common"),
 					resource.TestCheckResourceAttr(resourceName, "service_name", fmt.Sprintf("test-acc-sr-%s", rName2)),
 					resource.TestCheckResourceAttr(resourceName, "state", "RUNNING"),
-					resource.TestCheckResourceAttr(resourceName, "project", os.Getenv("AIVEN_PROJECT_NAME")),
+					resource.TestCheckResourceAttr(resourceName, "project", acc.ProjectName()),
 					resource.TestCheckResourceAttr(resourceName, "service_type", "kafka"),
 					resource.TestCheckResourceAttr(resourceName, "cloud_name", "google-europe-west1"),
 					resource.TestCheckResourceAttr(resourceName, "maintenance_window_dow", "monday"),
@@ -81,7 +80,7 @@ func TestAccAiven_kafka(t *testing.T) {
 
 						ctx := context.Background()
 
-						a, err := c.KafkaACLs.List(ctx, os.Getenv("AIVEN_PROJECT_NAME"), rName2)
+						a, err := c.KafkaACLs.List(ctx, acc.ProjectName(), rName2)
 						if common.IsCritical(err) {
 							return fmt.Errorf("cannot get a list of kafka ACLs: %w", err)
 						}
@@ -90,7 +89,7 @@ func TestAccAiven_kafka(t *testing.T) {
 							return fmt.Errorf("list of ACLs should be empty")
 						}
 
-						s, err := c.KafkaSchemaRegistryACLs.List(ctx, os.Getenv("AIVEN_PROJECT_NAME"), rName2)
+						s, err := c.KafkaSchemaRegistryACLs.List(ctx, acc.ProjectName(), rName2)
 						if common.IsCritical(err) {
 							return fmt.Errorf("cannot get a list of Kafka Schema ACLs: %w", err)
 						}
@@ -140,7 +139,7 @@ data "aiven_kafka" "common" {
   project      = aiven_kafka.bar.project
 
   depends_on = [aiven_kafka.bar]
-}`, os.Getenv("AIVEN_PROJECT_NAME"), name)
+}`, acc.ProjectName(), name)
 }
 
 func testAccKafkaWithoutDefaultACLResource(name string) string {
@@ -180,7 +179,7 @@ data "aiven_kafka" "common" {
   project      = aiven_kafka.bar.project
 
   depends_on = [aiven_kafka.bar]
-}`, os.Getenv("AIVEN_PROJECT_NAME"), name)
+}`, acc.ProjectName(), name)
 }
 
 func testAccKafkaDoubleTagResource(name string) string {
@@ -225,7 +224,7 @@ data "aiven_kafka" "common" {
   project      = aiven_kafka.bar.project
 
   depends_on = [aiven_kafka.bar]
-}`, os.Getenv("AIVEN_PROJECT_NAME"), name)
+}`, acc.ProjectName(), name)
 }
 
 // Kafka service tests
@@ -245,7 +244,7 @@ func TestAccAivenService_kafka(t *testing.T) {
 					testAccCheckAivenServiceKafkaAttributes("data.aiven_kafka.common"),
 					resource.TestCheckResourceAttr(resourceName, "service_name", fmt.Sprintf("test-acc-sr-%s", rName)),
 					resource.TestCheckResourceAttr(resourceName, "state", "RUNNING"),
-					resource.TestCheckResourceAttr(resourceName, "project", os.Getenv("AIVEN_PROJECT_NAME")),
+					resource.TestCheckResourceAttr(resourceName, "project", acc.ProjectName()),
 					resource.TestCheckResourceAttr(resourceName, "service_type", "kafka"),
 					resource.TestCheckResourceAttr(resourceName, "cloud_name", "google-europe-west1"),
 					resource.TestCheckResourceAttr(resourceName, "maintenance_window_dow", "monday"),
@@ -299,7 +298,7 @@ data "aiven_kafka" "common" {
   project      = aiven_kafka.bar.project
 
   depends_on = [aiven_kafka.bar]
-}`, os.Getenv("AIVEN_PROJECT_NAME"), name)
+}`, acc.ProjectName(), name)
 }
 
 func testAccCheckAivenServiceKafkaAttributes(n string) resource.TestCheckFunc {
@@ -375,7 +374,7 @@ resource "aiven_kafka" "kafka" {
 }
 
 func TestAccAiven_kafka_user_config_kafka_omits_null_fields(t *testing.T) {
-	project := os.Getenv("AIVEN_PROJECT_NAME")
+	project := acc.ProjectName()
 	prefix := "test-tf-acc-" + acctest.RandString(7)
 	resourceName := "aiven_kafka.kafka"
 	resource.ParallelTest(t, resource.TestCase{
@@ -397,7 +396,7 @@ func TestAccAiven_kafka_user_config_kafka_omits_null_fields(t *testing.T) {
 
 // TestAccAiven_kafka_user_config_boolean_field_removed removed boolean field should not get "false"
 func TestAccAiven_kafka_user_config_boolean_field_removed(t *testing.T) {
-	project := os.Getenv("AIVEN_PROJECT_NAME")
+	project := acc.ProjectName()
 	prefix := "test-tf-acc-" + acctest.RandString(7)
 	resourceName := "aiven_kafka.kafka"
 	withConfig := func(c string) string {

--- a/internal/sdkprovider/service/kafka/kafka_user_test.go
+++ b/internal/sdkprovider/service/kafka/kafka_user_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"os"
 	"testing"
 
 	"github.com/aiven/aiven-go-client/v2"
@@ -30,7 +29,7 @@ func TestAccAivenKafkaUser_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					schemautil.TestAccCheckAivenServiceUserAttributes("data.aiven_kafka_user.user"),
 					resource.TestCheckResourceAttr(resourceName, "service_name", fmt.Sprintf("test-acc-sr-%s", rName)),
-					resource.TestCheckResourceAttr(resourceName, "project", os.Getenv("AIVEN_PROJECT_NAME")),
+					resource.TestCheckResourceAttr(resourceName, "project", acc.ProjectName()),
 					resource.TestCheckResourceAttr(resourceName, "username", fmt.Sprintf("user-%s", rName)),
 					resource.TestCheckResourceAttr(resourceName, "password", "Test$1234"),
 				),
@@ -97,5 +96,5 @@ data "aiven_kafka_user" "user" {
   service_name = aiven_kafka_user.foo.service_name
   project      = aiven_kafka_user.foo.project
   username     = aiven_kafka_user.foo.username
-}`, os.Getenv("AIVEN_PROJECT_NAME"), name, name)
+}`, acc.ProjectName(), name, name)
 }

--- a/internal/sdkprovider/service/kafka/mirrormaker_replication_flow_test.go
+++ b/internal/sdkprovider/service/kafka/mirrormaker_replication_flow_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"os"
 	"regexp"
 	"testing"
 
@@ -27,11 +26,10 @@ func TestAccAivenMirrorMakerReplicationFlow_basic(t *testing.T) {
 		CheckDestroy:             testAccCheckAivenMirrorMakerReplicationFlowResourceDestroy,
 		Steps: []resource.TestStep{
 			{
-
 				Config: testAccMirrorMakerReplicationFlowResource(rName, ""),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAivenMirrorMakerReplicationFlowAttributes("data.aiven_mirrormaker_replication_flow.flow"),
-					resource.TestCheckResourceAttr(resourceName, "project", os.Getenv("AIVEN_PROJECT_NAME")),
+					resource.TestCheckResourceAttr(resourceName, "project", acc.ProjectName()),
 					resource.TestCheckResourceAttr(resourceName, "service_name", fmt.Sprintf("test-acc-sr-mm-%s", rName)),
 					resource.TestCheckResourceAttr(resourceName, "source_cluster", "source"),
 					resource.TestCheckResourceAttr(resourceName, "target_cluster", "target"),
@@ -249,7 +247,7 @@ data "aiven_mirrormaker_replication_flow" "flow" {
   target_cluster = aiven_mirrormaker_replication_flow.foo.target_cluster
 
   depends_on = [aiven_mirrormaker_replication_flow.foo]
-}`, os.Getenv("AIVEN_PROJECT_NAME"), name, configExclude)
+}`, acc.ProjectName(), name, configExclude)
 }
 
 func testAccCheckAivenMirrorMakerReplicationFlowAttributes(n string) resource.TestCheckFunc {

--- a/internal/sdkprovider/service/kafka/mirrormaker_test.go
+++ b/internal/sdkprovider/service/kafka/mirrormaker_test.go
@@ -2,7 +2,6 @@ package kafka_test
 
 import (
 	"fmt"
-	"os"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
@@ -28,7 +27,7 @@ func TestAccAivenService_mirrormaker(t *testing.T) {
 					testAccCheckAivenServiceMirrorMakerAttributes("data.aiven_kafka_mirrormaker.common"),
 					resource.TestCheckResourceAttr(resourceName, "service_name", fmt.Sprintf("test-acc-sr-%s", rName)),
 					resource.TestCheckResourceAttr(resourceName, "state", "RUNNING"),
-					resource.TestCheckResourceAttr(resourceName, "project", os.Getenv("AIVEN_PROJECT_NAME")),
+					resource.TestCheckResourceAttr(resourceName, "project", acc.ProjectName()),
 					resource.TestCheckResourceAttr(resourceName, "service_type", "kafka_mirrormaker"),
 					resource.TestCheckResourceAttr(resourceName, "cloud_name", "google-europe-west1"),
 					resource.TestCheckResourceAttr(resourceName, "state", "RUNNING"),
@@ -67,7 +66,7 @@ data "aiven_kafka_mirrormaker" "common" {
   project      = aiven_kafka_mirrormaker.bar.project
 
   depends_on = [aiven_kafka_mirrormaker.bar]
-}`, os.Getenv("AIVEN_PROJECT_NAME"), name)
+}`, acc.ProjectName(), name)
 }
 
 func testAccCheckAivenServiceMirrorMakerAttributes(n string) resource.TestCheckFunc {

--- a/internal/sdkprovider/service/kafkaschema/kafka_schema_configuration_test.go
+++ b/internal/sdkprovider/service/kafkaschema/kafka_schema_configuration_test.go
@@ -2,7 +2,6 @@ package kafkaschema_test
 
 import (
 	"fmt"
-	"os"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
@@ -25,7 +24,7 @@ func TestAccAivenKafkaSchemaConfiguration_basic(t *testing.T) {
 			{
 				Config: testAccKafkaSchemaConfigurationResource(rName),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(resourceName, "project", os.Getenv("AIVEN_PROJECT_NAME")),
+					resource.TestCheckResourceAttr(resourceName, "project", acc.ProjectName()),
 					resource.TestCheckResourceAttr(resourceName, "service_name", fmt.Sprintf("test-acc-sr-%s", rName)),
 					resource.TestCheckResourceAttr(resourceName, "compatibility_level", "BACKWARD"),
 				),
@@ -66,5 +65,5 @@ resource "aiven_kafka_schema_configuration" "foo" {
   project             = data.aiven_project.foo.project
   service_name        = aiven_kafka.bar.service_name
   compatibility_level = "BACKWARD"
-}`, os.Getenv("AIVEN_PROJECT_NAME"), name)
+}`, acc.ProjectName(), name)
 }

--- a/internal/sdkprovider/service/kafkaschema/kafka_schema_registry_acl_test.go
+++ b/internal/sdkprovider/service/kafkaschema/kafka_schema_registry_acl_test.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"log"
-	"os"
 	"regexp"
 	"testing"
 
@@ -66,7 +65,7 @@ func TestAccAivenKafkaSchemaRegistryACL_basic(t *testing.T) {
 				Config: testAccKafkaSchemaRegistryACLResource(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAivenKafkaSchemaRegistryACLAttributes("data.aiven_kafka_schema_registry_acl.acl"),
-					resource.TestCheckResourceAttr(resourceName, "project", os.Getenv("AIVEN_PROJECT_NAME")),
+					resource.TestCheckResourceAttr(resourceName, "project", acc.ProjectName()),
 					resource.TestCheckResourceAttr(resourceName, "service_name", fmt.Sprintf("test-acc-sr-%s", rName)),
 					resource.TestCheckResourceAttr(resourceName, "resource", fmt.Sprintf("Subject:test-acc-topic-%s", rName)),
 					resource.TestCheckResourceAttr(resourceName, "username", fmt.Sprintf("user-%s", rName)),
@@ -118,7 +117,6 @@ resource "aiven_kafka_schema_registry_acl" "foo" {
   username     = "user-1"
   permission   = "schema_registry_read"
 }`
-
 }
 
 func testAccKafkaSchemaRegistryACLWrongServiceNameResource(_ string) string {
@@ -130,7 +128,6 @@ resource "aiven_kafka_schema_registry_acl" "foo" {
   username     = "user-1"
   permission   = "schema_registry_read"
 }`
-
 }
 
 func testAccKafkaSchemaRegistryACLWrongPermissionResource(_ string) string {
@@ -142,7 +139,6 @@ resource "aiven_kafka_schema_registry_acl" "foo" {
   username     = "user-1"
   permission   = "wrong-permission"
 }`
-
 }
 
 func testAccKafkaSchemaRegistryACLWildcardResource(_ string) string {
@@ -154,7 +150,6 @@ resource "aiven_kafka_schema_registry_acl" "foo" {
   username     = "*"
   permission   = "schema_registry_read"
 }`
-
 }
 
 func testAccKafkaSchemaRegistryACLPrefixWildcardResource(_ string) string {
@@ -166,7 +161,6 @@ resource "aiven_kafka_schema_registry_acl" "foo" {
   username     = "group-user-*"
   permission   = "schema_registry_read"
 }`
-
 }
 
 func testAccKafkaSchemaRegistryACLWrongUsernameResource(_ string) string {
@@ -178,7 +172,6 @@ resource "aiven_kafka_schema_registry_acl" "foo" {
   username     = "#user"
   permission   = "schema_registry_read"
 }`
-
 }
 
 func testAccKafkaSchemaRegistryACLInvalidCharsResource(_ string) string {
@@ -190,7 +183,6 @@ resource "aiven_kafka_schema_registry_acl" "foo" {
   username     = "!./,£$^&*()_"
   permission   = "schema_registry_read"
 }`
-
 }
 
 func testAccKafkaSchemaRegistryACLResource(name string) string {
@@ -239,7 +231,7 @@ data "aiven_kafka_schema_registry_acl" "acl" {
   permission   = aiven_kafka_schema_registry_acl.foo.permission
 
   depends_on = [aiven_kafka_schema_registry_acl.foo]
-}`, os.Getenv("AIVEN_PROJECT_NAME"), name, name, name)
+}`, acc.ProjectName(), name, name, name)
 }
 
 func testAccCheckAivenKafkaSchemaRegistryACLResourceDestroy(s *terraform.State) error {

--- a/internal/sdkprovider/service/kafkaschema/kafka_schema_test.go
+++ b/internal/sdkprovider/service/kafkaschema/kafka_schema_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"os"
 	"regexp"
 	"testing"
 
@@ -20,7 +19,7 @@ import (
 // TestAccAivenKafkaSchema_import_compatibility_level
 // checks that compatibility_level doesn't appear in plan after KafkaSchema import
 func TestAccAivenKafkaSchema_import_compatibility_level(t *testing.T) {
-	project := os.Getenv("AIVEN_PROJECT_NAME")
+	project := acc.ProjectName()
 	serviceName := "test-acc-sr-" + acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
 	resourceName := "aiven_kafka_schema.schema"
 	resource.ParallelTest(t, resource.TestCase{
@@ -112,7 +111,7 @@ func TestAccAivenKafkaSchema_json_protobuf_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAivenKafkaSchemaAttributes("data.aiven_kafka_schema.schema"),
 					testAccCheckAivenKafkaSchemaAttributes("data.aiven_kafka_schema.schema2"),
-					resource.TestCheckResourceAttr(resourceName, "project", os.Getenv("AIVEN_PROJECT_NAME")),
+					resource.TestCheckResourceAttr(resourceName, "project", acc.ProjectName()),
 					resource.TestCheckResourceAttr(
 						resourceName, "service_name", fmt.Sprintf("test-acc-sr-%s", rName),
 					),
@@ -121,7 +120,7 @@ func TestAccAivenKafkaSchema_json_protobuf_basic(t *testing.T) {
 					),
 					resource.TestCheckResourceAttr(resourceName, "version", "1"),
 					resource.TestCheckResourceAttr(resourceName, "schema_type", "JSON"),
-					resource.TestCheckResourceAttr(resourceName2, "project", os.Getenv("AIVEN_PROJECT_NAME")),
+					resource.TestCheckResourceAttr(resourceName2, "project", acc.ProjectName()),
 					resource.TestCheckResourceAttr(
 						resourceName2, "service_name", fmt.Sprintf("test-acc-sr-%s", rName),
 					),
@@ -149,7 +148,7 @@ func TestAccAivenKafkaSchema_basic(t *testing.T) {
 				Config: testAccKafkaSchemaResource(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAivenKafkaSchemaAttributes("data.aiven_kafka_schema.schema"),
-					resource.TestCheckResourceAttr(resourceName, "project", os.Getenv("AIVEN_PROJECT_NAME")),
+					resource.TestCheckResourceAttr(resourceName, "project", acc.ProjectName()),
 					resource.TestCheckResourceAttr(resourceName, "service_name", fmt.Sprintf("test-acc-sr-%s", rName)),
 					resource.TestCheckResourceAttr(resourceName, "subject_name", fmt.Sprintf("kafka-schema-%s", rName)),
 					resource.TestCheckResourceAttr(resourceName, "version", "1"),
@@ -160,7 +159,7 @@ func TestAccAivenKafkaSchema_basic(t *testing.T) {
 				Config: testAccKafkaSchemaResourceGoodUpdate(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAivenKafkaSchemaAttributes("data.aiven_kafka_schema.schema"),
-					resource.TestCheckResourceAttr(resourceName, "project", os.Getenv("AIVEN_PROJECT_NAME")),
+					resource.TestCheckResourceAttr(resourceName, "project", acc.ProjectName()),
 					resource.TestCheckResourceAttr(resourceName, "service_name", fmt.Sprintf("test-acc-sr-%s", rName)),
 					resource.TestCheckResourceAttr(resourceName, "subject_name", fmt.Sprintf("kafka-schema-%s", rName)),
 					resource.TestCheckResourceAttr(resourceName, "version", "2"),
@@ -323,7 +322,7 @@ data "aiven_kafka_schema" "schema2" {
   subject_name = aiven_kafka_schema.bar.subject_name
 
   depends_on = [aiven_kafka_schema.bar]
-}`, os.Getenv("AIVEN_PROJECT_NAME"), name)
+}`, acc.ProjectName(), name)
 }
 
 func testAccKafkaSchemaResource(name string) string {
@@ -386,7 +385,7 @@ data "aiven_kafka_schema" "schema" {
   subject_name = aiven_kafka_schema.foo.subject_name
 
   depends_on = [aiven_kafka_schema.foo]
-}`, os.Getenv("AIVEN_PROJECT_NAME"), name, name)
+}`, acc.ProjectName(), name, name)
 }
 
 func testAccKafkaSchemaResourceInvalidUpdate(name string) string {
@@ -448,7 +447,7 @@ data "aiven_kafka_schema" "schema" {
   subject_name = aiven_kafka_schema.foo.subject_name
 
   depends_on = [aiven_kafka_schema.foo]
-}`, os.Getenv("AIVEN_PROJECT_NAME"), name, name)
+}`, acc.ProjectName(), name, name)
 }
 
 func testAccKafkaSchemaResourceGoodUpdate(name string) string {
@@ -517,7 +516,7 @@ data "aiven_kafka_schema" "schema" {
   subject_name = aiven_kafka_schema.foo.subject_name
 
   depends_on = [aiven_kafka_schema.foo]
-}`, os.Getenv("AIVEN_PROJECT_NAME"), name, name)
+}`, acc.ProjectName(), name, name)
 }
 
 func testAccCheckAivenKafkaSchemaAttributes(n string) resource.TestCheckFunc {

--- a/internal/sdkprovider/service/kafkatopic/kafka_topic_data_source_test.go
+++ b/internal/sdkprovider/service/kafkatopic/kafka_topic_data_source_test.go
@@ -2,7 +2,6 @@ package kafkatopic_test
 
 import (
 	"fmt"
-	"os"
 	"regexp"
 	"testing"
 
@@ -15,7 +14,7 @@ import (
 // TestAccAivenDatasourceKafkaTopic_doesnt_exist this datasource shares Read() function with real "resource"
 // This test makes sure the read func doesn't create missing topics as it does for "resources"
 func TestAccAivenDatasourceKafkaTopic_doesnt_exist(t *testing.T) {
-	project := os.Getenv("AIVEN_PROJECT_NAME")
+	project := acc.ProjectName()
 	prefix := "test-tf-acc-" + acctest.RandString(7)
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acc.TestAccPreCheck(t) },

--- a/internal/sdkprovider/service/kafkatopic/kafka_topic_test.go
+++ b/internal/sdkprovider/service/kafkatopic/kafka_topic_test.go
@@ -37,7 +37,7 @@ func TestAccAivenKafkaTopic_basic(t *testing.T) {
 				Config: testAccKafkaTopicResource(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAivenKafkaTopicAttributes("data.aiven_kafka_topic.topic"),
-					resource.TestCheckResourceAttr(resourceName, "project", os.Getenv("AIVEN_PROJECT_NAME")),
+					resource.TestCheckResourceAttr(resourceName, "project", acc.ProjectName()),
 					resource.TestCheckResourceAttr(resourceName, "service_name", fmt.Sprintf("test-acc-sr-%s", rName)),
 					resource.TestCheckResourceAttr(resourceName, "topic_name", fmt.Sprintf("test-acc-topic-%s", rName)),
 					resource.TestCheckResourceAttr(resourceName, "partitions", "3"),
@@ -64,7 +64,7 @@ func TestAccAivenKafkaTopic_many_topics(t *testing.T) {
 				Config: testAccKafka451TopicResource(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAivenKafkaTopicAttributes("data.aiven_kafka_topic.topic"),
-					resource.TestCheckResourceAttr(resourceName, "project", os.Getenv("AIVEN_PROJECT_NAME")),
+					resource.TestCheckResourceAttr(resourceName, "project", acc.ProjectName()),
 					resource.TestCheckResourceAttr(resourceName, "service_name", fmt.Sprintf("test-acc-sr-%s", rName)),
 					resource.TestCheckResourceAttr(resourceName, "topic_name", fmt.Sprintf("test-acc-topic-%s", rName)),
 					resource.TestCheckResourceAttr(resourceName, "partitions", "3"),
@@ -89,7 +89,7 @@ func TestAccAivenKafkaTopic_termination_protection(t *testing.T) {
 				ExpectNonEmptyPlan:        true,
 				PlanOnly:                  true,
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(resourceName, "project", os.Getenv("AIVEN_PROJECT_NAME")),
+					resource.TestCheckResourceAttr(resourceName, "project", acc.ProjectName()),
 					resource.TestCheckResourceAttr(resourceName, "service_name", fmt.Sprintf("test-acc-sr-%s", rName)),
 					resource.TestCheckResourceAttr(resourceName, "topic_name", fmt.Sprintf("test-acc-topic-%s", rName)),
 					resource.TestCheckResourceAttr(resourceName, "partitions", "3"),
@@ -113,7 +113,7 @@ func TestAccAivenKafkaTopic_custom_timeouts(t *testing.T) {
 				Config: testAccKafkaTopicCustomTimeoutsResource(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAivenKafkaTopicAttributes("data.aiven_kafka_topic.topic"),
-					resource.TestCheckResourceAttr(resourceName, "project", os.Getenv("AIVEN_PROJECT_NAME")),
+					resource.TestCheckResourceAttr(resourceName, "project", acc.ProjectName()),
 					resource.TestCheckResourceAttr(resourceName, "service_name", fmt.Sprintf("test-acc-sr-%s", rName)),
 					resource.TestCheckResourceAttr(resourceName, "topic_name", fmt.Sprintf("test-acc-topic-%s", rName)),
 					resource.TestCheckResourceAttr(resourceName, "partitions", "3"),
@@ -136,7 +136,6 @@ resource "aiven_kafka_topic" "more" {
   partitions   = 3
   replication  = 2
 }`
-
 }
 
 func testAccKafkaTopicResource(name string) string {
@@ -196,7 +195,7 @@ resource "aiven_kafka_topic" "topic2" {
   owner_user_group_id = aiven_organization_user_group.foo.group_id
   partitions          = 3
   replication         = 2
-}`, os.Getenv("AIVEN_ORGANIZATION_NAME"), name, os.Getenv("AIVEN_PROJECT_NAME"), name, name, name, name)
+}`, os.Getenv("AIVEN_ORGANIZATION_NAME"), name, acc.ProjectName(), name, name, name, name)
 }
 
 func testAccKafkaTopicCustomTimeoutsResource(name string) string {
@@ -238,7 +237,7 @@ data "aiven_kafka_topic" "topic" {
   topic_name   = aiven_kafka_topic.foo.topic_name
 
   depends_on = [aiven_kafka_topic.foo]
-}`, os.Getenv("AIVEN_PROJECT_NAME"), name, name)
+}`, acc.ProjectName(), name, name)
 }
 
 func testAccKafkaTopicTerminationProtectionResource(name string) string {
@@ -278,7 +277,7 @@ data "aiven_kafka_topic" "topic" {
   topic_name   = aiven_kafka_topic.foo.topic_name
 
   depends_on = [aiven_kafka_topic.foo]
-}`, os.Getenv("AIVEN_PROJECT_NAME"), name, name)
+}`, acc.ProjectName(), name, name)
 }
 
 func testAccCheckAivenKafkaTopicAttributes(n string) resource.TestCheckFunc {
@@ -395,7 +394,7 @@ func TestPartitions(t *testing.T) {
 // TestAccAivenKafkaTopic_recreate validates that topic is recreated if it is missing
 // Kafka looses all topics on turn off/on, then TF recreates topics. This test imitates the case.
 func TestAccAivenKafkaTopic_recreate_missing(t *testing.T) {
-	project := os.Getenv("AIVEN_PROJECT_NAME")
+	project := acc.ProjectName()
 
 	prefix := "test-tf-acc-" + acctest.RandString(7)
 	kafkaResource := "aiven_kafka.kafka"
@@ -502,7 +501,7 @@ resource "aiven_kafka_topic" "topic" {
 
 // TestAccAivenKafkaTopic_import_missing tests that simple import doesn't create a new topic
 func TestAccAivenKafkaTopic_import_missing(t *testing.T) {
-	project := os.Getenv("AIVEN_PROJECT_NAME")
+	project := acc.ProjectName()
 	prefix := "test-tf-acc-" + acctest.RandString(7)
 	kafkaName := prefix + "-kafka"
 	topicName := "topic"
@@ -569,7 +568,7 @@ resource "aiven_kafka_topic" "topic" {
 }
 
 func TestAccAivenKafkaTopic_conflicts_if_exists(t *testing.T) {
-	project := os.Getenv("AIVEN_PROJECT_NAME")
+	project := acc.ProjectName()
 	prefix := "test-tf-acc-" + acctest.RandString(7)
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acc.TestAccPreCheck(t) },
@@ -629,7 +628,7 @@ func partitions(numPartitions int) (partitions []*aiven.Partition) {
 }
 
 func TestAccAivenKafkaTopic_local_retention_bytes_overflow_error(t *testing.T) {
-	project := os.Getenv("AIVEN_PROJECT_NAME")
+	project := acc.ProjectName()
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acc.TestAccPreCheck(t) },
 		ProtoV6ProviderFactories: acc.TestProtoV6ProviderFactories,
@@ -657,7 +656,7 @@ resource "aiven_kafka_topic" "topic" {
 }
 
 func TestAccAivenKafkaTopic_local_retention_bytes_overflow_dependency(t *testing.T) {
-	project := os.Getenv("AIVEN_PROJECT_NAME")
+	project := acc.ProjectName()
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acc.TestAccPreCheck(t) },
 		ProtoV6ProviderFactories: acc.TestProtoV6ProviderFactories,

--- a/internal/sdkprovider/service/kafkatopic/kafka_topic_test.go
+++ b/internal/sdkprovider/service/kafkatopic/kafka_topic_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"log"
-	"os"
 	"reflect"
 	"regexp"
 	"testing"
@@ -195,7 +194,7 @@ resource "aiven_kafka_topic" "topic2" {
   owner_user_group_id = aiven_organization_user_group.foo.group_id
   partitions          = 3
   replication         = 2
-}`, os.Getenv("AIVEN_ORGANIZATION_NAME"), name, acc.ProjectName(), name, name, name, name)
+}`, acc.OrganizationName(), name, acc.ProjectName(), name, name, name, name)
 }
 
 func testAccKafkaTopicCustomTimeoutsResource(name string) string {

--- a/internal/sdkprovider/service/m3db/m3aggregator_test.go
+++ b/internal/sdkprovider/service/m3db/m3aggregator_test.go
@@ -2,7 +2,6 @@ package m3db_test
 
 import (
 	"fmt"
-	"os"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
@@ -28,7 +27,7 @@ func TestAccAiven_m3aggregator(t *testing.T) {
 					testAccCheckAivenServiceM3AggregatorAttributes("data.aiven_m3aggregator.common"),
 					resource.TestCheckResourceAttr(resourceName, "service_name", fmt.Sprintf("test-acc-m3a-%s", rName)),
 					resource.TestCheckResourceAttr(resourceName, "state", "RUNNING"),
-					resource.TestCheckResourceAttr(resourceName, "project", os.Getenv("AIVEN_PROJECT_NAME")),
+					resource.TestCheckResourceAttr(resourceName, "project", acc.ProjectName()),
 					resource.TestCheckResourceAttr(resourceName, "service_type", "m3aggregator"),
 					resource.TestCheckResourceAttr(resourceName, "cloud_name", "google-europe-west1"),
 					resource.TestCheckResourceAttr(resourceName, "maintenance_window_dow", "monday"),
@@ -82,7 +81,7 @@ data "aiven_m3aggregator" "common" {
   project      = aiven_m3aggregator.bar.project
 
   depends_on = [aiven_m3aggregator.bar]
-}`, os.Getenv("AIVEN_PROJECT_NAME"), name, name, name)
+}`, acc.ProjectName(), name, name, name)
 }
 
 func testAccCheckAivenServiceM3AggregatorAttributes(n string) resource.TestCheckFunc {

--- a/internal/sdkprovider/service/m3db/m3db_test.go
+++ b/internal/sdkprovider/service/m3db/m3db_test.go
@@ -222,7 +222,7 @@ resource "aiven_service_integration" "int-m3db-pg" {
 resource "aiven_grafana" "grafana1" {
   project      = data.aiven_project.foo.project
   cloud_name   = "google-europe-west1"
-  plan         = "startup-4"
+  plan         = "startup-1"
   service_name = "test-acc-sr-g-%s"
 
   grafana_user_config {
@@ -298,7 +298,7 @@ resource "aiven_service_integration" "int-m3db-pg" {
 resource "aiven_grafana" "grafana1" {
   project      = data.aiven_project.foo.project
   cloud_name   = "google-europe-west1"
-  plan         = "startup-4"
+  plan         = "startup-1"
   service_name = "test-acc-sr-g-%s"
 
   grafana_user_config {

--- a/internal/sdkprovider/service/m3db/m3db_test.go
+++ b/internal/sdkprovider/service/m3db/m3db_test.go
@@ -2,7 +2,6 @@ package m3db_test
 
 import (
 	"fmt"
-	"os"
 	"regexp"
 	"testing"
 
@@ -161,7 +160,7 @@ resource "aiven_m3db" "bar" {
 					acc.TestAccCheckAivenServiceCommonAttributes("data.aiven_m3db.common"),
 					testAccCheckAivenServiceM3DBAttributes("data.aiven_m3db.common"),
 					resource.TestCheckResourceAttr(resourceName, "service_name", fmt.Sprintf("test-acc-sr-%s", rName)),
-					resource.TestCheckResourceAttr(resourceName, "project", os.Getenv("AIVEN_PROJECT_NAME")),
+					resource.TestCheckResourceAttr(resourceName, "project", acc.ProjectName()),
 					resource.TestCheckResourceAttr(resourceName, "service_type", "m3db"),
 					resource.TestCheckResourceAttr(resourceName, "cloud_name", "google-europe-west1"),
 					resource.TestCheckResourceAttr(resourceName, "maintenance_window_dow", "monday"),
@@ -248,7 +247,7 @@ data "aiven_m3db" "common" {
   project      = aiven_m3db.bar.project
 
   depends_on = [aiven_m3db.bar]
-}`, os.Getenv("AIVEN_PROJECT_NAME"), name, name, name, name)
+}`, acc.ProjectName(), name, name, name, name)
 }
 
 func testAccM3DBDoubleTagResource(name string) string {
@@ -324,7 +323,7 @@ data "aiven_m3db" "common" {
   project      = aiven_m3db.bar.project
 
   depends_on = [aiven_m3db.bar]
-}`, os.Getenv("AIVEN_PROJECT_NAME"), name, name, name, name)
+}`, acc.ProjectName(), name, name, name, name)
 }
 
 func testAccCheckAivenServiceM3DBAttributes(n string) resource.TestCheckFunc {

--- a/internal/sdkprovider/service/m3db/m3db_user_test.go
+++ b/internal/sdkprovider/service/m3db/m3db_user_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"os"
 	"testing"
 
 	"github.com/aiven/aiven-go-client/v2"
@@ -30,7 +29,7 @@ func TestAccAivenM3DBUser_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					schemautil.TestAccCheckAivenServiceUserAttributes("data.aiven_m3db_user.user"),
 					resource.TestCheckResourceAttr(resourceName, "service_name", fmt.Sprintf("test-acc-sr-%s", rName)),
-					resource.TestCheckResourceAttr(resourceName, "project", os.Getenv("AIVEN_PROJECT_NAME")),
+					resource.TestCheckResourceAttr(resourceName, "project", acc.ProjectName()),
 					resource.TestCheckResourceAttr(resourceName, "username", fmt.Sprintf("user-%s", rName)),
 					resource.TestCheckResourceAttr(resourceName, "password", "Test$1234"),
 				),
@@ -104,5 +103,5 @@ data "aiven_m3db_user" "user" {
   service_name = aiven_m3db_user.foo.service_name
   project      = aiven_m3db_user.foo.project
   username     = aiven_m3db_user.foo.username
-}`, os.Getenv("AIVEN_PROJECT_NAME"), name, name, name)
+}`, acc.ProjectName(), name, name, name)
 }

--- a/internal/sdkprovider/service/mysql/mysql_database_test.go
+++ b/internal/sdkprovider/service/mysql/mysql_database_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"os"
 	"strings"
 	"testing"
 
@@ -19,7 +18,7 @@ import (
 
 func TestAccAivenMySQLDatabase_basic(t *testing.T) {
 	resourceName := "aiven_mysql_database.foo"
-	projectName := os.Getenv("AIVEN_PROJECT_NAME")
+	projectName := acc.ProjectName()
 	rName := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
 	rName2 := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
 

--- a/internal/sdkprovider/service/mysql/mysql_test.go
+++ b/internal/sdkprovider/service/mysql/mysql_test.go
@@ -2,7 +2,6 @@ package mysql_test
 
 import (
 	"fmt"
-	"os"
 	"regexp"
 	"testing"
 
@@ -28,7 +27,7 @@ func TestAccAiven_mysql(t *testing.T) {
 					acc.TestAccCheckAivenServiceCommonAttributes("data.aiven_mysql.common"),
 					testAccCheckAivenServiceMysqlAttributes("data.aiven_mysql.common"),
 					resource.TestCheckResourceAttr(resourceName, "service_name", fmt.Sprintf("test-acc-sr-%s", rName)),
-					resource.TestCheckResourceAttr(resourceName, "project", os.Getenv("AIVEN_PROJECT_NAME")),
+					resource.TestCheckResourceAttr(resourceName, "project", acc.ProjectName()),
 					resource.TestCheckResourceAttr(resourceName, "service_type", "mysql"),
 					resource.TestCheckResourceAttr(resourceName, "cloud_name", "google-europe-west1"),
 					resource.TestCheckResourceAttr(resourceName, "maintenance_window_dow", "monday"),
@@ -88,7 +87,7 @@ data "aiven_mysql" "common" {
   project      = aiven_mysql.bar.project
 
   depends_on = [aiven_mysql.bar]
-}`, os.Getenv("AIVEN_PROJECT_NAME"), name)
+}`, acc.ProjectName(), name)
 }
 
 func testAccMysqlDoubleTagResource(name string) string {
@@ -131,7 +130,7 @@ data "aiven_mysql" "common" {
   project      = aiven_mysql.bar.project
 
   depends_on = [aiven_mysql.bar]
-}`, os.Getenv("AIVEN_PROJECT_NAME"), name)
+}`, acc.ProjectName(), name)
 }
 
 // MySQL service tests
@@ -151,7 +150,7 @@ func TestAccAivenService_mysql(t *testing.T) {
 					testAccCheckAivenServiceMysqlAttributes("data.aiven_mysql.common"),
 					resource.TestCheckResourceAttr(resourceName, "service_name", fmt.Sprintf("test-acc-sr-%s", rName)),
 					resource.TestCheckResourceAttr(resourceName, "state", "RUNNING"),
-					resource.TestCheckResourceAttr(resourceName, "project", os.Getenv("AIVEN_PROJECT_NAME")),
+					resource.TestCheckResourceAttr(resourceName, "project", acc.ProjectName()),
 					resource.TestCheckResourceAttr(resourceName, "service_type", "mysql"),
 					resource.TestCheckResourceAttr(resourceName, "cloud_name", "google-europe-west1"),
 					resource.TestCheckResourceAttr(resourceName, "maintenance_window_dow", "monday"),
@@ -195,7 +194,7 @@ data "aiven_mysql" "common" {
   project      = aiven_mysql.bar.project
 
   depends_on = [aiven_mysql.bar]
-}`, os.Getenv("AIVEN_PROJECT_NAME"), name)
+}`, acc.ProjectName(), name)
 }
 
 func testAccCheckAivenServiceMysqlAttributes(n string) resource.TestCheckFunc {

--- a/internal/sdkprovider/service/mysql/mysql_user_test.go
+++ b/internal/sdkprovider/service/mysql/mysql_user_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"os"
 	"testing"
 
 	"github.com/aiven/aiven-go-client/v2"
@@ -30,7 +29,7 @@ func TestAccAivenMySQLUser_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					schemautil.TestAccCheckAivenServiceUserAttributes("data.aiven_mysql_user.user"),
 					resource.TestCheckResourceAttr(resourceName, "service_name", fmt.Sprintf("test-acc-sr-%s", rName)),
-					resource.TestCheckResourceAttr(resourceName, "project", os.Getenv("AIVEN_PROJECT_NAME")),
+					resource.TestCheckResourceAttr(resourceName, "project", acc.ProjectName()),
 					resource.TestCheckResourceAttr(resourceName, "username", fmt.Sprintf("user-%s", rName)),
 					resource.TestCheckResourceAttr(resourceName, "password", "Test$1234"),
 				),
@@ -97,5 +96,5 @@ data "aiven_mysql_user" "user" {
   service_name = aiven_mysql_user.foo.service_name
   project      = aiven_mysql_user.foo.project
   username     = aiven_mysql_user.foo.username
-}`, os.Getenv("AIVEN_PROJECT_NAME"), name, name)
+}`, acc.ProjectName(), name, name)
 }

--- a/internal/sdkprovider/service/opensearch/opensearch_acl_config_test.go
+++ b/internal/sdkprovider/service/opensearch/opensearch_acl_config_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"os"
 	"testing"
 
 	"github.com/aiven/aiven-go-client/v2"
@@ -28,7 +27,7 @@ func TestAccAivenOpenSearchACLConfig_basic(t *testing.T) {
 			{
 				Config: testAccOpenSearchACLConfigResource(rName),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(resourceName, "project", os.Getenv("AIVEN_PROJECT_NAME")),
+					resource.TestCheckResourceAttr(resourceName, "project", acc.ProjectName()),
 					resource.TestCheckResourceAttr(resourceName, "service_name", fmt.Sprintf("test-acc-sr-es-aclconf-%s", rName)),
 					resource.TestCheckResourceAttr(resourceName, "enabled", "true"),
 					resource.TestCheckResourceAttr(resourceName, "extended_acl", "false"),
@@ -64,7 +63,7 @@ resource "aiven_opensearch_acl_config" "foo" {
   service_name = aiven_opensearch.bar.service_name
   enabled      = true
   extended_acl = false
-}`, os.Getenv("AIVEN_PROJECT_NAME"), name, name)
+}`, acc.ProjectName(), name, name)
 }
 
 func testAccCheckAivenOpenSearchACLConfigResourceDestroy(s *terraform.State) error {

--- a/internal/sdkprovider/service/opensearch/opensearch_acl_rule_test.go
+++ b/internal/sdkprovider/service/opensearch/opensearch_acl_rule_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"os"
 	"testing"
 
 	"github.com/aiven/aiven-go-client/v2"
@@ -28,7 +27,7 @@ func TestAccAivenOpenSearchACLRule_basic(t *testing.T) {
 			{
 				Config: testAccOpenSearchACLRuleResource(rName),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(resourceName, "project", os.Getenv("AIVEN_PROJECT_NAME")),
+					resource.TestCheckResourceAttr(resourceName, "project", acc.ProjectName()),
 					resource.TestCheckResourceAttr(resourceName, "service_name", fmt.Sprintf("test-acc-sr-aclrule-%s", rName)),
 					resource.TestCheckResourceAttr(resourceName, "index", "test-index"),
 					resource.TestCheckResourceAttr(resourceName, "username", fmt.Sprintf("user-%s", rName)),
@@ -73,7 +72,7 @@ resource "aiven_opensearch_acl_rule" "foo" {
   username     = aiven_opensearch_user.foo.username
   index        = "test-index"
   permission   = "readwrite"
-}`, os.Getenv("AIVEN_PROJECT_NAME"), name, name)
+}`, acc.ProjectName(), name, name)
 }
 
 func testAccCheckAivenOpenSearchACLRuleResourceDestroy(s *terraform.State) error {

--- a/internal/sdkprovider/service/opensearch/opensearch_security_plugin_config_test.go
+++ b/internal/sdkprovider/service/opensearch/opensearch_security_plugin_config_test.go
@@ -3,7 +3,6 @@ package opensearch_test
 
 import (
 	"fmt"
-	"os"
 	"regexp"
 	"testing"
 
@@ -50,9 +49,9 @@ resource "aiven_opensearch_security_plugin_config" "foo" {
   admin_password = "%s"
 
   depends_on = [aiven_opensearch.bar, aiven_opensearch_user.foo]
-}`, os.Getenv("AIVEN_PROJECT_NAME"), rName, openSearchTestPassword),
+}`, acc.ProjectName(), rName, openSearchTestPassword),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(resourceName, "project", os.Getenv("AIVEN_PROJECT_NAME")),
+					resource.TestCheckResourceAttr(resourceName, "project", acc.ProjectName()),
 					resource.TestCheckResourceAttr(
 						resourceName, "service_name", fmt.Sprintf("test-acc-sr-os-sec-plugin-%s", rName),
 					),
@@ -85,9 +84,9 @@ resource "aiven_opensearch_security_plugin_config" "foo" {
   admin_password = "%s"
 
   depends_on = [aiven_opensearch.bar]
-}`, os.Getenv("AIVEN_PROJECT_NAME"), rName, openSearchTestPassword),
+}`, acc.ProjectName(), rName, openSearchTestPassword),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(resourceName, "project", os.Getenv("AIVEN_PROJECT_NAME")),
+					resource.TestCheckResourceAttr(resourceName, "project", acc.ProjectName()),
 					resource.TestCheckResourceAttr(
 						resourceName, "service_name", fmt.Sprintf("test-acc-sr-os-sec-plugin-%s", rName),
 					),
@@ -126,7 +125,7 @@ resource "aiven_opensearch_security_plugin_config" "foo" {
   admin_password = "%s"
 
   depends_on = [aiven_opensearch.bar, aiven_opensearch_user.foo]
-}`, os.Getenv("AIVEN_PROJECT_NAME"), rName, openSearchTestPassword),
+}`, acc.ProjectName(), rName, openSearchTestPassword),
 				ExpectError: regexp.MustCompile("when the OpenSearch Security Plugin is enabled"),
 			},
 		},

--- a/internal/sdkprovider/service/opensearch/opensearch_test.go
+++ b/internal/sdkprovider/service/opensearch/opensearch_test.go
@@ -267,7 +267,7 @@ func testAccAivenOpenSearchUserUserConfigZeroValues(kv ...string) string {
 resource "aiven_opensearch" "os2" {
   project      = "foo"
   cloud_name   = "google-europe-west1"
-  plan         = "business-4"
+  plan         = "startup-4"
   service_name = "bar"
 
   opensearch_user_config {

--- a/internal/sdkprovider/service/opensearch/opensearch_test.go
+++ b/internal/sdkprovider/service/opensearch/opensearch_test.go
@@ -2,7 +2,6 @@ package opensearch_test
 
 import (
 	"fmt"
-	"os"
 	"regexp"
 	"strings"
 	"testing"
@@ -17,7 +16,7 @@ import (
 // OpenSearch service tests
 func TestAccAivenService_os(t *testing.T) {
 	resourceName := "aiven_opensearch.bar-os"
-	projectName := os.Getenv("AIVEN_PROJECT_NAME")
+	projectName := acc.ProjectName()
 	serviceName := fmt.Sprintf("test-acc-os-%s", acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
 	manifest := fmt.Sprintf(`
 data "aiven_project" "foo-es" {

--- a/internal/sdkprovider/service/opensearch/opensearch_user_test.go
+++ b/internal/sdkprovider/service/opensearch/opensearch_user_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"os"
 	"testing"
 
 	"github.com/aiven/aiven-go-client/v2"
@@ -33,7 +32,7 @@ func TestAccAivenOpenSearchUser_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					schemautil.TestAccCheckAivenServiceUserAttributes("data.aiven_opensearch_user.user"),
 					resource.TestCheckResourceAttr(resourceName, "service_name", fmt.Sprintf("test-acc-sr-%s", rName)),
-					resource.TestCheckResourceAttr(resourceName, "project", os.Getenv("AIVEN_PROJECT_NAME")),
+					resource.TestCheckResourceAttr(resourceName, "project", acc.ProjectName()),
 					resource.TestCheckResourceAttr(resourceName, "username", fmt.Sprintf("user-%s", rName)),
 					resource.TestCheckResourceAttr(resourceName, "password", openSearchTestPassword),
 				),
@@ -100,5 +99,5 @@ data "aiven_opensearch_user" "user" {
   service_name = aiven_opensearch_user.foo.service_name
   project      = aiven_opensearch_user.foo.project
   username     = aiven_opensearch_user.foo.username
-}`, os.Getenv("AIVEN_PROJECT_NAME"), name, openSearchTestPassword)
+}`, acc.ProjectName(), name, openSearchTestPassword)
 }

--- a/internal/sdkprovider/service/organization/organization_application_user_data_source_test.go
+++ b/internal/sdkprovider/service/organization/organization_application_user_data_source_test.go
@@ -2,7 +2,6 @@ package organization_test
 
 import (
 	"fmt"
-	"os"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
@@ -32,7 +31,7 @@ data "aiven_organization_application_user" "foo" {
   organization_id = aiven_organization_application_user.foo.organization_id
   user_id         = aiven_organization_application_user.foo.user_id
 }
-`, os.Getenv("AIVEN_ORGANIZATION_NAME"), suffix),
+`, acc.OrganizationName(), suffix),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(dataUserFoo, "name", "test-acc-org-app-user-"+suffix),
 					resource.TestCheckResourceAttr(dataUserFoo, "is_super_admin", "false"),

--- a/internal/sdkprovider/service/organization/organization_application_user_test.go
+++ b/internal/sdkprovider/service/organization/organization_application_user_test.go
@@ -2,7 +2,6 @@ package organization_test
 
 import (
 	"fmt"
-	"os"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
@@ -28,7 +27,7 @@ resource "aiven_organization_application_user" "bar" {
   name            = "test-acc-bar-%[2]s"
   is_super_admin  = %[3]t
 }
-`, os.Getenv("AIVEN_ORGANIZATION_NAME"), suffix, barAdmin)
+`, acc.OrganizationName(), suffix, barAdmin)
 }
 
 func TestAccOrganizationApplicationUserResource(t *testing.T) {

--- a/internal/sdkprovider/service/organization/organization_application_user_token_test.go
+++ b/internal/sdkprovider/service/organization/organization_application_user_token_test.go
@@ -2,7 +2,6 @@ package organization_test
 
 import (
 	"fmt"
-	"os"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
@@ -11,7 +10,7 @@ import (
 )
 
 func TestAccOrganizationApplicationUserTokenResource(t *testing.T) {
-	org := os.Getenv("AIVEN_ORGANIZATION_NAME")
+	org := acc.OrganizationName()
 
 	tokenFoo := "aiven_organization_application_user_token.foo"
 	tokenBar := "aiven_organization_application_user_token.bar"

--- a/internal/sdkprovider/service/organization/organization_project_test.go
+++ b/internal/sdkprovider/service/organization/organization_project_test.go
@@ -195,7 +195,7 @@ resource "aiven_organization_project" "foo" {
 }
 
 func TestAccAivenOrganizationProjectUpdateStages(t *testing.T) {
-	acc.SkipIfEnvVarsNotSet(t, "PROVIDER_AIVEN_ENABLE_BETA")
+	acc.SkipIfNotBeta(t)
 
 	var (
 		rName = acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
@@ -349,7 +349,7 @@ func testAccCheckAivenOrganizationProjectResourceDestroy(s *terraform.State) err
 				return err
 			}
 
-			return nil //consider project as destroyed if it's not found
+			return nil // consider project as destroyed if it's not found
 		}
 
 		for _, p := range resp.Projects {

--- a/internal/sdkprovider/service/organization/organization_user_list_data_source_test.go
+++ b/internal/sdkprovider/service/organization/organization_user_list_data_source_test.go
@@ -3,7 +3,6 @@ package organization_test
 import (
 	"context"
 	"fmt"
-	"os"
 	"regexp"
 	"testing"
 
@@ -29,7 +28,7 @@ func TestAccAivenOrganizationUserListByName(t *testing.T) {
 		ProtoV6ProviderFactories: acc.TestProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAivenOrganizationUserListByName(os.Getenv("AIVEN_ORGANIZATION_NAME")),
+				Config: testAccAivenOrganizationUserListByName(acc.OrganizationName()),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet(resourceName, "users.#"),
 					resource.TestMatchResourceAttr(resourceName, "users.0.user_info.0.user_email", regexp.MustCompile(`.*@.*`)),
@@ -48,10 +47,11 @@ data "aiven_organization_user_list" "org" {
 }
 
 func TestAccAivenOrganizationUserListByID(t *testing.T) {
+	// Skip test if TF_ACC is not set
+	acc.TestAccPreCheck(t)
+
 	// This test creates Aiven client before running PreCheck part
 	// Runs checks manually
-	_ = acc.CommonTestDependencies(t)
-
 	resourceName := "data.aiven_organization_user_list.org"
 	client, err := acc.GetTestGenAivenClient()
 	require.NoError(t, err)
@@ -59,7 +59,7 @@ func TestAccAivenOrganizationUserListByID(t *testing.T) {
 	id, err := organization.GetOrganizationByName(
 		context.Background(),
 		client,
-		os.Getenv("AIVEN_ORGANIZATION_NAME"),
+		acc.OrganizationName(),
 	)
 	require.NoError(t, err)
 

--- a/internal/sdkprovider/service/pg/pg_database_test.go
+++ b/internal/sdkprovider/service/pg/pg_database_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"os"
 	"strings"
 	"testing"
 
@@ -19,7 +18,7 @@ import (
 
 func TestAccAivenPGDatabase_basic(t *testing.T) {
 	resourceName := "aiven_pg_database.foo"
-	projectName := os.Getenv("AIVEN_PROJECT_NAME")
+	projectName := acc.ProjectName()
 	rName := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
 	rName2 := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
 

--- a/internal/sdkprovider/service/pg/pg_import_test.go
+++ b/internal/sdkprovider/service/pg/pg_import_test.go
@@ -2,7 +2,6 @@ package pg_test
 
 import (
 	"fmt"
-	"os"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
@@ -15,7 +14,7 @@ import (
 
 func TestAccAivenPG_import(t *testing.T) {
 	resourceName := "aiven_pg.main"
-	projectName := os.Getenv("AIVEN_PROJECT_NAME")
+	projectName := acc.ProjectName()
 	rName := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
 
 	resource.ParallelTest(t, resource.TestCase{

--- a/internal/sdkprovider/service/pg/pg_test.go
+++ b/internal/sdkprovider/service/pg/pg_test.go
@@ -3,7 +3,6 @@ package pg_test
 import (
 	"context"
 	"fmt"
-	"os"
 	"regexp"
 	"strings"
 	"testing"
@@ -133,7 +132,7 @@ func TestAccAivenPG_static_ips(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "service_name", fmt.Sprintf("test-acc-sr-%s", rName)),
 					resource.TestCheckResourceAttrSet(resourceName, "state"),
-					resource.TestCheckResourceAttr(resourceName, "project", os.Getenv("AIVEN_PROJECT_NAME")),
+					resource.TestCheckResourceAttr(resourceName, "project", acc.ProjectName()),
 					resource.TestCheckResourceAttr(resourceName, "service_type", "pg"),
 					resource.TestCheckResourceAttr(resourceName, "cloud_name", "google-europe-west1"),
 					resource.TestCheckResourceAttr(resourceName, "maintenance_window_dow", "monday"),
@@ -200,7 +199,7 @@ func TestAccAivenPG_changing_plan(t *testing.T) {
 					testAccCheckAivenServicePGAttributes("data.aiven_pg.common"),
 					resource.TestCheckResourceAttr(resourceName, "service_name", fmt.Sprintf("test-acc-sr-%s", rName)),
 					resource.TestCheckResourceAttrSet(resourceName, "state"),
-					resource.TestCheckResourceAttr(resourceName, "project", os.Getenv("AIVEN_PROJECT_NAME")),
+					resource.TestCheckResourceAttr(resourceName, "project", acc.ProjectName()),
 					resource.TestCheckResourceAttr(resourceName, "service_type", "pg"),
 					resource.TestCheckResourceAttr(resourceName, "cloud_name", "google-europe-west1"),
 					resource.TestCheckResourceAttr(resourceName, "maintenance_window_dow", "monday"),
@@ -215,7 +214,7 @@ func TestAccAivenPG_changing_plan(t *testing.T) {
 					testAccCheckAivenServicePGAttributes("data.aiven_pg.common"),
 					resource.TestCheckResourceAttr(resourceName, "service_name", fmt.Sprintf("test-acc-sr-%s", rName)),
 					resource.TestCheckResourceAttrSet(resourceName, "state"),
-					resource.TestCheckResourceAttr(resourceName, "project", os.Getenv("AIVEN_PROJECT_NAME")),
+					resource.TestCheckResourceAttr(resourceName, "project", acc.ProjectName()),
 					resource.TestCheckResourceAttr(resourceName, "service_type", "pg"),
 					resource.TestCheckResourceAttr(resourceName, "cloud_name", "google-europe-west1"),
 					resource.TestCheckResourceAttr(resourceName, "maintenance_window_dow", "monday"),
@@ -242,7 +241,7 @@ func TestAccAivenPG_deleting_additional_disk_size(t *testing.T) {
 					testAccCheckAivenServicePGAttributes("data.aiven_pg.common"),
 					resource.TestCheckResourceAttr(resourceName, "service_name", fmt.Sprintf("test-acc-sr-%s", rName)),
 					resource.TestCheckResourceAttrSet(resourceName, "state"),
-					resource.TestCheckResourceAttr(resourceName, "project", os.Getenv("AIVEN_PROJECT_NAME")),
+					resource.TestCheckResourceAttr(resourceName, "project", acc.ProjectName()),
 					resource.TestCheckResourceAttr(resourceName, "service_type", "pg"),
 					resource.TestCheckResourceAttr(resourceName, "cloud_name", "google-europe-west1"),
 					resource.TestCheckResourceAttr(resourceName, "maintenance_window_dow", "monday"),
@@ -259,7 +258,7 @@ func TestAccAivenPG_deleting_additional_disk_size(t *testing.T) {
 					testAccCheckAivenServicePGAttributes("data.aiven_pg.common"),
 					resource.TestCheckResourceAttr(resourceName, "service_name", fmt.Sprintf("test-acc-sr-%s", rName)),
 					resource.TestCheckResourceAttrSet(resourceName, "state"),
-					resource.TestCheckResourceAttr(resourceName, "project", os.Getenv("AIVEN_PROJECT_NAME")),
+					resource.TestCheckResourceAttr(resourceName, "project", acc.ProjectName()),
 					resource.TestCheckResourceAttr(resourceName, "service_type", "pg"),
 					resource.TestCheckResourceAttr(resourceName, "cloud_name", "google-europe-west1"),
 					resource.TestCheckResourceAttr(resourceName, "maintenance_window_dow", "monday"),
@@ -287,7 +286,7 @@ func TestAccAivenPG_deleting_disk_size(t *testing.T) {
 					testAccCheckAivenServicePGAttributes("data.aiven_pg.common"),
 					resource.TestCheckResourceAttr(resourceName, "service_name", fmt.Sprintf("test-acc-sr-%s", rName)),
 					resource.TestCheckResourceAttrSet(resourceName, "state"),
-					resource.TestCheckResourceAttr(resourceName, "project", os.Getenv("AIVEN_PROJECT_NAME")),
+					resource.TestCheckResourceAttr(resourceName, "project", acc.ProjectName()),
 					resource.TestCheckResourceAttr(resourceName, "service_type", "pg"),
 					resource.TestCheckResourceAttr(resourceName, "cloud_name", "google-europe-west1"),
 					resource.TestCheckResourceAttr(resourceName, "maintenance_window_dow", "monday"),
@@ -303,7 +302,7 @@ func TestAccAivenPG_deleting_disk_size(t *testing.T) {
 					testAccCheckAivenServicePGAttributes("data.aiven_pg.common"),
 					resource.TestCheckResourceAttr(resourceName, "service_name", fmt.Sprintf("test-acc-sr-%s", rName)),
 					resource.TestCheckResourceAttrSet(resourceName, "state"),
-					resource.TestCheckResourceAttr(resourceName, "project", os.Getenv("AIVEN_PROJECT_NAME")),
+					resource.TestCheckResourceAttr(resourceName, "project", acc.ProjectName()),
 					resource.TestCheckResourceAttr(resourceName, "service_type", "pg"),
 					resource.TestCheckResourceAttr(resourceName, "cloud_name", "google-europe-west1"),
 					resource.TestCheckResourceAttr(resourceName, "maintenance_window_dow", "monday"),
@@ -331,7 +330,7 @@ func TestAccAivenPG_changing_disk_size(t *testing.T) {
 					testAccCheckAivenServicePGAttributes("data.aiven_pg.common"),
 					resource.TestCheckResourceAttr(resourceName, "service_name", fmt.Sprintf("test-acc-sr-%s", rName)),
 					resource.TestCheckResourceAttrSet(resourceName, "state"),
-					resource.TestCheckResourceAttr(resourceName, "project", os.Getenv("AIVEN_PROJECT_NAME")),
+					resource.TestCheckResourceAttr(resourceName, "project", acc.ProjectName()),
 					resource.TestCheckResourceAttr(resourceName, "service_type", "pg"),
 					resource.TestCheckResourceAttr(resourceName, "cloud_name", "google-europe-west1"),
 					resource.TestCheckResourceAttr(resourceName, "maintenance_window_dow", "monday"),
@@ -347,7 +346,7 @@ func TestAccAivenPG_changing_disk_size(t *testing.T) {
 					testAccCheckAivenServicePGAttributes("data.aiven_pg.common"),
 					resource.TestCheckResourceAttr(resourceName, "service_name", fmt.Sprintf("test-acc-sr-%s", rName)),
 					resource.TestCheckResourceAttrSet(resourceName, "state"),
-					resource.TestCheckResourceAttr(resourceName, "project", os.Getenv("AIVEN_PROJECT_NAME")),
+					resource.TestCheckResourceAttr(resourceName, "project", acc.ProjectName()),
 					resource.TestCheckResourceAttr(resourceName, "service_type", "pg"),
 					resource.TestCheckResourceAttr(resourceName, "cloud_name", "google-europe-west1"),
 					resource.TestCheckResourceAttr(resourceName, "maintenance_window_dow", "monday"),
@@ -392,7 +391,7 @@ data "aiven_pg" "common" {
   project      = aiven_pg.bar.project
 
   depends_on = [aiven_pg.bar]
-}`, os.Getenv("AIVEN_PROJECT_NAME"), count, name)
+}`, acc.ProjectName(), count, name)
 }
 
 func testAccPGResourceWithDiskSize(name, diskSize string) string {
@@ -428,7 +427,7 @@ data "aiven_pg" "common" {
   project      = aiven_pg.bar.project
 
   depends_on = [aiven_pg.bar]
-}`, os.Getenv("AIVEN_PROJECT_NAME"), name, diskSize)
+}`, acc.ProjectName(), name, diskSize)
 }
 
 func testAccPGResourceWithAdditionalDiskSize(name, diskSize string) string {
@@ -464,7 +463,7 @@ data "aiven_pg" "common" {
   project      = aiven_pg.bar.project
 
   depends_on = [aiven_pg.bar]
-}`, os.Getenv("AIVEN_PROJECT_NAME"), name, diskSize)
+}`, acc.ProjectName(), name, diskSize)
 }
 
 func testAccPGResourceWithoutDiskSize(name string) string {
@@ -504,7 +503,7 @@ data "aiven_pg" "common" {
   project      = aiven_pg.bar.project
 
   depends_on = [aiven_pg.bar]
-}`, os.Getenv("AIVEN_PROJECT_NAME"), name)
+}`, acc.ProjectName(), name)
 }
 
 func testAccPGResourcePlanChange(name, plan string) string {
@@ -544,7 +543,7 @@ data "aiven_pg" "common" {
   project      = aiven_pg.bar.project
 
   depends_on = [aiven_pg.bar]
-}`, os.Getenv("AIVEN_PROJECT_NAME"), plan, name)
+}`, acc.ProjectName(), plan, name)
 }
 
 func testAccPGDoubleTagResource(name string) string {
@@ -588,7 +587,7 @@ data "aiven_pg" "common" {
   project      = aiven_pg.bar.project
 
   depends_on = [aiven_pg.bar]
-}`, os.Getenv("AIVEN_PROJECT_NAME"), name)
+}`, acc.ProjectName(), name)
 }
 
 func testAccPGProjectDoesntExist() string {
@@ -609,7 +608,7 @@ resource "aiven_pg" "bar" {
 func TestAccAivenPG_admin_creds(t *testing.T) {
 	resourceName := "aiven_pg.pg"
 	prefix := "test-tf-acc-" + acctest.RandString(7)
-	project := os.Getenv("AIVEN_PROJECT_NAME")
+	project := acc.ProjectName()
 	expectedURLPrefix := fmt.Sprintf("postgres://root:%s-password", prefix)
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acc.TestAccPreCheck(t) },
@@ -665,7 +664,7 @@ func TestAccAivenServicePG_basic(t *testing.T) {
 					acc.TestAccCheckAivenServiceCommonAttributes("data.aiven_pg.common-pg"),
 					testAccCheckAivenServicePGAttributes("data.aiven_pg.common-pg"),
 					resource.TestCheckResourceAttr(resourceName, "service_name", fmt.Sprintf("test-acc-sr-%s", rName)),
-					resource.TestCheckResourceAttr(resourceName, "project", os.Getenv("AIVEN_PROJECT_NAME")),
+					resource.TestCheckResourceAttr(resourceName, "project", acc.ProjectName()),
 					resource.TestCheckResourceAttr(resourceName, "cloud_name", "google-europe-west1"),
 					resource.TestCheckResourceAttr(resourceName, "maintenance_window_dow", "monday"),
 					resource.TestCheckResourceAttr(resourceName, "maintenance_window_time", "10:00:00"),
@@ -692,7 +691,7 @@ func TestAccAivenServicePG_termination_protection(t *testing.T) {
 					acc.TestAccCheckAivenServiceCommonAttributes("data.aiven_pg.common-pg"),
 					testAccCheckAivenServicePGAttributes("data.aiven_pg.common-pg"),
 					resource.TestCheckResourceAttr(resourceName, "service_name", fmt.Sprintf("test-acc-sr-%s", rName)),
-					resource.TestCheckResourceAttr(resourceName, "project", os.Getenv("AIVEN_PROJECT_NAME")),
+					resource.TestCheckResourceAttr(resourceName, "project", acc.ProjectName()),
 					resource.TestCheckResourceAttr(resourceName, "cloud_name", "google-europe-west1"),
 					resource.TestCheckResourceAttr(resourceName, "maintenance_window_dow", "monday"),
 					resource.TestCheckResourceAttr(resourceName, "maintenance_window_time", "10:00:00"),
@@ -720,7 +719,7 @@ func TestAccAivenServicePG_read_replica(t *testing.T) {
 					acc.TestAccCheckAivenServiceCommonAttributes("data.aiven_pg.common-pg"),
 					testAccCheckAivenServicePGAttributes("data.aiven_pg.common-pg"),
 					resource.TestCheckResourceAttr(resourceName, "service_name", fmt.Sprintf("test-acc-sr-%s", rName)),
-					resource.TestCheckResourceAttr(resourceName, "project", os.Getenv("AIVEN_PROJECT_NAME")),
+					resource.TestCheckResourceAttr(resourceName, "project", acc.ProjectName()),
 					resource.TestCheckResourceAttr(resourceName, "cloud_name", "google-europe-west1"),
 					resource.TestCheckResourceAttr(resourceName, "maintenance_window_dow", "monday"),
 					resource.TestCheckResourceAttr(resourceName, "maintenance_window_time", "10:00:00"),
@@ -746,7 +745,7 @@ func TestAccAivenServicePG_custom_timeouts(t *testing.T) {
 					acc.TestAccCheckAivenServiceCommonAttributes("data.aiven_pg.common-pg"),
 					testAccCheckAivenServicePGAttributes("data.aiven_pg.common-pg"),
 					resource.TestCheckResourceAttr(resourceName, "service_name", fmt.Sprintf("test-acc-sr-%s", rName)),
-					resource.TestCheckResourceAttr(resourceName, "project", os.Getenv("AIVEN_PROJECT_NAME")),
+					resource.TestCheckResourceAttr(resourceName, "project", acc.ProjectName()),
 					resource.TestCheckResourceAttr(resourceName, "cloud_name", "google-europe-west1"),
 					resource.TestCheckResourceAttr(resourceName, "maintenance_window_dow", "monday"),
 					resource.TestCheckResourceAttr(resourceName, "maintenance_window_time", "10:00:00"),
@@ -789,7 +788,7 @@ data "aiven_pg" "common-pg" {
   project      = aiven_pg.bar-pg.project
 
   depends_on = [aiven_pg.bar-pg]
-}`, os.Getenv("AIVEN_PROJECT_NAME"), name)
+}`, acc.ProjectName(), name)
 }
 
 func testAccPGServiceCustomTimeoutsResource(name string) string {
@@ -828,7 +827,7 @@ data "aiven_pg" "common-pg" {
   project      = aiven_pg.bar-pg.project
 
   depends_on = [aiven_pg.bar-pg]
-}`, os.Getenv("AIVEN_PROJECT_NAME"), name)
+}`, acc.ProjectName(), name)
 }
 
 func testAccPGTerminationProtectionServiceResource(name string) string {
@@ -863,7 +862,7 @@ data "aiven_pg" "common-pg" {
   project      = aiven_pg.bar-pg.project
 
   depends_on = [aiven_pg.bar-pg]
-}`, os.Getenv("AIVEN_PROJECT_NAME"), name)
+}`, acc.ProjectName(), name)
 }
 
 func testAccPGReadReplicaServiceResource(name string) string {
@@ -935,7 +934,7 @@ data "aiven_pg" "common-pg" {
   project      = aiven_pg.bar-pg.project
 
   depends_on = [aiven_pg.bar-pg]
-}`, os.Getenv("AIVEN_PROJECT_NAME"), name, name)
+}`, acc.ProjectName(), name, name)
 }
 
 func testAccCheckAivenServiceTerminationProtection(n string) resource.TestCheckFunc {
@@ -983,7 +982,6 @@ func testAccCheckAivenServiceTerminationProtection(n string) resource.TestCheckF
 				UserConfig:            service.UserConfig,
 			},
 		)
-
 		if err != nil {
 			return fmt.Errorf("unable to update Aiven service to set termination_protection=false err: %w", err)
 		}
@@ -1092,7 +1090,7 @@ func testAccCheckAivenServicePGAttributes(n string) resource.TestCheckFunc {
 func TestAccAivenServicePG_disaster_recovery(t *testing.T) {
 	primaryName := "aiven_pg.primary"
 	secondaryName := "aiven_pg.secondary"
-	projectName := os.Getenv("AIVEN_PROJECT_NAME")
+	projectName := acc.ProjectName()
 	randStr := acc.RandStr()
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acc.TestAccPreCheck(t) },
@@ -1145,7 +1143,7 @@ resource "aiven_pg" "secondary" {
 }
 
 func TestAccAivenServicePG_user_config_zero_values(t *testing.T) {
-	projectName := os.Getenv("AIVEN_PROJECT_NAME")
+	projectName := acc.ProjectName()
 	serviceName := "test-acc-" + acc.RandStr()
 	resourceName := "aiven_pg.foo"
 	resource.ParallelTest(t, resource.TestCase{

--- a/internal/sdkprovider/service/pg/pg_user_test.go
+++ b/internal/sdkprovider/service/pg/pg_user_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"os"
 	"testing"
 
 	"github.com/aiven/aiven-go-client/v2"
@@ -19,7 +18,7 @@ import (
 
 func TestAccAivenPGUser_basic(t *testing.T) {
 	resourceName := "aiven_pg_user.foo.0" // checking the first user only
-	projectName := os.Getenv("AIVEN_PROJECT_NAME")
+	projectName := acc.ProjectName()
 	serviceName := "test-acc-sr-" + acc.RandStr()
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acc.TestAccPreCheck(t) },
@@ -77,7 +76,7 @@ func TestAccAivenPGUser_pg_no_password(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					schemautil.TestAccCheckAivenServiceUserAttributes("data.aiven_pg_user.user"),
 					resource.TestCheckResourceAttr(resourceName, "service_name", fmt.Sprintf("test-acc-sr-%s", rName)),
-					resource.TestCheckResourceAttr(resourceName, "project", os.Getenv("AIVEN_PROJECT_NAME")),
+					resource.TestCheckResourceAttr(resourceName, "project", acc.ProjectName()),
 					resource.TestCheckResourceAttr(resourceName, "username", fmt.Sprintf("user-%s", rName)),
 				),
 			},
@@ -99,7 +98,7 @@ func TestAccAivenPGUser_pg_replica(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					schemautil.TestAccCheckAivenServiceUserAttributes("data.aiven_pg_user.user"),
 					resource.TestCheckResourceAttr(resourceName, "service_name", fmt.Sprintf("test-acc-sr-%s", rName)),
-					resource.TestCheckResourceAttr(resourceName, "project", os.Getenv("AIVEN_PROJECT_NAME")),
+					resource.TestCheckResourceAttr(resourceName, "project", acc.ProjectName()),
 					resource.TestCheckResourceAttr(resourceName, "username", fmt.Sprintf("user-%s", rName)),
 					resource.TestCheckResourceAttr(resourceName, "password", "Test$1234"),
 					resource.TestCheckResourceAttr(resourceName, "pg_allow_replication", "true"),
@@ -110,7 +109,7 @@ func TestAccAivenPGUser_pg_replica(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					schemautil.TestAccCheckAivenServiceUserAttributes("data.aiven_pg_user.user"),
 					resource.TestCheckResourceAttr(resourceName, "service_name", fmt.Sprintf("test-acc-sr-%s", rName)),
-					resource.TestCheckResourceAttr(resourceName, "project", os.Getenv("AIVEN_PROJECT_NAME")),
+					resource.TestCheckResourceAttr(resourceName, "project", acc.ProjectName()),
 					resource.TestCheckResourceAttr(resourceName, "username", fmt.Sprintf("user-%s", rName)),
 					resource.TestCheckResourceAttr(resourceName, "password", "Test$1234"),
 					resource.TestCheckResourceAttr(resourceName, "pg_allow_replication", "false"),
@@ -121,7 +120,7 @@ func TestAccAivenPGUser_pg_replica(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					schemautil.TestAccCheckAivenServiceUserAttributes("data.aiven_pg_user.user"),
 					resource.TestCheckResourceAttr(resourceName, "service_name", fmt.Sprintf("test-acc-sr-%s", rName)),
-					resource.TestCheckResourceAttr(resourceName, "project", os.Getenv("AIVEN_PROJECT_NAME")),
+					resource.TestCheckResourceAttr(resourceName, "project", acc.ProjectName()),
 					resource.TestCheckResourceAttr(resourceName, "username", fmt.Sprintf("user-%s", rName)),
 					resource.TestCheckResourceAttr(resourceName, "password", "Test$1234"),
 					resource.TestCheckResourceAttr(resourceName, "pg_allow_replication", "true"),
@@ -192,7 +191,7 @@ data "aiven_pg_user" "user" {
   username     = aiven_pg_user.foo.username
 
   depends_on = [aiven_pg_user.foo]
-}`, os.Getenv("AIVEN_PROJECT_NAME"), name, name)
+}`, acc.ProjectName(), name, name)
 }
 
 func testAccPGUserPgReplicationDisableResource(name string) string {
@@ -224,7 +223,7 @@ data "aiven_pg_user" "user" {
   username     = aiven_pg_user.foo.username
 
   depends_on = [aiven_pg_user.foo]
-}`, os.Getenv("AIVEN_PROJECT_NAME"), name, name)
+}`, acc.ProjectName(), name, name)
 }
 
 func testAccPGUserPgReplicationEnableResource(name string) string {
@@ -256,7 +255,7 @@ data "aiven_pg_user" "user" {
   username     = aiven_pg_user.foo.username
 
   depends_on = [aiven_pg_user.foo]
-}`, os.Getenv("AIVEN_PROJECT_NAME"), name, name)
+}`, acc.ProjectName(), name, name)
 }
 
 // testAccPGUserNewPasswordResource creates 100 users to test bulk creation
@@ -327,5 +326,5 @@ data "aiven_pg_user" "user" {
   username     = aiven_pg_user.foo.username
 
   depends_on = [aiven_pg_user.foo]
-}`, os.Getenv("AIVEN_PROJECT_NAME"), name, name)
+}`, acc.ProjectName(), name, name)
 }

--- a/internal/sdkprovider/service/redis/redis_test.go
+++ b/internal/sdkprovider/service/redis/redis_test.go
@@ -2,7 +2,6 @@ package redis_test
 
 import (
 	"fmt"
-	"os"
 	"regexp"
 	"testing"
 
@@ -36,7 +35,7 @@ func TestAccAiven_redis(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "tech_emails.0.email", "techsupport@company.com"),
 					resource.TestCheckResourceAttr(resourceName, "service_name", fmt.Sprintf("test-acc-sr-%s", rName)),
 					resource.TestCheckResourceAttr(resourceName, "state", "RUNNING"),
-					resource.TestCheckResourceAttr(resourceName, "project", os.Getenv("AIVEN_PROJECT_NAME")),
+					resource.TestCheckResourceAttr(resourceName, "project", acc.ProjectName()),
 					resource.TestCheckResourceAttr(resourceName, "service_type", "redis"),
 					resource.TestCheckResourceAttr(resourceName, "cloud_name", "google-europe-west1"),
 					resource.TestCheckResourceAttr(resourceName, "maintenance_window_dow", "monday"),
@@ -65,7 +64,7 @@ func TestAccAiven_redis(t *testing.T) {
 					acc.TestAccCheckAivenServiceCommonAttributes("data.aiven_redis.common"),
 					testAccCheckAivenServiceRedisAttributes("data.aiven_redis.common"),
 					resource.TestCheckResourceAttr(resourceName, "service_name", fmt.Sprintf("test-acc-sr-%s", rName)),
-					resource.TestCheckResourceAttr(resourceName, "project", os.Getenv("AIVEN_PROJECT_NAME")),
+					resource.TestCheckResourceAttr(resourceName, "project", acc.ProjectName()),
 					resource.TestCheckResourceAttr(resourceName, "service_type", "redis"),
 					resource.TestCheckResourceAttr(resourceName, "cloud_name", "google-europe-west1"),
 					resource.TestCheckResourceAttr(resourceName, "maintenance_window_dow", "monday"),
@@ -121,7 +120,7 @@ data "aiven_redis" "common" {
   project      = data.aiven_project.foo.project
 
   depends_on = [aiven_redis.bar]
-}`, os.Getenv("AIVEN_PROJECT_NAME"), name)
+}`, acc.ProjectName(), name)
 }
 
 func testAccRedisRemoveEmailsResource(name string) string {
@@ -157,7 +156,7 @@ data "aiven_redis" "common" {
   project      = data.aiven_project.foo.project
 
   depends_on = [aiven_redis.bar]
-}`, os.Getenv("AIVEN_PROJECT_NAME"), name)
+}`, acc.ProjectName(), name)
 }
 
 func testAccRedisServiceResourceWithPersistenceOff(name string) string {
@@ -189,7 +188,7 @@ data "aiven_redis" "common" {
   project      = aiven_redis.bar.project
 
   depends_on = [aiven_redis.bar]
-}`, os.Getenv("AIVEN_PROJECT_NAME"), name)
+}`, acc.ProjectName(), name)
 }
 
 func testAccRedisDoubleTagResource(name string) string {
@@ -229,7 +228,7 @@ data "aiven_redis" "common" {
   project      = data.aiven_project.foo.project
 
   depends_on = [aiven_redis.bar]
-}`, os.Getenv("AIVEN_PROJECT_NAME"), name)
+}`, acc.ProjectName(), name)
 }
 
 func testAccCheckAivenServiceRedisAttributes(n string) resource.TestCheckFunc {

--- a/internal/sdkprovider/service/redis/redis_user_test.go
+++ b/internal/sdkprovider/service/redis/redis_user_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"os"
 	"testing"
 
 	"github.com/aiven/aiven-go-client/v2"
@@ -32,7 +31,7 @@ func TestAccAivenRedisUser_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					schemautil.TestAccCheckAivenServiceUserAttributes("data.aiven_redis_user.user"),
 					resource.TestCheckResourceAttr(resourceName, "service_name", fmt.Sprintf("test-acc-sr-%s", rName)),
-					resource.TestCheckResourceAttr(resourceName, "project", os.Getenv("AIVEN_PROJECT_NAME")),
+					resource.TestCheckResourceAttr(resourceName, "project", acc.ProjectName()),
 					resource.TestCheckResourceAttr(resourceName, "username", fmt.Sprintf("user-%s", rName)),
 				),
 			},
@@ -105,5 +104,5 @@ data "aiven_redis_user" "user" {
   username     = aiven_redis_user.foo.username
 
   depends_on = [aiven_redis_user.foo]
-}`, os.Getenv("AIVEN_PROJECT_NAME"), name, name)
+}`, acc.ProjectName(), name, name)
 }

--- a/internal/sdkprovider/service/servicecomponent/service_component_data_source_test.go
+++ b/internal/sdkprovider/service/servicecomponent/service_component_data_source_test.go
@@ -170,7 +170,7 @@ data "aiven_project" "foo" {
 resource "aiven_kafka" "bar" {
   project                 = data.aiven_project.foo.project
   cloud_name              = "google-europe-west1"
-  plan                    = "business-4"
+  plan                    = "startup-2"
   service_name            = "test-acc-sr-%s"
   maintenance_window_dow  = "monday"
   maintenance_window_time = "10:00:00"

--- a/internal/sdkprovider/service/servicecomponent/service_component_data_source_test.go
+++ b/internal/sdkprovider/service/servicecomponent/service_component_data_source_test.go
@@ -3,7 +3,6 @@ package servicecomponent_test
 import (
 	"errors"
 	"fmt"
-	"os"
 	"regexp"
 	"testing"
 
@@ -52,7 +51,7 @@ func testAccServiceComponentAttributes(n, component, route string) resource.Test
 		r := s.RootModule().Resources[n]
 		a := r.Primary.Attributes
 
-		if a["project"] != os.Getenv("AIVEN_PROJECT_NAME") {
+		if a["project"] != acc.ProjectName() {
 			return errors.New("expected to get a corect project name from Aiven got: " + a["project"])
 		}
 
@@ -159,7 +158,7 @@ data "aiven_service_component" "schema_registry" {
   route        = "dynamic"
 
   depends_on = [aiven_kafka.bar]
-}`, os.Getenv("AIVEN_PROJECT_NAME"), name)
+}`, acc.ProjectName(), name)
 }
 
 func testAccServiceComponentKafkaAuthMethodNotMatchErrorMessages(name string) string {
@@ -191,5 +190,5 @@ data "aiven_service_component" "kafka" {
   kafka_authentication_method = "sasl"
 
   depends_on = [aiven_kafka.bar]
-}`, os.Getenv("AIVEN_PROJECT_NAME"), name)
+}`, acc.ProjectName(), name)
 }

--- a/internal/sdkprovider/service/serviceintegration/service_integration_endpoint_test.go
+++ b/internal/sdkprovider/service/serviceintegration/service_integration_endpoint_test.go
@@ -3,7 +3,6 @@ package serviceintegration_test
 import (
 	"context"
 	"fmt"
-	"os"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
@@ -28,7 +27,7 @@ func TestAccAivenServiceIntegrationEndpoint_basic(t *testing.T) {
 				Config: testAccServiceIntegrationEndpointBasicResource(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAivenServiceEndpointIntegrationAttributes("data.aiven_service_integration_endpoint.endpoint"),
-					resource.TestCheckResourceAttr(resourceName, "project", os.Getenv("AIVEN_PROJECT_NAME")),
+					resource.TestCheckResourceAttr(resourceName, "project", acc.ProjectName()),
 					resource.TestCheckResourceAttr(resourceName, "endpoint_name", fmt.Sprintf("test-acc-ie-%s", rName)),
 					resource.TestCheckResourceAttr(resourceName, "endpoint_type", "external_opensearch_logs"),
 				),
@@ -52,7 +51,7 @@ func TestAccAivenServiceIntegrationEndpoint_username_password(t *testing.T) {
 					testAccCheckAivenServiceEndpointIntegrationAttributes(
 						"data.aiven_service_integration_endpoint.endpoint",
 					),
-					resource.TestCheckResourceAttr(resourceName, "project", os.Getenv("AIVEN_PROJECT_NAME")),
+					resource.TestCheckResourceAttr(resourceName, "project", acc.ProjectName()),
 					resource.TestCheckResourceAttr(
 						resourceName, "endpoint_name", fmt.Sprintf("test-acc-ie-%s", rName),
 					),
@@ -67,7 +66,7 @@ func TestAccAivenServiceIntegrationEndpoint_username_password(t *testing.T) {
 					testAccCheckAivenServiceEndpointIntegrationAttributes(
 						"data.aiven_service_integration_endpoint.endpoint",
 					),
-					resource.TestCheckResourceAttr(resourceName, "project", os.Getenv("AIVEN_PROJECT_NAME")),
+					resource.TestCheckResourceAttr(resourceName, "project", acc.ProjectName()),
 					resource.TestCheckResourceAttr(
 						resourceName, "endpoint_name", fmt.Sprintf("test-acc-ie-%s", rName),
 					),
@@ -131,7 +130,7 @@ data "aiven_service_integration_endpoint" "endpoint" {
   endpoint_name = aiven_service_integration_endpoint.bar.endpoint_name
 
   depends_on = [aiven_service_integration_endpoint.bar]
-}`, os.Getenv("AIVEN_PROJECT_NAME"), name, name, name)
+}`, acc.ProjectName(), name, name, name)
 }
 
 func testAccServiceIntegrationEndpointUsernamePasswordResource(name string) string {
@@ -179,7 +178,7 @@ data "aiven_service_integration_endpoint" "endpoint" {
   endpoint_name = aiven_service_integration_endpoint.bar.endpoint_name
 
   depends_on = [aiven_service_integration_endpoint.bar]
-}`, os.Getenv("AIVEN_PROJECT_NAME"), name)
+}`, acc.ProjectName(), name)
 }
 
 func testAccServiceIntegrationEndpointUpdatePasswordResource(name string) string {
@@ -227,7 +226,7 @@ data "aiven_service_integration_endpoint" "endpoint" {
   endpoint_name = aiven_service_integration_endpoint.bar.endpoint_name
 
   depends_on = [aiven_service_integration_endpoint.bar]
-}`, os.Getenv("AIVEN_PROJECT_NAME"), name)
+}`, acc.ProjectName(), name)
 }
 
 func testAccCheckAivenServiceIntegraitonEndpointResourceDestroy(s *terraform.State) error {
@@ -292,7 +291,7 @@ func TestAccAivenServiceIntegrationEndpointExternalPostgresql(t *testing.T) {
 				Config: testAccAivenServiceIntegrationEndpointExternalPostgresql(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAivenServiceEndpointIntegrationAttributes(resourceName),
-					resource.TestCheckResourceAttr(resourceName, "project", os.Getenv("AIVEN_PROJECT_NAME")),
+					resource.TestCheckResourceAttr(resourceName, "project", acc.ProjectName()),
 					resource.TestCheckResourceAttr(resourceName, "endpoint_type", "external_postgresql"),
 					resource.TestCheckResourceAttr(resourceName, "external_postgresql.0.port", "1234"),
 					resource.TestCheckResourceAttr(resourceName, "external_postgresql.0.ssl_mode", "require"),
@@ -325,5 +324,5 @@ resource "aiven_service_integration_endpoint" "pg" {
     ssl_mode = "require"
   }
 }
-`, os.Getenv("AIVEN_PROJECT_NAME"), name, name)
+`, acc.ProjectName(), name, name)
 }

--- a/internal/sdkprovider/service/serviceintegration/service_integration_test.go
+++ b/internal/sdkprovider/service/serviceintegration/service_integration_test.go
@@ -867,7 +867,7 @@ resource "aiven_thanos" "thanos" {
 resource "aiven_kafka" "kafka_service" {
   project                 = data.aiven_project.services.project
   cloud_name              = "google-europe-west1"
-  plan                    = "business-4"
+  plan                    = "startup-2"
   service_name            = "test-acc-kafka-%[3]s"
   maintenance_window_dow  = "sunday"
   maintenance_window_time = "10:00:00"

--- a/internal/sdkprovider/service/serviceintegration/service_integration_test.go
+++ b/internal/sdkprovider/service/serviceintegration/service_integration_test.go
@@ -44,7 +44,7 @@ func TestAccAivenServiceIntegration_preexisting_read_replica(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAivenServiceIntegrationAttributes("data.aiven_service_integration.int"),
 					resource.TestCheckResourceAttr(resourceName, "integration_type", "read_replica"),
-					resource.TestCheckResourceAttr(resourceName, "project", os.Getenv("AIVEN_PROJECT_NAME")),
+					resource.TestCheckResourceAttr(resourceName, "project", acc.ProjectName()),
 					resource.TestCheckResourceAttr(resourceName, "source_service_name", fmt.Sprintf("test-acc-sr-source-pg-%s", rName)),
 					resource.TestCheckResourceAttr(resourceName, "destination_service_name", fmt.Sprintf("test-acc-sr-sink-pg-%s", rName)),
 				),
@@ -66,7 +66,7 @@ func TestAccAivenServiceIntegration_logs(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAivenServiceIntegrationAttributes("data.aiven_service_integration.int"),
 					resource.TestCheckResourceAttr(resourceName, "integration_type", "logs"),
-					resource.TestCheckResourceAttr(resourceName, "project", os.Getenv("AIVEN_PROJECT_NAME")),
+					resource.TestCheckResourceAttr(resourceName, "project", acc.ProjectName()),
 					resource.TestCheckResourceAttr(resourceName, "source_service_name", fmt.Sprintf("test-acc-sr-source-pg-%s", rName)),
 					resource.TestCheckResourceAttr(resourceName, "destination_service_name", fmt.Sprintf("test-acc-sr-sink-os-%s", rName)),
 				),
@@ -87,7 +87,7 @@ func TestAccAivenServiceIntegration_mm(t *testing.T) {
 				Config: testAccServiceIntegrationMirrorMakerResource(rName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "integration_type", "kafka_mirrormaker"),
-					resource.TestCheckResourceAttr(resourceName, "project", os.Getenv("AIVEN_PROJECT_NAME")),
+					resource.TestCheckResourceAttr(resourceName, "project", acc.ProjectName()),
 					resource.TestCheckResourceAttr(resourceName, "source_service_name", fmt.Sprintf("test-acc-sr-source-%s", rName)),
 					resource.TestCheckResourceAttr(resourceName, "destination_service_name", fmt.Sprintf("test-acc-sr-mm-%s", rName)),
 				),
@@ -109,7 +109,7 @@ func TestAccAivenServiceIntegration_kafka_connect(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAivenServiceIntegrationAttributes("data.aiven_service_integration.int"),
 					resource.TestCheckResourceAttr(resourceName, "integration_type", "kafka_connect"),
-					resource.TestCheckResourceAttr(resourceName, "project", os.Getenv("AIVEN_PROJECT_NAME")),
+					resource.TestCheckResourceAttr(resourceName, "project", acc.ProjectName()),
 					resource.TestCheckResourceAttr(resourceName, "source_service_name", fmt.Sprintf("test-acc-sr-kafka-%s", rName)),
 					resource.TestCheckResourceAttr(resourceName, "destination_service_name", fmt.Sprintf("test-acc-sr-kafka-con-%s", rName)),
 				),
@@ -131,7 +131,7 @@ func TestAccAivenServiceIntegration_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAivenServiceIntegrationAttributes("data.aiven_service_integration.int"),
 					resource.TestCheckResourceAttr(resourceName, "integration_type", "metrics"),
-					resource.TestCheckResourceAttr(resourceName, "project", os.Getenv("AIVEN_PROJECT_NAME")),
+					resource.TestCheckResourceAttr(resourceName, "project", acc.ProjectName()),
 					resource.TestCheckResourceAttr(resourceName, "source_service_name", fmt.Sprintf("test-acc-sr-pg-%s", rName)),
 					resource.TestCheckResourceAttr(resourceName, "destination_service_name", fmt.Sprintf("test-acc-sr-influxdb-%s", rName)),
 				),
@@ -197,7 +197,7 @@ data "aiven_service_integration" "int" {
   destination_service_name = aiven_service_integration.bar.destination_service_name
 
   depends_on = [aiven_service_integration.bar]
-}`, os.Getenv("AIVEN_PROJECT_NAME"), name, name)
+}`, acc.ProjectName(), name, name)
 }
 
 func testAccServiceIntegrationKafkaConnectResource(name string) string {
@@ -256,7 +256,7 @@ data "aiven_service_integration" "int" {
   destination_service_name = aiven_service_integration.bar.destination_service_name
 
   depends_on = [aiven_service_integration.bar]
-}`, os.Getenv("AIVEN_PROJECT_NAME"), name, name)
+}`, acc.ProjectName(), name, name)
 }
 
 func testAccServiceIntegrationMirrorMakerResource(name string) string {
@@ -350,7 +350,7 @@ resource "aiven_service_integration" "i2" {
   kafka_mirrormaker_user_config {
     cluster_alias = "target"
   }
-}`, os.Getenv("AIVEN_PROJECT_NAME"), name, name, name, name, name)
+}`, acc.ProjectName(), name, name, name, name, name)
 }
 
 func testAccServiceIntegrationLogs(name string) string {
@@ -395,7 +395,7 @@ data "aiven_service_integration" "int" {
   destination_service_name = aiven_service_integration.bar.destination_service_name
 
   depends_on = [aiven_service_integration.bar]
-}`, os.Getenv("AIVEN_PROJECT_NAME"), name, name)
+}`, acc.ProjectName(), name, name)
 }
 
 func testAccServiceIntegrationPreexistingReadReplica(name string) string {
@@ -440,7 +440,7 @@ data "aiven_service_integration" "int" {
   destination_service_name = aiven_service_integration.bar.destination_service_name
 
   depends_on = [aiven_service_integration.bar]
-}`, os.Getenv("AIVEN_PROJECT_NAME"), name, name)
+}`, acc.ProjectName(), name, name)
 }
 
 func testAccServiceIntegrationShouldFailResource() string {
@@ -550,7 +550,7 @@ resource "aiven_service_integration" "postgres-datadog" {
     }
   }
 }
-`, os.Getenv("AIVEN_PROJECT_NAME"), name, name)
+`, acc.ProjectName(), name, name)
 }
 
 func TestAccAivenServiceIntegration_datadog_with_user_config_creates(t *testing.T) {
@@ -565,7 +565,7 @@ func TestAccAivenServiceIntegration_datadog_with_user_config_creates(t *testing.
 				Config: testAccServiceIntegrationDatadogWithUserConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "integration_type", "datadog"),
-					resource.TestCheckResourceAttr(resourceName, "project", os.Getenv("AIVEN_PROJECT_NAME")),
+					resource.TestCheckResourceAttr(resourceName, "project", acc.ProjectName()),
 					resource.TestCheckResourceAttr(resourceName, "source_service_name", fmt.Sprintf("test-acc-postgres-%s", rName)),
 					resource.TestCheckResourceAttr(resourceName, "datadog_user_config.0.datadog_tags.0.tag", "lol:bar"),
 					resource.TestCheckResourceAttr(resourceName, "datadog_user_config.0.datadog_tags.0.comment", "my custom config"),
@@ -633,7 +633,7 @@ resource "aiven_service_integration" "clickhouse_kafka_source" {
 }
 
 func TestAccAivenServiceIntegration_clickhouse_kafka_user_config_creates(t *testing.T) {
-	project := os.Getenv("AIVEN_PROJECT_NAME")
+	project := acc.ProjectName()
 	prefix := "test-acc-" + acctest.RandString(7)
 	resourceName := "aiven_service_integration.clickhouse_kafka_source"
 	resource.ParallelTest(t, resource.TestCase{
@@ -708,7 +708,7 @@ resource "aiven_service_integration" "clickhouse_pg_source" {
 }
 
 func TestAccAivenServiceIntegration_clickhouse_postgres_user_config_creates(t *testing.T) {
-	project := os.Getenv("AIVEN_PROJECT_NAME")
+	project := acc.ProjectName()
 	prefix := "test-acc-" + acctest.RandString(7)
 	resourceName := "aiven_service_integration.clickhouse_pg_source"
 	resource.ParallelTest(t, resource.TestCase{
@@ -767,11 +767,11 @@ resource "aiven_service_integration" "test_autoscaler" {
   source_service_name     = aiven_pg.test_pg.service_name
   destination_endpoint_id = aiven_service_integration_endpoint.test_endpoint.id
 }
-`, os.Getenv("AIVEN_PROJECT_NAME"), prefix, additionalDiskSpace)
+`, acc.ProjectName(), prefix, additionalDiskSpace)
 }
 
 func TestAccAivenServiceIntegration_autoscaler(t *testing.T) {
-	project := os.Getenv("AIVEN_PROJECT_NAME")
+	project := acc.ProjectName()
 	prefix := "test-acc-" + acctest.RandString(7)
 	resourceName := "aiven_service_integration.test_autoscaler"
 	endpointResourceName := "aiven_service_integration_endpoint.test_endpoint"
@@ -802,7 +802,7 @@ func TestAccAivenServiceIntegration_autoscaler(t *testing.T) {
 }
 
 func TestAccAivenServiceIntegration_destination_service_name(t *testing.T) {
-	projectMetrics := os.Getenv("AIVEN_PROJECT_NAME")
+	projectMetrics := acc.ProjectName()
 	projectServices := os.Getenv("AIVEN_PROJECT_NAME_SECONDARY")
 	if projectServices == "" {
 		t.Skip("AIVEN_PROJECT_NAME_SECONDARY is not set")

--- a/internal/sdkprovider/service/staticip/static_ip_test.go
+++ b/internal/sdkprovider/service/staticip/static_ip_test.go
@@ -3,7 +3,6 @@ package staticip_test
 import (
 	"errors"
 	"fmt"
-	"os"
 	"regexp"
 	"strings"
 	"testing"
@@ -16,7 +15,7 @@ import (
 
 func TestAccAivenResourceStaticIp(t *testing.T) {
 	resourceName := "aiven_static_ip.foo"
-	projectName := os.Getenv("AIVEN_PROJECT_NAME")
+	projectName := acc.ProjectName()
 	cloudName := "google-europe-west1"
 	manifest := fmt.Sprintf(`
 resource "aiven_static_ip" "foo" {
@@ -73,7 +72,7 @@ resource "aiven_static_ip" "foo" {
 
 func TestAccAivenResourceStaticIpNonExistentIdentifier(t *testing.T) {
 	resourceName := "aiven_static_ip.foo"
-	projectName := os.Getenv("AIVEN_PROJECT_NAME")
+	projectName := acc.ProjectName()
 	cloudName := "google-europe-west1"
 	manifest := fmt.Sprintf(`
 resource "aiven_static_ip" "foo" {

--- a/internal/sdkprovider/service/thanos/thanos_test.go
+++ b/internal/sdkprovider/service/thanos/thanos_test.go
@@ -2,7 +2,6 @@ package thanos_test
 
 import (
 	"fmt"
-	"os"
 	"regexp"
 	"testing"
 
@@ -32,7 +31,7 @@ func TestAccAiven_thanos(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "tech_emails.0.email", "techsupport@company.com"),
 					resource.TestCheckResourceAttr(resourceName, "service_name", fmt.Sprintf("test-acc-sr-%s", rName)),
 					resource.TestCheckResourceAttr(resourceName, "state", "RUNNING"),
-					resource.TestCheckResourceAttr(resourceName, "project", os.Getenv("AIVEN_PROJECT_NAME")),
+					resource.TestCheckResourceAttr(resourceName, "project", acc.ProjectName()),
 					resource.TestCheckResourceAttr(resourceName, "service_type", "thanos"),
 					resource.TestCheckResourceAttr(resourceName, "cloud_name", "google-europe-west1"),
 					resource.TestCheckResourceAttr(resourceName, "maintenance_window_dow", "monday"),
@@ -106,7 +105,7 @@ data "aiven_thanos" "common" {
   project      = data.aiven_project.foo.project
 
   depends_on = [aiven_thanos.bar]
-}`, os.Getenv("AIVEN_PROJECT_NAME"), name)
+}`, acc.ProjectName(), name)
 }
 
 func testAccThanosRemoveEmailsResource(name string) string {
@@ -144,7 +143,7 @@ data "aiven_thanos" "common" {
   project      = data.aiven_project.foo.project
 
   depends_on = [aiven_thanos.bar]
-}`, os.Getenv("AIVEN_PROJECT_NAME"), name)
+}`, acc.ProjectName(), name)
 }
 
 func testAccThanosDoubleTagResource(name string) string {
@@ -182,7 +181,7 @@ data "aiven_thanos" "common" {
   project      = data.aiven_project.foo.project
 
   depends_on = [aiven_thanos.bar]
-}`, os.Getenv("AIVEN_PROJECT_NAME"), name)
+}`, acc.ProjectName(), name)
 }
 
 // Thanos service tests
@@ -201,7 +200,7 @@ func TestAccAivenService_thanos(t *testing.T) {
 					acc.TestAccCheckAivenServiceCommonAttributes("data.aiven_thanos.common"),
 					testAccCheckAivenServiceThanosAttributes("data.aiven_thanos.common"),
 					resource.TestCheckResourceAttr(resourceName, "service_name", fmt.Sprintf("test-acc-sr-%s", rName)),
-					resource.TestCheckResourceAttr(resourceName, "project", os.Getenv("AIVEN_PROJECT_NAME")),
+					resource.TestCheckResourceAttr(resourceName, "project", acc.ProjectName()),
 					resource.TestCheckResourceAttr(resourceName, "service_type", "thanos"),
 					resource.TestCheckResourceAttr(resourceName, "cloud_name", "google-europe-west1"),
 					resource.TestCheckResourceAttr(resourceName, "maintenance_window_dow", "monday"),
@@ -216,7 +215,7 @@ func TestAccAivenService_thanos(t *testing.T) {
 					acc.TestAccCheckAivenServiceCommonAttributes("data.aiven_thanos.common"),
 					testAccCheckAivenServiceThanosAttributes("data.aiven_thanos.common"),
 					resource.TestCheckResourceAttr(resourceName, "service_name", fmt.Sprintf("test-acc-sr-%s", rName)),
-					resource.TestCheckResourceAttr(resourceName, "project", os.Getenv("AIVEN_PROJECT_NAME")),
+					resource.TestCheckResourceAttr(resourceName, "project", acc.ProjectName()),
 					resource.TestCheckResourceAttr(resourceName, "service_type", "thanos"),
 					resource.TestCheckResourceAttr(resourceName, "cloud_name", "google-europe-west1"),
 					resource.TestCheckResourceAttr(resourceName, "maintenance_window_dow", "monday"),
@@ -255,7 +254,7 @@ data "aiven_thanos" "common" {
   project      = aiven_thanos.bar.project
 
   depends_on = [aiven_thanos.bar]
-}`, os.Getenv("AIVEN_PROJECT_NAME"), name)
+}`, acc.ProjectName(), name)
 }
 
 func testAccThanosServiceResourceWithPersistenceOff(name string) string {
@@ -284,7 +283,7 @@ data "aiven_thanos" "common" {
   project      = aiven_thanos.bar.project
 
   depends_on = [aiven_thanos.bar]
-}`, os.Getenv("AIVEN_PROJECT_NAME"), name)
+}`, acc.ProjectName(), name)
 }
 
 func testAccCheckAivenServiceThanosAttributes(n string) resource.TestCheckFunc {

--- a/internal/sdkprovider/service/valkey/valkey_test.go
+++ b/internal/sdkprovider/service/valkey/valkey_test.go
@@ -2,7 +2,6 @@ package valkey_test
 
 import (
 	"fmt"
-	"os"
 	"regexp"
 	"testing"
 
@@ -32,7 +31,7 @@ func TestAccAiven_valkey(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "tech_emails.0.email", "techsupport@company.com"),
 					resource.TestCheckResourceAttr(resourceName, "service_name", fmt.Sprintf("test-acc-sr-%s", rName)),
 					resource.TestCheckResourceAttr(resourceName, "state", "RUNNING"),
-					resource.TestCheckResourceAttr(resourceName, "project", os.Getenv("AIVEN_PROJECT_NAME")),
+					resource.TestCheckResourceAttr(resourceName, "project", acc.ProjectName()),
 					resource.TestCheckResourceAttr(resourceName, "service_type", "valkey"),
 					resource.TestCheckResourceAttr(resourceName, "cloud_name", "google-europe-west1"),
 					resource.TestCheckResourceAttr(resourceName, "maintenance_window_dow", "monday"),
@@ -61,7 +60,7 @@ func TestAccAiven_valkey(t *testing.T) {
 					acc.TestAccCheckAivenServiceCommonAttributes("data.aiven_valkey.common"),
 					testAccCheckAivenServiceValkeyAttributes("data.aiven_valkey.common"),
 					resource.TestCheckResourceAttr(resourceName, "service_name", fmt.Sprintf("test-acc-sr-%s", rName)),
-					resource.TestCheckResourceAttr(resourceName, "project", os.Getenv("AIVEN_PROJECT_NAME")),
+					resource.TestCheckResourceAttr(resourceName, "project", acc.ProjectName()),
 					resource.TestCheckResourceAttr(resourceName, "service_type", "valkey"),
 					resource.TestCheckResourceAttr(resourceName, "cloud_name", "google-europe-west1"),
 					resource.TestCheckResourceAttr(resourceName, "maintenance_window_dow", "monday"),
@@ -117,7 +116,7 @@ data "aiven_valkey" "common" {
   project      = data.aiven_project.foo.project
 
   depends_on = [aiven_valkey.bar]
-}`, os.Getenv("AIVEN_PROJECT_NAME"), name)
+}`, acc.ProjectName(), name)
 }
 
 func testAccValkeyRemoveEmailsResource(name string) string {
@@ -153,7 +152,7 @@ data "aiven_valkey" "common" {
   project      = data.aiven_project.foo.project
 
   depends_on = [aiven_valkey.bar]
-}`, os.Getenv("AIVEN_PROJECT_NAME"), name)
+}`, acc.ProjectName(), name)
 }
 
 func testAccValkeyServiceResourceWithPersistenceOff(name string) string {
@@ -185,7 +184,7 @@ data "aiven_valkey" "common" {
   project      = aiven_valkey.bar.project
 
   depends_on = [aiven_valkey.bar]
-}`, os.Getenv("AIVEN_PROJECT_NAME"), name)
+}`, acc.ProjectName(), name)
 }
 
 func testAccValkeyDoubleTagResource(name string) string {
@@ -225,7 +224,7 @@ data "aiven_valkey" "common" {
   project      = data.aiven_project.foo.project
 
   depends_on = [aiven_valkey.bar]
-}`, os.Getenv("AIVEN_PROJECT_NAME"), name)
+}`, acc.ProjectName(), name)
 }
 
 func testAccCheckAivenServiceValkeyAttributes(n string) resource.TestCheckFunc {

--- a/internal/sdkprovider/service/valkey/valkey_user_test.go
+++ b/internal/sdkprovider/service/valkey/valkey_user_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"os"
 	"testing"
 
 	"github.com/aiven/aiven-go-client/v2"
@@ -30,7 +29,7 @@ func TestAccAivenValkeyUser_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					schemautil.TestAccCheckAivenServiceUserAttributes("data.aiven_valkey_user.user"),
 					resource.TestCheckResourceAttr(resourceName, "service_name", fmt.Sprintf("test-acc-sr-%s", rName)),
-					resource.TestCheckResourceAttr(resourceName, "project", os.Getenv("AIVEN_PROJECT_NAME")),
+					resource.TestCheckResourceAttr(resourceName, "project", acc.ProjectName()),
 					resource.TestCheckResourceAttr(resourceName, "username", fmt.Sprintf("user-%s", rName)),
 				),
 			},
@@ -103,5 +102,5 @@ data "aiven_valkey_user" "user" {
   username     = aiven_valkey_user.foo.username
 
   depends_on = [aiven_valkey_user.foo]
-}`, os.Getenv("AIVEN_PROJECT_NAME"), name, name)
+}`, acc.ProjectName(), name, name)
 }

--- a/internal/sdkprovider/service/vpc/aws_org_vpc_peering_connection_test.go
+++ b/internal/sdkprovider/service/vpc/aws_org_vpc_peering_connection_test.go
@@ -28,7 +28,7 @@ const (
 // 3. Validates that the creation fails with the expected error due to invalid AWS credentials
 func TestAccAivenAWSOrgVPCPeeringConnection(t *testing.T) {
 	var (
-		orgName = acc.SkipIfEnvVarsNotSet(t, "AIVEN_ORGANIZATION_NAME")["AIVEN_ORGANIZATION_NAME"]
+		orgName = acc.OrganizationName()
 
 		templBuilder = template.InitializeTemplateStore(t).NewBuilder().
 				AddDataSource("aiven_organization", map[string]interface{}{
@@ -83,18 +83,18 @@ func TestAccAivenAWSOrgVPCPeeringConnection(t *testing.T) {
 // - Proper AWS profile configuration (can be set via AWS_PROFILE env var)
 // - Required permissions: VPC creation/deletion, VPC peering, route table management
 func TestAccAivenAWSOrgVPCPeeringConnectionFull(t *testing.T) {
-	var envVars = acc.SkipIfEnvVarsNotSet(
-		t,
-		"AIVEN_ORGANIZATION_NAME",
+	var (
+		orgName   = acc.OrganizationName()
+		awsRegion = "eu-central-1"
+	)
+
+	acc.RequireEnvVars(t,
 		"AWS_ACCESS_KEY_ID",
 		"AWS_SECRET_ACCESS_KEY",
 		"AWS_SESSION_TOKEN",
 	)
 
 	var (
-		orgName   = envVars["AIVEN_ORGANIZATION_NAME"]
-		awsRegion = "eu-central-1"
-
 		templBuilder = template.InitializeTemplateStore(t).NewBuilder().
 				AddDataSource("aiven_organization", map[string]any{
 				"resource_name": "foo",

--- a/internal/sdkprovider/service/vpc/azure_org_vpc_peering_connection_test.go
+++ b/internal/sdkprovider/service/vpc/azure_org_vpc_peering_connection_test.go
@@ -24,7 +24,7 @@ func TestAccAivenAzureOrgVPCPeeringConnection(t *testing.T) {
 	t.Skip("Skipping due to Azure SDK dependency")
 
 	var (
-		orgName      = acc.SkipIfEnvVarsNotSet(t, "AIVEN_ORGANIZATION_NAME")["AIVEN_ORGANIZATION_NAME"]
+		orgName      = acc.OrganizationName()
 		templBuilder = template.InitializeTemplateStore(t).NewBuilder().
 				AddDataSource("aiven_organization", map[string]interface{}{
 				"resource_name": "foo",

--- a/internal/sdkprovider/service/vpc/azure_privatelink_test.go
+++ b/internal/sdkprovider/service/vpc/azure_privatelink_test.go
@@ -75,8 +75,8 @@ func testAccCheckAivenAzurePrivatelinkResourceDestroy(s *terraform.State) error 
 }
 
 func testAccAzurePrivatelinkResource(name string) string {
-	var principal = os.Getenv("AIVEN_AZURE_PRIVATELINK_SUB_ID")
-	var vpcID = os.Getenv("AIVEN_AZURE_PRIVATELINK_VPCID")
+	principal := os.Getenv("AIVEN_AZURE_PRIVATELINK_SUB_ID")
+	vpcID := os.Getenv("AIVEN_AZURE_PRIVATELINK_VPCID")
 
 	return fmt.Sprintf(`
 data "aiven_project" "foo" {
@@ -111,7 +111,7 @@ data "aiven_azure_privatelink" "pr" {
   service_name = aiven_pg.bar.service_name
 
   depends_on = [aiven_azure_privatelink.foo]
-}`, os.Getenv("AIVEN_PROJECT_NAME"), name, vpcID, principal)
+}`, acc.ProjectName(), name, vpcID, principal)
 }
 
 func testAccCheckAivenAzurePrivatelinkAttributes(n string) resource.TestCheckFunc {

--- a/internal/sdkprovider/service/vpc/gcp_org_vpc_peering_connection_test.go
+++ b/internal/sdkprovider/service/vpc/gcp_org_vpc_peering_connection_test.go
@@ -28,7 +28,7 @@ const (
 // 3. Validates that the creation fails with the expected error due to invalid GCP project ID
 func TestAccAivenGCPOrgVPCPeeringConnection(t *testing.T) {
 	var (
-		orgName      = acc.SkipIfEnvVarsNotSet(t, "AIVEN_ORGANIZATION_NAME")["AIVEN_ORGANIZATION_NAME"]
+		orgName      = acc.OrganizationName()
 		templBuilder = template.InitializeTemplateStore(t).NewBuilder()
 	)
 
@@ -76,16 +76,13 @@ func TestAccAivenGCPOrgVPCPeeringConnection(t *testing.T) {
 // - GCP project with VPC API enabled
 // - Required permissions: VPC creation/deletion, VPC peering, route management
 func TestAccAivenGCPOrgVPCPeeringConnectionFull(t *testing.T) {
-	var envVars = acc.SkipIfEnvVarsNotSet(
-		t,
-		"AIVEN_ORGANIZATION_NAME",
-		"GOOGLE_PROJECT",
+	var (
+		orgName   = acc.OrganizationName()
+		gcpRegion = "europe-west10"
 	)
 
 	var (
-		orgName      = envVars["AIVEN_ORGANIZATION_NAME"]
-		gcpProject   = envVars["GOOGLE_PROJECT"]
-		gcpRegion    = "europe-west10"
+		gcpProject   = acc.RequireEnvVars(t, "GOOGLE_PROJECT")["GOOGLE_PROJECT"]
 		resourceName = fmt.Sprintf("%s.%s", gcpOrgVPCPeeringResource, "test_peering")
 
 		randName    = acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)

--- a/internal/sdkprovider/service/vpc/gcp_privatelink_test.go
+++ b/internal/sdkprovider/service/vpc/gcp_privatelink_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"os"
 	"testing"
 
 	"github.com/aiven/aiven-go-client/v2"
@@ -110,7 +109,7 @@ data "aiven_gcp_privatelink" "pr" {
   service_name = aiven_kafka.bar.service_name
 
   depends_on = [aiven_gcp_privatelink.foo]
-}`, os.Getenv("AIVEN_PROJECT_NAME"), name)
+}`, acc.ProjectName(), name)
 }
 
 func testAccCheckAivenGCPPrivatelinkAttributes(n string) resource.TestCheckFunc {

--- a/internal/sdkprovider/service/vpc/organization_vpc_test.go
+++ b/internal/sdkprovider/service/vpc/organization_vpc_test.go
@@ -23,7 +23,7 @@ const (
 
 func TestAccAivenOrganizationVPC(t *testing.T) {
 	var (
-		orgName = acc.SkipIfEnvVarsNotSet(t, "AIVEN_ORGANIZATION_NAME")["AIVEN_ORGANIZATION_NAME"]
+		orgName = acc.OrganizationName()
 
 		templBuilder = template.InitializeTemplateStore(t).NewBuilder().
 				AddDataSource("aiven_organization", map[string]interface{}{

--- a/internal/sdkprovider/service/vpc/project_vpc_test.go
+++ b/internal/sdkprovider/service/vpc/project_vpc_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"os"
 	"regexp"
 	"testing"
 
@@ -32,7 +31,6 @@ func TestAccAivenProjectVPC_basic(t *testing.T) {
 				ExpectError: regexp.MustCompile("invalid resource id"),
 			},
 			{
-
 				Config:      testAccServiceProjectVPCResourceFail(rName),
 				ExpectError: regexp.MustCompile("invalid project_vpc_id"),
 			},
@@ -40,7 +38,7 @@ func TestAccAivenProjectVPC_basic(t *testing.T) {
 				Config: testAccProjectVPCResource(),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAivenProjectVPCAttributes("data.aiven_project_vpc.vpc"),
-					resource.TestCheckResourceAttr(resourceName, "project", os.Getenv("AIVEN_PROJECT_NAME")),
+					resource.TestCheckResourceAttr(resourceName, "project", acc.ProjectName()),
 					resource.TestCheckResourceAttr(resourceName, "cloud_name", "google-europe-west2"),
 					resource.TestCheckResourceAttr(resourceName, "network_cidr", "192.168.0.0/24"),
 					resource.TestCheckResourceAttr(resourceName, "state", "ACTIVE"),
@@ -50,7 +48,7 @@ func TestAccAivenProjectVPC_basic(t *testing.T) {
 				Config: testAccProjectVPCResourceGetByID(),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAivenProjectVPCAttributes("data.aiven_project_vpc.vpc2"),
-					resource.TestCheckResourceAttr(resourceName, "project", os.Getenv("AIVEN_PROJECT_NAME")),
+					resource.TestCheckResourceAttr(resourceName, "project", acc.ProjectName()),
 					resource.TestCheckResourceAttr(resourceName, "cloud_name", "azure-westeurope"),
 					resource.TestCheckResourceAttr(resourceName, "network_cidr", "192.168.1.0/24"),
 					resource.TestCheckResourceAttr(resourceName, "state", "ACTIVE"),
@@ -75,7 +73,7 @@ resource "aiven_project_vpc" "bar" {
 data "aiven_project_vpc" "vpc" {
   project    = aiven_project_vpc.bar.project
   cloud_name = aiven_project_vpc.bar.cloud_name
-}`, os.Getenv("AIVEN_PROJECT_NAME"))
+}`, acc.ProjectName())
 }
 
 func testAccCheckAivenProjectVPCAttributes(n string) resource.TestCheckFunc {
@@ -152,7 +150,7 @@ resource "aiven_pg" "bar" {
   service_name   = "test-acc-sr-%s"
   project_vpc_id = "wrong_vpc_id"
 }
-`, os.Getenv("AIVEN_PROJECT_NAME"), name)
+`, acc.ProjectName(), name)
 }
 
 func testAccProjectVPCResourceFail() string {
@@ -176,5 +174,5 @@ resource "aiven_project_vpc" "bar" {
 
 data "aiven_project_vpc" "vpc2" {
   vpc_id = aiven_project_vpc.bar.id
-}`, os.Getenv("AIVEN_PROJECT_NAME"))
+}`, acc.ProjectName())
 }


### PR DESCRIPTION
## About this change—what it does

* Unify and simplify env var handling in acceptance tests
* Fix semgrep in CI (I can separate this out to another PR if wanted)

Example semgrep error (https://github.com/aiven/terraform-provider-aiven/actions/runs/14044395840/job/39321731411?pr=2121):

![Capture](https://github.com/user-attachments/assets/91365118-e8b2-420c-b979-9078133cda7d)