### PR TITLE
docs: fix example usage for aiven_organization_project

### DIFF
--- a/docs/resources/organization_project.md
+++ b/docs/resources/organization_project.md
@@ -30,6 +30,7 @@ resource "random_string" "suffix" {
 resource "aiven_organization_project" "example_project" {
   project_id       = "example-project-${random_string.suffix.result}"
   organization_id  = aiven_organization.main.id
+  parent_id        = aiven_organization.main.id
   billing_group_id = aiven_billing_group.main.id
 
   tag {

--- a/examples/resources/aiven_organization_project/resource.tf
+++ b/examples/resources/aiven_organization_project/resource.tf
@@ -10,6 +10,7 @@ resource "random_string" "suffix" {
 resource "aiven_organization_project" "example_project" {
   project_id       = "example-project-${random_string.suffix.result}"
   organization_id  = aiven_organization.main.id
+  parent_id        = aiven_organization.main.id
   billing_group_id = aiven_billing_group.main.id
 
   tag {


### PR DESCRIPTION
<!-- All contributors, please complete these sections, including maintainers. -->

## About this change—what it does

Adds required `parent_id` field to the `aiven_organization_project` example.
