### PR TITLE
fix(clickhouse_database): import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ nav_order: 1
 - Marked `parent_id` field as required in `aiven_organization_project` resource
 - Allowed to move `aiven_organization_project` resource between different organizations
 - Fix `aiven_clickhouse_grant` import
+- Fix `aiven_clickhouse_database` import
 
 ## [4.37.0] - 2025-03-12
 

--- a/internal/sdkprovider/service/clickhouse/clickhouse_database.go
+++ b/internal/sdkprovider/service/clickhouse/clickhouse_database.go
@@ -23,7 +23,6 @@ var aivenClickhouseDatabaseSchema = map[string]*schema.Schema{
 	"termination_protection": {
 		Type:        schema.TypeBool,
 		Optional:    true,
-		Default:     false,
 		Description: userconfig.Desc(`Client-side deletion protection that prevents the ClickHouse database from being deleted by Terraform. Enable this for production databases containing critical data.`).DefaultValue(false).Build(),
 	},
 }
@@ -77,6 +76,12 @@ func resourceClickhouseDatabaseRead(ctx context.Context, d *schema.ResourceData,
 		return diag.FromErr(schemautil.ResourceReadHandleNotFound(err, d))
 	}
 
+	if err := d.Set("project", projectName); err != nil {
+		return diag.FromErr(err)
+	}
+	if err := d.Set("service_name", serviceName); err != nil {
+		return diag.FromErr(err)
+	}
 	if err := d.Set("name", database.Name); err != nil {
 		return diag.FromErr(err)
 	}

--- a/internal/sdkprovider/service/clickhouse/clickhouse_database_test.go
+++ b/internal/sdkprovider/service/clickhouse/clickhouse_database_test.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 
 	acc "github.com/aiven/terraform-provider-aiven/internal/acctest"
@@ -12,7 +11,7 @@ import (
 
 func TestAccAivenClickhouseDatabase_basic(t *testing.T) {
 	resourceName := "aiven_clickhouse_database.foo"
-	rName := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
+	rName := acc.RandStr()
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acc.TestAccPreCheck(t) },
@@ -24,8 +23,13 @@ func TestAccAivenClickhouseDatabase_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "project", acc.ProjectName()),
 					resource.TestCheckResourceAttr(resourceName, "service_name", fmt.Sprintf("test-acc-sr-%s", rName)),
 					resource.TestCheckResourceAttr(resourceName, "name", fmt.Sprintf("test-acc-db-%s", rName)),
-					resource.TestCheckResourceAttr(resourceName, "termination_protection", "false"),
 				),
+			},
+			{
+
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -34,14 +38,14 @@ func TestAccAivenClickhouseDatabase_basic(t *testing.T) {
 func testAccClickhouseDatabaseResource(name string) string {
 	return fmt.Sprintf(`
 data "aiven_project" "foo" {
-  project = "%s"
+  project = "%[1]s"
 }
 
 resource "aiven_clickhouse" "bar" {
   project                 = data.aiven_project.foo.project
   cloud_name              = "google-europe-west1"
-  plan                    = "startup-16"
-  service_name            = "test-acc-sr-%s"
+  plan                    = "hobbyist"
+  service_name            = "test-acc-sr-%[2]s"
   maintenance_window_dow  = "monday"
   maintenance_window_time = "10:00:00"
 }
@@ -49,12 +53,12 @@ resource "aiven_clickhouse" "bar" {
 resource "aiven_clickhouse_database" "foo" {
   project      = aiven_clickhouse.bar.project
   service_name = aiven_clickhouse.bar.service_name
-  name         = "test-acc-db-%s"
+  name         = "test-acc-db-%[2]s"
 }
 
 data "aiven_clickhouse_database" "database" {
   project      = aiven_clickhouse_database.foo.project
   service_name = aiven_clickhouse_database.foo.service_name
   name         = aiven_clickhouse_database.foo.name
-}`, acc.ProjectName(), name, name)
+}`, acc.ProjectName(), name)
 }


### PR DESCRIPTION
- Sets required fields on import
- Removes the default value for `termination_protection` default value,
  which caused unnecessary plan diffs
    
Resolves NEX-1357, #2132