### PR TITLE
feat(plugin): add config parameter to resource Update method

### DIFF
--- a/internal/plugin/adapter/resource.go
+++ b/internal/plugin/adapter/resource.go
@@ -144,18 +144,20 @@ func (a *resourceAdapter[T]) Update(
 	rsp *resource.UpdateResponse,
 ) {
 	var (
-		plan  = a.newModel()
-		state = a.newModel()
-		diags = &rsp.Diagnostics
+		plan   = a.newModel()
+		state  = a.newModel()
+		config = a.newModel()
+		diags  = &rsp.Diagnostics
 	)
 
 	diags.Append(req.Plan.Get(ctx, plan)...)
 	diags.Append(req.State.Get(ctx, state)...)
+	diags.Append(req.Config.Get(ctx, config)...)
 	if diags.HasError() {
 		return
 	}
 
-	diags.Append(a.view.Update(ctx, plan.SharedModel(), state.SharedModel())...)
+	diags.Append(a.view.Update(ctx, plan.SharedModel(), state.SharedModel(), config.SharedModel())...)
 	if diags.HasError() {
 		return
 	}

--- a/internal/plugin/adapter/view.go
+++ b/internal/plugin/adapter/view.go
@@ -25,11 +25,22 @@ type DatView[T any] interface {
 	Read(ctx context.Context, state *T) diag.Diagnostics
 }
 
-// ResView resource view interface
+// ResView represents a resource view that handles CRUD operations. It uses three main state objects:
+//
+// - state: The current state of the resource containing all values (required, optional, computed)
+// - config: The raw configuration from the user which may contain unknown values due to interpolation
+// - plan: The planned final state, combining user-defined values from "config" with computed/optional values from "state"
+//
+// Create and Update operations typically use plan as it represents the desired end state.
+// "config" is used when we need to check what values the user explicitly defined.
+//
+// For optional+computed attributes with UseStateForUnknown:
+// When a user removes a value from "config", the value persists in "state" and appears in "plan",
+// allowing the attribute to retain its last known value.
 type ResView[T any] interface {
 	DatView[T]
 	Create(ctx context.Context, plan *T) diag.Diagnostics
-	Update(ctx context.Context, plan, state *T) diag.Diagnostics
+	Update(ctx context.Context, plan, state, config *T) diag.Diagnostics
 	Delete(ctx context.Context, state *T) diag.Diagnostics
 }
 

--- a/internal/plugin/service/governance/access/access.go
+++ b/internal/plugin/service/governance/access/access.go
@@ -35,7 +35,7 @@ func (vw *view) Create(ctx context.Context, plan *tfModel) diag.Diagnostics {
 	return vw.Read(ctx, plan)
 }
 
-func (vw *view) Update(_ context.Context, _, _ *tfModel) diag.Diagnostics {
+func (vw *view) Update(_ context.Context, _, _, _ *tfModel) diag.Diagnostics {
 	var diags diag.Diagnostics
 	diags.AddError(errmsg.SummaryErrorUpdatingResource, "Update is not supported for this resource")
 	return diags

--- a/internal/plugin/service/organization/address/address.go
+++ b/internal/plugin/service/organization/address/address.go
@@ -40,7 +40,7 @@ func (vw *view) Create(ctx context.Context, plan *tfModel) diag.Diagnostics {
 	return vw.Read(ctx, plan)
 }
 
-func (vw *view) Update(ctx context.Context, plan, state *tfModel) diag.Diagnostics {
+func (vw *view) Update(ctx context.Context, plan, state, _ *tfModel) diag.Diagnostics {
 	var req organization.OrganizationAddressUpdateIn
 	diags := expandData(ctx, plan, state, &req)
 	if diags.HasError() {

--- a/internal/plugin/service/organization/application_user/application_user.go
+++ b/internal/plugin/service/organization/application_user/application_user.go
@@ -40,7 +40,7 @@ func (vw *view) Create(ctx context.Context, plan *tfModel) diag.Diagnostics {
 	return vw.Read(ctx, plan)
 }
 
-func (vw *view) Update(ctx context.Context, plan, state *tfModel) diag.Diagnostics {
+func (vw *view) Update(ctx context.Context, plan, state, _ *tfModel) diag.Diagnostics {
 	var req applicationuser.ApplicationUserUpdateIn
 	diags := expandData(ctx, plan, state, &req)
 	if diags.HasError() {

--- a/internal/plugin/service/organization/application_user_token/application_user_token.go
+++ b/internal/plugin/service/organization/application_user_token/application_user_token.go
@@ -49,7 +49,7 @@ func (vw *view) Create(ctx context.Context, plan *tfModel) diag.Diagnostics {
 	return vw.Read(ctx, plan)
 }
 
-func (vw *view) Update(_ context.Context, _, _ *tfModel) diag.Diagnostics {
+func (vw *view) Update(_ context.Context, _, _, _ *tfModel) diag.Diagnostics {
 	var diags diag.Diagnostics
 	diags.AddError(errmsg.SummaryErrorReadingResource, "This resource cannot be updated")
 	return diags

--- a/internal/plugin/service/organization/billinggroup/billing_group.go
+++ b/internal/plugin/service/organization/billinggroup/billing_group.go
@@ -41,7 +41,7 @@ func (vw *view) Create(ctx context.Context, plan *tfModel) diag.Diagnostics {
 	return vw.Read(ctx, plan)
 }
 
-func (vw *view) Update(ctx context.Context, plan, state *tfModel) diag.Diagnostics {
+func (vw *view) Update(ctx context.Context, plan, state, _ *tfModel) diag.Diagnostics {
 	var req organizationbilling.OrganizationBillingGroupUpdateIn
 	diags := expandData(ctx, plan, state, &req, emailsToMap)
 	if diags.HasError() {

--- a/internal/plugin/service/organization/organization/organization.go
+++ b/internal/plugin/service/organization/organization/organization.go
@@ -79,7 +79,7 @@ func (vw *view) Create(ctx context.Context, plan *tfModel) diag.Diagnostics {
 	return vw.Read(ctx, plan)
 }
 
-func (vw *view) Update(ctx context.Context, plan, state *tfModel) diag.Diagnostics {
+func (vw *view) Update(ctx context.Context, plan, state, _ *tfModel) diag.Diagnostics {
 	var req account.AccountUpdateIn
 	diags := expandData(ctx, plan, state, &req)
 	if diags.HasError() {

--- a/internal/plugin/service/organization/permission/permission.go
+++ b/internal/plugin/service/organization/permission/permission.go
@@ -54,10 +54,10 @@ func (vw *view) Create(ctx context.Context, plan *tfModel) diag.Diagnostics {
 		return diags
 	}
 
-	return vw.Update(ctx, plan, nil)
+	return vw.Update(ctx, plan, nil, nil)
 }
 
-func (vw *view) Update(ctx context.Context, plan, state *tfModel) diag.Diagnostics {
+func (vw *view) Update(ctx context.Context, plan, state, _ *tfModel) diag.Diagnostics {
 	var req organization.PermissionsSetIn
 	diags := expandData(ctx, plan, state, &req)
 	if diags.HasError() {

--- a/internal/plugin/service/organization/project/project.go
+++ b/internal/plugin/service/organization/project/project.go
@@ -43,7 +43,7 @@ func (vw *view) Create(ctx context.Context, plan *tfModel) diag.Diagnostics {
 	return vw.Read(ctx, plan)
 }
 
-func (vw *view) Update(ctx context.Context, plan, state *tfModel) diag.Diagnostics {
+func (vw *view) Update(ctx context.Context, plan, state, _ *tfModel) diag.Diagnostics {
 	var req organizationprojects.OrganizationProjectsUpdateIn
 	diags := expandData(ctx, plan, state, &req, vw.modifyReq(ctx))
 	if diags.HasError() {


### PR DESCRIPTION
Resolves NEX-1927.

Enables distinguishing between user-defined and API default values. For resources like Kafka topics, this prevents marking API defaults as user-defined when sending only explicitly configured values.
