### PR TITLE
feat(plugin): support plan modification

### DIFF
--- a/internal/plugin/adapter/view.go
+++ b/internal/plugin/adapter/view.go
@@ -65,6 +65,12 @@ type ResValidateConfig[T any] interface {
 	ResValidateConfig(ctx context.Context, config *T) diag.Diagnostics
 }
 
+// ResModifyPlan implements resource.ResourceWithModifyPlan.
+// https://developer.hashicorp.com/terraform/plugin/framework/resources/plan-modification#resource-plan-modification
+type ResModifyPlan[T any] interface {
+	ResModifyPlan(ctx context.Context, plan, state, config *T) diag.Diagnostics
+}
+
 // View base view that contains the client and potentially other dependencies
 type View struct {
 	Client avngen.Client


### PR DESCRIPTION
Resolves NEX-1967.

Allows to modify [the plan output](https://developer.hashicorp.com/terraform/plugin/framework/resources/plan-modification#resource-plan-modification) and prevent [resource termination](https://developer.hashicorp.com/terraform/plugin/framework/resources/plan-modification#resource-destroy-plan-diagnostics)
when `termination_protection` is enabled.