### PR TITLE
feat: add state to expandData

### DIFF
--- a/docs/data-sources/organization_address.md
+++ b/docs/data-sources/organization_address.md
@@ -22,7 +22,7 @@ the `PROVIDER_AIVEN_ENABLE_BETA` environment variable to use the resource.
 
 ### Required
 
-- `address_id` (String) Address id.
+- `address_id` (String) Address ID.
 - `organization_id` (String) ID of an organization.
 
 ### Optional

--- a/docs/data-sources/organization_billing_group.md
+++ b/docs/data-sources/organization_billing_group.md
@@ -22,7 +22,7 @@ the `PROVIDER_AIVEN_ENABLE_BETA` environment variable to use the resource.
 
 ### Required
 
-- `billing_group_id` (String) Billing group id.
+- `billing_group_id` (String) Billing group ID.
 - `organization_id` (String) ID of an organization.
 
 ### Optional

--- a/docs/resources/organization_address.md
+++ b/docs/resources/organization_address.md
@@ -36,7 +36,7 @@ the `PROVIDER_AIVEN_ENABLE_BETA` environment variable to use the resource.
 
 ### Read-Only
 
-- `address_id` (String) Address id.
+- `address_id` (String) Address ID.
 - `create_time` (String) Create Time.
 - `id` (String) Resource ID, a composite of `organization_id` and `address_id` IDs.
 - `update_time` (String) Update Time.

--- a/docs/resources/organization_billing_group.md
+++ b/docs/resources/organization_billing_group.md
@@ -39,7 +39,7 @@ the `PROVIDER_AIVEN_ENABLE_BETA` environment variable to use the resource.
 
 ### Read-Only
 
-- `billing_group_id` (String) Billing group id.
+- `billing_group_id` (String) Billing group ID.
 - `id` (String) Resource ID, a composite of `organization_id` and `billing_group_id` IDs.
 
 <a id="nestedblock--timeouts"></a>

--- a/internal/plugin/service/organization/address/address.go
+++ b/internal/plugin/service/organization/address/address.go
@@ -48,7 +48,7 @@ func (c *view) Configure(client avngen.Client) {
 
 func (c *view) Create(ctx context.Context, plan *dataModel) diag.Diagnostics {
 	var req organization.OrganizationAddressCreateIn
-	diags := expandData(ctx, plan, &req)
+	diags := expandData(ctx, plan, nil, &req)
 	if diags.HasError() {
 		return diags
 	}
@@ -66,7 +66,7 @@ func (c *view) Create(ctx context.Context, plan *dataModel) diag.Diagnostics {
 
 func (c *view) Update(ctx context.Context, plan, state *dataModel) diag.Diagnostics {
 	var req organization.OrganizationAddressUpdateIn
-	diags := expandData(ctx, plan, &req)
+	diags := expandData(ctx, plan, state, &req)
 	if diags.HasError() {
 		return diags
 	}

--- a/internal/plugin/service/organization/address/address_test.go
+++ b/internal/plugin/service/organization/address/address_test.go
@@ -90,6 +90,27 @@ func TestAccAivenOrganizationAddress(t *testing.T) {
 				),
 			},
 			{
+				// Test update: remove optional fields.
+				// State field can be omitted when the country code is not US.
+				Config: templBuilder().AddResource("aiven_organization_address", map[string]any{
+					"resource_name":   "address",
+					"organization_id": template.Reference("data.aiven_organization.org.id"),
+					"address_lines":   []string{"456 Market St", "Floor 3"},
+					"city":            "Berlin",
+					"name":            "Updated Company Deutschland",
+					"country_code":    "DE",
+					// "state":           "BE",
+					// "zip_code":        "10117".
+				}).MustRender(t),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(name, "city", "Berlin"),
+					resource.TestCheckResourceAttr(name, "name", "Updated Company Deutschland"),
+					resource.TestCheckResourceAttr(name, "country_code", "DE"),
+					resource.TestCheckNoResourceAttr(name, "state"),
+					resource.TestCheckNoResourceAttr(name, "zip_code"),
+				),
+			},
+			{
 				// Test import functionality
 				ResourceName:      name,
 				ImportState:       true,

--- a/internal/plugin/service/organization/address/zz_converters.go
+++ b/internal/plugin/service/organization/address/zz_converters.go
@@ -42,45 +42,51 @@ func (data *dataModel) SetID(vOrganizationID string, vAddressID string) {
 
 type dtoModel struct {
 	AddressID      *string   `json:"address_id,omitempty"`
-	AddressLines   *[]string `json:"address_lines"`
-	City           *string   `json:"city"`
-	CountryCode    *string   `json:"country_code"`
+	AddressLines   *[]string `json:"address_lines,omitempty"`
+	City           *string   `json:"city,omitempty"`
+	CountryCode    *string   `json:"country_code,omitempty"`
 	CreateTime     *string   `json:"create_time,omitempty"`
-	Name           *string   `json:"name"`
-	OrganizationID *string   `json:"organization_id"`
+	Name           *string   `json:"name,omitempty"`
+	OrganizationID *string   `json:"organization_id,omitempty"`
 	State          *string   `json:"state,omitempty"`
 	UpdateTime     *string   `json:"update_time,omitempty"`
 	ZipCode        *string   `json:"zip_code,omitempty"`
 }
 
 // expandData turns TF object into Request
-func expandData[R any](ctx context.Context, data *dataModel, rqs *R, modifiers ...util.MapModifier[dtoModel]) diag.Diagnostics {
+func expandData[R any](ctx context.Context, plan, state *dataModel, rqs *R, modifiers ...util.MapModifier[dtoModel]) diag.Diagnostics {
 	dto := new(dtoModel)
-	if !data.AddressLines.IsNull() {
-		var vAddressLines []string
-		diags := data.AddressLines.ElementsAs(ctx, &vAddressLines, false)
+	if !plan.AddressLines.IsNull() || state != nil && !state.AddressLines.IsNull() {
+		vAddressLines := make([]string, 0)
+		diags := plan.AddressLines.ElementsAs(ctx, &vAddressLines, false)
 		if diags.HasError() {
 			return diags
 		}
 		dto.AddressLines = &vAddressLines
 	}
-	if !data.City.IsNull() {
-		dto.City = data.City.ValueStringPointer()
+	if !plan.City.IsNull() || state != nil && !state.City.IsNull() {
+		vCity := plan.City.ValueString()
+		dto.City = &vCity
 	}
-	if !data.CountryCode.IsNull() {
-		dto.CountryCode = data.CountryCode.ValueStringPointer()
+	if !plan.CountryCode.IsNull() || state != nil && !state.CountryCode.IsNull() {
+		vCountryCode := plan.CountryCode.ValueString()
+		dto.CountryCode = &vCountryCode
 	}
-	if !data.Name.IsNull() {
-		dto.Name = data.Name.ValueStringPointer()
+	if !plan.Name.IsNull() || state != nil && !state.Name.IsNull() {
+		vName := plan.Name.ValueString()
+		dto.Name = &vName
 	}
-	if !data.OrganizationID.IsNull() {
-		dto.OrganizationID = data.OrganizationID.ValueStringPointer()
+	if !plan.OrganizationID.IsNull() || state != nil && !state.OrganizationID.IsNull() {
+		vOrganizationID := plan.OrganizationID.ValueString()
+		dto.OrganizationID = &vOrganizationID
 	}
-	if !data.State.IsNull() {
-		dto.State = data.State.ValueStringPointer()
+	if !plan.State.IsNull() || state != nil && !state.State.IsNull() {
+		vState := plan.State.ValueString()
+		dto.State = &vState
 	}
-	if !data.ZipCode.IsNull() {
-		dto.ZipCode = data.ZipCode.ValueStringPointer()
+	if !plan.ZipCode.IsNull() || state != nil && !state.ZipCode.IsNull() {
+		vZipCode := plan.ZipCode.ValueString()
+		dto.ZipCode = &vZipCode
 	}
 	err := util.Unmarshal(dto, rqs, modifiers...)
 	if err != nil {
@@ -92,7 +98,7 @@ func expandData[R any](ctx context.Context, data *dataModel, rqs *R, modifiers .
 }
 
 // flattenData turns Response into TF object
-func flattenData[R any](ctx context.Context, data *dataModel, rsp *R, modifiers ...util.MapModifier[R]) diag.Diagnostics {
+func flattenData[R any](ctx context.Context, state *dataModel, rsp *R, modifiers ...util.MapModifier[R]) diag.Diagnostics {
 	dto := new(dtoModel)
 	err := util.Unmarshal(rsp, dto, modifiers...)
 	if err != nil {
@@ -100,54 +106,54 @@ func flattenData[R any](ctx context.Context, data *dataModel, rsp *R, modifiers 
 		diags.AddError("Unmarshal error", fmt.Sprintf("Failed to unmarshal Response to dtoModel: %s", err.Error()))
 		return diags
 	}
-	if dto.AddressLines != nil {
+	if dto.AddressLines != nil && (len(*dto.AddressLines) > 0 || !state.AddressLines.IsNull()) {
 		vAddressLines, diags := types.SetValueFrom(ctx, types.StringType, dto.AddressLines)
 		if diags.HasError() {
 			return diags
 		}
-		data.AddressLines = vAddressLines
+		state.AddressLines = vAddressLines
 	}
-	if dto.AddressID != nil {
-		data.AddressID = types.StringPointerValue(dto.AddressID)
+	if dto.AddressID != nil && (*dto.AddressID != "" || !state.AddressID.IsNull()) {
+		state.AddressID = types.StringPointerValue(dto.AddressID)
 	}
-	if dto.City != nil {
-		data.City = types.StringPointerValue(dto.City)
+	if dto.City != nil && (*dto.City != "" || !state.City.IsNull()) {
+		state.City = types.StringPointerValue(dto.City)
 	}
-	if dto.CountryCode != nil {
-		data.CountryCode = types.StringPointerValue(dto.CountryCode)
+	if dto.CountryCode != nil && (*dto.CountryCode != "" || !state.CountryCode.IsNull()) {
+		state.CountryCode = types.StringPointerValue(dto.CountryCode)
 	}
-	if dto.CreateTime != nil {
-		data.CreateTime = types.StringPointerValue(dto.CreateTime)
+	if dto.CreateTime != nil && (*dto.CreateTime != "" || !state.CreateTime.IsNull()) {
+		state.CreateTime = types.StringPointerValue(dto.CreateTime)
 	}
-	if dto.Name != nil {
-		data.Name = types.StringPointerValue(dto.Name)
+	if dto.Name != nil && (*dto.Name != "" || !state.Name.IsNull()) {
+		state.Name = types.StringPointerValue(dto.Name)
 	}
-	if dto.OrganizationID != nil {
-		data.OrganizationID = types.StringPointerValue(dto.OrganizationID)
+	if dto.OrganizationID != nil && (*dto.OrganizationID != "" || !state.OrganizationID.IsNull()) {
+		state.OrganizationID = types.StringPointerValue(dto.OrganizationID)
 	}
-	if dto.State != nil {
-		data.State = types.StringPointerValue(dto.State)
+	if dto.State != nil && (*dto.State != "" || !state.State.IsNull()) {
+		state.State = types.StringPointerValue(dto.State)
 	}
-	if dto.UpdateTime != nil {
-		data.UpdateTime = types.StringPointerValue(dto.UpdateTime)
+	if dto.UpdateTime != nil && (*dto.UpdateTime != "" || !state.UpdateTime.IsNull()) {
+		state.UpdateTime = types.StringPointerValue(dto.UpdateTime)
 	}
-	if dto.ZipCode != nil {
-		data.ZipCode = types.StringPointerValue(dto.ZipCode)
+	if dto.ZipCode != nil && (*dto.ZipCode != "" || !state.ZipCode.IsNull()) {
+		state.ZipCode = types.StringPointerValue(dto.ZipCode)
 	}
 	// Response may not contain ID fields.
 	// In that case, `terraform import` won't be able to set them. Gets values from the ID.
-	if data.ID.ValueString() != "" {
+	if state.ID.ValueString() != "" {
 		var parts [2]string
-		for i, v := range strings.SplitN(data.ID.ValueString(), "/", 2) {
+		for i, v := range strings.SplitN(state.ID.ValueString(), "/", 2) {
 			parts[i] = v
 		}
-		if data.OrganizationID.ValueString() == "" {
-			data.OrganizationID = types.StringValue(parts[0])
+		if state.OrganizationID.ValueString() == "" {
+			state.OrganizationID = types.StringValue(parts[0])
 		}
-		if data.AddressID.ValueString() == "" {
-			data.AddressID = types.StringValue(parts[1])
+		if state.AddressID.ValueString() == "" {
+			state.AddressID = types.StringValue(parts[1])
 		}
 	}
-	data.SetID(data.OrganizationID.ValueString(), data.AddressID.ValueString())
+	state.SetID(state.OrganizationID.ValueString(), state.AddressID.ValueString())
 	return nil
 }

--- a/internal/plugin/service/organization/address/zz_datasource.go
+++ b/internal/plugin/service/organization/address/zz_datasource.go
@@ -28,7 +28,7 @@ func datasourceSchema(ctx context.Context) schema.Schema {
 	return schema.Schema{
 		Attributes: map[string]schema.Attribute{
 			"address_id": schema.StringAttribute{
-				MarkdownDescription: "Address id.",
+				MarkdownDescription: "Address ID.",
 				Required:            true,
 			},
 			"address_lines": schema.SetAttribute{

--- a/internal/plugin/service/organization/address/zz_resource.go
+++ b/internal/plugin/service/organization/address/zz_resource.go
@@ -31,7 +31,7 @@ func resourceSchema(ctx context.Context) schema.Schema {
 		Attributes: map[string]schema.Attribute{
 			"address_id": schema.StringAttribute{
 				Computed:            true,
-				MarkdownDescription: "Address id.",
+				MarkdownDescription: "Address ID.",
 			},
 			"address_lines": schema.SetAttribute{
 				ElementType:         types.StringType,

--- a/internal/plugin/service/organization/billinggroup/billing_group.go
+++ b/internal/plugin/service/organization/billinggroup/billing_group.go
@@ -48,7 +48,7 @@ func (c *view) Configure(client avngen.Client) {
 
 func (c *view) Create(ctx context.Context, plan *dataModel) diag.Diagnostics {
 	var req organizationbilling.OrganizationBillingGroupCreateIn
-	diags := expandData(ctx, plan, &req, emailsToMap)
+	diags := expandData(ctx, plan, nil, &req, emailsToMap)
 	if diags.HasError() {
 		return diags
 	}
@@ -66,7 +66,7 @@ func (c *view) Create(ctx context.Context, plan *dataModel) diag.Diagnostics {
 
 func (c *view) Update(ctx context.Context, plan, state *dataModel) diag.Diagnostics {
 	var req organizationbilling.OrganizationBillingGroupUpdateIn
-	diags := expandData(ctx, plan, &req, emailsToMap)
+	diags := expandData(ctx, plan, state, &req, emailsToMap)
 	if diags.HasError() {
 		return diags
 	}

--- a/internal/plugin/service/organization/billinggroup/zz_converters.go
+++ b/internal/plugin/service/organization/billinggroup/zz_converters.go
@@ -42,61 +42,69 @@ func (data *dataModel) SetID(vOrganizationID string, vBillingGroupID string) {
 }
 
 type dtoModel struct {
-	BillingAddressID     *string   `json:"billing_address_id"`
-	BillingContactEmails *[]string `json:"billing_contact_emails"`
+	BillingAddressID     *string   `json:"billing_address_id,omitempty"`
+	BillingContactEmails *[]string `json:"billing_contact_emails,omitempty"`
 	BillingCurrency      *string   `json:"billing_currency,omitempty"`
-	BillingEmails        *[]string `json:"billing_emails"`
+	BillingEmails        *[]string `json:"billing_emails,omitempty"`
 	BillingGroupID       *string   `json:"billing_group_id,omitempty"`
-	BillingGroupName     *string   `json:"billing_group_name"`
+	BillingGroupName     *string   `json:"billing_group_name,omitempty"`
 	CustomInvoiceText    *string   `json:"custom_invoice_text,omitempty"`
-	OrganizationID       *string   `json:"organization_id"`
-	PaymentMethodID      *string   `json:"payment_method_id"`
-	ShippingAddressID    *string   `json:"shipping_address_id"`
+	OrganizationID       *string   `json:"organization_id,omitempty"`
+	PaymentMethodID      *string   `json:"payment_method_id,omitempty"`
+	ShippingAddressID    *string   `json:"shipping_address_id,omitempty"`
 	VatID                *string   `json:"vat_id,omitempty"`
 }
 
 // expandData turns TF object into Request
-func expandData[R any](ctx context.Context, data *dataModel, rqs *R, modifiers ...util.MapModifier[dtoModel]) diag.Diagnostics {
+func expandData[R any](ctx context.Context, plan, state *dataModel, rqs *R, modifiers ...util.MapModifier[dtoModel]) diag.Diagnostics {
 	dto := new(dtoModel)
-	if !data.BillingContactEmails.IsNull() {
-		var vBillingContactEmails []string
-		diags := data.BillingContactEmails.ElementsAs(ctx, &vBillingContactEmails, false)
+	if !plan.BillingContactEmails.IsNull() || state != nil && !state.BillingContactEmails.IsNull() {
+		vBillingContactEmails := make([]string, 0)
+		diags := plan.BillingContactEmails.ElementsAs(ctx, &vBillingContactEmails, false)
 		if diags.HasError() {
 			return diags
 		}
 		dto.BillingContactEmails = &vBillingContactEmails
 	}
-	if !data.BillingEmails.IsNull() {
-		var vBillingEmails []string
-		diags := data.BillingEmails.ElementsAs(ctx, &vBillingEmails, false)
+	if !plan.BillingEmails.IsNull() || state != nil && !state.BillingEmails.IsNull() {
+		vBillingEmails := make([]string, 0)
+		diags := plan.BillingEmails.ElementsAs(ctx, &vBillingEmails, false)
 		if diags.HasError() {
 			return diags
 		}
 		dto.BillingEmails = &vBillingEmails
 	}
-	if !data.BillingAddressID.IsNull() {
-		dto.BillingAddressID = data.BillingAddressID.ValueStringPointer()
+	if !plan.BillingAddressID.IsNull() || state != nil && !state.BillingAddressID.IsNull() {
+		vBillingAddressID := plan.BillingAddressID.ValueString()
+		dto.BillingAddressID = &vBillingAddressID
 	}
-	if !data.BillingCurrency.IsNull() {
-		dto.BillingCurrency = data.BillingCurrency.ValueStringPointer()
+	if !plan.BillingCurrency.IsNull() || state != nil && !state.BillingCurrency.IsNull() {
+		vBillingCurrency := plan.BillingCurrency.ValueString()
+		dto.BillingCurrency = &vBillingCurrency
 	}
-	if !data.BillingGroupName.IsNull() {
-		dto.BillingGroupName = data.BillingGroupName.ValueStringPointer()
+	if !plan.BillingGroupName.IsNull() || state != nil && !state.BillingGroupName.IsNull() {
+		vBillingGroupName := plan.BillingGroupName.ValueString()
+		dto.BillingGroupName = &vBillingGroupName
 	}
-	if !data.CustomInvoiceText.IsNull() {
-		dto.CustomInvoiceText = data.CustomInvoiceText.ValueStringPointer()
+	if !plan.CustomInvoiceText.IsNull() || state != nil && !state.CustomInvoiceText.IsNull() {
+		vCustomInvoiceText := plan.CustomInvoiceText.ValueString()
+		dto.CustomInvoiceText = &vCustomInvoiceText
 	}
-	if !data.OrganizationID.IsNull() {
-		dto.OrganizationID = data.OrganizationID.ValueStringPointer()
+	if !plan.OrganizationID.IsNull() || state != nil && !state.OrganizationID.IsNull() {
+		vOrganizationID := plan.OrganizationID.ValueString()
+		dto.OrganizationID = &vOrganizationID
 	}
-	if !data.PaymentMethodID.IsNull() {
-		dto.PaymentMethodID = data.PaymentMethodID.ValueStringPointer()
+	if !plan.PaymentMethodID.IsNull() || state != nil && !state.PaymentMethodID.IsNull() {
+		vPaymentMethodID := plan.PaymentMethodID.ValueString()
+		dto.PaymentMethodID = &vPaymentMethodID
 	}
-	if !data.ShippingAddressID.IsNull() {
-		dto.ShippingAddressID = data.ShippingAddressID.ValueStringPointer()
+	if !plan.ShippingAddressID.IsNull() || state != nil && !state.ShippingAddressID.IsNull() {
+		vShippingAddressID := plan.ShippingAddressID.ValueString()
+		dto.ShippingAddressID = &vShippingAddressID
 	}
-	if !data.VatID.IsNull() {
-		dto.VatID = data.VatID.ValueStringPointer()
+	if !plan.VatID.IsNull() || state != nil && !state.VatID.IsNull() {
+		vVatID := plan.VatID.ValueString()
+		dto.VatID = &vVatID
 	}
 	err := util.Unmarshal(dto, rqs, modifiers...)
 	if err != nil {
@@ -108,7 +116,7 @@ func expandData[R any](ctx context.Context, data *dataModel, rqs *R, modifiers .
 }
 
 // flattenData turns Response into TF object
-func flattenData[R any](ctx context.Context, data *dataModel, rsp *R, modifiers ...util.MapModifier[R]) diag.Diagnostics {
+func flattenData[R any](ctx context.Context, state *dataModel, rsp *R, modifiers ...util.MapModifier[R]) diag.Diagnostics {
 	dto := new(dtoModel)
 	err := util.Unmarshal(rsp, dto, modifiers...)
 	if err != nil {
@@ -116,61 +124,61 @@ func flattenData[R any](ctx context.Context, data *dataModel, rsp *R, modifiers 
 		diags.AddError("Unmarshal error", fmt.Sprintf("Failed to unmarshal Response to dtoModel: %s", err.Error()))
 		return diags
 	}
-	if dto.BillingContactEmails != nil {
+	if dto.BillingContactEmails != nil && (len(*dto.BillingContactEmails) > 0 || !state.BillingContactEmails.IsNull()) {
 		vBillingContactEmails, diags := types.SetValueFrom(ctx, types.StringType, dto.BillingContactEmails)
 		if diags.HasError() {
 			return diags
 		}
-		data.BillingContactEmails = vBillingContactEmails
+		state.BillingContactEmails = vBillingContactEmails
 	}
-	if dto.BillingEmails != nil {
+	if dto.BillingEmails != nil && (len(*dto.BillingEmails) > 0 || !state.BillingEmails.IsNull()) {
 		vBillingEmails, diags := types.SetValueFrom(ctx, types.StringType, dto.BillingEmails)
 		if diags.HasError() {
 			return diags
 		}
-		data.BillingEmails = vBillingEmails
+		state.BillingEmails = vBillingEmails
 	}
-	if dto.BillingAddressID != nil {
-		data.BillingAddressID = types.StringPointerValue(dto.BillingAddressID)
+	if dto.BillingAddressID != nil && (*dto.BillingAddressID != "" || !state.BillingAddressID.IsNull()) {
+		state.BillingAddressID = types.StringPointerValue(dto.BillingAddressID)
 	}
-	if dto.BillingCurrency != nil {
-		data.BillingCurrency = types.StringPointerValue(dto.BillingCurrency)
+	if dto.BillingCurrency != nil && (*dto.BillingCurrency != "" || !state.BillingCurrency.IsNull()) {
+		state.BillingCurrency = types.StringPointerValue(dto.BillingCurrency)
 	}
-	if dto.BillingGroupID != nil {
-		data.BillingGroupID = types.StringPointerValue(dto.BillingGroupID)
+	if dto.BillingGroupID != nil && (*dto.BillingGroupID != "" || !state.BillingGroupID.IsNull()) {
+		state.BillingGroupID = types.StringPointerValue(dto.BillingGroupID)
 	}
-	if dto.BillingGroupName != nil {
-		data.BillingGroupName = types.StringPointerValue(dto.BillingGroupName)
+	if dto.BillingGroupName != nil && (*dto.BillingGroupName != "" || !state.BillingGroupName.IsNull()) {
+		state.BillingGroupName = types.StringPointerValue(dto.BillingGroupName)
 	}
-	if dto.CustomInvoiceText != nil {
-		data.CustomInvoiceText = types.StringPointerValue(dto.CustomInvoiceText)
+	if dto.CustomInvoiceText != nil && (*dto.CustomInvoiceText != "" || !state.CustomInvoiceText.IsNull()) {
+		state.CustomInvoiceText = types.StringPointerValue(dto.CustomInvoiceText)
 	}
-	if dto.OrganizationID != nil {
-		data.OrganizationID = types.StringPointerValue(dto.OrganizationID)
+	if dto.OrganizationID != nil && (*dto.OrganizationID != "" || !state.OrganizationID.IsNull()) {
+		state.OrganizationID = types.StringPointerValue(dto.OrganizationID)
 	}
-	if dto.PaymentMethodID != nil {
-		data.PaymentMethodID = types.StringPointerValue(dto.PaymentMethodID)
+	if dto.PaymentMethodID != nil && (*dto.PaymentMethodID != "" || !state.PaymentMethodID.IsNull()) {
+		state.PaymentMethodID = types.StringPointerValue(dto.PaymentMethodID)
 	}
-	if dto.ShippingAddressID != nil {
-		data.ShippingAddressID = types.StringPointerValue(dto.ShippingAddressID)
+	if dto.ShippingAddressID != nil && (*dto.ShippingAddressID != "" || !state.ShippingAddressID.IsNull()) {
+		state.ShippingAddressID = types.StringPointerValue(dto.ShippingAddressID)
 	}
-	if dto.VatID != nil {
-		data.VatID = types.StringPointerValue(dto.VatID)
+	if dto.VatID != nil && (*dto.VatID != "" || !state.VatID.IsNull()) {
+		state.VatID = types.StringPointerValue(dto.VatID)
 	}
 	// Response may not contain ID fields.
 	// In that case, `terraform import` won't be able to set them. Gets values from the ID.
-	if data.ID.ValueString() != "" {
+	if state.ID.ValueString() != "" {
 		var parts [2]string
-		for i, v := range strings.SplitN(data.ID.ValueString(), "/", 2) {
+		for i, v := range strings.SplitN(state.ID.ValueString(), "/", 2) {
 			parts[i] = v
 		}
-		if data.OrganizationID.ValueString() == "" {
-			data.OrganizationID = types.StringValue(parts[0])
+		if state.OrganizationID.ValueString() == "" {
+			state.OrganizationID = types.StringValue(parts[0])
 		}
-		if data.BillingGroupID.ValueString() == "" {
-			data.BillingGroupID = types.StringValue(parts[1])
+		if state.BillingGroupID.ValueString() == "" {
+			state.BillingGroupID = types.StringValue(parts[1])
 		}
 	}
-	data.SetID(data.OrganizationID.ValueString(), data.BillingGroupID.ValueString())
+	state.SetID(state.OrganizationID.ValueString(), state.BillingGroupID.ValueString())
 	return nil
 }

--- a/internal/plugin/service/organization/billinggroup/zz_datasource.go
+++ b/internal/plugin/service/organization/billinggroup/zz_datasource.go
@@ -47,7 +47,7 @@ func datasourceSchema(ctx context.Context) schema.Schema {
 				MarkdownDescription: "List of billing contact emails.",
 			},
 			"billing_group_id": schema.StringAttribute{
-				MarkdownDescription: "Billing group id.",
+				MarkdownDescription: "Billing group ID.",
 				Required:            true,
 			},
 			"billing_group_name": schema.StringAttribute{

--- a/internal/plugin/service/organization/billinggroup/zz_resource.go
+++ b/internal/plugin/service/organization/billinggroup/zz_resource.go
@@ -50,7 +50,7 @@ func resourceSchema(ctx context.Context) schema.Schema {
 			},
 			"billing_group_id": schema.StringAttribute{
 				Computed:            true,
-				MarkdownDescription: "Billing group id.",
+				MarkdownDescription: "Billing group ID.",
 			},
 			"billing_group_name": schema.StringAttribute{
 				MarkdownDescription: "Billing Group Name. Maximum length: `128`.",

--- a/internal/plugin/service/organization/billinggrouplist/zz_converters.go
+++ b/internal/plugin/service/organization/billinggrouplist/zz_converters.go
@@ -67,7 +67,7 @@ type dtoBillingGroups struct {
 }
 
 // flattenData turns Response into TF object
-func flattenData[R any](ctx context.Context, data *dataModel, rsp *R, modifiers ...util.MapModifier[R]) diag.Diagnostics {
+func flattenData[R any](ctx context.Context, state *dataModel, rsp *R, modifiers ...util.MapModifier[R]) diag.Diagnostics {
 	dto := new(dtoModel)
 	err := util.Unmarshal(rsp, dto, modifiers...)
 	if err != nil {
@@ -80,70 +80,70 @@ func flattenData[R any](ctx context.Context, data *dataModel, rsp *R, modifiers 
 		if diags.HasError() {
 			return diags
 		}
-		data.BillingGroups = vBillingGroups
+		state.BillingGroups = vBillingGroups
 	}
-	if dto.OrganizationID != nil {
-		data.OrganizationID = types.StringPointerValue(dto.OrganizationID)
+	if dto.OrganizationID != nil && (*dto.OrganizationID != "" || !state.OrganizationID.IsNull()) {
+		state.OrganizationID = types.StringPointerValue(dto.OrganizationID)
 	}
 	// Response may not contain ID fields.
 	// In that case, `terraform import` won't be able to set them. Gets values from the ID.
-	if data.ID.ValueString() != "" {
+	if state.ID.ValueString() != "" {
 		var parts [1]string
-		for i, v := range strings.SplitN(data.ID.ValueString(), "/", 1) {
+		for i, v := range strings.SplitN(state.ID.ValueString(), "/", 1) {
 			parts[i] = v
 		}
-		if data.OrganizationID.ValueString() == "" {
-			data.OrganizationID = types.StringValue(parts[0])
+		if state.OrganizationID.ValueString() == "" {
+			state.OrganizationID = types.StringValue(parts[0])
 		}
 	}
-	data.SetID(data.OrganizationID.ValueString())
+	state.SetID(state.OrganizationID.ValueString())
 	return nil
 }
 
 func flattenBillingGroups(ctx context.Context, dto *dtoBillingGroups) (*dataBillingGroups, diag.Diagnostics) {
-	data := new(dataBillingGroups)
+	state := new(dataBillingGroups)
 	if dto.BillingContactEmails != nil {
 		vBillingContactEmails, diags := types.SetValueFrom(ctx, types.StringType, dto.BillingContactEmails)
 		if diags.HasError() {
 			return nil, diags
 		}
-		data.BillingContactEmails = vBillingContactEmails
+		state.BillingContactEmails = vBillingContactEmails
 	}
 	if dto.BillingEmails != nil {
 		vBillingEmails, diags := types.SetValueFrom(ctx, types.StringType, dto.BillingEmails)
 		if diags.HasError() {
 			return nil, diags
 		}
-		data.BillingEmails = vBillingEmails
+		state.BillingEmails = vBillingEmails
 	}
 	if dto.BillingAddressID != nil {
-		data.BillingAddressID = types.StringPointerValue(dto.BillingAddressID)
+		state.BillingAddressID = types.StringPointerValue(dto.BillingAddressID)
 	}
 	if dto.BillingCurrency != nil {
-		data.BillingCurrency = types.StringPointerValue(dto.BillingCurrency)
+		state.BillingCurrency = types.StringPointerValue(dto.BillingCurrency)
 	}
 	if dto.BillingGroupID != nil {
-		data.BillingGroupID = types.StringPointerValue(dto.BillingGroupID)
+		state.BillingGroupID = types.StringPointerValue(dto.BillingGroupID)
 	}
 	if dto.BillingGroupName != nil {
-		data.BillingGroupName = types.StringPointerValue(dto.BillingGroupName)
+		state.BillingGroupName = types.StringPointerValue(dto.BillingGroupName)
 	}
 	if dto.CustomInvoiceText != nil {
-		data.CustomInvoiceText = types.StringPointerValue(dto.CustomInvoiceText)
+		state.CustomInvoiceText = types.StringPointerValue(dto.CustomInvoiceText)
 	}
 	if dto.OrganizationID != nil {
-		data.OrganizationID = types.StringPointerValue(dto.OrganizationID)
+		state.OrganizationID = types.StringPointerValue(dto.OrganizationID)
 	}
 	if dto.PaymentMethodID != nil {
-		data.PaymentMethodID = types.StringPointerValue(dto.PaymentMethodID)
+		state.PaymentMethodID = types.StringPointerValue(dto.PaymentMethodID)
 	}
 	if dto.ShippingAddressID != nil {
-		data.ShippingAddressID = types.StringPointerValue(dto.ShippingAddressID)
+		state.ShippingAddressID = types.StringPointerValue(dto.ShippingAddressID)
 	}
 	if dto.VatID != nil {
-		data.VatID = types.StringPointerValue(dto.VatID)
+		state.VatID = types.StringPointerValue(dto.VatID)
 	}
-	return data, nil
+	return state, nil
 }
 
 func attrsBillingGroups() types.ObjectType {

--- a/internal/plugin/service/organization/organization/organization.go
+++ b/internal/plugin/service/organization/organization/organization.go
@@ -87,7 +87,7 @@ func (vw *view) DatValidators(_ context.Context) []datasource.ConfigValidator {
 
 func (vw *view) Create(ctx context.Context, plan *dataModel) diag.Diagnostics {
 	var req account.AccountCreateIn
-	diags := expandData(ctx, plan, &req)
+	diags := expandData(ctx, plan, nil, &req)
 	if diags.HasError() {
 		return diags
 	}
@@ -105,7 +105,7 @@ func (vw *view) Create(ctx context.Context, plan *dataModel) diag.Diagnostics {
 
 func (vw *view) Update(ctx context.Context, plan, state *dataModel) diag.Diagnostics {
 	var req account.AccountUpdateIn
-	diags := expandData(ctx, plan, &req)
+	diags := expandData(ctx, plan, state, &req)
 	if diags.HasError() {
 		return diags
 	}

--- a/internal/plugin/util/converters.go
+++ b/internal/plugin/util/converters.go
@@ -52,6 +52,7 @@ func Unmarshal[I any, O any](in *I, out *O, modifiers ...MapModifier[I]) error {
 //	}
 //
 // In this case, the function can be used with any type of Request/Response object.
+// The map's keys are equal to original API keys, not TF schema fields.
 type MapModifier[I any] func(reqRsp map[string]any, in *I) error
 
 // Expand sets values to Request from a nested object.


### PR DESCRIPTION
The "plan" doesn't know if a field was removed. That comes from the "state".

- Extends `expandData` to support the "state"
- Improves array values drain (when removed from the config file)
- Ignores empty string values from Response, if the state doesn't have `""` explicitly

Contributes to NEX-1446.
