### PR TITLE
refactor: convertors must return diags

### DIFF
--- a/internal/schemautil/userconfig/desc.go
+++ b/internal/schemautil/userconfig/desc.go
@@ -206,5 +206,10 @@ the ` + "`PROVIDER_AIVEN_ENABLE_BETA`" + ` environment variable to use the %[1]s
 		))
 	}
 
-	return builder.String()
+	// Avoids redundant descriptions.
+	s := strings.TrimSpace(builder.String())
+	if s == "." {
+		return ""
+	}
+	return s
 }


### PR DESCRIPTION
Expanders and Flatteners must return diags to align interfaces with supervising functions.