### PR TITLE
refactor: generate docs with provider-name flag

### DIFF
--- a/TaskInternal.yml
+++ b/TaskInternal.yml
@@ -109,7 +109,7 @@ tasks:
       PROVIDER_AIVEN_ENABLE_BETA: 1
     cmds:
       - rm -f docs/.DS_Store
-      - "{{.TFPLUGINDOCS}} generate"
+      - "{{.TFPLUGINDOCS}} generate --provider-name terraform-provider-aiven"
       - rm -f docs/data-sources/influxdb*.md
       - rm -f docs/resources/influxdb*.md
 


### PR DESCRIPTION
By default, the docs generator uses the current directory name as the provider name. This prevents checking out the repository into a different directory.
For example, when setting up a separate development environment.

