### PR TITLE
feat(plugin): generate usage examples

### DIFF
--- a/generators/plugin/expand.go
+++ b/generators/plugin/expand.go
@@ -66,7 +66,7 @@ func genExpandModelProperties(item *Item, rootLevel bool) ([]jen.Code, error) {
 
 	for _, k := range nestedFirst(item.Properties) {
 		v := item.Properties[k]
-		if !v.IsReadOnly() {
+		if !v.IsReadOnly(true) {
 			value, err := genExpandField(v, rootLevel)
 			if err != nil {
 				return nil, err

--- a/generators/plugin/flatten.go
+++ b/generators/plugin/flatten.go
@@ -285,7 +285,7 @@ func genAttrFunc(item *Item) *jen.Statement {
 
 func genAttrFieldType(item *Item) *jen.Statement {
 	switch {
-	case item.IsScalar():
+	case item.IsScalar(), item.IsMap():
 		return jen.Qual(typesPackage, item.TFType()+"Type")
 	case item.IsObject():
 		return jen.Id(attrPrefix + item.UniqueName()).Call()

--- a/generators/plugin/item.go
+++ b/generators/plugin/item.go
@@ -197,9 +197,13 @@ func (item *Item) Path() string {
 	return strings.Join(chunks[1:], "/")
 }
 
-func (item *Item) IsReadOnly() bool {
-	// XOR, they both can be false, but only one can be true
-	return item.Required == item.Optional
+func (item *Item) IsReadOnly(isResource bool) bool {
+	if isResource {
+		return !item.Required && !item.Optional
+	}
+
+	// ID attributes are not read-only in data sources
+	return !item.InIDAttribute
 }
 
 func (item *Item) IsScalar() bool {
@@ -224,7 +228,7 @@ func (item *Item) IsArray() bool {
 }
 
 func (item *Item) IsObject() bool {
-	return item.Type == SchemaTypeObject && item.Items == nil
+	return item.Type == SchemaTypeObject && item.Items == nil && len(item.Properties) > 0
 }
 
 func (item *Item) IsRoot() bool {
@@ -233,6 +237,10 @@ func (item *Item) IsRoot() bool {
 
 func (item *Item) IsRootProperty() bool {
 	return !item.IsRoot() && item.Parent.IsRoot()
+}
+
+func (item *Item) IsEnum() bool {
+	return len(item.Enum) > 0
 }
 
 func (item *Item) GetIDFields() []*Item {

--- a/generators/plugin/main.go
+++ b/generators/plugin/main.go
@@ -115,7 +115,7 @@ func genDefinition(doc *OpenAPIDoc, defPath string) error {
 			return err
 		}
 
-		root.Name = string(entity)
+		root.Name = resName
 		isResource := entity == resourceType
 		schema, err := genSchema(def.Beta, isResource, root, def.IDAttribute)
 		if err != nil {
@@ -511,6 +511,9 @@ func fromSchema(scope *Scope, item *Item, itemSchema *OASchema, appearsIn Appear
 				if err != nil {
 					return err
 				}
+			} else {
+				// A special case for maps with invalid schema
+				elementSchema = &OASchema{Type: SchemaTypeString}
 			}
 
 			// ANY is a special case is additional properties

--- a/generators/plugin/utils.go
+++ b/generators/plugin/utils.go
@@ -68,7 +68,7 @@ func fmtDescription(isResource bool, item *Item) string {
 
 	if !isResource {
 		b.MarkAsDataSource()
-	} else if !item.IsReadOnly() {
+	} else if !item.IsReadOnly(isResource) {
 		if item.ForceNew {
 			b.ForceNew()
 		}

--- a/go.sum
+++ b/go.sum
@@ -432,6 +432,8 @@ github.com/hashicorp/golang-lru/v2 v2.0.7 h1:a+bsQ5rvGLjzHuww6tVxozPZFVghXaHOwFs
 github.com/hashicorp/golang-lru/v2 v2.0.7/go.mod h1:QeFd9opnmA6QUJc5vARoKUSoFhyfM2/ZepoAG6RGpeM=
 github.com/hashicorp/hc-install v0.9.2 h1:v80EtNX4fCVHqzL9Lg/2xkp62bbvQMnvPQ0G+OmtO24=
 github.com/hashicorp/hc-install v0.9.2/go.mod h1:XUqBQNnuT4RsxoxiM9ZaUk0NX8hi2h+Lb6/c0OZnC/I=
+github.com/hashicorp/hcl v1.0.0 h1:0Anlzjpi4vEasTeNFn2mLJgTSwt0+6sfsiTG8qcWGx4=
+github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
 github.com/hashicorp/hcl/v2 v2.23.0 h1:Fphj1/gCylPxHutVSEOf2fBOh1VE4AuLV7+kbJf3qos=
 github.com/hashicorp/hcl/v2 v2.23.0/go.mod h1:62ZYHrXgPoX8xBnzl8QzbWq4dyDsDtfCRgIq1rbJEvA=
 github.com/hashicorp/logutils v1.0.0 h1:dLEQVugN8vlakKOUE3ihGLTZJRB4j+M2cdTm/ORI65Y=

--- a/internal/plugin/service/governance/access/zz_resource.go
+++ b/internal/plugin/service/governance/access/zz_resource.go
@@ -32,6 +32,34 @@ func (tf *resourceModel) SharedModel() *tfModel {
 	return &tf.tfModel
 }
 
+/*
+newResourceSchema:
+
+	resource "aiven_governance_access" "example" {
+	  access_data {
+	    acls {
+	      host            = "foo" // Force new
+	      operation       = "Read" // Force new
+	      permission_type = "ALLOW" // Force new
+	      resource_name   = "test" // Force new
+	      resource_type   = "Topic" // Force new
+	      id              = "foo"
+	      pattern_type    = "LITERAL"
+	      principal       = "foo"
+	    }
+	    project      = "foo" // Force new
+	    service_name = "test" // Force new
+	    username     = "test" // Force new
+	  }
+	  access_name         = "test" // Force new
+	  access_type         = "KAFKA" // Force new
+	  organization_id     = "org1a23f456789" // Force new
+	  owner_user_group_id = "foo" // Force new
+
+	  // COMPUTED FIELDS
+	  susbcription_id = "foo"
+	}
+*/
 func newResourceSchema(ctx context.Context) schema.Schema {
 	return schema.Schema{
 		Attributes: map[string]schema.Attribute{

--- a/internal/plugin/service/organization/address/zz_datasource.go
+++ b/internal/plugin/service/organization/address/zz_datasource.go
@@ -29,6 +29,24 @@ func (tf *datasourceModel) SharedModel() *tfModel {
 	return &tf.tfModel
 }
 
+/*
+newDatasourceSchema:
+
+	data "aiven_organization_address" "example" {
+	  organization_id = "org1a23f456789"
+	  address_id      = "foo"
+
+	  // COMPUTED FIELDS
+	  address_lines = ["foo"]
+	  city          = "foo"
+	  country_code  = "foo"
+	  create_time   = "foo"
+	  name          = "test"
+	  state         = "foo"
+	  update_time   = "foo"
+	  zip_code      = "foo"
+	}
+*/
 func newDatasourceSchema(ctx context.Context) schema.Schema {
 	return schema.Schema{
 		Attributes: map[string]schema.Attribute{

--- a/internal/plugin/service/organization/address/zz_resource.go
+++ b/internal/plugin/service/organization/address/zz_resource.go
@@ -32,6 +32,24 @@ func (tf *resourceModel) SharedModel() *tfModel {
 	return &tf.tfModel
 }
 
+/*
+newResourceSchema:
+
+	resource "aiven_organization_address" "example" {
+	  organization_id = "org1a23f456789" // Force new
+	  address_lines   = ["foo"]
+	  city            = "foo"
+	  country_code    = "foo"
+	  name            = "test"
+	  state           = "foo"
+	  zip_code        = "foo"
+
+	  // COMPUTED FIELDS
+	  create_time = "foo"
+	  update_time = "foo"
+	  address_id  = "foo"
+	}
+*/
 func newResourceSchema(ctx context.Context) schema.Schema {
 	return schema.Schema{
 		Attributes: map[string]schema.Attribute{

--- a/internal/plugin/service/organization/billinggroup/zz_datasource.go
+++ b/internal/plugin/service/organization/billinggroup/zz_datasource.go
@@ -29,6 +29,25 @@ func (tf *datasourceModel) SharedModel() *tfModel {
 	return &tf.tfModel
 }
 
+/*
+newDatasourceSchema:
+
+	data "aiven_organization_billing_group" "example" {
+	  organization_id  = "org1a23f456789"
+	  billing_group_id = "foo"
+
+	  // COMPUTED FIELDS
+	  billing_address_id     = "foo"
+	  billing_contact_emails = ["test@example.com"]
+	  billing_emails         = ["test@example.com"]
+	  billing_group_name     = "test"
+	  currency               = "AUD"
+	  custom_invoice_text    = "foo"
+	  payment_method_id      = "foo"
+	  shipping_address_id    = "foo"
+	  vat_id                 = "foo"
+	}
+*/
 func newDatasourceSchema(ctx context.Context) schema.Schema {
 	return schema.Schema{
 		Attributes: map[string]schema.Attribute{

--- a/internal/plugin/service/organization/billinggroup/zz_resource.go
+++ b/internal/plugin/service/organization/billinggroup/zz_resource.go
@@ -31,6 +31,25 @@ func (tf *resourceModel) SharedModel() *tfModel {
 	return &tf.tfModel
 }
 
+/*
+newResourceSchema:
+
+	resource "aiven_organization_billing_group" "example" {
+	  organization_id        = "org1a23f456789" // Force new
+	  billing_address_id     = "foo"
+	  billing_contact_emails = ["test@example.com"]
+	  billing_emails         = ["test@example.com"]
+	  billing_group_name     = "test"
+	  currency               = "AUD"
+	  custom_invoice_text    = "foo"
+	  payment_method_id      = "foo"
+	  shipping_address_id    = "foo"
+	  vat_id                 = "foo"
+
+	  // COMPUTED FIELDS
+	  billing_group_id = "foo"
+	}
+*/
 func newResourceSchema(ctx context.Context) schema.Schema {
 	return schema.Schema{
 		Attributes: map[string]schema.Attribute{

--- a/internal/plugin/service/organization/billinggrouplist/zz_datasource.go
+++ b/internal/plugin/service/organization/billinggrouplist/zz_datasource.go
@@ -27,6 +27,28 @@ func (tf *datasourceModel) SharedModel() *tfModel {
 	return &tf.tfModel
 }
 
+/*
+newDatasourceSchema:
+
+	data "aiven_organization_billing_group_list" "example" {
+	  organization_id = "org1a23f456789"
+
+	  // COMPUTED FIELDS
+	  billing_groups {
+	    billing_address_id     = "foo"
+	    billing_contact_emails = ["test@example.com"]
+	    billing_emails         = ["test@example.com"]
+	    billing_group_id       = "foo"
+	    billing_group_name     = "test"
+	    currency               = "AUD"
+	    custom_invoice_text    = "foo"
+	    organization_id        = "org1a23f456789"
+	    payment_method_id      = "foo"
+	    shipping_address_id    = "foo"
+	    vat_id                 = "foo"
+	  }
+	}
+*/
 func newDatasourceSchema(ctx context.Context) schema.Schema {
 	return schema.Schema{
 		Attributes: map[string]schema.Attribute{

--- a/internal/plugin/service/organization/organization/zz_datasource.go
+++ b/internal/plugin/service/organization/organization/zz_datasource.go
@@ -26,6 +26,19 @@ func (tf *datasourceModel) SharedModel() *tfModel {
 	return &tf.tfModel
 }
 
+/*
+newDatasourceSchema:
+
+	data "aiven_organization" "example" {
+	  id = "foo"
+
+	  // COMPUTED FIELDS
+	  create_time = "foo"
+	  name        = "test"
+	  tenant_id   = "foo"
+	  update_time = "foo"
+	}
+*/
 func newDatasourceSchema(ctx context.Context) schema.Schema {
 	return schema.Schema{
 		Attributes: map[string]schema.Attribute{

--- a/internal/plugin/service/organization/organization/zz_resource.go
+++ b/internal/plugin/service/organization/organization/zz_resource.go
@@ -30,6 +30,19 @@ func (tf *resourceModel) SharedModel() *tfModel {
 	return &tf.tfModel
 }
 
+/*
+newResourceSchema:
+
+	resource "aiven_organization" "example" {
+	  name = "test"
+
+	  // COMPUTED FIELDS
+	  create_time = "foo"
+	  id          = "foo"
+	  tenant_id   = "foo"
+	  update_time = "foo"
+	}
+*/
 func newResourceSchema(ctx context.Context) schema.Schema {
 	return schema.Schema{
 		Attributes: map[string]schema.Attribute{

--- a/internal/plugin/service/organization/project/zz_datasource.go
+++ b/internal/plugin/service/organization/project/zz_datasource.go
@@ -29,6 +29,25 @@ func (tf *datasourceModel) SharedModel() *tfModel {
 	return &tf.tfModel
 }
 
+/*
+newDatasourceSchema:
+
+	data "aiven_organization_project" "example" {
+	  organization_id = "org1a23f456789"
+	  project_id      = "foo"
+
+	  // COMPUTED FIELDS
+	  base_port        = 42
+	  billing_group_id = "foo"
+	  ca_cert          = "foo"
+	  parent_id        = "foo"
+	  tag {
+	    key   = "foo"
+	    value = "foo"
+	  }
+	  technical_emails = ["test@example.com"]
+	}
+*/
 func newDatasourceSchema(ctx context.Context) schema.Schema {
 	return schema.Schema{
 		Attributes: map[string]schema.Attribute{

--- a/internal/plugin/service/organization/project/zz_resource.go
+++ b/internal/plugin/service/organization/project/zz_resource.go
@@ -32,6 +32,25 @@ func (tf *resourceModel) SharedModel() *tfModel {
 	return &tf.tfModel
 }
 
+/*
+newResourceSchema:
+
+	resource "aiven_organization_project" "example" {
+	  organization_id  = "org1a23f456789"
+	  project_id       = "foo" // Force new
+	  base_port        = 42
+	  billing_group_id = "foo"
+	  parent_id        = "foo"
+	  tag {
+	    key   = "foo"
+	    value = "foo"
+	  }
+	  technical_emails = ["test@example.com"]
+
+	  // COMPUTED FIELDS
+	  ca_cert = "foo"
+	}
+*/
 func newResourceSchema(ctx context.Context) schema.Schema {
 	return schema.Schema{
 		Attributes: map[string]schema.Attribute{

--- a/opa/policies/README.md
+++ b/opa/policies/README.md
@@ -14,6 +14,6 @@ These policies use [OPA](https://www.openpolicyagent.org/) and [Conftest](https:
 - Prevents creating duplicate `aiven_organization_permission` resources for the same entity
 - Catches both configuration-time and plan-time duplicates
 
-**2. Autoscaler Integration and Service Modification Conflict Prevention** 
+**2. Autoscaler Integration and Service Modification Conflict Prevention**
 - Prevents removing autoscaler integrations while simultaneously modifying the associated service
 - Helps avoid "Provider produced inconsistent final plan" errors


### PR DESCRIPTION
Resolves NEX-1660.

Examples will help to review schemas.

- Better detection `Map` vs `Object`
- Adds examples to the generated schemas: first renders mandatory fields, then computed
