### PR TITLE
chore: deprecated default timeouts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ nav_order: 1
 
 ## [MAJOR.MINOR.PATCH] - YYYY-MM-DD
 
+- Deprecated `timeouts.default` attribute. The `timeouts.default` attribute is now deprecated and will be removed in a future major version. Use specific CRUD timeouts (`create`, `read`, `update`, `delete`) instead. See the [Migration Guide](https://github.com/aiven/terraform-provider-aiven/blob/main/docs/guides/update-deprecated-resources.md) for more information.
 - Add end-of-life service warnings for existing services
 - Remove beta flag from `aiven_organization_project` resource and datasource
 - Change `aiven_service_integration` field `integration_type` (enum): add `autoscaler_service`

--- a/TaskInternal.yml
+++ b/TaskInternal.yml
@@ -174,6 +174,7 @@ tasks:
           rm -f docs/data-sources/${resource}*.md
           rm -f docs/resources/${resource}*.md
         done
+      - find docs/resources -name "*.md" -type f -exec sed -i'' -e 's/^- `default` (String)/- `default` (String, Deprecated) Use specific CRUD timeouts instead./' {} +
 
   generate:
     desc: "Run all code generation tasks"

--- a/docs/guides/update-deprecated-resources.md
+++ b/docs/guides/update-deprecated-resources.md
@@ -381,3 +381,54 @@ Migrate your Aiven for M3 databases to [Aiven for Thanos Metrics](https://aiven.
       ```bash
       terraform apply --auto-approve
       ```
+
+## Migrate from `timeouts.default`
+
+The `timeouts.default` field is deprecated and will be removed in a future version. The [Terraform Plugin Framework does not support the `default` timeout field](https://developer.hashicorp.com/terraform/plugin/framework/resources/timeouts).
+
+### What changed
+
+Resources that previously used `timeouts.default` now require specific CRUD timeouts:
+
+**Before (deprecated):**
+```hcl
+resource "aiven_pg" "example" {
+  project      = "my-project"
+  cloud_name   = "google-europe-west1"
+  plan         = "startup-4"
+  service_name = "my-postgres"
+
+  timeouts {
+    default = "20m"  # This is deprecated
+  }
+}
+```
+
+**After (recommended):**
+```hcl
+resource "aiven_pg" "example" {
+  project      = "my-project"
+  cloud_name   = "google-europe-west1"
+  plan         = "startup-4"
+  service_name = "my-postgres"
+
+  timeouts {
+    create = "20m"
+    read   = "5m"
+    update = "20m"
+    delete = "20m"
+  }
+}
+```
+
+### Migration steps
+
+1. Replace `timeouts.default` with specific CRUD timeouts in your Terraform configuration
+2. Set appropriate timeouts for each operation based on your needs:
+    - `create`: Time for resource creation (typically longer)
+    - `read`: Time for reading resource state (typically shorter)
+    - `update`: Time for resource updates (typically longer)
+    - `delete`: Time for resource deletion (typically medium)
+
+-> **Note**
+You'll see deprecation warnings during `terraform plan` and `terraform apply` operations until you migrate to specific CRUD timeouts.

--- a/docs/resources/account.md
+++ b/docs/resources/account.md
@@ -51,7 +51,7 @@ resource "aiven_account" "account1" {
 Optional:
 
 - `create` (String)
-- `default` (String)
+- `default` (String, Deprecated) Use specific CRUD timeouts instead.
 - `delete` (String)
 - `read` (String)
 - `update` (String)

--- a/docs/resources/account_authentication.md
+++ b/docs/resources/account_authentication.md
@@ -83,7 +83,7 @@ Optional:
 Optional:
 
 - `create` (String)
-- `default` (String)
+- `default` (String, Deprecated) Use specific CRUD timeouts instead.
 - `delete` (String)
 - `read` (String)
 - `update` (String)

--- a/docs/resources/account_team.md
+++ b/docs/resources/account_team.md
@@ -58,7 +58,7 @@ resource "aiven_account_team" "example_team" {
 Optional:
 
 - `create` (String)
-- `default` (String)
+- `default` (String, Deprecated) Use specific CRUD timeouts instead.
 - `delete` (String)
 - `read` (String)
 - `update` (String)

--- a/docs/resources/account_team_member.md
+++ b/docs/resources/account_team_member.md
@@ -68,7 +68,7 @@ resource "aiven_account_team_member" "main" {
 Optional:
 
 - `create` (String)
-- `default` (String)
+- `default` (String, Deprecated) Use specific CRUD timeouts instead.
 - `delete` (String)
 - `read` (String)
 - `update` (String)

--- a/docs/resources/account_team_project.md
+++ b/docs/resources/account_team_project.md
@@ -70,7 +70,7 @@ resource "aiven_account_team_project" "main" {
 Optional:
 
 - `create` (String)
-- `default` (String)
+- `default` (String, Deprecated) Use specific CRUD timeouts instead.
 - `delete` (String)
 - `read` (String)
 - `update` (String)

--- a/docs/resources/alloydbomni.md
+++ b/docs/resources/alloydbomni.md
@@ -364,7 +364,7 @@ Required:
 Optional:
 
 - `create` (String)
-- `default` (String)
+- `default` (String, Deprecated) Use specific CRUD timeouts instead.
 - `delete` (String)
 - `read` (String)
 - `update` (String)

--- a/docs/resources/alloydbomni_database.md
+++ b/docs/resources/alloydbomni_database.md
@@ -67,7 +67,7 @@ account team.
 Optional:
 
 - `create` (String)
-- `default` (String)
+- `default` (String, Deprecated) Use specific CRUD timeouts instead.
 - `delete` (String)
 - `read` (String)
 - `update` (String)

--- a/docs/resources/alloydbomni_user.md
+++ b/docs/resources/alloydbomni_user.md
@@ -70,7 +70,7 @@ account team.
 Optional:
 
 - `create` (String)
-- `default` (String)
+- `default` (String, Deprecated) Use specific CRUD timeouts instead.
 - `delete` (String)
 - `read` (String)
 - `update` (String)

--- a/docs/resources/aws_org_vpc_peering_connection.md
+++ b/docs/resources/aws_org_vpc_peering_connection.md
@@ -61,7 +61,7 @@ resource "aiven_aws_org_vpc_peering_connection" "example_peering" {
 Optional:
 
 - `create` (String)
-- `default` (String)
+- `default` (String, Deprecated) Use specific CRUD timeouts instead.
 - `delete` (String)
 - `read` (String)
 - `update` (String)

--- a/docs/resources/aws_privatelink.md
+++ b/docs/resources/aws_privatelink.md
@@ -48,7 +48,7 @@ resource "aiven_aws_privatelink" "main" {
 Optional:
 
 - `create` (String)
-- `default` (String)
+- `default` (String, Deprecated) Use specific CRUD timeouts instead.
 - `delete` (String)
 - `read` (String)
 - `update` (String)

--- a/docs/resources/aws_vpc_peering_connection.md
+++ b/docs/resources/aws_vpc_peering_connection.md
@@ -55,7 +55,7 @@ resource "aiven_aws_vpc_peering_connection" "aws_to_aiven_peering" {
 Optional:
 
 - `create` (String)
-- `default` (String)
+- `default` (String, Deprecated) Use specific CRUD timeouts instead.
 - `delete` (String)
 - `read` (String)
 - `update` (String)

--- a/docs/resources/azure_org_vpc_peering_connection.md
+++ b/docs/resources/azure_org_vpc_peering_connection.md
@@ -64,7 +64,7 @@ resource "aiven_azure_org_vpc_peering_connection" "example_peering" {
 Optional:
 
 - `create` (String)
-- `default` (String)
+- `default` (String, Deprecated) Use specific CRUD timeouts instead.
 - `delete` (String)
 - `read` (String)
 - `update` (String)

--- a/docs/resources/azure_privatelink.md
+++ b/docs/resources/azure_privatelink.md
@@ -51,7 +51,7 @@ resource "aiven_azure_privatelink" "main" {
 Optional:
 
 - `create` (String)
-- `default` (String)
+- `default` (String, Deprecated) Use specific CRUD timeouts instead.
 - `delete` (String)
 - `read` (String)
 - `update` (String)

--- a/docs/resources/azure_privatelink_connection_approval.md
+++ b/docs/resources/azure_privatelink_connection_approval.md
@@ -94,7 +94,7 @@ resource "aiven_azure_privatelink_connection_approval" "approval" {
 Optional:
 
 - `create` (String)
-- `default` (String)
+- `default` (String, Deprecated) Use specific CRUD timeouts instead.
 - `delete` (String)
 - `read` (String)
 - `update` (String)

--- a/docs/resources/azure_vpc_peering_connection.md
+++ b/docs/resources/azure_vpc_peering_connection.md
@@ -58,7 +58,7 @@ resource "aiven_azure_vpc_peering_connection" "azure_to_aiven_peering" {
 Optional:
 
 - `create` (String)
-- `default` (String)
+- `default` (String, Deprecated) Use specific CRUD timeouts instead.
 - `delete` (String)
 - `read` (String)
 - `update` (String)

--- a/docs/resources/billing_group.md
+++ b/docs/resources/billing_group.md
@@ -61,7 +61,7 @@ resource "aiven_project" "example_project" {
 Optional:
 
 - `create` (String)
-- `default` (String)
+- `default` (String, Deprecated) Use specific CRUD timeouts instead.
 - `delete` (String)
 - `read` (String)
 - `update` (String)

--- a/docs/resources/cassandra.md
+++ b/docs/resources/cassandra.md
@@ -189,7 +189,7 @@ Required:
 Optional:
 
 - `create` (String)
-- `default` (String)
+- `default` (String, Deprecated) Use specific CRUD timeouts instead.
 - `delete` (String)
 - `read` (String)
 - `update` (String)

--- a/docs/resources/cassandra_user.md
+++ b/docs/resources/cassandra_user.md
@@ -61,7 +61,7 @@ resource "aiven_cassandra_user" "example_service_user" {
 Optional:
 
 - `create` (String)
-- `default` (String)
+- `default` (String, Deprecated) Use specific CRUD timeouts instead.
 - `delete` (String)
 - `read` (String)
 - `update` (String)

--- a/docs/resources/clickhouse.md
+++ b/docs/resources/clickhouse.md
@@ -172,7 +172,7 @@ Required:
 Optional:
 
 - `create` (String)
-- `default` (String)
+- `default` (String, Deprecated) Use specific CRUD timeouts instead.
 - `delete` (String)
 - `read` (String)
 - `update` (String)

--- a/docs/resources/clickhouse_database.md
+++ b/docs/resources/clickhouse_database.md
@@ -58,7 +58,7 @@ resource "aiven_clickhouse_database" "example_db" {
 Optional:
 
 - `create` (String)
-- `default` (String)
+- `default` (String, Deprecated) Use specific CRUD timeouts instead.
 - `delete` (String)
 - `read` (String)
 - `update` (String)

--- a/docs/resources/clickhouse_grant.md
+++ b/docs/resources/clickhouse_grant.md
@@ -127,7 +127,7 @@ Optional:
 Optional:
 
 - `create` (String)
-- `default` (String)
+- `default` (String, Deprecated) Use specific CRUD timeouts instead.
 - `delete` (String)
 - `read` (String)
 - `update` (String)

--- a/docs/resources/clickhouse_role.md
+++ b/docs/resources/clickhouse_role.md
@@ -43,7 +43,7 @@ resource "aiven_clickhouse_role" "example_role" {
 Optional:
 
 - `create` (String)
-- `default` (String)
+- `default` (String, Deprecated) Use specific CRUD timeouts instead.
 - `delete` (String)
 - `read` (String)
 - `update` (String)

--- a/docs/resources/clickhouse_user.md
+++ b/docs/resources/clickhouse_user.md
@@ -46,7 +46,7 @@ resource "aiven_clickhouse_user" "example_user" {
 Optional:
 
 - `create` (String)
-- `default` (String)
+- `default` (String, Deprecated) Use specific CRUD timeouts instead.
 - `delete` (String)
 - `read` (String)
 - `update` (String)

--- a/docs/resources/connection_pool.md
+++ b/docs/resources/connection_pool.md
@@ -52,7 +52,7 @@ resource "aiven_connection_pool" "main" {
 Optional:
 
 - `create` (String)
-- `default` (String)
+- `default` (String, Deprecated) Use specific CRUD timeouts instead.
 - `delete` (String)
 - `read` (String)
 - `update` (String)

--- a/docs/resources/dragonfly.md
+++ b/docs/resources/dragonfly.md
@@ -193,7 +193,7 @@ Required:
 Optional:
 
 - `create` (String)
-- `default` (String)
+- `default` (String, Deprecated) Use specific CRUD timeouts instead.
 - `delete` (String)
 - `read` (String)
 - `update` (String)

--- a/docs/resources/flink.md
+++ b/docs/resources/flink.md
@@ -158,7 +158,7 @@ Required:
 Optional:
 
 - `create` (String)
-- `default` (String)
+- `default` (String, Deprecated) Use specific CRUD timeouts instead.
 - `delete` (String)
 - `read` (String)
 - `update` (String)

--- a/docs/resources/flink_application.md
+++ b/docs/resources/flink_application.md
@@ -48,7 +48,7 @@ resource "aiven_flink_application" "example_app" {
 Optional:
 
 - `create` (String)
-- `default` (String)
+- `default` (String, Deprecated) Use specific CRUD timeouts instead.
 - `delete` (String)
 - `read` (String)
 - `update` (String)

--- a/docs/resources/flink_application_deployment.md
+++ b/docs/resources/flink_application_deployment.md
@@ -95,7 +95,7 @@ resource "aiven_flink_application_deployment" "main" {
 Optional:
 
 - `create` (String)
-- `default` (String)
+- `default` (String, Deprecated) Use specific CRUD timeouts instead.
 - `delete` (String)
 - `read` (String)
 - `update` (String)

--- a/docs/resources/flink_application_version.md
+++ b/docs/resources/flink_application_version.md
@@ -139,7 +139,7 @@ Optional:
 Optional:
 
 - `create` (String)
-- `default` (String)
+- `default` (String, Deprecated) Use specific CRUD timeouts instead.
 - `delete` (String)
 - `read` (String)
 - `update` (String)

--- a/docs/resources/flink_jar_application.md
+++ b/docs/resources/flink_jar_application.md
@@ -69,7 +69,7 @@ resource "aiven_flink_jar_application" "example" {
 Optional:
 
 - `create` (String)
-- `default` (String)
+- `default` (String, Deprecated) Use specific CRUD timeouts instead.
 - `delete` (String)
 - `read` (String)
 - `update` (String)

--- a/docs/resources/flink_jar_application_deployment.md
+++ b/docs/resources/flink_jar_application_deployment.md
@@ -89,7 +89,7 @@ resource "aiven_flink_jar_application_deployment" "example" {
 Optional:
 
 - `create` (String)
-- `default` (String)
+- `default` (String, Deprecated) Use specific CRUD timeouts instead.
 - `delete` (String)
 - `read` (String)
 - `update` (String)

--- a/docs/resources/flink_jar_application_version.md
+++ b/docs/resources/flink_jar_application_version.md
@@ -76,7 +76,7 @@ resource "aiven_flink_jar_application_version" "example" {
 Optional:
 
 - `create` (String)
-- `default` (String)
+- `default` (String, Deprecated) Use specific CRUD timeouts instead.
 - `delete` (String)
 - `read` (String)
 - `update` (String)

--- a/docs/resources/gcp_org_vpc_peering_connection.md
+++ b/docs/resources/gcp_org_vpc_peering_connection.md
@@ -58,7 +58,7 @@ resource "aiven_gcp_org_vpc_peering_connection" "example" {
 Optional:
 
 - `create` (String)
-- `default` (String)
+- `default` (String, Deprecated) Use specific CRUD timeouts instead.
 - `delete` (String)
 - `read` (String)
 - `update` (String)

--- a/docs/resources/gcp_privatelink.md
+++ b/docs/resources/gcp_privatelink.md
@@ -44,7 +44,7 @@ resource "aiven_gcp_privatelink" "main" {
 Optional:
 
 - `create` (String)
-- `default` (String)
+- `default` (String, Deprecated) Use specific CRUD timeouts instead.
 - `delete` (String)
 - `read` (String)
 - `update` (String)

--- a/docs/resources/gcp_privatelink_connection_approval.md
+++ b/docs/resources/gcp_privatelink_connection_approval.md
@@ -46,7 +46,7 @@ resource "aiven_gcp_privatelink_connection_approval" "approve" {
 Optional:
 
 - `create` (String)
-- `default` (String)
+- `default` (String, Deprecated) Use specific CRUD timeouts instead.
 - `delete` (String)
 - `read` (String)
 - `update` (String)

--- a/docs/resources/gcp_vpc_peering_connection.md
+++ b/docs/resources/gcp_vpc_peering_connection.md
@@ -46,7 +46,7 @@ resource "aiven_gcp_vpc_peering_connection" "foo" {
 Optional:
 
 - `create` (String)
-- `default` (String)
+- `default` (String, Deprecated) Use specific CRUD timeouts instead.
 - `delete` (String)
 - `read` (String)
 - `update` (String)

--- a/docs/resources/grafana.md
+++ b/docs/resources/grafana.md
@@ -331,7 +331,7 @@ Required:
 Optional:
 
 - `create` (String)
-- `default` (String)
+- `default` (String, Deprecated) Use specific CRUD timeouts instead.
 - `delete` (String)
 - `read` (String)
 - `update` (String)

--- a/docs/resources/kafka.md
+++ b/docs/resources/kafka.md
@@ -427,7 +427,7 @@ Required:
 Optional:
 
 - `create` (String)
-- `default` (String)
+- `default` (String, Deprecated) Use specific CRUD timeouts instead.
 - `delete` (String)
 - `read` (String)
 - `update` (String)

--- a/docs/resources/kafka_acl.md
+++ b/docs/resources/kafka_acl.md
@@ -53,7 +53,7 @@ resource "aiven_kafka_acl" "example_acl" {
 Optional:
 
 - `create` (String)
-- `default` (String)
+- `default` (String, Deprecated) Use specific CRUD timeouts instead.
 - `delete` (String)
 - `read` (String)
 - `update` (String)

--- a/docs/resources/kafka_connect.md
+++ b/docs/resources/kafka_connect.md
@@ -273,7 +273,7 @@ Required:
 Optional:
 
 - `create` (String)
-- `default` (String)
+- `default` (String, Deprecated) Use specific CRUD timeouts instead.
 - `delete` (String)
 - `read` (String)
 - `update` (String)

--- a/docs/resources/kafka_connector.md
+++ b/docs/resources/kafka_connector.md
@@ -66,7 +66,7 @@ resource "aiven_kafka_connector" "kafka-os-connector" {
 Optional:
 
 - `create` (String)
-- `default` (String)
+- `default` (String, Deprecated) Use specific CRUD timeouts instead.
 - `delete` (String)
 - `read` (String)
 - `update` (String)

--- a/docs/resources/kafka_mirrormaker.md
+++ b/docs/resources/kafka_mirrormaker.md
@@ -151,7 +151,7 @@ Required:
 Optional:
 
 - `create` (String)
-- `default` (String)
+- `default` (String, Deprecated) Use specific CRUD timeouts instead.
 - `delete` (String)
 - `read` (String)
 - `update` (String)

--- a/docs/resources/kafka_native_acl.md
+++ b/docs/resources/kafka_native_acl.md
@@ -60,7 +60,7 @@ resource "aiven_kafka_native_acl" "example_acl" {
 Optional:
 
 - `create` (String)
-- `default` (String)
+- `default` (String, Deprecated) Use specific CRUD timeouts instead.
 - `delete` (String)
 - `read` (String)
 - `update` (String)

--- a/docs/resources/kafka_quota.md
+++ b/docs/resources/kafka_quota.md
@@ -65,7 +65,7 @@ It is possible to set default quotas for each (user, client-id), user or client-
 Optional:
 
 - `create` (String)
-- `default` (String)
+- `default` (String, Deprecated) Use specific CRUD timeouts instead.
 - `delete` (String)
 - `read` (String)
 - `update` (String)

--- a/docs/resources/kafka_schema.md
+++ b/docs/resources/kafka_schema.md
@@ -66,7 +66,7 @@ resource "aiven_kafka_schema" "kafka-schema1" {
 Optional:
 
 - `create` (String)
-- `default` (String)
+- `default` (String, Deprecated) Use specific CRUD timeouts instead.
 - `delete` (String)
 - `read` (String)
 - `update` (String)

--- a/docs/resources/kafka_schema_configuration.md
+++ b/docs/resources/kafka_schema_configuration.md
@@ -43,7 +43,7 @@ resource "aiven_kafka_schema_configuration" "config" {
 Optional:
 
 - `create` (String)
-- `default` (String)
+- `default` (String, Deprecated) Use specific CRUD timeouts instead.
 - `delete` (String)
 - `read` (String)
 - `update` (String)

--- a/docs/resources/kafka_schema_registry_acl.md
+++ b/docs/resources/kafka_schema_registry_acl.md
@@ -48,7 +48,7 @@ resource "aiven_kafka_schema_registry_acl" "foo" {
 Optional:
 
 - `create` (String)
-- `default` (String)
+- `default` (String, Deprecated) Use specific CRUD timeouts instead.
 - `delete` (String)
 - `read` (String)
 - `update` (String)

--- a/docs/resources/kafka_topic.md
+++ b/docs/resources/kafka_topic.md
@@ -112,7 +112,7 @@ Optional:
 Optional:
 
 - `create` (String)
-- `default` (String)
+- `default` (String, Deprecated) Use specific CRUD timeouts instead.
 - `delete` (String)
 - `read` (String)
 - `update` (String)

--- a/docs/resources/kafka_user.md
+++ b/docs/resources/kafka_user.md
@@ -48,7 +48,7 @@ resource "aiven_kafka_user" "example_service_user" {
 Optional:
 
 - `create` (String)
-- `default` (String)
+- `default` (String, Deprecated) Use specific CRUD timeouts instead.
 - `delete` (String)
 - `read` (String)
 - `update` (String)

--- a/docs/resources/mirrormaker_replication_flow.md
+++ b/docs/resources/mirrormaker_replication_flow.md
@@ -77,7 +77,7 @@ resource "aiven_mirrormaker_replication_flow" "example_replication_flow" {
 Optional:
 
 - `create` (String)
-- `default` (String)
+- `default` (String, Deprecated) Use specific CRUD timeouts instead.
 - `delete` (String)
 - `read` (String)
 - `update` (String)

--- a/docs/resources/mysql.md
+++ b/docs/resources/mysql.md
@@ -277,7 +277,7 @@ Required:
 Optional:
 
 - `create` (String)
-- `default` (String)
+- `default` (String, Deprecated) Use specific CRUD timeouts instead.
 - `delete` (String)
 - `read` (String)
 - `update` (String)

--- a/docs/resources/mysql_database.md
+++ b/docs/resources/mysql_database.md
@@ -44,7 +44,7 @@ resource "aiven_mysql_database" "example_mysql_database" {
 Optional:
 
 - `create` (String)
-- `default` (String)
+- `default` (String, Deprecated) Use specific CRUD timeouts instead.
 - `delete` (String)
 - `read` (String)
 - `update` (String)

--- a/docs/resources/mysql_user.md
+++ b/docs/resources/mysql_user.md
@@ -49,7 +49,7 @@ resource "aiven_mysql_user" "example_mysql_user" {
 Optional:
 
 - `create` (String)
-- `default` (String)
+- `default` (String, Deprecated) Use specific CRUD timeouts instead.
 - `delete` (String)
 - `read` (String)
 - `update` (String)

--- a/docs/resources/opensearch.md
+++ b/docs/resources/opensearch.md
@@ -669,7 +669,7 @@ Required:
 Optional:
 
 - `create` (String)
-- `default` (String)
+- `default` (String, Deprecated) Use specific CRUD timeouts instead.
 - `delete` (String)
 - `read` (String)
 - `update` (String)

--- a/docs/resources/opensearch_acl_config.md
+++ b/docs/resources/opensearch_acl_config.md
@@ -52,7 +52,7 @@ resource "aiven_opensearch_acl_config" "main" {
 Optional:
 
 - `create` (String)
-- `default` (String)
+- `default` (String, Deprecated) Use specific CRUD timeouts instead.
 - `delete` (String)
 - `read` (String)
 - `update` (String)

--- a/docs/resources/opensearch_acl_rule.md
+++ b/docs/resources/opensearch_acl_rule.md
@@ -98,7 +98,7 @@ resource "aiven_opensearch_acl_rule" "os_acl_rule" {
 Optional:
 
 - `create` (String)
-- `default` (String)
+- `default` (String, Deprecated) Use specific CRUD timeouts instead.
 - `delete` (String)
 - `read` (String)
 - `update` (String)

--- a/docs/resources/opensearch_security_plugin_config.md
+++ b/docs/resources/opensearch_security_plugin_config.md
@@ -54,7 +54,7 @@ resource "aiven_opensearch_security_plugin_config" "main" {
 Optional:
 
 - `create` (String)
-- `default` (String)
+- `default` (String, Deprecated) Use specific CRUD timeouts instead.
 - `delete` (String)
 - `read` (String)
 - `update` (String)

--- a/docs/resources/opensearch_user.md
+++ b/docs/resources/opensearch_user.md
@@ -46,7 +46,7 @@ resource "aiven_opensearch_user" "example_opensearch_user" {
 Optional:
 
 - `create` (String)
-- `default` (String)
+- `default` (String, Deprecated) Use specific CRUD timeouts instead.
 - `delete` (String)
 - `read` (String)
 - `update` (String)

--- a/docs/resources/organization_user.md
+++ b/docs/resources/organization_user.md
@@ -51,7 +51,7 @@ and `aiven_organization_permission` resources.
 Optional:
 
 - `create` (String)
-- `default` (String)
+- `default` (String, Deprecated) Use specific CRUD timeouts instead.
 - `delete` (String)
 - `read` (String)
 - `update` (String)

--- a/docs/resources/organization_user_group.md
+++ b/docs/resources/organization_user_group.md
@@ -46,7 +46,7 @@ resource "aiven_organization_user_group" "example" {
 Optional:
 
 - `create` (String)
-- `default` (String)
+- `default` (String, Deprecated) Use specific CRUD timeouts instead.
 - `delete` (String)
 - `read` (String)
 - `update` (String)

--- a/docs/resources/organization_vpc.md
+++ b/docs/resources/organization_vpc.md
@@ -52,7 +52,7 @@ resource "aiven_organization_vpc" "example_vpc" {
 Optional:
 
 - `create` (String)
-- `default` (String)
+- `default` (String, Deprecated) Use specific CRUD timeouts instead.
 - `delete` (String)
 - `read` (String)
 - `update` (String)

--- a/docs/resources/organizational_unit.md
+++ b/docs/resources/organizational_unit.md
@@ -44,7 +44,7 @@ resource "aiven_organizational_unit" "example_unit" {
 Optional:
 
 - `create` (String)
-- `default` (String)
+- `default` (String, Deprecated) Use specific CRUD timeouts instead.
 - `delete` (String)
 - `read` (String)
 - `update` (String)

--- a/docs/resources/pg.md
+++ b/docs/resources/pg.md
@@ -385,7 +385,7 @@ Required:
 Optional:
 
 - `create` (String)
-- `default` (String)
+- `default` (String, Deprecated) Use specific CRUD timeouts instead.
 - `delete` (String)
 - `read` (String)
 - `update` (String)

--- a/docs/resources/pg_database.md
+++ b/docs/resources/pg_database.md
@@ -46,7 +46,7 @@ resource "aiven_pg_database" "main" {
 Optional:
 
 - `create` (String)
-- `default` (String)
+- `default` (String, Deprecated) Use specific CRUD timeouts instead.
 - `delete` (String)
 - `read` (String)
 - `update` (String)

--- a/docs/resources/pg_user.md
+++ b/docs/resources/pg_user.md
@@ -59,7 +59,7 @@ resource "aiven_pg_user" "admin_user" {
 Optional:
 
 - `create` (String)
-- `default` (String)
+- `default` (String, Deprecated) Use specific CRUD timeouts instead.
 - `delete` (String)
 - `read` (String)
 - `update` (String)

--- a/docs/resources/project.md
+++ b/docs/resources/project.md
@@ -69,7 +69,7 @@ Required:
 Optional:
 
 - `create` (String)
-- `default` (String)
+- `default` (String, Deprecated) Use specific CRUD timeouts instead.
 - `delete` (String)
 - `read` (String)
 - `update` (String)

--- a/docs/resources/project_user.md
+++ b/docs/resources/project_user.md
@@ -53,7 +53,7 @@ resource "aiven_project_user" "mytestuser" {
 Optional:
 
 - `create` (String)
-- `default` (String)
+- `default` (String, Deprecated) Use specific CRUD timeouts instead.
 - `delete` (String)
 - `read` (String)
 - `update` (String)

--- a/docs/resources/project_vpc.md
+++ b/docs/resources/project_vpc.md
@@ -48,7 +48,7 @@ resource "aiven_project_vpc" "example_vpc" {
 Optional:
 
 - `create` (String)
-- `default` (String)
+- `default` (String, Deprecated) Use specific CRUD timeouts instead.
 - `delete` (String)
 - `read` (String)
 - `update` (String)

--- a/docs/resources/redis.md
+++ b/docs/resources/redis.md
@@ -226,7 +226,7 @@ Required:
 Optional:
 
 - `create` (String)
-- `default` (String)
+- `default` (String, Deprecated) Use specific CRUD timeouts instead.
 - `delete` (String)
 - `read` (String)
 - `update` (String)

--- a/docs/resources/redis_user.md
+++ b/docs/resources/redis_user.md
@@ -65,7 +65,7 @@ resource "aiven_redis_user" "foo" {
 Optional:
 
 - `create` (String)
-- `default` (String)
+- `default` (String, Deprecated) Use specific CRUD timeouts instead.
 - `delete` (String)
 - `read` (String)
 - `update` (String)

--- a/docs/resources/service_integration.md
+++ b/docs/resources/service_integration.md
@@ -438,7 +438,7 @@ Optional:
 Optional:
 
 - `create` (String)
-- `default` (String)
+- `default` (String, Deprecated) Use specific CRUD timeouts instead.
 - `delete` (String)
 - `read` (String)
 - `update` (String)

--- a/docs/resources/service_integration_endpoint.md
+++ b/docs/resources/service_integration_endpoint.md
@@ -390,7 +390,7 @@ Optional:
 Optional:
 
 - `create` (String)
-- `default` (String)
+- `default` (String, Deprecated) Use specific CRUD timeouts instead.
 - `delete` (String)
 - `read` (String)
 - `update` (String)

--- a/docs/resources/static_ip.md
+++ b/docs/resources/static_ip.md
@@ -38,7 +38,7 @@ The aiven_static_ip resource allows the creation and deletion of static ips. Ple
 Optional:
 
 - `create` (String)
-- `default` (String)
+- `default` (String, Deprecated) Use specific CRUD timeouts instead.
 - `delete` (String)
 - `read` (String)
 - `update` (String)

--- a/docs/resources/thanos.md
+++ b/docs/resources/thanos.md
@@ -213,7 +213,7 @@ Optional:
 Optional:
 
 - `create` (String)
-- `default` (String)
+- `default` (String, Deprecated) Use specific CRUD timeouts instead.
 - `delete` (String)
 - `read` (String)
 - `update` (String)

--- a/docs/resources/transit_gateway_vpc_attachment.md
+++ b/docs/resources/transit_gateway_vpc_attachment.md
@@ -52,7 +52,7 @@ resource "aiven_transit_gateway_vpc_attachment" "attachment" {
 Optional:
 
 - `create` (String)
-- `default` (String)
+- `default` (String, Deprecated) Use specific CRUD timeouts instead.
 - `delete` (String)
 - `read` (String)
 - `update` (String)

--- a/docs/resources/valkey.md
+++ b/docs/resources/valkey.md
@@ -99,7 +99,7 @@ Required:
 Optional:
 
 - `create` (String)
-- `default` (String)
+- `default` (String, Deprecated) Use specific CRUD timeouts instead.
 - `delete` (String)
 - `read` (String)
 - `update` (String)

--- a/docs/resources/valkey_user.md
+++ b/docs/resources/valkey_user.md
@@ -86,7 +86,7 @@ resource "aiven_valkey_user" "manage_sessions" {
 Optional:
 
 - `create` (String)
-- `default` (String)
+- `default` (String, Deprecated) Use specific CRUD timeouts instead.
 - `delete` (String)
 - `read` (String)
 - `update` (String)

--- a/internal/common/diagnostics.go
+++ b/internal/common/diagnostics.go
@@ -1,0 +1,20 @@
+package common
+
+import (
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+// CheckDeprecatedTimeoutDefault adds a warning diagnostic if timeouts.default is configured
+func CheckDeprecatedTimeoutDefault(d *schema.ResourceData) diag.Diagnostic {
+	if timeout := d.Timeout(schema.TimeoutDefault); timeout > 0 {
+		return diag.Diagnostic{
+			Severity: diag.Warning,
+			Summary:  "Deprecated timeout configuration",
+			Detail: "The 'timeouts.default' field is deprecated and will be removed in a future version.\n\n" +
+				"Use specific CRUD timeouts (create, read, update, delete) instead.\n\n" +
+				"See: https://github.com/aiven/terraform-provider-aiven/blob/main/docs/guides/update-deprecated-resources.md",
+		}
+	}
+	return diag.Diagnostic{}
+}

--- a/internal/schemautil/service.go
+++ b/internal/schemautil/service.go
@@ -35,9 +35,13 @@ var defaultTimeout time.Duration = 20
 
 func DefaultResourceTimeouts() *schema.ResourceTimeout {
 	return &schema.ResourceTimeout{
-		Create:  schema.DefaultTimeout(defaultTimeout * time.Minute),
-		Update:  schema.DefaultTimeout(defaultTimeout * time.Minute),
-		Delete:  schema.DefaultTimeout(defaultTimeout * time.Minute),
+		Create: schema.DefaultTimeout(defaultTimeout * time.Minute),
+		Update: schema.DefaultTimeout(defaultTimeout * time.Minute),
+		Delete: schema.DefaultTimeout(defaultTimeout * time.Minute),
+		// DEPRECATED: Default timeout is deprecated.
+		// The Plugin Framework does not support the Default timeout field.
+		// This field will be removed in a future major version.
+		// See: https://developer.hashicorp.com/terraform/plugin/framework/resources/timeouts
 		Default: schema.DefaultTimeout(defaultTimeout * time.Minute),
 		Read:    schema.DefaultTimeout(defaultTimeout * time.Minute),
 	}
@@ -438,6 +442,10 @@ func ResourceServiceRead(ctx context.Context, d *schema.ResourceData, m interfac
 				Detail:   fmt.Sprintf(detail, lo.FromPtr(v.Metadata.EndOfLifeHelpArticleUrl)),
 			})
 		}
+	}
+
+	if timeoutWarning := common.CheckDeprecatedTimeoutDefault(d); timeoutWarning.Severity != 0 {
+		diags = append(diags, timeoutWarning)
 	}
 
 	return diags

--- a/templates/guides/update-deprecated-resources.md
+++ b/templates/guides/update-deprecated-resources.md
@@ -381,3 +381,54 @@ Migrate your Aiven for M3 databases to [Aiven for Thanos Metrics](https://aiven.
       ```bash
       terraform apply --auto-approve
       ```
+
+## Migrate from `timeouts.default`
+
+The `timeouts.default` field is deprecated and will be removed in a future version. The [Terraform Plugin Framework does not support the `default` timeout field](https://developer.hashicorp.com/terraform/plugin/framework/resources/timeouts).
+
+### What changed
+
+Resources that previously used `timeouts.default` now require specific CRUD timeouts:
+
+**Before (deprecated):**
+```hcl
+resource "aiven_pg" "example" {
+  project      = "my-project"
+  cloud_name   = "google-europe-west1"
+  plan         = "startup-4"
+  service_name = "my-postgres"
+
+  timeouts {
+    default = "20m"  # This is deprecated
+  }
+}
+```
+
+**After (recommended):**
+```hcl
+resource "aiven_pg" "example" {
+  project      = "my-project"
+  cloud_name   = "google-europe-west1"
+  plan         = "startup-4"
+  service_name = "my-postgres"
+
+  timeouts {
+    create = "20m"
+    read   = "5m"
+    update = "20m"
+    delete = "20m"
+  }
+}
+```
+
+### Migration steps
+
+1. Replace `timeouts.default` with specific CRUD timeouts in your Terraform configuration
+2. Set appropriate timeouts for each operation based on your needs:
+    - `create`: Time for resource creation (typically longer)
+    - `read`: Time for reading resource state (typically shorter)
+    - `update`: Time for resource updates (typically longer)
+    - `delete`: Time for resource deletion (typically medium)
+
+-> **Note**
+You'll see deprecation warnings during `terraform plan` and `terraform apply` operations until you migrate to specific CRUD timeouts.


### PR DESCRIPTION
<!-- All contributors, please complete these sections, including maintainers. -->

## About this change—what it does

<!-- Provide a small sentence that summarizes the change. -->

<!-- Provide the issue number below, if it exists. -->
Resolves: NEX-1871

- All resources now show runtime deprecation warnings during `plan/apply` operations if `timeout.default` field was set
- Added migration guide and deprecation notice to the documentation

<!-- Provide a small explanation on why this is the approach you took for solving this problem. -->
