### PR TITLE
docs(kafka): migrate karapace example from dev center

### DIFF
--- a/examples/kafka/karapace_schema_registry/README.md
+++ b/examples/kafka/karapace_schema_registry/README.md
@@ -1,0 +1,11 @@
+# Manage Aiven for Apache Kafka® with the open source Karapace schema registry
+
+Karapace is Aiven's [open source HTTP API interface and schema registry](https://aiven.io/docs/products/kafka/karapace).
+
+This example creates an Aiven for Apache Kafka® service and a Kafka topic. It sets up Karapace on the Kafka service by enabling the schema registry and the REST API.
+The REST API feature lets you produce and consume messages over HTTP. It also enables automatic topic creation, which allows you to send messages to topics
+that don't already exist on the Kafka cluster.
+
+[Run the example files](https://registry.terraform.io/providers/aiven/aiven/latest/docs/guides/examples) to set up Karapace and log into the Aiven Console to see the service.
+
+More information on using Karapace is available in the [Karapace documentation](https://www.karapace.io/quickstart) and [Aiven docs](https://aiven.io/docs/products/kafka/karapace).

--- a/examples/kafka/karapace_schema_registry/kafka.tf
+++ b/examples/kafka/karapace_schema_registry/kafka.tf
@@ -1,0 +1,25 @@
+resource "aiven_kafka" "kafka_karapace_schema_registry" {
+  project                 = var.aiven_project
+  cloud_name              = "google-northamerica-northeast1"
+  plan                    = "business-4"
+  service_name            = var.kafka_service_name
+  maintenance_window_dow  = "monday"
+  maintenance_window_time = "10:00:00"
+  kafka_user_config {
+    // Enables Karapace schema registry and REST
+    schema_registry = true
+    kafka_rest      = true
+    // Enables automatic topic creation
+    kafka {
+      auto_create_topics_enable = true
+    }
+  }
+}
+
+resource "aiven_kafka_topic" "source" {
+  project      = var.aiven_project
+  service_name = aiven_kafka.demo-kafka.service_name
+  topic_name   = "topic-a"
+  partitions   = 3
+  replication  = 2
+}

--- a/examples/kafka/karapace_schema_registry/provider.tf
+++ b/examples/kafka/karapace_schema_registry/provider.tf
@@ -1,5 +1,4 @@
 terraform {
-  required_version = ">=0.13"
   required_providers {
     aiven = {
       source  = "aiven/aiven"
@@ -9,5 +8,5 @@ terraform {
 }
 
 provider "aiven" {
-  api_token = var.aiven_api_token
+  api_token = var.aiven_token
 }

--- a/examples/kafka/karapace_schema_registry/variables.tf
+++ b/examples/kafka/karapace_schema_registry/variables.tf
@@ -1,0 +1,15 @@
+variable "aiven_token" {
+  description = "Aiven token"
+  type        = string
+}
+
+variable "aiven_project" {
+  description = "Aiven project name"
+  type        = string
+}
+
+variable "kafka_service_name" {
+  description = "Name of the Kafka service"
+  type        = string
+  default     = "example-kafka-with-karapace-schema-registry"
+}


### PR DESCRIPTION
<!-- All contributors, please complete these sections, including maintainers. -->

## About this change—what it does

Adds the Karapace example from the Dev Center.
