### PR TITLE
chore(task): added no_spec flag to generate task

### DIFF
--- a/TaskInternal.yml
+++ b/TaskInternal.yml
@@ -133,8 +133,18 @@ tasks:
 
   gen-plugin:
     desc: "Generate Terraform Plugin Framework resources"
+    vars:
+      no_spec: '{{.no_spec | default "false"}}'
     cmds:
-      - task: get-spec
+      - task: '{{if eq .no_spec "true"}}nothing{{else}}get-spec{{end}}'
+      - task: gen-plugin-generator
+
+  gen-plugin-generator:
+    desc: "Run the plugin generator (requires openapi.json to exist)"
+    preconditions:
+      - sh: test -f {{.OPENAPI_FILE}}
+        msg: "{{.OPENAPI_FILE}} not found. Run 'task get-spec' to download it."
+    cmds:
       - "{{.GO_CMD}} run ./generators/plugin/..."
 
   gen-docs:
@@ -149,9 +159,13 @@ tasks:
 
   generate:
     desc: "Run all code generation tasks"
+    vars:
+      no_spec: '{{.no_spec | default "false"}}'
     deps:
       - gen-go
-      - gen-plugin
+      - task: gen-plugin
+        vars:
+          no_spec: '{{.no_spec}}'
       - gen-docs
     cmds:
       - task: mockery

--- a/Taskfile.dist.yml
+++ b/Taskfile.dist.yml
@@ -121,10 +121,14 @@ tasks:
 
   generate:
     desc: Generate Go code, documentation, and mocks
+    vars:
+      no_spec: '{{.no_spec | default "false"}}'
     cmds:
       - defer:
           task: fmt
       - task: internal:generate
+        vars:
+          no_spec: '{{.no_spec}}'
 
   docs:
     desc: Generate documentation for the provider


### PR DESCRIPTION
<!-- All contributors, please complete these sections, including maintainers. -->

## About this change—what it does

<!-- Provide a small sentence that summarizes the change. -->

<!-- Provide the issue number below, if it exists. -->
- added `no_spec` flag to `task generate` command which allows to skip openAPI spec update if needed

Resolves: NEX-1661

<!-- Provide a small explanation on why this is the approach you took for solving this problem. -->
