### PR TITLE
fix(kafka_quota): added retry to the kafka quotas read

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ nav_order: 1
 
 ## [MAJOR.MINOR.PATCH] - YYYY-MM-DD
 
+- Fix `aiven_kafka_quota` added retry logic to handle API eventual consistency
+
 ## [4.46.0] - 2025-10-09
 
 - Added `maintenance_window_enabled` field to service resources: Indicates whether the maintenance window is currently enabled for this service.

--- a/internal/sdkprovider/service/organization/sweep.go
+++ b/internal/sdkprovider/service/organization/sweep.go
@@ -24,6 +24,10 @@ func init() {
 	sweep.AddTestSweepers("aiven_organization", &resource.Sweeper{
 		Name: "aiven_organization",
 		F:    sweepOrganizations(ctx),
+		Dependencies: []string{
+			"aiven_organizational_unit",
+			"aiven_organization_project",
+		},
 	})
 
 	sweep.AddTestSweepers("aiven_organization_application_user", &resource.Sweeper{


### PR DESCRIPTION
<!-- All contributors, please complete these sections, including maintainers. -->

## About this change—what it does

<!-- Provide a small sentence that summarizes the change. -->

<!-- Provide the issue number below, if it exists. -->
Contributes to: NEX-1933
- added retry to the `kafka quotas` read
- fixed organization resources sweeping order

## Why this way

<!-- Provide a small explanation on why this is the approach you took for solving this problem. -->
