### PR TITLE
fix: clickhouse_grant privilege case validation error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ nav_order: 1
 ## [MAJOR.MINOR.PATCH] - YYYY-MM-DD
 
 - Change `aiven_organization_user_list.billing_groups` to type `Set`. The order is not guaranteed.
+- Fix `aiven_clickhouse_grant.privilege_grant.privilege` case validation
 
 ## [4.39.0] - 2025-04-24
 

--- a/internal/sdkprovider/service/clickhouse/clickhouse_grant.go
+++ b/internal/sdkprovider/service/clickhouse/clickhouse_grant.go
@@ -46,7 +46,7 @@ var aivenClickhouseGrantSchema = map[string]*schema.Schema{
 					Type:         schema.TypeString,
 					Optional:     true,
 					ForceNew:     true,
-					ValidateFunc: validation.StringMatch(regexp.MustCompile("^[A-Z0-9 ]+$"), "Must be a phrase of words that contain only uppercase letters and numbers."),
+					ValidateFunc: validation.StringMatch(regexp.MustCompile("^[a-zA-Z0-9 ]+$"), "Must be a phrase of words that contain only letters and numbers."),
 				},
 				"database": {
 					Description: userconfig.Desc("The database to grant access to.").Referenced().ForceNew().Build(),


### PR DESCRIPTION
The validation expected upper case letters while Clickhouse may return privileges with lower case letters, for example https://clickhouse.com/docs/sql-reference/statements/grant#dictget

Resolves NEX-1443
