### PR TITLE
fix: fixed default timeout warning

### DIFF
--- a/internal/common/diagnostics.go
+++ b/internal/common/diagnostics.go
@@ -5,16 +5,33 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
-// CheckDeprecatedTimeoutDefault adds a warning diagnostic if timeouts.default is configured
+// CheckDeprecatedTimeoutDefault adds a warning diagnostic if timeouts.default is configured during apply operations.
+// During plan refresh, GetRawConfig returns null, so warning won't be shown.
 func CheckDeprecatedTimeoutDefault(d *schema.ResourceData) diag.Diagnostic {
-	if timeout := d.Timeout(schema.TimeoutDefault); timeout > 0 {
-		return diag.Diagnostic{
-			Severity: diag.Warning,
-			Summary:  "Deprecated timeout configuration",
-			Detail: "The 'timeouts.default' field is deprecated and will be removed in a future version.\n\n" +
-				"Use specific CRUD timeouts (create, read, update, delete) instead.\n\n" +
-				"See: https://github.com/aiven/terraform-provider-aiven/blob/main/docs/guides/update-deprecated-resources.md",
-		}
+	rawConfig := d.GetRawConfig()
+	if rawConfig.IsNull() {
+		return diag.Diagnostic{}
 	}
-	return diag.Diagnostic{}
+
+	timeoutsVal := rawConfig.GetAttr(schema.TimeoutsConfigKey)
+	if timeoutsVal.IsNull() {
+		return diag.Diagnostic{}
+	}
+
+	if !timeoutsVal.Type().HasAttribute(schema.TimeoutDefault) {
+		return diag.Diagnostic{}
+	}
+
+	defaultVal := timeoutsVal.GetAttr(schema.TimeoutDefault)
+	if defaultVal.IsNull() {
+		return diag.Diagnostic{}
+	}
+
+	return diag.Diagnostic{
+		Severity: diag.Warning,
+		Summary:  "Deprecated timeout configuration",
+		Detail: "The 'timeouts.default' field is deprecated and will be removed in a future version.\n\n" +
+			"Use specific CRUD timeouts (create, read, update, delete) instead.\n\n" +
+			"See: https://github.com/aiven/terraform-provider-aiven/blob/main/docs/guides/update-deprecated-resources.md",
+	}
 }


### PR DESCRIPTION
<!-- All contributors, please complete these sections, including maintainers. -->

## About this change—what it does

<!-- Provide a small sentence that summarizes the change. -->

<!-- Provide the issue number below, if it exists. -->
Resolves: NEX-1903

-  Original implementation checked `d.Timeout(schema.TimeoutDefault) > 0` to detect deprecated `timeouts.default`, this always returns true because `Timeout()` returns either user value, schema default, or system default (20min). As a result -> false positive warnings on all resources, even without `timeouts` block
- `d.GetRawConfig()` checks actual configuration, but warning only shows after `terraform apply`, not plan stage.

<!-- Provide a small explanation on why this is the approach you took for solving this problem. -->
