### PR TITLE
patch: kafka-native-acl host field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ nav_order: 1
   Default: `false`.
 - Add `aiven_opensearch` field `opensearch_user_config.s3_migration.readonly`: Whether the repository is read-only.
   Default: `false`.
+  - Change `aiven_kafka_native_acl` field `host`: Gets default value from API if not provided, mark as computed.
 
 ## [4.36.0] - 2025-02-20
 

--- a/internal/acctest/template/store_test.go
+++ b/internal/acctest/template/store_test.go
@@ -210,8 +210,8 @@ func TestOrganizationResource(t *testing.T) {
 	})
 
 	expected := `resource "aiven_organization" "test-org" {
-	  name = "Test Organization"
-	}`
+  name = "Test Organization"
+}`
 
 	res := b.MustRender(t)
 

--- a/internal/plugin/service/organization/org/organization_data_source_test.go
+++ b/internal/plugin/service/organization/org/organization_data_source_test.go
@@ -83,10 +83,10 @@ func TestAccAivenOrganizationDataSourceValidation(t *testing.T) {
 			{
 				// Test case: both id and name provided
 				Config: `
-					data "aiven_organization" "test" {
-						id   = "test-id"
-						name = "test-name"
-					}
+data "aiven_organization" "test" {
+  id   = "test-id"
+  name = "test-name"
+}
 				`,
 				ExpectError: regexp.MustCompile(
 					`These attributes cannot be configured together: \[id,name\]`,
@@ -95,9 +95,9 @@ func TestAccAivenOrganizationDataSourceValidation(t *testing.T) {
 			{
 				// Test case: empty id provided
 				Config: `
-					data "aiven_organization" "test" {
-						id = ""
-					}
+data "aiven_organization" "test" {
+  id = ""
+}
 				`,
 				ExpectError: regexp.MustCompile(
 					`Organization ID not found`,

--- a/internal/sdkprovider/service/kafka/kafka_native_acl.go
+++ b/internal/sdkprovider/service/kafka/kafka_native_acl.go
@@ -48,6 +48,7 @@ var aivenKafkaNativeACLSchema = map[string]*schema.Schema{
 		Type:         schema.TypeString,
 		Optional:     true,
 		ForceNew:     true,
+		Computed:     true,
 		ValidateFunc: validation.StringLenBetween(1, 256),
 		Description:  userconfig.Desc("The IP address from which a principal is allowed or denied access to the resource. Use `*` for all hosts.").ForceNew().MaxLen(256).Build(),
 	},

--- a/internal/sdkprovider/service/kafka/kafka_native_acl_test.go
+++ b/internal/sdkprovider/service/kafka/kafka_native_acl_test.go
@@ -15,6 +15,7 @@ func TestKafkaNativeAcl(t *testing.T) {
 	projectName := acc.ProjectName()
 	serviceName := fmt.Sprintf("test-acc-native-acl-%s", acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
 	resourceName := "aiven_kafka_native_acl.foo"
+	resourceName2 := "aiven_kafka_native_acl.bar"
 
 	resource.ParallelTest(t, resource.TestCase{
 		ProtoV6ProviderFactories: acc.TestProtoV6ProviderFactories,
@@ -32,6 +33,7 @@ func TestKafkaNativeAcl(t *testing.T) {
 					resource.TestCheckResourceAttrSet(resourceName, "host"),
 					resource.TestCheckResourceAttrSet(resourceName, "operation"),
 					resource.TestCheckResourceAttrSet(resourceName, "permission_type"),
+					resource.TestCheckResourceAttr(resourceName2, "host", "*"),
 				),
 			},
 		},
@@ -70,5 +72,17 @@ resource "aiven_kafka_native_acl" "foo" {
   host            = "host-test"
   operation       = "Create"
   permission_type = "ALLOW"
-}`, projectName, serviceName)
+}
+
+resource "aiven_kafka_native_acl" "bar" {
+  project         = data.aiven_project.foo.project
+  service_name    = aiven_kafka.bar.service_name
+  resource_name   = "name-test"
+  resource_type   = "Topic"
+  pattern_type    = "LITERAL"
+  principal       = "User:alice"
+  operation       = "Create"
+  permission_type = "ALLOW"
+}
+`, projectName, serviceName)
 }


### PR DESCRIPTION
host will get default value of * from Aiven API
if not provided. To reflect this to the schemas,
the field can be marked as computed. In addition,
document the default value.

<!-- All contributors, please complete these sections, including maintainers. -->

## About this change—what it does

<!-- Provide a small sentence that summarizes the change. -->

<!-- Provide the issue number below, if it exists. -->
Resolves: #2124 

## Why this way

<!-- Provide a small explanation on why this is the approach you took for solving this problem. -->
