### PR TITLE
fix(clickhouse_grant): allow S3 as privilege

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,9 +19,7 @@ nav_order: 1
 - Added `base_port` to the `aiven_organization_project` resource
 - Deprecated `is_super_admin` in the `aiven_organization_application_user` resource
 - Fixed `aiven_clickhouse_grant` when setting database to wildcard (*)
-
-- Fix aiven_clickhouse_grant allow setting S3 privilege
-- Fix aiven_clickhouse_grant when setting database to wildcard (*)
+- Fixed `aiven_clickhouse_grant` allow setting S3 privilege
 
 ## [4.38.0] - 2025-04-10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@ nav_order: 1
 - Deprecated `is_super_admin` in the `aiven_organization_application_user` resource
 - Fixed `aiven_clickhouse_grant` when setting database to wildcard (*)
 
+- Fix aiven_clickhouse_grant allow setting S3 privilege
+- Fix aiven_clickhouse_grant when setting database to wildcard (*)
+
 ## [4.38.0] - 2025-04-10
 
 - Upgraded `go` version to `1.24`

--- a/internal/sdkprovider/service/clickhouse/clickhouse_grant.go
+++ b/internal/sdkprovider/service/clickhouse/clickhouse_grant.go
@@ -46,7 +46,7 @@ var aivenClickhouseGrantSchema = map[string]*schema.Schema{
 					Type:         schema.TypeString,
 					Optional:     true,
 					ForceNew:     true,
-					ValidateFunc: validation.StringMatch(regexp.MustCompile("^[A-Z ]+$"), "Must be a phrase of words that contain only uppercase letters."),
+					ValidateFunc: validation.StringMatch(regexp.MustCompile("^[A-Z0-9 ]+$"), "Must be a phrase of words that contain only uppercase letters and numbers."),
 				},
 				"database": {
 					Description: userconfig.Desc("The database to grant access to.").Referenced().ForceNew().Build(),

--- a/internal/sdkprovider/service/clickhouse/clickhouse_grant_test.go
+++ b/internal/sdkprovider/service/clickhouse/clickhouse_grant_test.go
@@ -123,6 +123,15 @@ resource "aiven_clickhouse_grant" "foo-user-grant" {
 						},
 					),
 
+					resource.TestCheckTypeSetElemNestedAttrs(
+						"aiven_clickhouse_grant.foo-role-grant",
+						"privilege_grant.*",
+						map[string]string{
+							"privilege": "S3",
+							"database":  "*",
+						},
+					),
+
 					resource.TestCheckResourceAttr(
 						"aiven_clickhouse_grant.foo-user-grant",
 						"user",

--- a/internal/sdkprovider/service/clickhouse/clickhouse_grant_test.go
+++ b/internal/sdkprovider/service/clickhouse/clickhouse_grant_test.go
@@ -63,6 +63,11 @@ resource "aiven_clickhouse_grant" "foo-role-grant" {
     privilege = "DROP FUNCTION"
     database  = "*"
   }
+
+  privilege_grant {
+    privilege = "S3"
+    database = "*"
+  }
 }
 
 resource "aiven_clickhouse_user" "foo-user" {

--- a/internal/sdkprovider/service/clickhouse/escape.go
+++ b/internal/sdkprovider/service/clickhouse/escape.go
@@ -6,6 +6,9 @@ import (
 )
 
 func escape(identifier string) string {
+	if identifier == "*" {
+		return identifier
+	}
 	return escapeBytes([]byte(identifier))
 }
 

--- a/internal/sdkprovider/service/clickhouse/escape.go
+++ b/internal/sdkprovider/service/clickhouse/escape.go
@@ -6,9 +6,6 @@ import (
 )
 
 func escape(identifier string) string {
-	if identifier == "*" {
-		return identifier
-	}
 	return escapeBytes([]byte(identifier))
 }
 


### PR DESCRIPTION
Privileges in Clickhouse can have numbers for example the S3 privilege,
this just changes the validation to allow numbers

This PR relies on this PR https://github.com/aiven/terraform-provider-aiven/pull/2148 to fix issue when specifying wildcards in database field so that one needs to be merged first.

<!-- Provide the issue number below, if it exists. -->
Resolves: #xxxxx.

## Why this way

<!-- Provide a small explanation on why this is the approach you took for solving this problem. -->
