### PR TITLE
docs: update kafka connect example for use in Aiven Docs

### DIFF
--- a/examples/kafka_connect/kafka_connect_service.tf
+++ b/examples/kafka_connect/kafka_connect_service.tf
@@ -1,16 +1,6 @@
-# Kafka service
-resource "aiven_kafka" "kafka_service" {
-  project                 = var.avn_project
-  service_name            = var.kafka_name
-  cloud_name              = "google-europe-west1"
-  plan                    = "startup-2"
-  maintenance_window_dow  = "monday"
-  maintenance_window_time = "10:00:00"
-}
-
 # Kafka connect service
 resource "aiven_kafka_connect" "kafka_connect" {
-  project                 = var.avn_project
+  project                 = var.aiven_project_name
   service_name            = var.kafka_connect_name
   cloud_name              = "google-europe-west1"
   plan                    = "startup-4"
@@ -28,9 +18,9 @@ resource "aiven_kafka_connect" "kafka_connect" {
   }
 }
 
-# Kafka connect service integration
+# Kafka Connect service integration with Kafka service
 resource "aiven_service_integration" "kafka_integration" {
-  project                  = var.avn_project
+  project                  = var.aiven_project_name
   integration_type         = "kafka_connect"
   source_service_name      = aiven_kafka.kafka_service.service_name
   destination_service_name = aiven_kafka_connect.kafka_connect.service_name

--- a/examples/kafka_connect/kafka_service.tf
+++ b/examples/kafka_connect/kafka_service.tf
@@ -1,0 +1,9 @@
+# Kafka service
+resource "aiven_kafka" "kafka_service" {
+  project                 = var.aiven_project_name
+  service_name            = var.kafka_service_name
+  cloud_name              = "google-europe-west1"
+  plan                    = "startup-2"
+  maintenance_window_dow  = "monday"
+  maintenance_window_time = "10:00:00"
+}

--- a/examples/kafka_connect/output.tf
+++ b/examples/kafka_connect/output.tf
@@ -1,0 +1,16 @@
+output "kafka_service_host" {
+  value = aiven_kafka.kafka_service.service_host
+}
+
+output "kafka_service_port" {
+  value = aiven_kafka.kafka_service.service_port
+}
+
+output "kafka_service_username" {
+  value = aiven_kafka.kafka_service.service_username
+}
+
+output "kafka_service_password" {
+  value     = aiven_kafka.kafka_service.service_password
+  sensitive = true
+}

--- a/examples/kafka_connect/variables.tf
+++ b/examples/kafka_connect/variables.tf
@@ -1,4 +1,21 @@
-variable "aiven_token" {}
-variable "avn_project" {}
-variable "kafka_name" {}
-variable "kafka_connect_name" {}
+variable "aiven_token" {
+  description = "Aiven token"
+  type        = string
+}
+
+variable "aiven_project_name" {
+  description = "Name of an Aiven project assigned to a billing group"
+  type        = string
+}
+
+variable "kafka_service_name" {
+  description = "Name of the Kafka service"
+  type        = string
+  default     = "example-kafka-service"
+}
+
+variable "kafka_connect_name" {
+  description = "Name of the Kafka Connect service"
+  type        = string
+  default     = "example-kafka-connect-service"
+}

--- a/examples_tests/kafka_connect_test.go
+++ b/examples_tests/kafka_connect_test.go
@@ -29,8 +29,8 @@ func (s *KafkaConnectTestSuite) TestKafkaConnect() {
 		TerraformDir: "../examples/kafka_connect",
 		Vars: map[string]interface{}{
 			"aiven_token":        s.config.Token,
-			"avn_project":        s.config.Project,
-			"kafka_name":         kafkaServiceName,
+			"aiven_project_name": s.config.Project,
+			"kafka_service_name": kafkaServiceName,
 			"kafka_connect_name": kafkaConnectName,
 		},
 	})


### PR DESCRIPTION
<!-- All contributors, please complete these sections, including maintainers. -->

## About this change—what it does

Kafka and Kafka Connect services are in their own files so that each can be embedded in Aiven Docs for the Kafka and Connect get started guides respectively.
