### PR TITLE
feat(aiven_clickhouse_grant): skip named collection grants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ nav_order: 1
 
 ## [MAJOR.MINOR.PATCH] - YYYY-MM-DD
 
+- `aiven_clickhouse_grant`: The resource will no longer attempt to manage or interfere with privileges granted on ClickHouse Named Collections. This prevents potential errors when such grants are managed externally.
 - Add `aiven_opensearch` field `opensearch_user_config.opensearch.cluster_filecache_remote_data_ratio`: Defines a limit
   of how much total remote data can be referenced as a ratio of the size of the disk reserved for the file cache
 - Add `aiven_opensearch` field `opensearch_user_config.opensearch.cluster_remote_store`

--- a/docs/resources/clickhouse_grant.md
+++ b/docs/resources/clickhouse_grant.md
@@ -5,7 +5,7 @@ subcategory: ""
 description: |-
   Creates and manages ClickHouse grants to give users and roles privileges to a ClickHouse service.
   Note:
-  Users cannot have the same name as roles.Global privileges cannot be granted on the database level. To grant global privileges, use database="*".To grant a privilege on all tables of a database, omit the table and only keep the database. Don't use table="*".Changes first revoke all grants and then reissue the remaining grants for convergence.
+  Users cannot have the same name as roles.Global privileges cannot be granted on the database level. To grant global privileges, use database="*".To grant a privilege on all tables of a database, omit the table and only keep the database. Don't use table="*".Privileges granted on ClickHouse Named Collections are not currently managed by this resource and will be ignored. If you have grants on Named Collections managed outside of Terraform, this resource will not attempt to alter them.Changes first revoke all grants and then reissue the remaining grants for convergence.
 ---
 
 # aiven_clickhouse_grant (Resource)
@@ -16,6 +16,7 @@ Creates and manages ClickHouse grants to give users and roles privileges to a Cl
 * Users cannot have the same name as roles.
 * Global privileges cannot be granted on the database level. To grant global privileges, use `database="*"`.
 * To grant a privilege on all tables of a database, omit the table and only keep the database. Don't use `table="*"`.
+* Privileges granted on ClickHouse Named Collections are not currently managed by this resource and will be ignored. If you have grants on Named Collections managed outside of Terraform, this resource will not attempt to alter them.
 * Changes first revoke all grants and then reissue the remaining grants for convergence.
 
 ## Example Usage

--- a/internal/sdkprovider/service/clickhouse/clickhouse_grant.go
+++ b/internal/sdkprovider/service/clickhouse/clickhouse_grant.go
@@ -140,6 +140,7 @@ func ResourceClickhouseGrant() *schema.Resource {
 * Users cannot have the same name as roles.
 * Global privileges cannot be granted on the database level. To grant global privileges, use ` + "`database=\"*\"`" + `.
 * To grant a privilege on all tables of a database, omit the table and only keep the database. Don't use ` + "`table=\"*\"`" + `.
+* Privileges granted on ClickHouse Named Collections are not currently managed by this resource and will be ignored. If you have grants on Named Collections managed outside of Terraform, this resource will not attempt to alter them.
 * Changes first revoke all grants and then reissue the remaining grants for convergence.
 `,
 		CreateContext: resourceClickhouseGrantCreate,


### PR DESCRIPTION
<!-- All contributors, please complete these sections, including maintainers. -->

## About this change—what it does

<!-- Provide a small sentence that summarizes the change. -->

<!-- Provide the issue number below, if it exists. -->
-  skips the `NAMED COLLECTION` grants for the grants that were added outside of Terraform

## Why this way
- as we can not fully manage the NAMED COLLECTION grants in ClickHouse, [due](https://github.com/ClickHouse/ClickHouse/issues/80853) to the empty `database` field in `system.grants` table we will skip these types of GRANTS that it can be possible to assign them outside of Terraform

<!-- Provide a small explanation on why this is the approach you took for solving this problem. -->
