### PR TITLE
feat(plugin): generate validation rules

### DIFF
--- a/definitions/.schema.yml
+++ b/definitions/.schema.yml
@@ -224,4 +224,9 @@ definitions:
           - boolean
           - array
           - object
+      alsoRequires:
+        type: array
+        items:
+          type: string
+        $comment: List of other attributes that must be set if this attribute is set
     additionalProperties: false

--- a/generators/plugin/imports.go
+++ b/generators/plugin/imports.go
@@ -25,6 +25,7 @@ const (
 	attrPackage      = "github.com/hashicorp/terraform-plugin-framework/attr"
 	diagPackage      = "github.com/hashicorp/terraform-plugin-framework/diag"
 	typesPackage     = "github.com/hashicorp/terraform-plugin-framework/types"
+	pathPackage      = "github.com/hashicorp/terraform-plugin-framework/path"
 	validatorPackage = "github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	utilPackage      = "github.com/aiven/terraform-provider-aiven/internal/plugin/util"
 	adapterPackage   = "github.com/aiven/terraform-provider-aiven/internal/plugin/adapter"
@@ -35,6 +36,7 @@ func getUntypedImports() []string {
 		attrPackage,
 		diagPackage,
 		typesPackage,
+		pathPackage,
 		validatorPackage,
 		utilPackage,
 		adapterPackage,

--- a/generators/plugin/item.go
+++ b/generators/plugin/item.go
@@ -86,6 +86,13 @@ type Item struct {
 	UserSensitive *bool `yaml:"sensitive"`
 	UserForceNew  *bool `yaml:"forceNew"`
 
+	// TF Validators
+	// https://developer.hashicorp.com/terraform/plugin/framework/migrating/attributes-blocks/validators-predefined#background
+	ConflictsWith []string `yaml:"conflictsWith"`
+	ExactlyOneOf  []string `yaml:"exactlyOneOf"`
+	AtLeastOneOf  []string `yaml:"atLeastOneOf"`
+	AlsoRequires  []string `yaml:"alsoRequires"`
+
 	JSONName           string     `yaml:"jsonName"`
 	Type               SchemaType `yaml:"type"`
 	Description        string     `yaml:"description"`

--- a/generators/plugin/schemas.go
+++ b/generators/plugin/schemas.go
@@ -252,6 +252,7 @@ func genAttributeValues(isResource bool, item *Item) (jen.Dict, error) {
 		}
 	}
 
+	// So far no validations for datasources
 	if !item.IsReadOnly(isResource) {
 		validators, err := genValidators(item)
 		if err != nil {

--- a/generators/plugin/utils.go
+++ b/generators/plugin/utils.go
@@ -33,7 +33,12 @@ func mergeSlices[T any](args ...[]T) []T {
 	for _, a := range args {
 		merged = append(merged, a...)
 	}
-	return distinct(merged...)
+
+	result := distinct(merged...)
+	if len(result) == 0 {
+		return nil
+	}
+	return result
 }
 
 func or[T comparable](a, b T) T {
@@ -51,7 +56,7 @@ func orLonger[T ~string](a, b T) T {
 	return b
 }
 
-func orDefault[T any](v *T, def T) T {
+func ptrOrDefault[T any](v *T, def T) T {
 	if v == nil {
 		return def
 	}
@@ -98,6 +103,20 @@ func fmtDescription(isResource bool, item *Item) string {
 
 	if item.Default != nil {
 		b.DefaultValue(item.Default)
+	}
+
+	// Validators
+	if item.AlsoRequires != nil {
+		b.RequiredWith(item.AlsoRequires...)
+	}
+	if item.ConflictsWith != nil {
+		b.ConflictsWith(item.ConflictsWith...)
+	}
+	if item.ExactlyOneOf != nil {
+		b.ExactlyOneOf(item.ExactlyOneOf...)
+	}
+	if item.AtLeastOneOf != nil {
+		b.AtLeastOneOf(item.AtLeastOneOf...)
 	}
 
 	return b.Build()

--- a/internal/plugin/adapter/datasource.go
+++ b/internal/plugin/adapter/datasource.go
@@ -104,7 +104,7 @@ func (a *datasourceAdapter[T]) Read(
 }
 
 func (a *datasourceAdapter[T]) ConfigValidators(ctx context.Context) []datasource.ConfigValidator {
-	v, ok := a.view.(DatConfigValidators)
+	v, ok := a.view.(DatConfigValidators[T])
 	if !ok {
 		return nil
 	}

--- a/internal/plugin/adapter/view.go
+++ b/internal/plugin/adapter/view.go
@@ -35,14 +35,21 @@ type ResView[T any] interface {
 
 // DatConfigValidators implements datasource.DataSourceWithConfigValidators.
 // It renames the method, so it can be used with ResConfigValidators without collisions.
-type DatConfigValidators interface {
+type DatConfigValidators[T any] interface {
 	DatConfigValidators(ctx context.Context) []datasource.ConfigValidator
 }
 
 // ResConfigValidators implements resource.ResourceWithConfigValidators.
 // It renames the method, so it can be used with DatConfigValidators without collisions.
-type ResConfigValidators interface {
+// https://developer.hashicorp.com/terraform/plugin/framework/resources/validate-configuration#configvalidators-method
+type ResConfigValidators[T any] interface {
 	ResConfigValidators(ctx context.Context) []resource.ConfigValidator
+}
+
+// ResValidateConfig implements resource.ResourceWithValidateConfig.
+// https://developer.hashicorp.com/terraform/plugin/framework/resources/validate-configuration#validateconfig-method
+type ResValidateConfig[T any] interface {
+	ResValidateConfig(ctx context.Context, config *T) diag.Diagnostics
 }
 
 // View base view that contains the client and potentially other dependencies

--- a/internal/plugin/service/organization/organization/organization.go
+++ b/internal/plugin/service/organization/organization/organization.go
@@ -45,7 +45,7 @@ func datasourceSchemaPatched(ctx context.Context) dataschema.Schema {
 	return result
 }
 
-var _ adapter.DatConfigValidators = (*view)(nil)
+var _ adapter.DatConfigValidators[tfModel] = (*view)(nil)
 
 type view struct{ adapter.View }
 

--- a/internal/schemautil/userconfig/desc.go
+++ b/internal/schemautil/userconfig/desc.go
@@ -177,21 +177,26 @@ the ` + "`PROVIDER_AIVEN_ENABLE_BETA`" + ` environment variable to use the %[1]s
 	}
 
 	// Adds validators information.
-	// There should be only one of this, so we don't need to preserve the order.
-	validators := map[string][]string{
-		"The field is required with ":                    db.withRequiredWith,
-		"The field conflicts with ":                      db.withConflictsWith,
-		"Exactly one of the fields must be specified: ":  db.withExactlyOneOf,
-		"At least one of the fields must be specified: ": db.withAtLeastOneOf,
+	validators := [][]string{
+		db.withRequiredWith,
+		db.withConflictsWith,
+		db.withExactlyOneOf,
+		db.withAtLeastOneOf,
 	}
 
-	for k, v := range validators {
+	validatorTitles := []string{
+		"The field is required with ",
+		"The field conflicts with ",
+		"Exactly one of the fields must be specified: ",
+		"At least one of the fields must be specified: ",
+	}
+
+	for i, v := range validators {
 		if len(v) > 0 {
 			builder.WriteRune(' ')
-			builder.WriteString(k)
+			builder.WriteString(validatorTitles[i])
 			builder.WriteString(listOfCodes(v...))
 			builder.WriteRune('.')
-			break
 		}
 	}
 


### PR DESCRIPTION
Resolves NEX-1844.

- Generate validation rules from definition schema
- Child notes inherit `Computed` property from the parent.
  This allows to mark a whole block as "computed" with just one attribute.
  Validation rules do not apply to computed fields.
