### PR TITLE
feat(plugin): generate legacy timeouts block

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -24,6 +24,10 @@ linters:
   settings:
     lll:
       line-length: 140
+    revive:
+      rules:
+        - name: unused-parameter
+          disabled: true
   exclusions:
     generated: lax
     presets:

--- a/definitions/.schema.yml
+++ b/definitions/.schema.yml
@@ -9,6 +9,11 @@ properties:
     type: boolean
     $comment: |
       Set to true if this resource/datasource is in beta and may have breaking changes.
+  legacyTimeouts:
+    type: boolean
+    $comment: |
+      Set to true to use legacy timeout handling for this resource.
+      This is only needed for SDKv2 compatibility.
   datasource:
     $ref: '#/definitions/SchemaMeta'
     $comment: |

--- a/generators/plugin/imports.go
+++ b/generators/plugin/imports.go
@@ -22,13 +22,14 @@ func boolEntity(isResource bool) entityType {
 
 // Generic untyped imports
 const (
-	attrPackage      = "github.com/hashicorp/terraform-plugin-framework/attr"
-	diagPackage      = "github.com/hashicorp/terraform-plugin-framework/diag"
-	typesPackage     = "github.com/hashicorp/terraform-plugin-framework/types"
-	pathPackage      = "github.com/hashicorp/terraform-plugin-framework/path"
-	validatorPackage = "github.com/hashicorp/terraform-plugin-framework/schema/validator"
-	utilPackage      = "github.com/aiven/terraform-provider-aiven/internal/plugin/util"
-	adapterPackage   = "github.com/aiven/terraform-provider-aiven/internal/plugin/adapter"
+	attrPackage           = "github.com/hashicorp/terraform-plugin-framework/attr"
+	diagPackage           = "github.com/hashicorp/terraform-plugin-framework/diag"
+	typesPackage          = "github.com/hashicorp/terraform-plugin-framework/types"
+	pathPackage           = "github.com/hashicorp/terraform-plugin-framework/path"
+	validatorPackage      = "github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	utilPackage           = "github.com/aiven/terraform-provider-aiven/internal/plugin/util"
+	adapterPackage        = "github.com/aiven/terraform-provider-aiven/internal/plugin/adapter"
+	legacyTimeoutsPackage = "github.com/aiven/terraform-provider-aiven/internal/plugin/legacytimeouts"
 )
 
 func getUntypedImports() []string {
@@ -40,6 +41,7 @@ func getUntypedImports() []string {
 		validatorPackage,
 		utilPackage,
 		adapterPackage,
+		legacyTimeoutsPackage,
 	}
 }
 

--- a/generators/plugin/item.go
+++ b/generators/plugin/item.go
@@ -56,16 +56,17 @@ type IDAttribute struct {
 }
 
 type Definition struct {
-	Beta        bool                 `yaml:"beta"`
-	Location    string               `yaml:"location"`
-	Schema      map[string]*Item     `yaml:"schema,omitempty"`
-	Delete      []string             `yaml:"delete,omitempty"`
-	Rename      map[string]string    `yaml:"rename,omitempty"`
-	ObjectKey   string               `yaml:"objectKey,omitempty"`
-	Resource    *SchemaMeta          `yaml:"resource,omitempty"`
-	Datasource  *SchemaMeta          `yaml:"datasource,omitempty"`
-	IDAttribute *IDAttribute         `yaml:"idAttribute"`
-	Operations  map[string]Operation `yaml:"operations"`
+	Beta           bool                 `yaml:"beta"`
+	Location       string               `yaml:"location"`
+	Schema         map[string]*Item     `yaml:"schema,omitempty"`
+	Delete         []string             `yaml:"delete,omitempty"`
+	Rename         map[string]string    `yaml:"rename,omitempty"`
+	ObjectKey      string               `yaml:"objectKey,omitempty"`
+	Resource       *SchemaMeta          `yaml:"resource,omitempty"`
+	Datasource     *SchemaMeta          `yaml:"datasource,omitempty"`
+	IDAttribute    *IDAttribute         `yaml:"idAttribute"`
+	LegacyTimeouts bool                 `yaml:"legacyTimeouts,omitempty"`
+	Operations     map[string]Operation `yaml:"operations"`
 }
 
 type Item struct {

--- a/generators/plugin/main.go
+++ b/generators/plugin/main.go
@@ -120,7 +120,7 @@ func genDefinition(doc *OpenAPIDoc, defPath string) error {
 
 		root.Name = resName
 		isResource := entity == resourceType
-		schema, err := genSchema(def.Beta, isResource, root, def.IDAttribute)
+		schema, err := genSchema(isResource, root, def)
 		if err != nil {
 			return err
 		}

--- a/generators/plugin/models.go
+++ b/generators/plugin/models.go
@@ -64,6 +64,13 @@ func genTFModel(isResource bool, item *Item) []jen.Code {
 		meth.Clone().
 			Id("SharedModel").Params().Op("*").Id(item.TFModelName()).
 			Block(jen.Return(jen.Op("&").Id(tfVar).Dot(item.TFModelName()))).
+			Line().
+			Line(), // Had to add this extra to separate methods visually
+
+		// Adds TimeoutsObject method that returns types.Object (see TimeoutsObject usage)
+		meth.Clone().
+			Id("TimeoutsObject").Params().Qual(typesPackage, "Object").
+			Block(jen.Return(jen.Id(tfVar).Dot("Timeouts").Dot("Object"))).
 			Line(),
 	}
 }

--- a/internal/plugin/adapter/datasource.go
+++ b/internal/plugin/adapter/datasource.go
@@ -90,10 +90,18 @@ func (a *datasourceAdapter[T]) Read(
 		state = a.newModel()
 		diags = &rsp.Diagnostics
 	)
+
 	diags.Append(req.Config.Get(ctx, state)...)
 	if diags.HasError() {
 		return
 	}
+
+	ctx, cancel, d := withTimeout(ctx, state.TimeoutsObject(), timeoutRead)
+	diags.Append(d...)
+	if diags.HasError() {
+		return
+	}
+	defer cancel()
 
 	diags.Append(a.view.Read(ctx, state.SharedModel())...)
 	if diags.HasError() {

--- a/internal/plugin/adapter/resource.go
+++ b/internal/plugin/adapter/resource.go
@@ -108,6 +108,13 @@ func (a *resourceAdapter[T]) Create(
 		return
 	}
 
+	ctx, cancel, d := withTimeout(ctx, plan.TimeoutsObject(), timeoutCreate)
+	diags.Append(d...)
+	if diags.HasError() {
+		return
+	}
+	defer cancel()
+
 	diags.Append(a.view.Create(ctx, plan.SharedModel())...)
 	if diags.HasError() {
 		return
@@ -125,10 +132,18 @@ func (a *resourceAdapter[T]) Read(
 		state = a.newModel()
 		diags = &rsp.Diagnostics
 	)
+
 	diags.Append(req.State.Get(ctx, state)...)
 	if diags.HasError() {
 		return
 	}
+
+	ctx, cancel, d := withTimeout(ctx, state.TimeoutsObject(), timeoutRead)
+	diags.Append(d...)
+	if diags.HasError() {
+		return
+	}
+	defer cancel()
 
 	diags.Append(a.view.Read(ctx, state.SharedModel())...)
 	if diags.HasError() {
@@ -158,9 +173,12 @@ func (a *resourceAdapter[T]) Update(
 	}
 
 	diags.Append(a.view.Update(ctx, plan.SharedModel(), state.SharedModel(), config.SharedModel())...)
+	ctx, cancel, d := withTimeout(ctx, plan.TimeoutsObject(), timeoutUpdate)
+	diags.Append(d...)
 	if diags.HasError() {
 		return
 	}
+	defer cancel()
 
 	diags.Append(rsp.State.Set(ctx, plan)...)
 }
@@ -174,10 +192,18 @@ func (a *resourceAdapter[T]) Delete(
 		state = a.newModel()
 		diags = &rsp.Diagnostics
 	)
+
 	diags.Append(req.State.Get(ctx, state)...)
 	if diags.HasError() {
 		return
 	}
+
+	ctx, cancel, d := withTimeout(ctx, state.TimeoutsObject(), timeoutDelete)
+	diags.Append(d...)
+	if diags.HasError() {
+		return
+	}
+	defer cancel()
 
 	diags.Append(a.view.Delete(ctx, state.SharedModel())...)
 }

--- a/internal/plugin/adapter/timeouts.go
+++ b/internal/plugin/adapter/timeouts.go
@@ -1,0 +1,80 @@
+// Copyright (c) 2025 Aiven, Helsinki, Finland. https://aiven.io/
+
+package adapter
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+
+	"github.com/aiven/terraform-provider-aiven/internal/schemautil"
+)
+
+type timeoutType string
+
+const (
+	timeoutCreate  timeoutType = "create"
+	timeoutRead    timeoutType = "read"
+	timeoutUpdate  timeoutType = "update"
+	timeoutDelete  timeoutType = "delete"
+	timeoutDefault timeoutType = "default"
+)
+
+// withTimeout returns a new context with the specified timeout from the timeouts object.
+// Uses schemautil.GetDefaultTimeout() value from "ldflags" as the fallback.
+func withTimeout(ctx context.Context, timeouts types.Object, timeoutKey timeoutType) (context.Context, func(), diag.Diagnostics) {
+	timeout, diags := getTimeoutValue(ctx, timeouts, timeoutKey, schemautil.GetDefaultTimeout())
+	if diags.HasError() {
+		// Return original context if timeout value is invalid to avoid nil pointer dereference.
+		return ctx, nil, diags
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, timeout)
+	return ctx, cancel, nil
+}
+
+// getTimeoutValue retrieves the timeout value in SDKv2 legacy manner (the plugin framework doesn't have "default" key):
+// 1. The specific timeout value for the given key (e.g. "create", "read", "update", "delete")
+// 2. The "default" timeout value if specific one not found
+// 3. The provided fallback duration if no timeouts configured
+// Returns the resolved duration and any validation diagnostics.
+func getTimeoutValue(
+	ctx context.Context,
+	timeouts types.Object,
+	timeoutKey timeoutType,
+	fallback time.Duration,
+) (time.Duration, diag.Diagnostics) {
+	values := make(map[timeoutType]time.Duration)
+	for k, v := range timeouts.Attributes() {
+		if v.IsNull() || v.IsUnknown() {
+			continue
+		}
+
+		// The schema ensures that the value is a string.
+		duration, err := time.ParseDuration(v.(types.String).ValueString())
+		if err != nil {
+			return 0, diag.Diagnostics{diag.NewErrorDiagnostic(
+				"Invalid Timeout Value",
+				fmt.Sprintf("Failed to parse timeout value for %q: %s", timeoutKey, err.Error()),
+			)}
+		}
+		values[timeoutType(k)] = duration
+	}
+
+	if v, ok := values[timeoutKey]; ok {
+		tflog.Info(ctx, fmt.Sprintf("Using %q timeout: %s", timeoutKey, v))
+		return v, nil
+	}
+
+	if v, ok := values[timeoutDefault]; ok {
+		tflog.Info(ctx, fmt.Sprintf("Using %q value for %q timeout: %s", timeoutDefault, timeoutKey, v))
+		return v, nil
+	}
+
+	tflog.Info(ctx, fmt.Sprintf("Using fallback timeout for %q: %s", timeoutKey, fallback))
+	return fallback, nil
+}

--- a/internal/plugin/adapter/timeouts_test.go
+++ b/internal/plugin/adapter/timeouts_test.go
@@ -1,0 +1,124 @@
+// Copyright (c) 2025 Aiven, Helsinki, Finland. https://aiven.io/
+
+package adapter
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/stretchr/testify/require"
+)
+
+func testTimeoutsMap(kw ...string) map[string]attr.Value {
+	base := map[string]attr.Value{
+		"create":  types.StringNull(),
+		"read":    types.StringNull(),
+		"update":  types.StringNull(),
+		"delete":  types.StringNull(),
+		"default": types.StringNull(),
+	}
+	for i := 0; i < len(kw); i += 2 {
+		if i+1 < len(kw) {
+			base[kw[i]] = types.StringValue(kw[i+1])
+		}
+	}
+	return base
+}
+
+func TestGetTimeoutValue(t *testing.T) {
+	t.Parallel()
+
+	const fallbackTimeout = 5 * time.Minute
+	tests := []struct {
+		name        string
+		timeouts    map[string]attr.Value
+		timeoutType timeoutType
+		want        time.Duration
+		wantError   bool
+	}{
+		{
+			name:        "valid create timeout",
+			timeouts:    testTimeoutsMap("create", "30s"),
+			timeoutType: timeoutCreate,
+			want:        30 * time.Second,
+		},
+		{
+			name:        "valid read timeout",
+			timeouts:    testTimeoutsMap("read", "45s"),
+			timeoutType: timeoutRead,
+			want:        45 * time.Second,
+		},
+		{
+			name:        "valid update timeout",
+			timeouts:    testTimeoutsMap("update", "1m"),
+			timeoutType: timeoutUpdate,
+			want:        1 * time.Minute,
+		},
+		{
+			name:        "valid delete timeout",
+			timeouts:    testTimeoutsMap("delete", "2m"),
+			timeoutType: timeoutDelete,
+			want:        2 * time.Minute,
+		},
+		{
+			name:        "valid default timeout",
+			timeouts:    testTimeoutsMap("default", "1m"),
+			timeoutType: timeoutCreate,
+			want:        1 * time.Minute,
+		},
+		{
+			name:        "invalid duration format",
+			timeouts:    testTimeoutsMap("create", "invalid"),
+			timeoutType: timeoutCreate,
+			want:        0,
+			wantError:   true,
+		},
+		{
+			name:        "uses default when timeout not specified",
+			timeouts:    testTimeoutsMap("update", "45s"),
+			timeoutType: timeoutCreate,
+			want:        fallbackTimeout,
+		},
+		{
+			name:        "empty timeouts uses fallback",
+			timeouts:    testTimeoutsMap(),
+			timeoutType: timeoutCreate,
+			want:        fallbackTimeout,
+		},
+		{
+			name:        "complex duration format",
+			timeouts:    testTimeoutsMap("create", "1h2m3s"),
+			timeoutType: timeoutCreate,
+			want:        1*time.Hour + 2*time.Minute + 3*time.Second,
+		},
+	}
+
+	ctx := context.Background()
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			timeoutsObj, diags := types.ObjectValue(
+				map[string]attr.Type{
+					"create":  types.StringType,
+					"read":    types.StringType,
+					"update":  types.StringType,
+					"delete":  types.StringType,
+					"default": types.StringType,
+				},
+				tt.timeouts,
+			)
+			require.Empty(t, diags)
+
+			got, diags := getTimeoutValue(ctx, timeoutsObj, tt.timeoutType, fallbackTimeout)
+			if tt.wantError {
+				require.True(t, diags.HasError())
+				return
+			}
+
+			require.False(t, diags.HasError())
+			require.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/internal/plugin/adapter/view.go
+++ b/internal/plugin/adapter/view.go
@@ -7,12 +7,14 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
 // Model implements resource or datasource model with the shared fields model.
 type Model[T any] interface {
 	// SharedModel returns the shared fields model between resource and datasource.
 	SharedModel() *T
+	TimeoutsObject() types.Object
 }
 
 // newModel returns a new instance of the Model.

--- a/internal/plugin/legacytimeouts/legacytimeouts.go
+++ b/internal/plugin/legacytimeouts/legacytimeouts.go
@@ -1,0 +1,63 @@
+package legacytimeouts
+
+import (
+	"context"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+
+	"github.com/aiven/terraform-provider-aiven/internal/plugin/validators"
+)
+
+// BlockAll returns a legacy timeouts block schema with a "default" key for SDKv2 compatibility.
+func BlockAll(ctx context.Context) schema.Block {
+	attrTypes := map[string]attr.Type{
+		"default": types.StringType,
+	}
+
+	attributes := map[string]schema.Attribute{
+		"default": schema.StringAttribute{
+			Optional:           true,
+			Description:        "Timeout for all operations. Deprecated, use operation-specific timeouts instead.",
+			DeprecationMessage: "Use operation-specific timeouts instead. This field will be removed in the next major version.",
+		},
+	}
+
+	// Copies the doctstrings from the Terraform core timeouts block.
+	for k, a := range timeouts.BlockAll(ctx).GetNestedObject().GetAttributes() {
+		attrTypes[k] = a.GetType()
+		attributes[k] = schema.StringAttribute{
+			Optional:    true,
+			Description: a.GetDescription(),
+			Validators: []validator.String{
+				TimeDuration(),
+			},
+		}
+	}
+
+	return schema.SingleNestedBlock{
+		Attributes: attributes,
+		CustomType: timeouts.Type{
+			ObjectType: types.ObjectType{
+				AttrTypes: attrTypes,
+			},
+		},
+	}
+}
+
+// TimeDuration validates that a string value is a valid duration format (e.g. "30s", "5m", "1h").
+// This reimplements similar functionality from Terraform core, since their implementation
+// is in an internal package and cannot be imported directly.
+func TimeDuration() validator.String {
+	return validators.NewStringValidator(
+		`must be a valid time duration string, e.g. "30s", "5m", "1h"`,
+		func(v string) error {
+			_, err := time.ParseDuration(v)
+			return err
+		},
+	)
+}

--- a/internal/plugin/legacytimeouts/legacytimeouts_test.go
+++ b/internal/plugin/legacytimeouts/legacytimeouts_test.go
@@ -1,0 +1,78 @@
+// Copyright (c) 2025 Aiven, Helsinki, Finland. https://aiven.io/
+
+package legacytimeouts
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTimeDuration(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		value       types.String
+		diagnostics diag.Diagnostics
+		name        string
+	}{
+		{
+			name:        "valid duration - seconds",
+			value:       types.StringValue("30s"),
+			diagnostics: nil,
+		},
+		{
+			name:        "valid duration - minutes",
+			value:       types.StringValue("5m"),
+			diagnostics: nil,
+		},
+		{
+			name:        "valid duration - hours",
+			value:       types.StringValue("1h"),
+			diagnostics: nil,
+		},
+		{
+			name:        "valid duration - mixed",
+			value:       types.StringValue("1h2m3s"),
+			diagnostics: nil,
+		},
+		{
+			name:  "invalid duration",
+			value: types.StringValue("invalid"),
+			diagnostics: diag.Diagnostics{
+				diag.NewAttributeErrorDiagnostic(
+					path.Root("test"),
+					"Invalid String Attribute",
+					`"invalid" must be a valid time duration string, e.g. "30s", "5m", "1h"`,
+				),
+			},
+		},
+		{
+			name:        "null value",
+			value:       types.StringNull(),
+			diagnostics: nil,
+		},
+		{
+			name:        "unknown value",
+			value:       types.StringUnknown(),
+			diagnostics: nil,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			req := validator.StringRequest{
+				Path:        path.Root("test"),
+				ConfigValue: tc.value,
+			}
+			res := &validator.StringResponse{}
+			TimeDuration().ValidateString(context.Background(), req, res)
+			assert.Equal(t, tc.diagnostics, res.Diagnostics)
+		})
+	}
+}

--- a/internal/plugin/service/governance/access/zz_resource.go
+++ b/internal/plugin/service/governance/access/zz_resource.go
@@ -14,6 +14,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
 
 	"github.com/aiven/terraform-provider-aiven/internal/plugin/adapter"
 )
@@ -30,6 +31,10 @@ type resourceModel struct {
 
 func (tf *resourceModel) SharedModel() *tfModel {
 	return &tf.tfModel
+}
+
+func (tf *resourceModel) TimeoutsObject() types.Object {
+	return tf.Timeouts.Object
 }
 
 /*

--- a/internal/plugin/service/organization/address/zz_datasource.go
+++ b/internal/plugin/service/organization/address/zz_datasource.go
@@ -29,6 +29,10 @@ func (tf *datasourceModel) SharedModel() *tfModel {
 	return &tf.tfModel
 }
 
+func (tf *datasourceModel) TimeoutsObject() types.Object {
+	return tf.Timeouts.Object
+}
+
 /*
 newDatasourceSchema:
 

--- a/internal/plugin/service/organization/address/zz_resource.go
+++ b/internal/plugin/service/organization/address/zz_resource.go
@@ -32,6 +32,10 @@ func (tf *resourceModel) SharedModel() *tfModel {
 	return &tf.tfModel
 }
 
+func (tf *resourceModel) TimeoutsObject() types.Object {
+	return tf.Timeouts.Object
+}
+
 /*
 newResourceSchema:
 

--- a/internal/plugin/service/organization/application_user/zz_datasource.go
+++ b/internal/plugin/service/organization/application_user/zz_datasource.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-framework-timeouts/datasource/timeouts"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
 
 	"github.com/aiven/terraform-provider-aiven/internal/plugin/adapter"
 )
@@ -24,6 +25,10 @@ type datasourceModel struct {
 
 func (tf *datasourceModel) SharedModel() *tfModel {
 	return &tf.tfModel
+}
+
+func (tf *datasourceModel) TimeoutsObject() types.Object {
+	return tf.Timeouts.Object
 }
 
 /*

--- a/internal/plugin/service/organization/application_user/zz_resource.go
+++ b/internal/plugin/service/organization/application_user/zz_resource.go
@@ -11,6 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/types"
 
 	"github.com/aiven/terraform-provider-aiven/internal/plugin/adapter"
 )
@@ -27,6 +28,10 @@ type resourceModel struct {
 
 func (tf *resourceModel) SharedModel() *tfModel {
 	return &tf.tfModel
+}
+
+func (tf *resourceModel) TimeoutsObject() types.Object {
+	return tf.Timeouts.Object
 }
 
 /*

--- a/internal/plugin/service/organization/application_user_token/zz_resource.go
+++ b/internal/plugin/service/organization/application_user_token/zz_resource.go
@@ -37,6 +37,10 @@ func (tf *resourceModel) SharedModel() *tfModel {
 	return &tf.tfModel
 }
 
+func (tf *resourceModel) TimeoutsObject() types.Object {
+	return tf.Timeouts.Object
+}
+
 /*
 newResourceSchema:
 

--- a/internal/plugin/service/organization/billinggroup/zz_datasource.go
+++ b/internal/plugin/service/organization/billinggroup/zz_datasource.go
@@ -29,6 +29,10 @@ func (tf *datasourceModel) SharedModel() *tfModel {
 	return &tf.tfModel
 }
 
+func (tf *datasourceModel) TimeoutsObject() types.Object {
+	return tf.Timeouts.Object
+}
+
 /*
 newDatasourceSchema:
 

--- a/internal/plugin/service/organization/billinggroup/zz_resource.go
+++ b/internal/plugin/service/organization/billinggroup/zz_resource.go
@@ -31,6 +31,10 @@ func (tf *resourceModel) SharedModel() *tfModel {
 	return &tf.tfModel
 }
 
+func (tf *resourceModel) TimeoutsObject() types.Object {
+	return tf.Timeouts.Object
+}
+
 /*
 newResourceSchema:
 

--- a/internal/plugin/service/organization/billinggrouplist/zz_datasource.go
+++ b/internal/plugin/service/organization/billinggrouplist/zz_datasource.go
@@ -27,6 +27,10 @@ func (tf *datasourceModel) SharedModel() *tfModel {
 	return &tf.tfModel
 }
 
+func (tf *datasourceModel) TimeoutsObject() types.Object {
+	return tf.Timeouts.Object
+}
+
 /*
 newDatasourceSchema:
 

--- a/internal/plugin/service/organization/organization/zz_datasource.go
+++ b/internal/plugin/service/organization/organization/zz_datasource.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-framework-timeouts/datasource/timeouts"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
 
 	"github.com/aiven/terraform-provider-aiven/internal/plugin/adapter"
 )
@@ -24,6 +25,10 @@ type datasourceModel struct {
 
 func (tf *datasourceModel) SharedModel() *tfModel {
 	return &tf.tfModel
+}
+
+func (tf *datasourceModel) TimeoutsObject() types.Object {
+	return tf.Timeouts.Object
 }
 
 /*

--- a/internal/plugin/service/organization/organization/zz_resource.go
+++ b/internal/plugin/service/organization/organization/zz_resource.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
 
 	"github.com/aiven/terraform-provider-aiven/internal/plugin/adapter"
 )
@@ -28,6 +29,10 @@ type resourceModel struct {
 
 func (tf *resourceModel) SharedModel() *tfModel {
 	return &tf.tfModel
+}
+
+func (tf *resourceModel) TimeoutsObject() types.Object {
+	return tf.Timeouts.Object
 }
 
 /*

--- a/internal/plugin/service/organization/permission/zz_resource.go
+++ b/internal/plugin/service/organization/permission/zz_resource.go
@@ -32,6 +32,10 @@ func (tf *resourceModel) SharedModel() *tfModel {
 	return &tf.tfModel
 }
 
+func (tf *resourceModel) TimeoutsObject() types.Object {
+	return tf.Timeouts.Object
+}
+
 /*
 newResourceSchema:
 

--- a/internal/plugin/service/organization/project/zz_datasource.go
+++ b/internal/plugin/service/organization/project/zz_datasource.go
@@ -29,6 +29,10 @@ func (tf *datasourceModel) SharedModel() *tfModel {
 	return &tf.tfModel
 }
 
+func (tf *datasourceModel) TimeoutsObject() types.Object {
+	return tf.Timeouts.Object
+}
+
 /*
 newDatasourceSchema:
 

--- a/internal/plugin/service/organization/project/zz_resource.go
+++ b/internal/plugin/service/organization/project/zz_resource.go
@@ -32,6 +32,10 @@ func (tf *resourceModel) SharedModel() *tfModel {
 	return &tf.tfModel
 }
 
+func (tf *resourceModel) TimeoutsObject() types.Object {
+	return tf.Timeouts.Object
+}
+
 /*
 newResourceSchema:
 

--- a/internal/plugin/validators/stringvalidator.go
+++ b/internal/plugin/validators/stringvalidator.go
@@ -1,0 +1,51 @@
+// Copyright (c) 2025 Aiven, Helsinki, Finland. https://aiven.io/
+
+package validators
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+)
+
+var _ validator.String = (*stringValidator)(nil)
+
+// NewStringValidator creates a string validator with custom validation logic.
+// Example: NewStringValidator("must be a valid time", validateTimeString)
+func NewStringValidator(message string, validate func(v string) error) validator.String {
+	return &stringValidator{
+		message:  message,
+		validate: validate,
+	}
+}
+
+type stringValidator struct {
+	message  string
+	validate func(v string) error
+}
+
+func (s *stringValidator) Description(ctx context.Context) string {
+	return s.message
+}
+
+func (s *stringValidator) MarkdownDescription(ctx context.Context) string {
+	return s.message
+}
+
+func (s *stringValidator) ValidateString(ctx context.Context, req validator.StringRequest, rsp *validator.StringResponse) {
+	if req.ConfigValue.IsNull() || req.ConfigValue.IsUnknown() {
+		return
+	}
+
+	v := req.ConfigValue.ValueString()
+	err := s.validate(v)
+	if err != nil {
+		rsp.Diagnostics.Append(diag.NewAttributeErrorDiagnostic(
+			req.Path,
+			"Invalid String Attribute",
+			fmt.Sprintf("%q %s", v, s.message),
+		))
+	}
+}

--- a/internal/schemautil/service.go
+++ b/internal/schemautil/service.go
@@ -47,6 +47,11 @@ func DefaultResourceTimeouts() *schema.ResourceTimeout {
 	}
 }
 
+// GetDefaultTimeout returns the default timeout for service operations.
+func GetDefaultTimeout() time.Duration {
+	return defaultTimeout * time.Minute
+}
+
 const (
 	ServiceTypeAlloyDBOmni      = "alloydbomni"
 	ServiceTypePG               = "pg"


### PR DESCRIPTION
Resolves NEX-1907.

The Plugin Framework doesn't have the `default` timeout key. That's a breaking change for the resources we are migrating from SDKv2.

- Adds a custom `timeouts` block to the generator
- Adds timeouts string validator
- Uses timeouts to cancel the context in CRUD operations
- Disables `unused-parameter` linter rule (a waste of time)
