### PR TITLE
docs(clickhouse): add instructions for granting global privileges

### DIFF
--- a/docs/resources/clickhouse_grant.md
+++ b/docs/resources/clickhouse_grant.md
@@ -5,7 +5,7 @@ subcategory: ""
 description: |-
   Creates and manages ClickHouse grants to give users and roles privileges to a ClickHouse service.
   Note:
-  Users cannot have the same name as roles.To grant a privilege on all tables of a database, omit the table and only keep the database. Don't use table="*".Changes first revoke all grants and then reissue the remaining grants for convergence.
+  Users cannot have the same name as roles.Global privileges cannot be granted on the database level. To grant global privileges, use database="*".To grant a privilege on all tables of a database, omit the table and only keep the database. Don't use table="*".Changes first revoke all grants and then reissue the remaining grants for convergence.
 ---
 
 # aiven_clickhouse_grant (Resource)
@@ -14,6 +14,7 @@ Creates and manages ClickHouse grants to give users and roles privileges to a Cl
 
 **Note:**
 * Users cannot have the same name as roles.
+* Global privileges cannot be granted on the database level. To grant global privileges, use `database="*"`.
 * To grant a privilege on all tables of a database, omit the table and only keep the database. Don't use `table="*"`.
 * Changes first revoke all grants and then reissue the remaining grants for convergence.
 
@@ -41,6 +42,17 @@ resource "aiven_clickhouse_grant" "role_privileges" {
   privilege_grant {
     privilege = "SELECT"
     database  = aiven_clickhouse_database.example_db.name
+  }
+
+  # Global privileges
+    privilege_grant {
+    privilege = "CREATE TEMPORARY TABLE"
+    database  = "*"
+  }
+
+  privilege_grant {
+    privilege = "SYSTEM DROP CACHE"
+    database  = "*"
   }
 }
 

--- a/examples/resources/aiven_clickhouse_grant/resource.tf
+++ b/examples/resources/aiven_clickhouse_grant/resource.tf
@@ -20,6 +20,17 @@ resource "aiven_clickhouse_grant" "role_privileges" {
     privilege = "SELECT"
     database  = aiven_clickhouse_database.example_db.name
   }
+
+  # Global privileges
+    privilege_grant {
+    privilege = "CREATE TEMPORARY TABLE"
+    database  = "*"
+  }
+
+  privilege_grant {
+    privilege = "SYSTEM DROP CACHE"
+    database  = "*"
+  }
 }
 
 # Grant the role to the user.

--- a/internal/sdkprovider/service/clickhouse/clickhouse_grant.go
+++ b/internal/sdkprovider/service/clickhouse/clickhouse_grant.go
@@ -100,6 +100,7 @@ func ResourceClickhouseGrant() *schema.Resource {
 
 **Note:**
 * Users cannot have the same name as roles.
+* Global privileges cannot be granted on the database level. To grant global privileges, use ` + "`database=\"*\"`" + `.
 * To grant a privilege on all tables of a database, omit the table and only keep the database. Don't use ` + "`table=\"*\"`" + `.
 * Changes first revoke all grants and then reissue the remaining grants for convergence.
 `,


### PR DESCRIPTION
<!-- All contributors, please complete these sections, including maintainers. -->

## About this change—what it does

Adds a note about granting global privileges and includes an example of this.
