### PR TITLE
fix(billing_group): sweep all testing billing groups

### DIFF
--- a/internal/sdkprovider/service/project/sweep.go
+++ b/internal/sdkprovider/service/project/sweep.go
@@ -96,7 +96,7 @@ func sweepBillingGroups(ctx context.Context) func(region string) error {
 		}
 
 		for _, billingGroup := range billingGroups {
-			if strings.Contains(billingGroup.BillingGroupName, "test-acc-") {
+			if strings.Contains(billingGroup.BillingGroupName, "test-") {
 				if err := client.BillingGroup.Delete(ctx, billingGroup.Id); err != nil {
 					// billing group not found
 					var e aiven.Error


### PR DESCRIPTION
<!-- All contributors, please complete these sections, including maintainers. -->

## About this change—what it does

<!-- Provide a small sentence that summarizes the change. -->

<!-- Provide the issue number below, if it exists. -->
Resolves: NEX-1815
- Sweep billing groups with `test-` prefix instead of `test-acc`

<!-- Provide a small explanation on why this is the approach you took for solving this problem. -->
