### PR TITLE
feat(plugin): ignore state values

### DIFF
--- a/internal/plugin/service/governance/access/zz_converters.go
+++ b/internal/plugin/service/governance/access/zz_converters.go
@@ -88,26 +88,26 @@ func composeID() []string {
 // expandData turns TF object into Request
 func expandData[R any](ctx context.Context, plan, state *tfModel, req *R, modifiers ...util.MapModifier[apiModel]) diag.Diagnostics {
 	api := new(apiModel)
-	if !plan.AccessData.IsNull() || state != nil && !state.AccessData.IsNull() {
+	if !plan.AccessData.IsNull() {
 		vAccessData, diags := util.ExpandSingleNested(ctx, expandAccessData, plan.AccessData)
 		if diags.HasError() {
 			return diags
 		}
 		api.AccessData = vAccessData
 	}
-	if !plan.AccessName.IsNull() || state != nil && !state.AccessName.IsNull() {
+	if !plan.AccessName.IsNull() {
 		vAccessName := plan.AccessName.ValueString()
 		api.AccessName = &vAccessName
 	}
-	if !plan.AccessType.IsNull() || state != nil && !state.AccessType.IsNull() {
+	if !plan.AccessType.IsNull() {
 		vAccessType := plan.AccessType.ValueString()
 		api.AccessType = &vAccessType
 	}
-	if !plan.OrganizationID.IsNull() || state != nil && !state.OrganizationID.IsNull() {
+	if !plan.OrganizationID.IsNull() {
 		vOrganizationID := plan.OrganizationID.ValueString()
 		api.OrganizationID = &vOrganizationID
 	}
-	if !plan.OwnerUserGroupID.IsNull() || state != nil && !state.OwnerUserGroupID.IsNull() {
+	if !plan.OwnerUserGroupID.IsNull() {
 		vOwnerUserGroupID := plan.OwnerUserGroupID.ValueString()
 		api.OwnerUserGroupID = &vOwnerUserGroupID
 	}
@@ -137,7 +137,7 @@ func expandAccessData(ctx context.Context, plan *tfModelAccessData) (*apiModelAc
 		vServiceName := plan.ServiceName.ValueString()
 		api.ServiceName = &vServiceName
 	}
-	if !plan.Username.IsNull() && !plan.Username.IsUnknown() {
+	if !plan.Username.IsNull() {
 		vUsername := plan.Username.ValueString()
 		api.Username = &vUsername
 	}
@@ -146,7 +146,7 @@ func expandAccessData(ctx context.Context, plan *tfModelAccessData) (*apiModelAc
 
 func expandAccessDataAcls(ctx context.Context, plan *tfModelAccessDataAcls) (*apiModelAccessDataAcls, diag.Diagnostics) {
 	api := new(apiModelAccessDataAcls)
-	if !plan.Host.IsNull() && !plan.Host.IsUnknown() {
+	if !plan.Host.IsNull() {
 		vHost := plan.Host.ValueString()
 		api.Host = &vHost
 	}

--- a/internal/plugin/service/organization/address/zz_converters.go
+++ b/internal/plugin/service/organization/address/zz_converters.go
@@ -67,27 +67,27 @@ func expandData[R any](ctx context.Context, plan, state *tfModel, req *R, modifi
 		}
 		api.AddressLines = &vAddressLines
 	}
-	if !plan.City.IsNull() || state != nil && !state.City.IsNull() {
+	if !plan.City.IsNull() {
 		vCity := plan.City.ValueString()
 		api.City = &vCity
 	}
-	if !plan.CountryCode.IsNull() || state != nil && !state.CountryCode.IsNull() {
+	if !plan.CountryCode.IsNull() {
 		vCountryCode := plan.CountryCode.ValueString()
 		api.CountryCode = &vCountryCode
 	}
-	if !plan.Name.IsNull() || state != nil && !state.Name.IsNull() {
+	if !plan.Name.IsNull() {
 		vName := plan.Name.ValueString()
 		api.Name = &vName
 	}
-	if !plan.OrganizationID.IsNull() || state != nil && !state.OrganizationID.IsNull() {
+	if !plan.OrganizationID.IsNull() {
 		vOrganizationID := plan.OrganizationID.ValueString()
 		api.OrganizationID = &vOrganizationID
 	}
-	if !plan.State.IsNull() || state != nil && !state.State.IsNull() {
+	if !plan.State.IsNull() {
 		vState := plan.State.ValueString()
 		api.State = &vState
 	}
-	if !plan.ZipCode.IsNull() || state != nil && !state.ZipCode.IsNull() {
+	if !plan.ZipCode.IsNull() {
 		vZipCode := plan.ZipCode.ValueString()
 		api.ZipCode = &vZipCode
 	}

--- a/internal/plugin/service/organization/application_user/zz_converters.go
+++ b/internal/plugin/service/organization/application_user/zz_converters.go
@@ -49,15 +49,15 @@ func composeID() []string {
 // expandData turns TF object into Request
 func expandData[R any](ctx context.Context, plan, state *tfModel, req *R, modifiers ...util.MapModifier[apiModel]) diag.Diagnostics {
 	api := new(apiModel)
-	if !plan.IsSuperAdmin.IsNull() && !plan.IsSuperAdmin.IsUnknown() {
+	if !plan.IsSuperAdmin.IsNull() {
 		vIsSuperAdmin := plan.IsSuperAdmin.ValueBool()
 		api.IsSuperAdmin = &vIsSuperAdmin
 	}
-	if !plan.Name.IsNull() || state != nil && !state.Name.IsNull() {
+	if !plan.Name.IsNull() {
 		vName := plan.Name.ValueString()
 		api.Name = &vName
 	}
-	if !plan.OrganizationID.IsNull() || state != nil && !state.OrganizationID.IsNull() {
+	if !plan.OrganizationID.IsNull() {
 		vOrganizationID := plan.OrganizationID.ValueString()
 		api.OrganizationID = &vOrganizationID
 	}

--- a/internal/plugin/service/organization/application_user_token/zz_converters.go
+++ b/internal/plugin/service/organization/application_user_token/zz_converters.go
@@ -90,23 +90,23 @@ func expandData[R any](ctx context.Context, plan, state *tfModel, req *R, modifi
 		}
 		api.Scopes = &vScopes
 	}
-	if !plan.Description.IsNull() || state != nil && !state.Description.IsNull() {
+	if !plan.Description.IsNull() {
 		vDescription := plan.Description.ValueString()
 		api.Description = &vDescription
 	}
-	if !plan.ExtendWhenUsed.IsNull() && !plan.ExtendWhenUsed.IsUnknown() {
+	if !plan.ExtendWhenUsed.IsNull() {
 		vExtendWhenUsed := plan.ExtendWhenUsed.ValueBool()
 		api.ExtendWhenUsed = &vExtendWhenUsed
 	}
-	if !plan.MaxAgeSeconds.IsNull() || state != nil && !state.MaxAgeSeconds.IsNull() {
+	if !plan.MaxAgeSeconds.IsNull() {
 		vMaxAgeSeconds := plan.MaxAgeSeconds.ValueInt64()
 		api.MaxAgeSeconds = &vMaxAgeSeconds
 	}
-	if !plan.OrganizationID.IsNull() || state != nil && !state.OrganizationID.IsNull() {
+	if !plan.OrganizationID.IsNull() {
 		vOrganizationID := plan.OrganizationID.ValueString()
 		api.OrganizationID = &vOrganizationID
 	}
-	if !plan.UserID.IsNull() || state != nil && !state.UserID.IsNull() {
+	if !plan.UserID.IsNull() {
 		vUserID := plan.UserID.ValueString()
 		api.UserID = &vUserID
 	}

--- a/internal/plugin/service/organization/billinggroup/zz_converters.go
+++ b/internal/plugin/service/organization/billinggroup/zz_converters.go
@@ -77,35 +77,35 @@ func expandData[R any](ctx context.Context, plan, state *tfModel, req *R, modifi
 		}
 		api.BillingEmails = &vBillingEmails
 	}
-	if !plan.BillingAddressID.IsNull() || state != nil && !state.BillingAddressID.IsNull() {
+	if !plan.BillingAddressID.IsNull() {
 		vBillingAddressID := plan.BillingAddressID.ValueString()
 		api.BillingAddressID = &vBillingAddressID
 	}
-	if !plan.BillingGroupName.IsNull() || state != nil && !state.BillingGroupName.IsNull() {
+	if !plan.BillingGroupName.IsNull() {
 		vBillingGroupName := plan.BillingGroupName.ValueString()
 		api.BillingGroupName = &vBillingGroupName
 	}
-	if !plan.Currency.IsNull() || state != nil && !state.Currency.IsNull() {
+	if !plan.Currency.IsNull() {
 		vCurrency := plan.Currency.ValueString()
 		api.Currency = &vCurrency
 	}
-	if !plan.CustomInvoiceText.IsNull() || state != nil && !state.CustomInvoiceText.IsNull() {
+	if !plan.CustomInvoiceText.IsNull() {
 		vCustomInvoiceText := plan.CustomInvoiceText.ValueString()
 		api.CustomInvoiceText = &vCustomInvoiceText
 	}
-	if !plan.OrganizationID.IsNull() || state != nil && !state.OrganizationID.IsNull() {
+	if !plan.OrganizationID.IsNull() {
 		vOrganizationID := plan.OrganizationID.ValueString()
 		api.OrganizationID = &vOrganizationID
 	}
-	if !plan.PaymentMethodID.IsNull() || state != nil && !state.PaymentMethodID.IsNull() {
+	if !plan.PaymentMethodID.IsNull() {
 		vPaymentMethodID := plan.PaymentMethodID.ValueString()
 		api.PaymentMethodID = &vPaymentMethodID
 	}
-	if !plan.ShippingAddressID.IsNull() || state != nil && !state.ShippingAddressID.IsNull() {
+	if !plan.ShippingAddressID.IsNull() {
 		vShippingAddressID := plan.ShippingAddressID.ValueString()
 		api.ShippingAddressID = &vShippingAddressID
 	}
-	if !plan.VatID.IsNull() || state != nil && !state.VatID.IsNull() {
+	if !plan.VatID.IsNull() {
 		vVatID := plan.VatID.ValueString()
 		api.VatID = &vVatID
 	}

--- a/internal/plugin/service/organization/organization/zz_converters.go
+++ b/internal/plugin/service/organization/organization/zz_converters.go
@@ -45,7 +45,7 @@ func composeID() []string {
 // expandData turns TF object into Request
 func expandData[R any](ctx context.Context, plan, state *tfModel, req *R, modifiers ...util.MapModifier[apiModel]) diag.Diagnostics {
 	api := new(apiModel)
-	if !plan.Name.IsNull() || state != nil && !state.Name.IsNull() {
+	if !plan.Name.IsNull() {
 		vName := plan.Name.ValueString()
 		api.Name = &vName
 	}

--- a/internal/plugin/service/organization/permission/zz_converters.go
+++ b/internal/plugin/service/organization/permission/zz_converters.go
@@ -72,15 +72,15 @@ func expandData[R any](ctx context.Context, plan, state *tfModel, req *R, modifi
 		}
 		api.Permissions = &vPermissions
 	}
-	if !plan.OrganizationID.IsNull() || state != nil && !state.OrganizationID.IsNull() {
+	if !plan.OrganizationID.IsNull() {
 		vOrganizationID := plan.OrganizationID.ValueString()
 		api.OrganizationID = &vOrganizationID
 	}
-	if !plan.ResourceID.IsNull() || state != nil && !state.ResourceID.IsNull() {
+	if !plan.ResourceID.IsNull() {
 		vResourceID := plan.ResourceID.ValueString()
 		api.ResourceID = &vResourceID
 	}
-	if !plan.ResourceType.IsNull() || state != nil && !state.ResourceType.IsNull() {
+	if !plan.ResourceType.IsNull() {
 		vResourceType := plan.ResourceType.ValueString()
 		api.ResourceType = &vResourceType
 	}

--- a/internal/plugin/service/organization/project/zz_converters.go
+++ b/internal/plugin/service/organization/project/zz_converters.go
@@ -81,23 +81,23 @@ func expandData[R any](ctx context.Context, plan, state *tfModel, req *R, modifi
 		}
 		api.TechnicalEmails = &vTechnicalEmails
 	}
-	if !plan.BasePort.IsNull() && !plan.BasePort.IsUnknown() {
+	if !plan.BasePort.IsNull() {
 		vBasePort := plan.BasePort.ValueInt64()
 		api.BasePort = &vBasePort
 	}
-	if !plan.BillingGroupID.IsNull() || state != nil && !state.BillingGroupID.IsNull() {
+	if !plan.BillingGroupID.IsNull() {
 		vBillingGroupID := plan.BillingGroupID.ValueString()
 		api.BillingGroupID = &vBillingGroupID
 	}
-	if !plan.OrganizationID.IsNull() || state != nil && !state.OrganizationID.IsNull() {
+	if !plan.OrganizationID.IsNull() {
 		vOrganizationID := plan.OrganizationID.ValueString()
 		api.OrganizationID = &vOrganizationID
 	}
-	if !plan.ParentID.IsNull() || state != nil && !state.ParentID.IsNull() {
+	if !plan.ParentID.IsNull() {
 		vParentID := plan.ParentID.ValueString()
 		api.ParentID = &vParentID
 	}
-	if !plan.ProjectID.IsNull() || state != nil && !state.ProjectID.IsNull() {
+	if !plan.ProjectID.IsNull() {
 		vProjectID := plan.ProjectID.ValueString()
 		api.ProjectID = &vProjectID
 	}


### PR DESCRIPTION
Resolves NEX-1906.

TF shouldn't send state values that might have computed values
received from the API as default values.
    
For instance, `aiven_kafka_topic` gets full list of config values from the BE.
