### PR TITLE
fix(alloydb): deprecated alloyDB tests

### DIFF
--- a/internal/sdkprovider/service/alloydbomni/alloydbomni_database_test.go
+++ b/internal/sdkprovider/service/alloydbomni/alloydbomni_database_test.go
@@ -17,6 +17,8 @@ import (
 )
 
 func TestAccAivenAlloyDBOmniDatabase_basic(t *testing.T) {
+	t.Skip("Deprecated resource")
+
 	resourceName := "aiven_alloydbomni_database.foo"
 	projectName := acc.ProjectName()
 	rName := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)

--- a/internal/sdkprovider/service/alloydbomni/alloydbomni_user_test.go
+++ b/internal/sdkprovider/service/alloydbomni/alloydbomni_user_test.go
@@ -16,6 +16,8 @@ import (
 )
 
 func TestAccAivenAlloyDBOmniUser_basic(t *testing.T) {
+	t.Skip("Deprecated resource")
+
 	resourceName := "aiven_alloydbomni_user.foo"
 	rName := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
 	resource.ParallelTest(t, resource.TestCase{


### PR DESCRIPTION
<!-- All contributors, please complete these sections, including maintainers. -->

## About this change—what it does

<!-- Provide a small sentence that summarizes the change. -->

<!-- Provide the issue number below, if it exists. -->
Resolves: NEX-1890

- deprecated the AlloyDB tests due to the resource deprecation

<!-- Provide a small explanation on why this is the approach you took for solving this problem. -->
