### PR TITLE
fix: sort userconfig enum values

### DIFF
--- a/docs/resources/alloydbomni.md
+++ b/docs/resources/alloydbomni.md
@@ -238,7 +238,7 @@ Optional:
 - `log` (List of String) Specifies which classes of statements will be logged by session audit logging.
 - `log_catalog` (Boolean) Specifies that session logging should be enabled in the casewhere all relations in a statement are in pg_catalog. Default: `true`.
 - `log_client` (Boolean) Specifies whether log messages will be visible to a client process such as psql. Default: `false`.
-- `log_level` (String) Enum: `debug1`, `debug2`, `debug3`, `debug4`, `debug5`, `info`, `notice`, `warning`, `log`. Specifies the log level that will be used for log entries. Default: `log`.
+- `log_level` (String) Enum: `debug1`, `debug2`, `debug3`, `debug4`, `debug5`, `info`, `log`, `notice`, `warning`. Specifies the log level that will be used for log entries. Default: `log`.
 - `log_max_string_length` (Number) Crop parameters representation and whole statements if they exceed this threshold. A (default) value of -1 disable the truncation. Default: `-1`.
 - `log_nested_statements` (Boolean) This GUC allows to turn off logging nested statements, that is, statements that are executed as part of another ExecutorRun. Default: `true`.
 - `log_parameter` (Boolean) Specifies that audit logging should include the parameters that were passed with the statement. Default: `false`.

--- a/internal/sdkprovider/userconfig/service/alloydbomni.go
+++ b/internal/sdkprovider/userconfig/service/alloydbomni.go
@@ -407,10 +407,10 @@ func alloydbomniUserConfig() *schema.Schema {
 						Type:        schema.TypeBool,
 					},
 					"log_level": {
-						Description:  "Enum: `debug1`, `debug2`, `debug3`, `debug4`, `debug5`, `info`, `notice`, `warning`, `log`. Specifies the log level that will be used for log entries. Default: `log`.",
+						Description:  "Enum: `debug1`, `debug2`, `debug3`, `debug4`, `debug5`, `info`, `log`, `notice`, `warning`. Specifies the log level that will be used for log entries. Default: `log`.",
 						Optional:     true,
 						Type:         schema.TypeString,
-						ValidateFunc: validation.StringInSlice([]string{"debug1", "debug2", "debug3", "debug4", "debug5", "info", "notice", "warning", "log"}, false),
+						ValidateFunc: validation.StringInSlice([]string{"debug1", "debug2", "debug3", "debug4", "debug5", "info", "log", "notice", "warning"}, false),
 					},
 					"log_max_string_length": {
 						Description: "Crop parameters representation and whole statements if they exceed this threshold. A (default) value of -1 disable the truncation. Default: `-1`.",

--- a/ucgenerator/models.go
+++ b/ucgenerator/models.go
@@ -168,12 +168,10 @@ func (o *object) init(name string) {
 		o.Default = nil
 	}
 
-	// Sorts version enum values
-	if o.Enum != nil && strings.HasSuffix(name, "version") {
-		sort.Slice(o.Enum, func(i, j int) bool {
-			return o.Enum[i].Value < o.Enum[j].Value
-		})
-	}
+	// Sorts version enum values for consistent order
+	sort.Slice(o.Enum, func(i, j int) bool {
+		return o.Enum[i].Value < o.Enum[j].Value
+	})
 }
 
 func (o *object) isNestedBlock() bool {


### PR DESCRIPTION
For the consistent result enum values must be always sorted.
