### PR TITLE
fix(ogranization): mark datasource id field required

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ nav_order: 1
 - Change `aiven_account_team_project` field `team_type` (enum): remove `organization:idps:write`
 - Change `aiven_organization_permission` resource field `permissions.permissions` (enum): remove `organization:idps:write`
 - Change `aiven_project_user` field `member_type` (enum): remove `organization:idps:write`
+- Fix datasource `aiven_organization`: mark `id` field as required since the datasource cannot be read with computed-only fields
 
 ## [4.42.0] - 2025-06-23
 

--- a/generators/plugin/schemas.go
+++ b/generators/plugin/schemas.go
@@ -70,8 +70,15 @@ func genIDField(isResource bool, idField *IDAttribute) jen.Code {
 
 	attrs := jen.Dict{
 		jen.Id("MarkdownDescription"): jen.Lit(description),
-		jen.Id("Computed"):            jen.True(),
 	}
+
+	if !isResource && len(idField.Compose) == 1 && idField.Compose[0] == "id" {
+		// If datasource id is literally "id", it is required.
+		attrs[jen.Id("Required")] = jen.True()
+	} else {
+		attrs[jen.Id("Computed")] = jen.True()
+	}
+
 	if isResource && !idField.Mutable {
 		// Make ID field plan modifier to use state for unknown
 		// https://developer.hashicorp.com/terraform/plugin/framework/resources/plan-modification#usestateforunknown

--- a/internal/plugin/service/organization/organization/zz_datasource.go
+++ b/internal/plugin/service/organization/organization/zz_datasource.go
@@ -34,8 +34,8 @@ func newDatasourceSchema(ctx context.Context) schema.Schema {
 				MarkdownDescription: "Timestamp in ISO 8601 format, always in UTC.",
 			},
 			"id": schema.StringAttribute{
-				Computed:            true,
 				MarkdownDescription: "The organization ID.",
+				Required:            true,
 			},
 			"name": schema.StringAttribute{
 				Computed:            true,


### PR DESCRIPTION
Resolves NEX-1656.

Fix datasource `aiven_organization`: mark `id` field as required since the datasource cannot be read with computed-only fields.
