### PR TITLE
feat: added validation to the service maintenance window time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ nav_order: 1
   disk usage
 - Deprecate `aiven_kafka_topic` field `config.message_format_version` in Kafka 4.0+: this configuration is removed
   and any supplied value will be ignored; for services upgraded to 4.0+, the returned value may be `"None"`.
+- Added validation for services `maintenance_window_time`: requires HH:mm:ss format
 
 ## [4.44.0] - 2025-08-14
 

--- a/internal/schemautil/schemautil.go
+++ b/internal/schemautil/schemautil.go
@@ -196,6 +196,25 @@ func ValidateEmailAddress(v any, k string) (ws []string, errors []error) {
 	return
 }
 
+// ValidateMaintenanceWindowTime ensures a string is a valid HH:mm:ss time format
+func ValidateMaintenanceWindowTime(v any, k string) (ws []string, errors []error) {
+	timeStr, ok := v.(string)
+	if !ok {
+		errors = append(errors, fmt.Errorf("%q: expected string, got %T", k, v))
+		return
+	}
+
+	if ok, _ := regexp.MatchString("^(2[0-3]|[01][0-9]):[0-5][0-9]:[0-5][0-9]$", timeStr); !ok {
+		errors = append(
+			errors,
+			fmt.Errorf(`%q: must be in HH:mm:ss format where HH is 00-23 (two digits), mm and ss are 00-59 (e.g., "09:30:00", "23:59:59")`, k),
+		)
+		return
+	}
+
+	return
+}
+
 func BuildResourceID(parts ...string) string {
 	finalParts := make([]string, len(parts))
 	for idx, part := range parts {

--- a/internal/schemautil/service.go
+++ b/internal/schemautil/service.go
@@ -167,9 +167,10 @@ func ServiceCommonSchema() map[string]*schema.Schema {
 			ValidateFunc: validation.StringInSlice([]string{"monday", "tuesday", "wednesday", "thursday", "friday", "saturday", "sunday"}, false),
 		},
 		"maintenance_window_time": {
-			Type:        schema.TypeString,
-			Optional:    true,
-			Description: "Time of day when maintenance operations should be performed. UTC time in HH:mm:ss format.",
+			Type:         schema.TypeString,
+			Optional:     true,
+			Description:  "Time of day when maintenance operations should be performed. UTC time in HH:mm:ss format.",
+			ValidateFunc: ValidateMaintenanceWindowTime,
 			DiffSuppressFunc: func(_, _, newValue string, _ *schema.ResourceData) bool {
 				return newValue == ""
 			},


### PR DESCRIPTION
<!-- All contributors, please complete these sections, including maintainers. -->

## About this change—what it does

<!-- Provide a small sentence that summarizes the change. -->

<!-- Provide the issue number below, if it exists. -->
Resolves: NEX-1864
- added validation for `maintenance_window_time` field requiring **HH:mm:ss** format
- validation matches API, so this should not be a breaking change

<!-- Provide a small explanation on why this is the approach you took for solving this problem. -->
