### PR TITLE
feat: use `json.Number` to unmarshal json

### DIFF
--- a/internal/plugin/util/converters.go
+++ b/internal/plugin/util/converters.go
@@ -1,6 +1,7 @@
 package util
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -16,7 +17,11 @@ func remarshal(in, out any) error {
 	if err != nil {
 		return err
 	}
-	return json.Unmarshal(b, out)
+
+	// Uses json.Number to avoid int->float64->int overflow issue.
+	d := json.NewDecoder(bytes.NewReader(b))
+	d.UseNumber()
+	return d.Decode(out)
 }
 
 // Remarshal remarshals a value from in to out, applies typed modifiers before unmarshalling to out.

--- a/internal/schemautil/schemautil.go
+++ b/internal/schemautil/schemautil.go
@@ -1,6 +1,7 @@
 package schemautil
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"net/mail"
@@ -568,5 +569,9 @@ func Remarshal(in, out any) error {
 	if err != nil {
 		return err
 	}
-	return json.Unmarshal(b, out)
+
+	// Uses json.Number to avoid int->float64->int overflow issue.
+	d := json.NewDecoder(bytes.NewReader(b))
+	d.UseNumber()
+	return d.Decode(out)
 }


### PR DESCRIPTION
Resolves NEX-1947.

Uses `json.Number` to unmarshal json.
