### PR TITLE
refactor(plugin): rename `Unmarshal` to `Remarshal`

### DIFF
--- a/generators/plugin/expand.go
+++ b/generators/plugin/expand.go
@@ -19,13 +19,13 @@ func genExpand(item *Item) ([]jen.Code, error) {
 		block,
 		jen.Id("err").
 			Op(":=").
-			Qual(utilPackage, "Unmarshal").
+			Qual(utilPackage, "Remarshal").
 			Call(
 				jen.Id(apiVar),
 				jen.Id("req"),
 				jen.Id("modifiers").Op("..."),
 			),
-		jen.Add(ifErr(true, "Unmarshal error", "Failed to unmarshal dtoModel to Request: %s")),
+		jen.Add(ifErr(true, "Remarshal error", "Failed to remarshal dtoModel to Request: %s")),
 		jen.Return(jen.Nil()),
 	)
 

--- a/generators/plugin/flatten.go
+++ b/generators/plugin/flatten.go
@@ -32,14 +32,14 @@ func genFlatten(item *Item) ([]jen.Code, error) {
 		// Renders Unmarshal
 		jen.Id("err").
 			Op(":=").
-			Qual(utilPackage, "Unmarshal").
+			Qual(utilPackage, "Remarshal").
 			Call(
 				jen.Id("rsp"),
 				jen.Id(apiVar),
 				jen.Id("modifiers").Op("..."),
 			),
 
-		jen.Add(ifErr(true, "Unmarshal error", "Failed to unmarshal Response to dtoModel: %s")),
+		jen.Add(ifErr(true, "Remarshal error", "Failed to remarshal Response to dtoModel: %s")),
 	}
 
 	props, err := genFlattenProperties(item, true)

--- a/internal/plugin/service/governance/access/zz_converters.go
+++ b/internal/plugin/service/governance/access/zz_converters.go
@@ -111,10 +111,10 @@ func expandData[R any](ctx context.Context, plan, state *tfModel, req *R, modifi
 		vOwnerUserGroupID := plan.OwnerUserGroupID.ValueString()
 		api.OwnerUserGroupID = &vOwnerUserGroupID
 	}
-	err := util.Unmarshal(api, req, modifiers...)
+	err := util.Remarshal(api, req, modifiers...)
 	if err != nil {
 		var diags diag.Diagnostics
-		diags.AddError("Unmarshal error", fmt.Sprintf("Failed to unmarshal dtoModel to Request: %s", err.Error()))
+		diags.AddError("Remarshal error", fmt.Sprintf("Failed to remarshal dtoModel to Request: %s", err.Error()))
 		return diags
 	}
 	return nil
@@ -172,10 +172,10 @@ func expandAccessDataAcls(ctx context.Context, plan *tfModelAccessDataAcls) (*ap
 // flattenData turns Response into TF object
 func flattenData[R any](ctx context.Context, state *tfModel, rsp *R, modifiers ...util.MapModifier[R]) diag.Diagnostics {
 	api := new(apiModel)
-	err := util.Unmarshal(rsp, api, modifiers...)
+	err := util.Remarshal(rsp, api, modifiers...)
 	if err != nil {
 		var diags diag.Diagnostics
-		diags.AddError("Unmarshal error", fmt.Sprintf("Failed to unmarshal Response to dtoModel: %s", err.Error()))
+		diags.AddError("Remarshal error", fmt.Sprintf("Failed to remarshal Response to dtoModel: %s", err.Error()))
 		return diags
 	}
 	if api.AccessData != nil {

--- a/internal/plugin/service/organization/address/zz_converters.go
+++ b/internal/plugin/service/organization/address/zz_converters.go
@@ -91,10 +91,10 @@ func expandData[R any](ctx context.Context, plan, state *tfModel, req *R, modifi
 		vZipCode := plan.ZipCode.ValueString()
 		api.ZipCode = &vZipCode
 	}
-	err := util.Unmarshal(api, req, modifiers...)
+	err := util.Remarshal(api, req, modifiers...)
 	if err != nil {
 		var diags diag.Diagnostics
-		diags.AddError("Unmarshal error", fmt.Sprintf("Failed to unmarshal dtoModel to Request: %s", err.Error()))
+		diags.AddError("Remarshal error", fmt.Sprintf("Failed to remarshal dtoModel to Request: %s", err.Error()))
 		return diags
 	}
 	return nil
@@ -103,10 +103,10 @@ func expandData[R any](ctx context.Context, plan, state *tfModel, req *R, modifi
 // flattenData turns Response into TF object
 func flattenData[R any](ctx context.Context, state *tfModel, rsp *R, modifiers ...util.MapModifier[R]) diag.Diagnostics {
 	api := new(apiModel)
-	err := util.Unmarshal(rsp, api, modifiers...)
+	err := util.Remarshal(rsp, api, modifiers...)
 	if err != nil {
 		var diags diag.Diagnostics
-		diags.AddError("Unmarshal error", fmt.Sprintf("Failed to unmarshal Response to dtoModel: %s", err.Error()))
+		diags.AddError("Remarshal error", fmt.Sprintf("Failed to remarshal Response to dtoModel: %s", err.Error()))
 		return diags
 	}
 	if api.AddressLines != nil && (len(*api.AddressLines) > 0 || !state.AddressLines.IsNull()) {

--- a/internal/plugin/service/organization/application_user/zz_converters.go
+++ b/internal/plugin/service/organization/application_user/zz_converters.go
@@ -61,10 +61,10 @@ func expandData[R any](ctx context.Context, plan, state *tfModel, req *R, modifi
 		vOrganizationID := plan.OrganizationID.ValueString()
 		api.OrganizationID = &vOrganizationID
 	}
-	err := util.Unmarshal(api, req, modifiers...)
+	err := util.Remarshal(api, req, modifiers...)
 	if err != nil {
 		var diags diag.Diagnostics
-		diags.AddError("Unmarshal error", fmt.Sprintf("Failed to unmarshal dtoModel to Request: %s", err.Error()))
+		diags.AddError("Remarshal error", fmt.Sprintf("Failed to remarshal dtoModel to Request: %s", err.Error()))
 		return diags
 	}
 	return nil
@@ -73,10 +73,10 @@ func expandData[R any](ctx context.Context, plan, state *tfModel, req *R, modifi
 // flattenData turns Response into TF object
 func flattenData[R any](ctx context.Context, state *tfModel, rsp *R, modifiers ...util.MapModifier[R]) diag.Diagnostics {
 	api := new(apiModel)
-	err := util.Unmarshal(rsp, api, modifiers...)
+	err := util.Remarshal(rsp, api, modifiers...)
 	if err != nil {
 		var diags diag.Diagnostics
-		diags.AddError("Unmarshal error", fmt.Sprintf("Failed to unmarshal Response to dtoModel: %s", err.Error()))
+		diags.AddError("Remarshal error", fmt.Sprintf("Failed to remarshal Response to dtoModel: %s", err.Error()))
 		return diags
 	}
 	if api.Email != nil && (*api.Email != "" || !state.Email.IsNull()) {

--- a/internal/plugin/service/organization/application_user_token/zz_converters.go
+++ b/internal/plugin/service/organization/application_user_token/zz_converters.go
@@ -110,10 +110,10 @@ func expandData[R any](ctx context.Context, plan, state *tfModel, req *R, modifi
 		vUserID := plan.UserID.ValueString()
 		api.UserID = &vUserID
 	}
-	err := util.Unmarshal(api, req, modifiers...)
+	err := util.Remarshal(api, req, modifiers...)
 	if err != nil {
 		var diags diag.Diagnostics
-		diags.AddError("Unmarshal error", fmt.Sprintf("Failed to unmarshal dtoModel to Request: %s", err.Error()))
+		diags.AddError("Remarshal error", fmt.Sprintf("Failed to remarshal dtoModel to Request: %s", err.Error()))
 		return diags
 	}
 	return nil
@@ -122,10 +122,10 @@ func expandData[R any](ctx context.Context, plan, state *tfModel, req *R, modifi
 // flattenData turns Response into TF object
 func flattenData[R any](ctx context.Context, state *tfModel, rsp *R, modifiers ...util.MapModifier[R]) diag.Diagnostics {
 	api := new(apiModel)
-	err := util.Unmarshal(rsp, api, modifiers...)
+	err := util.Remarshal(rsp, api, modifiers...)
 	if err != nil {
 		var diags diag.Diagnostics
-		diags.AddError("Unmarshal error", fmt.Sprintf("Failed to unmarshal Response to dtoModel: %s", err.Error()))
+		diags.AddError("Remarshal error", fmt.Sprintf("Failed to remarshal Response to dtoModel: %s", err.Error()))
 		return diags
 	}
 	if api.IpAllowlist != nil && (len(*api.IpAllowlist) > 0 || !state.IpAllowlist.IsNull()) {

--- a/internal/plugin/service/organization/billinggroup/zz_converters.go
+++ b/internal/plugin/service/organization/billinggroup/zz_converters.go
@@ -109,10 +109,10 @@ func expandData[R any](ctx context.Context, plan, state *tfModel, req *R, modifi
 		vVatID := plan.VatID.ValueString()
 		api.VatID = &vVatID
 	}
-	err := util.Unmarshal(api, req, modifiers...)
+	err := util.Remarshal(api, req, modifiers...)
 	if err != nil {
 		var diags diag.Diagnostics
-		diags.AddError("Unmarshal error", fmt.Sprintf("Failed to unmarshal dtoModel to Request: %s", err.Error()))
+		diags.AddError("Remarshal error", fmt.Sprintf("Failed to remarshal dtoModel to Request: %s", err.Error()))
 		return diags
 	}
 	return nil
@@ -121,10 +121,10 @@ func expandData[R any](ctx context.Context, plan, state *tfModel, req *R, modifi
 // flattenData turns Response into TF object
 func flattenData[R any](ctx context.Context, state *tfModel, rsp *R, modifiers ...util.MapModifier[R]) diag.Diagnostics {
 	api := new(apiModel)
-	err := util.Unmarshal(rsp, api, modifiers...)
+	err := util.Remarshal(rsp, api, modifiers...)
 	if err != nil {
 		var diags diag.Diagnostics
-		diags.AddError("Unmarshal error", fmt.Sprintf("Failed to unmarshal Response to dtoModel: %s", err.Error()))
+		diags.AddError("Remarshal error", fmt.Sprintf("Failed to remarshal Response to dtoModel: %s", err.Error()))
 		return diags
 	}
 	if api.BillingContactEmails != nil && (len(*api.BillingContactEmails) > 0 || !state.BillingContactEmails.IsNull()) {

--- a/internal/plugin/service/organization/billinggrouplist/zz_converters.go
+++ b/internal/plugin/service/organization/billinggrouplist/zz_converters.go
@@ -65,10 +65,10 @@ type apiModelBillingGroups struct {
 // flattenData turns Response into TF object
 func flattenData[R any](ctx context.Context, state *tfModel, rsp *R, modifiers ...util.MapModifier[R]) diag.Diagnostics {
 	api := new(apiModel)
-	err := util.Unmarshal(rsp, api, modifiers...)
+	err := util.Remarshal(rsp, api, modifiers...)
 	if err != nil {
 		var diags diag.Diagnostics
-		diags.AddError("Unmarshal error", fmt.Sprintf("Failed to unmarshal Response to dtoModel: %s", err.Error()))
+		diags.AddError("Remarshal error", fmt.Sprintf("Failed to remarshal Response to dtoModel: %s", err.Error()))
 		return diags
 	}
 	if api.BillingGroups != nil {

--- a/internal/plugin/service/organization/organization/zz_converters.go
+++ b/internal/plugin/service/organization/organization/zz_converters.go
@@ -49,10 +49,10 @@ func expandData[R any](ctx context.Context, plan, state *tfModel, req *R, modifi
 		vName := plan.Name.ValueString()
 		api.Name = &vName
 	}
-	err := util.Unmarshal(api, req, modifiers...)
+	err := util.Remarshal(api, req, modifiers...)
 	if err != nil {
 		var diags diag.Diagnostics
-		diags.AddError("Unmarshal error", fmt.Sprintf("Failed to unmarshal dtoModel to Request: %s", err.Error()))
+		diags.AddError("Remarshal error", fmt.Sprintf("Failed to remarshal dtoModel to Request: %s", err.Error()))
 		return diags
 	}
 	return nil
@@ -61,10 +61,10 @@ func expandData[R any](ctx context.Context, plan, state *tfModel, req *R, modifi
 // flattenData turns Response into TF object
 func flattenData[R any](ctx context.Context, state *tfModel, rsp *R, modifiers ...util.MapModifier[R]) diag.Diagnostics {
 	api := new(apiModel)
-	err := util.Unmarshal(rsp, api, modifiers...)
+	err := util.Remarshal(rsp, api, modifiers...)
 	if err != nil {
 		var diags diag.Diagnostics
-		diags.AddError("Unmarshal error", fmt.Sprintf("Failed to unmarshal Response to dtoModel: %s", err.Error()))
+		diags.AddError("Remarshal error", fmt.Sprintf("Failed to remarshal Response to dtoModel: %s", err.Error()))
 		return diags
 	}
 	if api.CreateTime != nil && (*api.CreateTime != "" || !state.CreateTime.IsNull()) {

--- a/internal/plugin/service/organization/permission/zz_converters.go
+++ b/internal/plugin/service/organization/permission/zz_converters.go
@@ -84,10 +84,10 @@ func expandData[R any](ctx context.Context, plan, state *tfModel, req *R, modifi
 		vResourceType := plan.ResourceType.ValueString()
 		api.ResourceType = &vResourceType
 	}
-	err := util.Unmarshal(api, req, modifiers...)
+	err := util.Remarshal(api, req, modifiers...)
 	if err != nil {
 		var diags diag.Diagnostics
-		diags.AddError("Unmarshal error", fmt.Sprintf("Failed to unmarshal dtoModel to Request: %s", err.Error()))
+		diags.AddError("Remarshal error", fmt.Sprintf("Failed to remarshal dtoModel to Request: %s", err.Error()))
 		return diags
 	}
 	return nil
@@ -117,10 +117,10 @@ func expandPermissions(ctx context.Context, plan *tfModelPermissions) (*apiModel
 // flattenData turns Response into TF object
 func flattenData[R any](ctx context.Context, state *tfModel, rsp *R, modifiers ...util.MapModifier[R]) diag.Diagnostics {
 	api := new(apiModel)
-	err := util.Unmarshal(rsp, api, modifiers...)
+	err := util.Remarshal(rsp, api, modifiers...)
 	if err != nil {
 		var diags diag.Diagnostics
-		diags.AddError("Unmarshal error", fmt.Sprintf("Failed to unmarshal Response to dtoModel: %s", err.Error()))
+		diags.AddError("Remarshal error", fmt.Sprintf("Failed to remarshal Response to dtoModel: %s", err.Error()))
 		return diags
 	}
 	if api.Permissions != nil {

--- a/internal/plugin/service/organization/project/zz_converters.go
+++ b/internal/plugin/service/organization/project/zz_converters.go
@@ -101,10 +101,10 @@ func expandData[R any](ctx context.Context, plan, state *tfModel, req *R, modifi
 		vProjectID := plan.ProjectID.ValueString()
 		api.ProjectID = &vProjectID
 	}
-	err := util.Unmarshal(api, req, modifiers...)
+	err := util.Remarshal(api, req, modifiers...)
 	if err != nil {
 		var diags diag.Diagnostics
-		diags.AddError("Unmarshal error", fmt.Sprintf("Failed to unmarshal dtoModel to Request: %s", err.Error()))
+		diags.AddError("Remarshal error", fmt.Sprintf("Failed to remarshal dtoModel to Request: %s", err.Error()))
 		return diags
 	}
 	return nil
@@ -126,10 +126,10 @@ func expandTag(ctx context.Context, plan *tfModelTag) (*apiModelTag, diag.Diagno
 // flattenData turns Response into TF object
 func flattenData[R any](ctx context.Context, state *tfModel, rsp *R, modifiers ...util.MapModifier[R]) diag.Diagnostics {
 	api := new(apiModel)
-	err := util.Unmarshal(rsp, api, modifiers...)
+	err := util.Remarshal(rsp, api, modifiers...)
 	if err != nil {
 		var diags diag.Diagnostics
-		diags.AddError("Unmarshal error", fmt.Sprintf("Failed to unmarshal Response to dtoModel: %s", err.Error()))
+		diags.AddError("Remarshal error", fmt.Sprintf("Failed to remarshal Response to dtoModel: %s", err.Error()))
 		return diags
 	}
 	if api.Tag != nil {

--- a/internal/plugin/util/converters.go
+++ b/internal/plugin/util/converters.go
@@ -19,8 +19,8 @@ func remarshal(in, out any) error {
 	return json.Unmarshal(b, out)
 }
 
-// Unmarshal unmarshals a value from in to out, applies typed modifiers before unmarshalling to out.
-func Unmarshal[I any, O any](in *I, out *O, modifiers ...MapModifier[I]) error {
+// Remarshal remarshals a value from in to out, applies typed modifiers before unmarshalling to out.
+func Remarshal[I any, O any](in *I, out *O, modifiers ...MapModifier[I]) error {
 	if len(modifiers) == 0 {
 		return remarshal(in, out)
 	}


### PR DESCRIPTION
Resolves NEX-1948.

`Unmarshal` is confusing, because `json` package uses the same name for its function.
