### PR TITLE
refactor: remove singleflight

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -27,7 +27,6 @@ require (
 	github.com/stretchr/testify v1.10.0
 	github.com/xeipuuv/gojsonschema v1.2.0
 	golang.org/x/exp v0.0.0-20241009180824-f66d83c29e7c
-	golang.org/x/sync v0.16.0
 	golang.org/x/tools v0.34.0
 	gopkg.in/yaml.v3 v3.0.1
 )
@@ -250,6 +249,7 @@ require (
 	go.uber.org/multierr v1.11.0 // indirect
 	go.uber.org/zap v1.24.0 // indirect
 	golang.org/x/exp/typeparams v0.0.0-20250210185358-939b2ce775ac // indirect
+	golang.org/x/sync v0.16.0 // indirect
 	golang.org/x/term v0.32.0 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20250313205543-e70fdf4c4cb4 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect

--- a/internal/schemautil/database_test.go
+++ b/internal/schemautil/database_test.go
@@ -2,6 +2,7 @@ package schemautil
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/aiven/go-client-codegen/handler/service"
@@ -48,21 +49,17 @@ func TestCheckDbConflict(t *testing.T) {
 		},
 	}
 
-	// Adds randomness, because functions use global state.
-	const projectName = "test-project"
-	const serviceName = "test-service"
-
-	ctx := context.Background()
-	mockClient := mocks.NewMockClient(t)
-
-	// This one for CheckServiceIsPowered. Called once per service.
-	mockClient.EXPECT().
-		ServiceGet(ctx, projectName, serviceName).
-		Return(&service.ServiceGetOut{State: service.ServiceStateTypeRunning}, nil).
-		Once()
-
-	for _, tt := range tests {
+	for i, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			projectName := fmt.Sprintf("test-project-db-conflict-%d", i)
+			serviceName := fmt.Sprintf("test-service-db-conflict-%d", i)
+
+			ctx := context.Background()
+			mockClient := mocks.NewMockClient(t)
+			mockClient.EXPECT().
+				ServiceGet(ctx, projectName, serviceName).
+				Return(&service.ServiceGetOut{State: service.ServiceStateTypeRunning}, nil).
+				Once()
 			mockClient.EXPECT().
 				ServiceDatabaseList(ctx, projectName, serviceName).
 				Return(tt.remoteDBs, nil).
@@ -79,8 +76,8 @@ func TestCheckDbConflict(t *testing.T) {
 
 func TestCheckDbConflict_ConcurrentCalls(t *testing.T) {
 	// Adds randomness, because functions use global state.
-	const projectName = "test-project-a7b3c9d"
-	const serviceName = "test-service-f8e2d4m"
+	const projectName = "test-project-concurrent-calls"
+	const serviceName = "test-service-concurrent-calls"
 	const dbName = "test-db"
 
 	ctx := context.Background()


### PR DESCRIPTION
Contributes to NEX-1687.

Doesn't really cache the result, but can help with burst calls only.

