### PR TITLE
feat(plugin): generate schema version

### DIFF
--- a/definitions/.schema.yml
+++ b/definitions/.schema.yml
@@ -5,6 +5,11 @@ $comment: |
   This schema defines the structure for configuring Terraform provider resources and datasources.
   Use this file to specify how your provider's resources and datasources should behave.
 properties:
+  version:
+    type: integer
+    $comment: |
+      Specifies the version/generation of the resource schema.
+      Usually you don't need to set this.
   beta:
     type: boolean
     $comment: |

--- a/generators/plugin/item.go
+++ b/generators/plugin/item.go
@@ -67,6 +67,7 @@ type Definition struct {
 	IDAttribute    *IDAttribute         `yaml:"idAttribute"`
 	LegacyTimeouts bool                 `yaml:"legacyTimeouts,omitempty"`
 	Operations     map[string]Operation `yaml:"operations"`
+	Version        *int                 `yaml:"version"`
 }
 
 type Item struct {

--- a/generators/plugin/schemas.go
+++ b/generators/plugin/schemas.go
@@ -27,6 +27,11 @@ func genSchema(isResource bool, item *Item, def *Definition) (jen.Code, error) {
 	}
 	attrs[jen.Id("MarkdownDescription")] = jen.Lit(desc)
 
+	if isResource && def.Version != nil {
+		// Only resources have Version field
+		attrs[jen.Id("Version")] = jen.Lit(*def.Version)
+	}
+
 	example, err := exampleRoot(isResource, item)
 	if err != nil {
 		return nil, fmt.Errorf("example error: %w", err)


### PR DESCRIPTION
Resolves NEX-1949.

Some old resources have schema version defined.
Adds `Version` [field](https://developer.hashicorp.com/terraform/plugin/framework/handling-data/schemas#version) generation.
