### PR TITLE
fix(plugin): infinitive recursion

### DIFF
--- a/TaskInternal.yml
+++ b/TaskInternal.yml
@@ -143,6 +143,7 @@ tasks:
       no_spec: '{{.no_spec | default "false"}}'
     cmds:
       - task: '{{if eq .no_spec "true"}}nothing{{else}}get-spec{{end}}'
+      - task: gen-plugin-generator
 
   gen-plugin-generator:
     desc: "Run the plugin generator (requires openapi.json to exist)"

--- a/definitions/governance_access.yml
+++ b/definitions/governance_access.yml
@@ -24,10 +24,15 @@ delete:
   - created_by
   - create_time
 schema:
-  access_data/username:
-    optional: true
-    computed: true
-  access_data/acls/host:
-    description: The IP address from which a principal is allowed or denied access to the resource. Use `*` for all hosts.
-    computed: true # has default value "*"
-    optional: true
+  access_data:
+    properties:
+      username:
+        optional: true
+        computed: true
+      acls:
+        items:
+          properties:
+            host:
+              description: The IP address from which a principal is allowed or denied access to the resource. Use `*` for all hosts.
+              computed: true # has default value "*"
+              optional: true

--- a/definitions/organization_billing_group.yml
+++ b/definitions/organization_billing_group.yml
@@ -17,14 +17,8 @@ operations:
   OrganizationBillingGroupUpdate: update
 schema:
   billing_contact_emails:
-    required: true
-    type: array
     items:
       type: string
-    description: List of billing contact emails.
   billing_emails:
-    required: true
-    type: array
     items:
       type: string
-    description: List of billing contact emails.

--- a/definitions/organization_billing_group_list.yml
+++ b/definitions/organization_billing_group_list.yml
@@ -13,13 +13,11 @@ schema:
     items:
       properties:
         billing_contact_emails:
-          required: true
           type: array
           items:
             type: string
           description: List of billing contact emails.
         billing_emails:
-          required: true
           type: array
           items:
             type: string

--- a/definitions/organization_project.yml
+++ b/definitions/organization_project.yml
@@ -47,6 +47,7 @@ schema:
     jsonName: tags
     type: array
     description: Tags are key-value pairs that allow you to categorize projects.
+    optional: true
     items:
       type: object
       properties:
@@ -61,6 +62,7 @@ schema:
   technical_emails:
     jsonName: tech_emails
     type: array
+    optional: true
     description: |
       The email addresses for [project contacts](https://aiven.io/docs/platform/howto/technical-emails),
       who will receive important alerts and updates about this project and its services.

--- a/generators/plugin/examples.go
+++ b/generators/plugin/examples.go
@@ -97,7 +97,7 @@ func exampleObjectItem(isResource bool, item *Item, body *hclwrite.Body) error {
 			valBlock := body.AppendNewBlock(k, nil)
 			err := exampleObjectItem(isResource, v, valBlock.Body())
 			if err != nil {
-				return err
+				return fmt.Errorf("example items error: %w", err)
 			}
 
 			continue
@@ -147,7 +147,7 @@ func exampleObjectItem(isResource bool, item *Item, body *hclwrite.Body) error {
 				return err
 			}
 		default:
-			return fmt.Errorf("unknown type %s for %s", v.Type, v.Path())
+			return fmt.Errorf("unknown property type %q for %s", v.Type, v.Path())
 		}
 
 		tokens := hclwrite.TokensForValue(val)

--- a/generators/plugin/utils.go
+++ b/generators/plugin/utils.go
@@ -44,6 +44,20 @@ func or[T comparable](a, b T) T {
 	return b
 }
 
+func orLonger[T ~string](a, b T) T {
+	if len(a) > len(b) {
+		return a
+	}
+	return b
+}
+
+func orDefault[T any](v *T, def T) T {
+	if v == nil {
+		return def
+	}
+	return *v
+}
+
 func sortedKeys[K cmp.Ordered, V any](m map[K]V) []K {
 	keys := slices.Collect(maps.Keys(m))
 	slices.Sort(keys)
@@ -54,7 +68,7 @@ var reNewline = regexp.MustCompile(`\s*\n+\s*`)
 
 func fmtDescription(isResource bool, item *Item) string {
 	description := strings.TrimSpace(reNewline.ReplaceAllString(item.Description, " "))
-	if isResource && item.Required && item.IsNested() {
+	if isResource && !item.IsRoot() && item.Required && item.IsNested() {
 		// The documentation generator renders required nested blocks as optional.
 		// https://github.com/hashicorp/terraform-plugin-docs/issues/363
 		// fixme: remove this once the we render the docs on our own


### PR DESCRIPTION
Resolves NEX-1717.

- Fixes stack overflow in the plugin generator
- Adds a validation that prevents cycles
- Improves the patching: 
  - it is possible to set now `optional` or `required` to `false` in yaml file
  - improved merging: for instance, array element can be replaced without defining the whole node
- Reverts generator removal from the update command