### PR TITLE
chore: quick formatting tool instead of pre-commit

### DIFF
--- a/TaskInternal.yml
+++ b/TaskInternal.yml
@@ -100,8 +100,37 @@ tasks:
       - find . -type f -name '*.go' -exec sed -i'' -e '/^import ($/,/^)$/{/^[[:space:]]*$/d;}' {} +
       - goimports -local "github.com/aiven/terraform-provider-aiven" -w .
 
+  #-------------------------------------
+  # Format Sub-Tasks
+  #-------------------------------------
+  # Two formatting approaches available:
+  #
+  # fmt-fast: Custom Go implementation for quick development workflow
+  #   - Removes trailing whitespace (spaces/tabs)
+  #   - Normalizes file endings (preserves original newline behavior)
+  #   - Processes .go, .yml, .yaml, .md, .json files
+  #   - Concurrent processing for performance
+  #   - No Docker dependency
+  #   - Use after code generation or during development
+  #
+  # fmt-precommit: Comprehensive Docker-based validation
+  #   - All fmt-fast functionality plus additional checks
+  #   - YAML validation, Terraform fmt/lint, file structure checks
+  #   - Slower but more thorough
+  #   - Use before commits for complete validation
+  #
+  # Usage:
+  #   FAST_FORMAT=true task fmt  # Uses fmt-fast
+  #   task fmt                   # Uses fmt-precommit (default)
+  #   go run ./tools/... format  # Direct fmt-fast usage
+
+  fmt-fast:
+    desc: "Fast formatting for basic whitespace cleanup (no Docker). Custom Go implementation that performs the core formatting tasks of fmt-precommit (trailing whitespace removal, file ending normalization) without Docker overhead. Ideal for development workflow and post-generation cleanup."
+    cmds:
+      - "{{.GO_CMD}} run ./tools/... format --root {{.ROOT_DIR}}"
+
   fmt-precommit:
-    desc: "Run pre-commit hooks using Docker"
+    desc: "Run comprehensive pre-commit hooks using Docker. Includes all formatting checks (YAML validation, trailing whitespace, file endings, Terraform fmt/lint). More thorough than fmt-fast but slower due to Docker overhead. Use for final validation before commits."
     preconditions:
       - sh: "test -f {{.PRECOMMIT_CONFIG}}"
         msg: "Pre-commit configuration file '{{.PRECOMMIT_CONFIG}}' not found."

--- a/Taskfile.dist.yml
+++ b/Taskfile.dist.yml
@@ -105,15 +105,15 @@ tasks:
       - internal:semgrep
 
   fmt:
-    desc: Run all formatters (Terraform tests, Go imports)
+    desc: "Run all formatters (Go, Terraform, whitespace). Use FAST_FORMAT=true for quick formatting."
     vars:
-      SKIP_PRECOMMIT: '{{default "false" .SKIP_PRECOMMIT}}'
+      FAST_FORMAT: '{{default "false" .FAST_FORMAT}}'
     cmds:
       - defer:
           task: internal:fmt-imports
       - task: internal:fmt-go
       - task: internal:fmt-test
-      - task: '{{if ne .SKIP_PRECOMMIT "true"}}internal:fmt-precommit{{else}}internal:nothing{{end}}'
+      - task: '{{if ne .FAST_FORMAT "true"}}internal:fmt-precommit{{else}}internal:fmt-fast{{end}}'
 
   #################################################
   # Utility Tasks
@@ -124,6 +124,8 @@ tasks:
     cmds:
       - defer:
           task: fmt
+          vars:
+            FAST_FORMAT: true
       - task: internal:generate
 
   docs:

--- a/tools/cmd/format.go
+++ b/tools/cmd/format.go
@@ -1,0 +1,200 @@
+package cmd
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"sync"
+
+	"github.com/spf13/cobra"
+)
+
+var (
+	defaultExtensions   = []string{".go", ".yml", ".yaml", ".md", ".json"}
+	defaultExcludeFiles = []string{"definitions/.schema.yml"}
+	defaultExcludeDirs  = []string{".git", "vendor"}
+
+	excludeExtensions []string
+	excludeFiles      []string
+	excludeDirs       []string
+	rootDir           string
+	workers           int
+)
+
+var formatCmd = &cobra.Command{
+	Use:   "format",
+	Short: "Fast formatting for basic whitespace cleanup",
+	Long: `Fast formatting tool for basic whitespace cleanup without Docker overhead.
+
+This is a custom Go implementation that performs the core formatting tasks of pre-commit hooks:
+- Removes trailing whitespace (spaces and tabs) from lines
+- Normalizes file endings (preserves original newline behavior)
+- Processes .go, .yml, .yaml, .md, .json files by default
+- Concurrent processing for better performance
+
+Ideal for:
+- Development workflow and post-generation cleanup
+- CI/CD environments where speed is important
+- When Docker is not available or desired
+
+For comprehensive validation including YAML validation, Terraform lint, and other checks,
+use the full pre-commit Docker-based workflow instead.`,
+	RunE: runFormat,
+}
+
+func init() {
+	formatCmd.Flags().StringSliceVar(&excludeExtensions, "exclude-ext", []string{}, "File extensions to exclude (e.g., .tmp,.bak)")
+	formatCmd.Flags().StringSliceVar(&excludeFiles, "exclude-files", defaultExcludeFiles, "Specific files to exclude")
+	formatCmd.Flags().StringSliceVar(&excludeDirs, "exclude-dirs", defaultExcludeDirs, "Directories to exclude")
+	formatCmd.Flags().StringVar(&rootDir, "root", ".", "Root directory to format (default: current directory)")
+	formatCmd.Flags().IntVar(&workers, "workers", runtime.NumCPU(), "Number of concurrent workers")
+}
+
+func runFormat(_ *cobra.Command, _ []string) error {
+	var (
+		targetExtSet   = toSet(defaultExtensions)
+		excludeExtSet  = toSet(excludeExtensions)
+		excludeFileSet = toSet(excludeFiles)
+		excludeDirSet  = toSet(excludeDirs)
+
+		filesToFormat []string
+	)
+
+	err := filepath.Walk(rootDir, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+
+		if info.IsDir() {
+			if _, ok := excludeDirSet[info.Name()]; ok {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+
+		// check excluded files
+		if _, ok := excludeFileSet[path]; ok {
+			return nil
+		}
+
+		// check excluded extensions
+		ext := filepath.Ext(path)
+		if _, ok := excludeExtSet[ext]; ok {
+			return nil
+		}
+
+		if _, ok := targetExtSet[ext]; ok {
+			filesToFormat = append(filesToFormat, path)
+		}
+
+		return nil
+	})
+	if err != nil {
+		return fmt.Errorf("error walking directory %s: %w", rootDir, err)
+	}
+
+	if err = processFiles(filesToFormat); err != nil {
+		return err
+	}
+
+	fmt.Printf("formatting completed successfully! Processed %d files.\n", len(filesToFormat))
+	return nil
+}
+
+func processFiles(files []string) error {
+	fileCh := make(chan string, len(files))
+	errorCh := make(chan error, workers)
+
+	var wg sync.WaitGroup
+	for i := 0; i < workers; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for file := range fileCh {
+				if err := formatFile(file); err != nil {
+					select {
+					case errorCh <- fmt.Errorf("failed to format %s: %w", file, err):
+					default:
+					}
+				}
+			}
+		}()
+	}
+
+	for _, file := range files {
+		fileCh <- file
+	}
+	close(fileCh)
+
+	go func() {
+		wg.Wait()
+		close(errorCh)
+	}()
+
+	var allErrors []string
+	for err := range errorCh {
+		if err != nil {
+			allErrors = append(allErrors, err.Error())
+		}
+	}
+
+	if len(allErrors) > 0 {
+		return fmt.Errorf("failed to format %d files:\n- %s", len(allErrors), strings.Join(allErrors, "\n- "))
+	}
+
+	return nil
+}
+
+func formatFile(path string) error {
+	fileInfo, err := os.Stat(path)
+	if err != nil {
+		return fmt.Errorf("could not stat file: %w", err)
+	}
+
+	content, err := os.ReadFile(path)
+	if err != nil {
+		return fmt.Errorf("could not read file: %w", err)
+	}
+
+	if len(content) == 0 {
+		return nil
+	}
+
+	originalHasNewline := bytes.HasSuffix(content, []byte("\n"))
+
+	lines := bytes.Split(content, []byte("\n"))
+
+	// trim trailing space and tabs
+	for i, line := range lines {
+		lines[i] = bytes.TrimRight(line, " \t")
+	}
+
+	newContent := bytes.Join(lines, []byte("\n"))
+
+	// trim ALL trailing whitespace
+	newContent = bytes.TrimRight(newContent, " \t\n")
+
+	// if the original had a newline, add one back
+	if originalHasNewline {
+		newContent = append(newContent, '\n')
+	}
+
+	if !bytes.Equal(content, newContent) {
+		return os.WriteFile(path, newContent, fileInfo.Mode())
+	}
+
+	return nil
+}
+
+// toSet converts a slice to a map
+func toSet(items []string) map[string]struct{} {
+	set := make(map[string]struct{}, len(items))
+	for _, item := range items {
+		set[item] = struct{}{}
+	}
+
+	return set
+}

--- a/tools/cmd/format_test.go
+++ b/tools/cmd/format_test.go
@@ -1,0 +1,375 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFormatFile(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		input        string
+		expected     string
+		shouldChange bool
+		fileMode     os.FileMode
+	}{
+		{
+			name:         "remove trailing spaces",
+			input:        "line with spaces   \nanother line  \n",
+			expected:     "line with spaces\nanother line\n",
+			shouldChange: true,
+			fileMode:     0o644,
+		},
+		{
+			name:         "remove trailing tabs",
+			input:        "line with tabs\t\t\nanother line\t\n",
+			expected:     "line with tabs\nanother line\n",
+			shouldChange: true,
+			fileMode:     0o644,
+		},
+		{
+			name:         "mixed trailing whitespace",
+			input:        "line with mixed \t \nanother line \t\n",
+			expected:     "line with mixed\nanother line\n",
+			shouldChange: true,
+			fileMode:     0o644,
+		},
+		{
+			name:         "preserve file ending with newline",
+			input:        "line one\nline two\n",
+			expected:     "line one\nline two\n",
+			shouldChange: false,
+			fileMode:     0o644,
+		},
+		{
+			name:         "preserve file ending without newline",
+			input:        "line one\nline two",
+			expected:     "line one\nline two",
+			shouldChange: false,
+			fileMode:     0o644,
+		},
+		{
+			name:         "file with only trailing whitespace",
+			input:        "clean line\nline with spaces   ",
+			expected:     "clean line\nline with spaces",
+			shouldChange: true,
+			fileMode:     0o644,
+		},
+		{
+			name:         "empty file",
+			input:        "",
+			expected:     "",
+			shouldChange: false,
+			fileMode:     0o644,
+		},
+		{
+			name:         "single line with trailing space",
+			input:        "single line   ",
+			expected:     "single line",
+			shouldChange: true,
+			fileMode:     0o644,
+		},
+		{
+			name:         "executable file permissions",
+			input:        "#!/bin/bash\necho hello   \n",
+			expected:     "#!/bin/bash\necho hello\n",
+			shouldChange: true,
+			fileMode:     0o755,
+		},
+		{
+			name:         "preserve multiple trailing newlines behavior",
+			input:        "line one\nline two\n\n",
+			expected:     "line one\nline two\n",
+			shouldChange: true,
+			fileMode:     0o644,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			tmpDir := t.TempDir()
+			tmpFile := filepath.Join(tmpDir, "test.txt")
+
+			err := os.WriteFile(tmpFile, []byte(tt.input), tt.fileMode)
+			require.NoError(t, err, "Failed to create temp file")
+
+			originalInfo, err := os.Stat(tmpFile)
+			require.NoError(t, err, "Failed to stat temp file")
+
+			err = formatFile(tmpFile)
+			require.NoError(t, err)
+
+			result, err := os.ReadFile(tmpFile)
+			require.NoError(t, err)
+
+			assert.Equal(t, tt.expected, string(result), "Formatted content does not match expected output")
+
+			newInfo, err := os.Stat(tmpFile)
+			require.NoError(t, err, "Failed to stat file after formatting")
+
+			assert.Equal(t, originalInfo.Mode(), newInfo.Mode(), "File permissions should be preserved")
+		})
+	}
+}
+
+func TestFormatFileErrorHandling(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		setupFunc   func(t *testing.T) string
+		expectError bool
+	}{
+		{
+			name: "nonexistent file",
+			setupFunc: func(t *testing.T) string {
+				return "/nonexistent/path/file.txt"
+			},
+			expectError: true,
+		},
+		{
+			name: "directory instead of file",
+			setupFunc: func(t *testing.T) string {
+				return t.TempDir()
+			},
+			expectError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			path := tt.setupFunc(t)
+			err := formatFile(path)
+
+			if tt.expectError {
+				assert.Error(t, err, "Expected an error but got none")
+			} else {
+				assert.NoError(t, err, "Expected no error but got: %v", err)
+			}
+		})
+	}
+}
+
+func TestDefaultValues(t *testing.T) {
+	t.Parallel()
+
+	// Test that default values are set correctly
+	expectedExtensions := []string{".go", ".yml", ".yaml", ".md", ".json"}
+	expectedExcludeFiles := []string{"definitions/.schema.yml"}
+	expectedExcludeDirs := []string{".git", "vendor"}
+
+	assert.Equal(t, expectedExtensions, defaultExtensions, "Default extensions should match expected values")
+	assert.Equal(t, expectedExcludeFiles, defaultExcludeFiles, "Default exclude files should match expected values")
+	assert.Equal(t, expectedExcludeDirs, defaultExcludeDirs, "Default exclude directories should match expected values")
+}
+
+func TestProcessFiles(t *testing.T) {
+	t.Parallel()
+
+	// Create temporary directory with test files
+	tmpDir := t.TempDir()
+
+	// Create test files
+	testFiles := map[string]string{
+		"file1.txt": "line with spaces   \nclean line\n",
+		"file2.txt": "another line  \nclean line\n",
+		"file3.txt": "clean file\nno changes needed\n",
+	}
+
+	var filePaths []string
+	for filename, content := range testFiles {
+		path := filepath.Join(tmpDir, filename)
+		err := os.WriteFile(path, []byte(content), 0o644)
+		require.NoError(t, err, "Failed to create test file %s", filename)
+		filePaths = append(filePaths, path)
+	}
+
+	// Set workers to 2 for testing
+	originalWorkers := workers
+	workers = 2
+	defer func() { workers = originalWorkers }()
+
+	// Process files
+	err := processFiles(filePaths)
+	require.NoError(t, err, "processFiles should not fail")
+
+	// Verify results
+	expectedResults := map[string]string{
+		"file1.txt": "line with spaces\nclean line\n",
+		"file2.txt": "another line\nclean line\n",
+		"file3.txt": "clean file\nno changes needed\n",
+	}
+
+	for filename, expected := range expectedResults {
+		path := filepath.Join(tmpDir, filename)
+		result, err := os.ReadFile(path)
+		require.NoError(t, err, "Failed to read result file %s", filename)
+
+		assert.Equal(t, expected, string(result), "File %s content should match expected output", filename)
+	}
+}
+
+func TestProcessFilesWithError(t *testing.T) {
+	t.Parallel()
+
+	// Create a file that will cause an error (we'll make it unreadable)
+	tmpDir := t.TempDir()
+	problemFile := filepath.Join(tmpDir, "problem.txt")
+
+	err := os.WriteFile(problemFile, []byte("content"), 0o644)
+	require.NoError(t, err, "Failed to create problem file")
+
+	// Make file unreadable
+	err = os.Chmod(problemFile, 0o000)
+	require.NoError(t, err, "Failed to change file permissions")
+
+	// Restore permissions after test
+	defer os.Chmod(problemFile, 0o644)
+
+	// Set workers to 1 for predictable testing
+	originalWorkers := workers
+	workers = 1
+	defer func() { workers = originalWorkers }()
+
+	// This should return an error
+	err = processFiles([]string{problemFile})
+	assert.Error(t, err, "Expected an error when processing unreadable file")
+}
+
+func TestRootDirFlag(t *testing.T) {
+	// Create a temporary directory structure
+	tmpDir := t.TempDir()
+	subDir := filepath.Join(tmpDir, "subdir")
+	err := os.MkdirAll(subDir, 0o755)
+	require.NoError(t, err, "Failed to create subdirectory")
+
+	// Create test files in different directories
+	rootFile := filepath.Join(tmpDir, "root.go")
+	subFile := filepath.Join(subDir, "sub.go")
+
+	rootContent := "package main   \n"
+	subContent := "package sub  \n"
+
+	err = os.WriteFile(rootFile, []byte(rootContent), 0o644)
+	require.NoError(t, err, "Failed to create root file")
+
+	err = os.WriteFile(subFile, []byte(subContent), 0o644)
+	require.NoError(t, err, "Failed to create sub file")
+
+	// Test with different root directories
+	tests := []struct {
+		name           string
+		rootDir        string
+		expectedFiles  int
+		shouldFindRoot bool
+		shouldFindSub  bool
+	}{
+		{
+			name:           "root directory processes all files",
+			rootDir:        tmpDir,
+			expectedFiles:  2,
+			shouldFindRoot: true,
+			shouldFindSub:  true,
+		},
+		{
+			name:           "subdirectory processes only subdirectory files",
+			rootDir:        subDir,
+			expectedFiles:  1,
+			shouldFindRoot: false,
+			shouldFindSub:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Reset file contents before each test
+			os.WriteFile(rootFile, []byte(rootContent), 0o644)
+			os.WriteFile(subFile, []byte(subContent), 0o644)
+
+			// Save original values
+			originalRootDir := rootDir
+			originalWorkers := workers
+
+			// Set test values
+			rootDir = tt.rootDir
+			workers = 2
+
+			// Restore after test
+			defer func() {
+				rootDir = originalRootDir
+				workers = originalWorkers
+			}()
+
+			// Run the format command logic (simulating runFormat)
+			extensions := defaultExtensions
+			var filesToFormat []string
+			err := filepath.Walk(rootDir, func(path string, info os.FileInfo, err error) error {
+				if err != nil {
+					return err
+				}
+
+				// Skip directories we want to exclude
+				for _, excludeDir := range defaultExcludeDirs {
+					if strings.Contains(path, excludeDir) {
+						return nil
+					}
+				}
+
+				// Skip specific files
+				for _, excludeFile := range defaultExcludeFiles {
+					if strings.Contains(path, excludeFile) {
+						return nil
+					}
+				}
+
+				// Check if file has one of our target extensions
+				if !info.IsDir() {
+					ext := filepath.Ext(path)
+					for _, targetExt := range extensions {
+						if ext == targetExt {
+							filesToFormat = append(filesToFormat, path)
+							break
+						}
+					}
+				}
+
+				return nil
+			})
+
+			require.NoError(t, err, "Failed to walk directory")
+
+			// Check file count
+			assert.Equal(t, tt.expectedFiles, len(filesToFormat), "Number of files to format should match expected")
+
+			// Process the files
+			err = processFiles(filesToFormat)
+			require.NoError(t, err, "Failed to process files")
+
+			// Check if files were processed correctly
+			if tt.shouldFindRoot {
+				content, err := os.ReadFile(rootFile)
+				require.NoError(t, err, "Failed to read root file")
+				expected := "package main\n"
+				assert.Equal(t, expected, string(content), "Root file should be formatted correctly")
+			}
+
+			if tt.shouldFindSub {
+				content, err := os.ReadFile(subFile)
+				require.NoError(t, err, "Failed to read sub file")
+				expected := "package sub\n"
+				assert.Equal(t, expected, string(content), "Sub file should be formatted correctly")
+			}
+		})
+	}
+}

--- a/tools/cmd/root.go
+++ b/tools/cmd/root.go
@@ -24,4 +24,5 @@ func init() {
 	rootCmd.AddCommand(changelogCmd)
 	rootCmd.AddCommand(versionCmd)
 	rootCmd.AddCommand(testsCmd)
+	rootCmd.AddCommand(formatCmd)
 }


### PR DESCRIPTION
<!-- All contributors, please complete these sections, including maintainers. -->

## About this change—what it does

<!-- Provide a small sentence that summarizes the change. -->

<!-- Provide the issue number below, if it exists. -->
Resolves: NEX-1667
- added quick formatter to the task to speed up the generation process instead of pre-commit fmt

<!-- Provide a small explanation on why this is the approach you took for solving this problem. -->
