### PR TITLE
refactor: rename organization packages

### DIFF
--- a/internal/plugin/provider.go
+++ b/internal/plugin/provider.go
@@ -19,9 +19,9 @@ import (
 	"github.com/aiven/terraform-provider-aiven/internal/plugin/service/organization/address"
 	"github.com/aiven/terraform-provider-aiven/internal/plugin/service/organization/billinggroup"
 	"github.com/aiven/terraform-provider-aiven/internal/plugin/service/organization/billinggrouplist"
+	"github.com/aiven/terraform-provider-aiven/internal/plugin/service/organization/groupproject"
 	"github.com/aiven/terraform-provider-aiven/internal/plugin/service/organization/organization"
-	"github.com/aiven/terraform-provider-aiven/internal/plugin/service/organization/project"
-	"github.com/aiven/terraform-provider-aiven/internal/plugin/service/organization/usergroup"
+	"github.com/aiven/terraform-provider-aiven/internal/plugin/service/organization/usergroupmember"
 	providertypes "github.com/aiven/terraform-provider-aiven/internal/plugin/types"
 	"github.com/aiven/terraform-provider-aiven/internal/plugin/util"
 )
@@ -156,8 +156,8 @@ func (p *AivenProvider) Resources(context.Context) []func() resource.Resource {
 	// List of resources that are currently available in the provider.
 	resources := []func() resource.Resource{
 		organization.NewOrganizationResource,
-		usergroup.NewOrganizationUserGroupMembersResource,
-		project.NewOrganizationGroupProjectResource,
+		usergroupmember.NewOrganizationUserGroupMembersResource,
+		groupproject.NewOrganizationGroupProjectResource,
 	}
 
 	// Add to a list of resources that are currently in beta.

--- a/internal/plugin/service/organization/groupproject/organization_group_project.go
+++ b/internal/plugin/service/organization/groupproject/organization_group_project.go
@@ -1,4 +1,4 @@
-package project
+package groupproject
 
 import (
 	"context"

--- a/internal/plugin/service/organization/groupproject/organization_group_project_test.go
+++ b/internal/plugin/service/organization/groupproject/organization_group_project_test.go
@@ -1,4 +1,4 @@
-package project_test
+package groupproject_test
 
 import (
 	"fmt"

--- a/internal/plugin/service/organization/usergroupmember/organization_user_group_member.go
+++ b/internal/plugin/service/organization/usergroupmember/organization_user_group_member.go
@@ -1,4 +1,4 @@
-package usergroup
+package usergroupmember
 
 import (
 	"context"

--- a/internal/plugin/service/organization/usergroupmember/organization_user_group_member_test.go
+++ b/internal/plugin/service/organization/usergroupmember/organization_user_group_member_test.go
@@ -1,4 +1,4 @@
-package usergroup_test
+package usergroupmember_test
 
 import (
 	"fmt"


### PR DESCRIPTION
Renames `groupproject` and `usergroupmember` packages. 
Similar to their resource names, so we can add `project` package later which is currently taken by the `groupproject` package.

Contributes to NEX-1446.
