### PR TITLE
feat(clickhouse_grant): added ignore for case-sensitive privilege names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ nav_order: 1
 - Add `aiven_opensearch` field `opensearch_user_config.opensearch.enable_searchable_snapshots`: Enable searchable snapshots.
 - Remove `aiven_kafka_topic.config.unclean_leader_election_enable` deprecation
 - Fix the provider crash when `*_user_config` dynamic block values are known during the apply phase.
+- Ignores case sensitive privileges in `aiven_clickhouse_grant.privilege_grant.privilege` resource.
 
 ## [4.39.0] - 2025-04-24
 

--- a/internal/sdkprovider/service/clickhouse/clickhouse_grant_test.go
+++ b/internal/sdkprovider/service/clickhouse/clickhouse_grant_test.go
@@ -20,7 +20,7 @@ func TestAccAivenClickhouseGrant(t *testing.T) {
 	serviceName := fmt.Sprintf("test-acc-ch-%s", acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
 	projectName := acc.ProjectName()
 
-	manifest := fmt.Sprintf(`
+	baseConfig := fmt.Sprintf(`
 resource "aiven_clickhouse" "bar" {
   project                 = "%s"
   cloud_name              = "google-europe-west1"
@@ -42,6 +42,231 @@ resource "aiven_clickhouse_role" "foo-role" {
   role         = "foo-role"
 }
 
+resource "aiven_clickhouse_user" "foo-user" {
+  service_name = aiven_clickhouse.bar.service_name
+  project      = aiven_clickhouse.bar.project
+  username     = "foo-user"
+}`, projectName, serviceName)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acc.TestAccPreCheck(t) },
+		ProtoV6ProviderFactories: acc.TestProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckAivenClickhouseGrantResourceDestroy,
+		Steps: []resource.TestStep{
+			{
+				// Step 1: Test role grant with a single privilege
+				Config: baseConfig + `
+resource "aiven_clickhouse_grant" "foo-role-grant" {
+  service_name = aiven_clickhouse.bar.service_name
+  project      = aiven_clickhouse.bar.project
+  role         = aiven_clickhouse_role.foo-role.role
+
+  privilege_grant {
+    privilege = "INSERT"
+    database  = aiven_clickhouse_database.testdb.name
+    table     = "test-table"
+    column    = "test-column"
+  }
+}`,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckTypeSetElemNestedAttrs(
+						"aiven_clickhouse_grant.foo-role-grant",
+						"privilege_grant.*",
+						map[string]string{
+							"privilege": "INSERT",
+							"database":  "test-db",
+							"table":     "test-table",
+							"column":    "test-column",
+						},
+					),
+				),
+			},
+			{
+				// Step 2: Test case sensitivity with privilege names. The correct privilege name is "dictGet"
+				Config: baseConfig + `
+resource "aiven_clickhouse_grant" "foo-role-grant" {
+  service_name = aiven_clickhouse.bar.service_name
+  project      = aiven_clickhouse.bar.project
+  role         = aiven_clickhouse_role.foo-role.role
+
+  privilege_grant {
+    privilege = "DICTGET"
+    database  = "default"
+  }
+}`,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckTypeSetElemNestedAttrs(
+						"aiven_clickhouse_grant.foo-role-grant",
+						"privilege_grant.*",
+						map[string]string{
+							"privilege": "DICTGET", // the privilege name is stored as is
+							"database":  "default",
+						},
+					),
+				),
+			},
+			{
+				// Step 3: Test case sensitivity with privilege names. The correct privilege name is "dictGet"
+				Config: baseConfig + `
+resource "aiven_clickhouse_grant" "foo-role-grant" {
+  service_name = aiven_clickhouse.bar.service_name
+  project      = aiven_clickhouse.bar.project
+  role         = aiven_clickhouse_role.foo-role.role
+
+  privilege_grant {
+    privilege = "dictGet"
+    database  = "default"
+  }
+}`,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckTypeSetElemNestedAttrs(
+						"aiven_clickhouse_grant.foo-role-grant",
+						"privilege_grant.*",
+						map[string]string{
+							"privilege": "dictGet", // the privilege name is stored as is
+							"database":  "default",
+						},
+					),
+				),
+			},
+			{
+				// Step 4: Test privileges with asterisk (*)
+				Config: baseConfig + `
+resource "aiven_clickhouse_grant" "foo-role-grant" {
+  service_name = aiven_clickhouse.bar.service_name
+  project      = aiven_clickhouse.bar.project
+  role         = aiven_clickhouse_role.foo-role.role
+
+  privilege_grant {
+    privilege = "CREATE TEMPORARY TABLE"
+    database  = "*"
+  }
+
+  privilege_grant {
+    privilege = "DROP FUNCTION"
+    database  = "*"
+  }
+
+  privilege_grant {
+    privilege = "S3"
+    database  = "*"
+  }
+
+  privilege_grant {
+    privilege = "INSERT"
+    database  = aiven_clickhouse_database.testdb.name
+    table     = "*"
+  }
+}`,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckTypeSetElemNestedAttrs(
+						"aiven_clickhouse_grant.foo-role-grant",
+						"privilege_grant.*",
+						map[string]string{
+							"privilege": "CREATE TEMPORARY TABLE",
+							"database":  "*",
+						},
+					),
+					resource.TestCheckTypeSetElemNestedAttrs(
+						"aiven_clickhouse_grant.foo-role-grant",
+						"privilege_grant.*",
+						map[string]string{
+							"privilege": "DROP FUNCTION",
+							"database":  "*",
+						},
+					),
+					resource.TestCheckTypeSetElemNestedAttrs(
+						"aiven_clickhouse_grant.foo-role-grant",
+						"privilege_grant.*",
+						map[string]string{
+							"privilege": "S3",
+							"database":  "*",
+						},
+					),
+					resource.TestCheckTypeSetElemNestedAttrs(
+						"aiven_clickhouse_grant.foo-role-grant",
+						"privilege_grant.*",
+						map[string]string{
+							"privilege": "INSERT",
+							"database":  "test-db",
+							"table":     "*",
+						},
+					),
+				),
+			},
+			{
+				// Step 5: Clickhouse allows having a table name as asterisk (*)
+				// So this scenario grants SELECT privilege only on one table with name "*", not all tables in the database
+				Config: baseConfig + `
+resource "aiven_clickhouse_grant" "foo-role-grant" {
+  service_name = aiven_clickhouse.bar.service_name
+  project      = aiven_clickhouse.bar.project
+  role         = aiven_clickhouse_role.foo-role.role
+
+  privilege_grant {
+    privilege = "SELECT"
+    database  = "default"
+    table     = "*"
+  }
+}`,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckTypeSetElemNestedAttrs(
+						"aiven_clickhouse_grant.foo-role-grant",
+						"privilege_grant.*",
+						map[string]string{
+							"privilege": "SELECT",
+							"database":  "default",
+							"table":     "*",
+						},
+					),
+				),
+			},
+			{
+				// Step 6: This test case is to check the error when using asterisk (*) for both database and table
+				Config: baseConfig + `
+resource "aiven_clickhouse_grant" "foo-role-grant" {
+  service_name = aiven_clickhouse.bar.service_name
+  project      = aiven_clickhouse.bar.project
+  role         = aiven_clickhouse_role.foo-role.role
+
+  privilege_grant {
+    privilege = "SELECT"
+    database  = "*"
+    table     = "*"
+  }
+}`,
+				ExpectError: regexp.MustCompile("DB::Exception: Syntax error.*`\\*`"),
+			},
+			{
+				// Step 7: Test user grant with role
+				Config: baseConfig + `
+resource "aiven_clickhouse_grant" "foo-user-grant" {
+  service_name = aiven_clickhouse.bar.service_name
+  project      = aiven_clickhouse.bar.project
+  user         = aiven_clickhouse_user.foo-user.username
+
+  role_grant {
+    role = aiven_clickhouse_role.foo-role.role
+  }
+}`,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(
+						"aiven_clickhouse_grant.foo-user-grant",
+						"user",
+						"foo-user",
+					),
+					resource.TestCheckTypeSetElemNestedAttrs(
+						"aiven_clickhouse_grant.foo-user-grant",
+						"role_grant.*",
+						map[string]string{
+							"role": "foo-role",
+						},
+					),
+				),
+			},
+			{
+				// Step 8: Test both role grant and user grant together
+				Config: baseConfig + `
 resource "aiven_clickhouse_grant" "foo-role-grant" {
   service_name = aiven_clickhouse.bar.service_name
   project      = aiven_clickhouse.bar.project
@@ -58,22 +283,6 @@ resource "aiven_clickhouse_grant" "foo-role-grant" {
     privilege = "CREATE TEMPORARY TABLE"
     database  = "*"
   }
-
-  privilege_grant {
-    privilege = "DROP FUNCTION"
-    database  = "*"
-  }
-
-  privilege_grant {
-    privilege = "S3"
-    database  = "*"
-  }
-}
-
-resource "aiven_clickhouse_user" "foo-user" {
-  service_name = aiven_clickhouse.bar.service_name
-  project      = aiven_clickhouse.bar.project
-  username     = "foo-user"
 }
 
 resource "aiven_clickhouse_grant" "foo-user-grant" {
@@ -84,15 +293,7 @@ resource "aiven_clickhouse_grant" "foo-user-grant" {
   role_grant {
     role = aiven_clickhouse_role.foo-role.role
   }
-}`, projectName, serviceName)
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { acc.TestAccPreCheck(t) },
-		ProtoV6ProviderFactories: acc.TestProtoV6ProviderFactories,
-		CheckDestroy:             testAccCheckAivenClickhouseGrantResourceDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: manifest,
+}`,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckTypeSetElemNestedAttrs(
 						"aiven_clickhouse_grant.foo-role-grant",
@@ -104,40 +305,11 @@ resource "aiven_clickhouse_grant" "foo-user-grant" {
 							"column":    "test-column",
 						},
 					),
-
-					resource.TestCheckTypeSetElemNestedAttrs(
-						"aiven_clickhouse_grant.foo-role-grant",
-						"privilege_grant.*",
-						map[string]string{
-							"privilege": "CREATE TEMPORARY TABLE",
-							"database":  "*",
-						},
-					),
-
-					resource.TestCheckTypeSetElemNestedAttrs(
-						"aiven_clickhouse_grant.foo-role-grant",
-						"privilege_grant.*",
-						map[string]string{
-							"privilege": "DROP FUNCTION",
-							"database":  "*",
-						},
-					),
-
-					resource.TestCheckTypeSetElemNestedAttrs(
-						"aiven_clickhouse_grant.foo-role-grant",
-						"privilege_grant.*",
-						map[string]string{
-							"privilege": "S3",
-							"database":  "*",
-						},
-					),
-
 					resource.TestCheckResourceAttr(
 						"aiven_clickhouse_grant.foo-user-grant",
 						"user",
 						"foo-user",
 					),
-
 					resource.TestCheckTypeSetElemNestedAttrs(
 						"aiven_clickhouse_grant.foo-user-grant",
 						"role_grant.*",
@@ -148,8 +320,14 @@ resource "aiven_clickhouse_grant" "foo-user-grant" {
 				),
 			},
 			{
-
+				// Step 9: Test import of role grant
 				ResourceName:      "aiven_clickhouse_grant.foo-role-grant",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				// Step 10: Test import of user grant
+				ResourceName:      "aiven_clickhouse_grant.foo-user-grant",
 				ImportState:       true,
 				ImportStateVerify: true,
 			},


### PR DESCRIPTION
<!-- All contributors, please complete these sections, including maintainers. -->

## About this change—what it does
- added Set function to the `aiven_clickhouse_grant` to ignore case sensitive privilege names during the plan phase

<!-- Provide a small sentence that summarizes the change. -->

<!-- Provide the issue number below, if it exists. -->

## Why this way
- `DiffSuppressFunc` for `privilege` field does not works in this case, because the privilege is ForceNew and the hash is calculated before this function is called
- `StateFunc` for `privilege` field doesn't work because apparently there is a bug inside the plugin and when we'll transform the `Set` into the list like here: `d.Get("privilege_grant").(*schema.Set).List()` we will get additional elements in the list with empty values
- `CustomizeDiff` for the whole resource looks like a more complex option as it requires to disassemble quite complicated schema

<!-- Provide a small explanation on why this is the approach you took for solving this problem. -->
