### PR TITLE
chore: quick formatting tool instead of pre-commit

### DIFF
--- a/TaskInternal.yml
+++ b/TaskInternal.yml
@@ -110,6 +110,12 @@ tasks:
     cmds:
       - "{{.CONTAINER_TOOL}} run --rm -v \"{{.ROOT_DIR}}:/lint\" -w /lint {{.PRECOMMIT_IMAGE}} run -a"
 
+  fmt-fast:
+    desc: "Fast formatting for docs/ after generation, removes trailing whitespace and empty lines from markdown files"
+    cmds:
+      - find docs -name "*.md" -type f -exec sed -i'' -e 's/[[:space:]]*$//' {} +
+      - find docs -name "*.md" -type f -exec sed -i'' -e '${/^$/d}' {} +
+
   #-------------------------------------
   # Generate Sub-Tasks
   #-------------------------------------

--- a/Taskfile.dist.yml
+++ b/Taskfile.dist.yml
@@ -105,15 +105,15 @@ tasks:
       - internal:semgrep
 
   fmt:
-    desc: Run all formatters (Terraform tests, Go imports)
+    desc: "Run all formatters (Go, Terraform, whitespace). Use FAST_FORMAT=true for quick formatting"
     vars:
-      SKIP_PRECOMMIT: '{{default "false" .SKIP_PRECOMMIT}}'
+      FAST_FORMAT: '{{default "false" .FAST_FORMAT}}'
     cmds:
       - defer:
           task: internal:fmt-imports
       - task: internal:fmt-go
       - task: internal:fmt-test
-      - task: '{{if ne .SKIP_PRECOMMIT "true"}}internal:fmt-precommit{{else}}internal:nothing{{end}}'
+      - task: '{{if ne .FAST_FORMAT "true"}}internal:fmt-precommit{{else}}internal:fmt-fast{{end}}'
 
   #################################################
   # Utility Tasks
@@ -126,6 +126,8 @@ tasks:
     cmds:
       - defer:
           task: fmt
+          vars:
+            FAST_FORMAT: true
       - task: internal:generate
         vars:
           no_spec: '{{.no_spec}}'


### PR DESCRIPTION
<!-- All contributors, please complete these sections, including maintainers. -->

## About this change—what it does

<!-- Provide a small sentence that summarizes the change. -->

<!-- Provide the issue number below, if it exists. -->
Resolves: NEX-1667

- added quick formatter to the task to speed up the generation process instead of pre-commit fmt


<!-- Provide a small explanation on why this is the approach you took for solving this problem. -->
