### PR TITLE
feat: expose kafka components field `kafka_ssl_ca`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ nav_order: 1
 - Add `aiven_organization_address` resource & datasource
 - Add `aiven_organization_billing` resource & datasource and `aiven_organization_billing_list` datasource
 - Promoted `aiven_organization_user_list` datasource from Beta to GA
+- Add `kafka_ssl_ca` field in service components
 
 ## [4.37.0] - 2025-03-12
 

--- a/docs/data-sources/alloydbomni.md
+++ b/docs/data-sources/alloydbomni.md
@@ -255,6 +255,7 @@ Read-Only:
 - `connection_uri` (String)
 - `host` (String)
 - `kafka_authentication_method` (String)
+- `kafka_ssl_ca` (String)
 - `port` (Number)
 - `route` (String)
 - `ssl` (Boolean)

--- a/docs/data-sources/cassandra.md
+++ b/docs/data-sources/cassandra.md
@@ -147,6 +147,7 @@ Read-Only:
 - `connection_uri` (String)
 - `host` (String)
 - `kafka_authentication_method` (String)
+- `kafka_ssl_ca` (String)
 - `port` (Number)
 - `route` (String)
 - `ssl` (Boolean)

--- a/docs/data-sources/clickhouse.md
+++ b/docs/data-sources/clickhouse.md
@@ -135,6 +135,7 @@ Read-Only:
 - `connection_uri` (String)
 - `host` (String)
 - `kafka_authentication_method` (String)
+- `kafka_ssl_ca` (String)
 - `port` (Number)
 - `route` (String)
 - `ssl` (Boolean)

--- a/docs/data-sources/dragonfly.md
+++ b/docs/data-sources/dragonfly.md
@@ -66,6 +66,7 @@ Read-Only:
 - `connection_uri` (String)
 - `host` (String)
 - `kafka_authentication_method` (String)
+- `kafka_ssl_ca` (String)
 - `port` (Number)
 - `route` (String)
 - `ssl` (Boolean)

--- a/docs/data-sources/flink.md
+++ b/docs/data-sources/flink.md
@@ -66,6 +66,7 @@ Read-Only:
 - `connection_uri` (String)
 - `host` (String)
 - `kafka_authentication_method` (String)
+- `kafka_ssl_ca` (String)
 - `port` (Number)
 - `route` (String)
 - `ssl` (Boolean)

--- a/docs/data-sources/grafana.md
+++ b/docs/data-sources/grafana.md
@@ -66,6 +66,7 @@ Read-Only:
 - `connection_uri` (String)
 - `host` (String)
 - `kafka_authentication_method` (String)
+- `kafka_ssl_ca` (String)
 - `port` (Number)
 - `route` (String)
 - `ssl` (Boolean)

--- a/docs/data-sources/kafka.md
+++ b/docs/data-sources/kafka.md
@@ -68,6 +68,7 @@ Read-Only:
 - `connection_uri` (String)
 - `host` (String)
 - `kafka_authentication_method` (String)
+- `kafka_ssl_ca` (String)
 - `port` (Number)
 - `route` (String)
 - `ssl` (Boolean)

--- a/docs/data-sources/kafka_connect.md
+++ b/docs/data-sources/kafka_connect.md
@@ -65,6 +65,7 @@ Read-Only:
 - `connection_uri` (String)
 - `host` (String)
 - `kafka_authentication_method` (String)
+- `kafka_ssl_ca` (String)
 - `port` (Number)
 - `route` (String)
 - `ssl` (Boolean)

--- a/docs/data-sources/kafka_mirrormaker.md
+++ b/docs/data-sources/kafka_mirrormaker.md
@@ -65,6 +65,7 @@ Read-Only:
 - `connection_uri` (String)
 - `host` (String)
 - `kafka_authentication_method` (String)
+- `kafka_ssl_ca` (String)
 - `port` (Number)
 - `route` (String)
 - `ssl` (Boolean)

--- a/docs/data-sources/m3aggregator.md
+++ b/docs/data-sources/m3aggregator.md
@@ -66,6 +66,7 @@ Read-Only:
 - `connection_uri` (String)
 - `host` (String)
 - `kafka_authentication_method` (String)
+- `kafka_ssl_ca` (String)
 - `port` (Number)
 - `route` (String)
 - `ssl` (Boolean)

--- a/docs/data-sources/m3db.md
+++ b/docs/data-sources/m3db.md
@@ -77,6 +77,7 @@ Read-Only:
 - `connection_uri` (String)
 - `host` (String)
 - `kafka_authentication_method` (String)
+- `kafka_ssl_ca` (String)
 - `port` (Number)
 - `route` (String)
 - `ssl` (Boolean)

--- a/docs/data-sources/mysql.md
+++ b/docs/data-sources/mysql.md
@@ -66,6 +66,7 @@ Read-Only:
 - `connection_uri` (String)
 - `host` (String)
 - `kafka_authentication_method` (String)
+- `kafka_ssl_ca` (String)
 - `port` (Number)
 - `route` (String)
 - `ssl` (Boolean)

--- a/docs/data-sources/opensearch.md
+++ b/docs/data-sources/opensearch.md
@@ -66,6 +66,7 @@ Read-Only:
 - `connection_uri` (String)
 - `host` (String)
 - `kafka_authentication_method` (String)
+- `kafka_ssl_ca` (String)
 - `port` (Number)
 - `route` (String)
 - `ssl` (Boolean)

--- a/docs/data-sources/pg.md
+++ b/docs/data-sources/pg.md
@@ -66,6 +66,7 @@ Read-Only:
 - `connection_uri` (String)
 - `host` (String)
 - `kafka_authentication_method` (String)
+- `kafka_ssl_ca` (String)
 - `port` (Number)
 - `route` (String)
 - `ssl` (Boolean)

--- a/docs/data-sources/redis.md
+++ b/docs/data-sources/redis.md
@@ -81,6 +81,7 @@ Read-Only:
 - `connection_uri` (String)
 - `host` (String)
 - `kafka_authentication_method` (String)
+- `kafka_ssl_ca` (String)
 - `port` (Number)
 - `route` (String)
 - `ssl` (Boolean)

--- a/docs/data-sources/service_component.md
+++ b/docs/data-sources/service_component.md
@@ -39,5 +39,6 @@ data "aiven_service_component" "sc1" {
 
 - `host` (String) DNS name for connecting to the service component
 - `id` (String) The ID of this resource.
+- `kafka_ssl_ca` (String) Kafka certificate used. The possible values are `letsencrypt` and `project_ca`.
 - `port` (Number) Port number for connecting to the service component
 

--- a/docs/data-sources/thanos.md
+++ b/docs/data-sources/thanos.md
@@ -66,6 +66,7 @@ Read-Only:
 - `connection_uri` (String)
 - `host` (String)
 - `kafka_authentication_method` (String)
+- `kafka_ssl_ca` (String)
 - `port` (Number)
 - `route` (String)
 - `ssl` (Boolean)

--- a/docs/data-sources/valkey.md
+++ b/docs/data-sources/valkey.md
@@ -66,6 +66,7 @@ Read-Only:
 - `connection_uri` (String)
 - `host` (String)
 - `kafka_authentication_method` (String)
+- `kafka_ssl_ca` (String)
 - `port` (Number)
 - `route` (String)
 - `ssl` (Boolean)

--- a/docs/resources/alloydbomni.md
+++ b/docs/resources/alloydbomni.md
@@ -331,6 +331,7 @@ Read-Only:
 - `connection_uri` (String)
 - `host` (String)
 - `kafka_authentication_method` (String)
+- `kafka_ssl_ca` (String)
 - `port` (Number)
 - `route` (String)
 - `ssl` (Boolean)

--- a/docs/resources/cassandra.md
+++ b/docs/resources/cassandra.md
@@ -204,6 +204,7 @@ Read-Only:
 - `connection_uri` (String)
 - `host` (String)
 - `kafka_authentication_method` (String)
+- `kafka_ssl_ca` (String)
 - `port` (Number)
 - `route` (String)
 - `ssl` (Boolean)

--- a/docs/resources/clickhouse.md
+++ b/docs/resources/clickhouse.md
@@ -184,6 +184,7 @@ Read-Only:
 - `connection_uri` (String)
 - `host` (String)
 - `kafka_authentication_method` (String)
+- `kafka_ssl_ca` (String)
 - `port` (Number)
 - `route` (String)
 - `ssl` (Boolean)

--- a/docs/resources/dragonfly.md
+++ b/docs/resources/dragonfly.md
@@ -208,6 +208,7 @@ Read-Only:
 - `connection_uri` (String)
 - `host` (String)
 - `kafka_authentication_method` (String)
+- `kafka_ssl_ca` (String)
 - `port` (Number)
 - `route` (String)
 - `ssl` (Boolean)

--- a/docs/resources/flink.md
+++ b/docs/resources/flink.md
@@ -173,6 +173,7 @@ Read-Only:
 - `connection_uri` (String)
 - `host` (String)
 - `kafka_authentication_method` (String)
+- `kafka_ssl_ca` (String)
 - `port` (Number)
 - `route` (String)
 - `ssl` (Boolean)

--- a/docs/resources/grafana.md
+++ b/docs/resources/grafana.md
@@ -346,6 +346,7 @@ Read-Only:
 - `connection_uri` (String)
 - `host` (String)
 - `kafka_authentication_method` (String)
+- `kafka_ssl_ca` (String)
 - `port` (Number)
 - `route` (String)
 - `ssl` (Boolean)

--- a/docs/resources/kafka.md
+++ b/docs/resources/kafka.md
@@ -429,6 +429,7 @@ Read-Only:
 - `connection_uri` (String)
 - `host` (String)
 - `kafka_authentication_method` (String)
+- `kafka_ssl_ca` (String)
 - `port` (Number)
 - `route` (String)
 - `ssl` (Boolean)

--- a/docs/resources/kafka_connect.md
+++ b/docs/resources/kafka_connect.md
@@ -288,6 +288,7 @@ Read-Only:
 - `connection_uri` (String)
 - `host` (String)
 - `kafka_authentication_method` (String)
+- `kafka_ssl_ca` (String)
 - `port` (Number)
 - `route` (String)
 - `ssl` (Boolean)

--- a/docs/resources/kafka_mirrormaker.md
+++ b/docs/resources/kafka_mirrormaker.md
@@ -166,6 +166,7 @@ Read-Only:
 - `connection_uri` (String)
 - `host` (String)
 - `kafka_authentication_method` (String)
+- `kafka_ssl_ca` (String)
 - `port` (Number)
 - `route` (String)
 - `ssl` (Boolean)

--- a/docs/resources/m3aggregator.md
+++ b/docs/resources/m3aggregator.md
@@ -155,6 +155,7 @@ Read-Only:
 - `connection_uri` (String)
 - `host` (String)
 - `kafka_authentication_method` (String)
+- `kafka_ssl_ca` (String)
 - `port` (Number)
 - `route` (String)
 - `ssl` (Boolean)

--- a/docs/resources/m3db.md
+++ b/docs/resources/m3db.md
@@ -317,6 +317,7 @@ Read-Only:
 - `connection_uri` (String)
 - `host` (String)
 - `kafka_authentication_method` (String)
+- `kafka_ssl_ca` (String)
 - `port` (Number)
 - `route` (String)
 - `ssl` (Boolean)

--- a/docs/resources/mysql.md
+++ b/docs/resources/mysql.md
@@ -279,6 +279,7 @@ Read-Only:
 - `connection_uri` (String)
 - `host` (String)
 - `kafka_authentication_method` (String)
+- `kafka_ssl_ca` (String)
 - `port` (Number)
 - `route` (String)
 - `ssl` (Boolean)

--- a/docs/resources/opensearch.md
+++ b/docs/resources/opensearch.md
@@ -665,6 +665,7 @@ Read-Only:
 - `connection_uri` (String)
 - `host` (String)
 - `kafka_authentication_method` (String)
+- `kafka_ssl_ca` (String)
 - `port` (Number)
 - `route` (String)
 - `ssl` (Boolean)

--- a/docs/resources/pg.md
+++ b/docs/resources/pg.md
@@ -398,6 +398,7 @@ Read-Only:
 - `connection_uri` (String)
 - `host` (String)
 - `kafka_authentication_method` (String)
+- `kafka_ssl_ca` (String)
 - `port` (Number)
 - `route` (String)
 - `ssl` (Boolean)

--- a/docs/resources/redis.md
+++ b/docs/resources/redis.md
@@ -241,6 +241,7 @@ Read-Only:
 - `connection_uri` (String)
 - `host` (String)
 - `kafka_authentication_method` (String)
+- `kafka_ssl_ca` (String)
 - `port` (Number)
 - `route` (String)
 - `ssl` (Boolean)

--- a/docs/resources/thanos.md
+++ b/docs/resources/thanos.md
@@ -228,6 +228,7 @@ Read-Only:
 - `connection_uri` (String)
 - `host` (String)
 - `kafka_authentication_method` (String)
+- `kafka_ssl_ca` (String)
 - `port` (Number)
 - `route` (String)
 - `ssl` (Boolean)

--- a/docs/resources/valkey.md
+++ b/docs/resources/valkey.md
@@ -222,6 +222,7 @@ Read-Only:
 - `connection_uri` (String)
 - `host` (String)
 - `kafka_authentication_method` (String)
+- `kafka_ssl_ca` (String)
 - `port` (Number)
 - `route` (String)
 - `ssl` (Boolean)

--- a/internal/schemautil/service.go
+++ b/internal/schemautil/service.go
@@ -299,6 +299,11 @@ func ServiceCommonSchema() map[string]*schema.Schema {
 						Computed:    true,
 						Description: "Kafka authentication method. This is a value specific to the 'kafka' service component",
 					},
+					"kafka_ssl_ca": {
+						Type:        schema.TypeString,
+						Computed:    true,
+						Description: "Kafka certificate used. The possible values are `letsencrypt` and `project_ca`.",
+					},
 					"route": {
 						Type:        schema.TypeString,
 						Computed:    true,
@@ -833,6 +838,7 @@ func FlattenServiceComponents(r *service.ServiceGetOut) []map[string]interface{}
 			"port":                        c.Port,
 			"connection_uri":              fmt.Sprintf("%s:%d", c.Host, c.Port),
 			"kafka_authentication_method": c.KafkaAuthenticationMethod,
+			"kafka_ssl_ca":                c.KafkaSslCa,
 			"route":                       c.Route,
 			// By default, endpoints are always encrypted and
 			// this property is only included for service components that may disable encryption.

--- a/internal/sdkprovider/service/servicecomponent/service_component_data_source.go
+++ b/internal/sdkprovider/service/servicecomponent/service_component_data_source.go
@@ -65,6 +65,11 @@ func DatasourceServiceComponent() *schema.Resource {
 				ValidateFunc: validation.StringInSlice(service.KafkaAuthenticationMethodTypeChoices(), false),
 				Description:  userconfig.Desc("Kafka authentication method. This is a value specific to the 'kafka' service component").PossibleValuesString(service.KafkaAuthenticationMethodTypeChoices()...).Build(),
 			},
+			"kafka_ssl_ca": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: userconfig.Desc("Kafka certificate used").PossibleValuesString(service.KafkaSslCaTypeChoices()...).Build(),
+			},
 			"ssl": {
 				Type:     schema.TypeBool,
 				Optional: true,


### PR DESCRIPTION
Following to a recent PR extending Acorn’s ServiceGet endpoint to SASL Let’s Encrypt ports when letsencrypt_sasl_ports = true, reading the TF import state of corresponding kafka resources became confusing, due to `kafka_ssl_ca` field missing.

NEX-1354