### PR TITLE
feat(kafka_topic): set nil config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ nav_order: 1
   that one process can execute simultaneously
 - Add `aiven_pg` field `pg_user_config.pg.io_workers`: EXPERIMENTAL: Number of IO worker processes, for io_method=worker.
   Version 18 and up only
+- Change `aiven_kafka_topic`: do not set "config" block in the state if no user-defined configuration values exist.
+  This change prepares for future Plugin Framework migration which doesn't support computed+optional blocks
 
 ## [4.46.0] - 2025-10-09
 

--- a/internal/sdkprovider/service/kafkatopic/kafka_topic_test.go
+++ b/internal/sdkprovider/service/kafkatopic/kafka_topic_test.go
@@ -67,10 +67,14 @@ func TestAccAivenKafkaTopic(t *testing.T) {
 						resource.TestCheckResourceAttr(resourceName, "partitions", "3"),
 						resource.TestCheckResourceAttr(resourceName, "replication", "2"),
 						resource.TestCheckResourceAttr(resourceName, "termination_protection", "false"),
+						resource.TestCheckResourceAttr(resourceName, "config.#", "1"),
 						resource.TestCheckResourceAttr(resourceName, "config.0.retention_bytes", "1234"),
 						resource.TestCheckResourceAttr(resourceName, "config.0.segment_bytes", "1610612736"),
 						resource.TestCheckResourceAttr(topic2ResourceName, "topic_description", fmt.Sprintf("test-acc-topic2-desc-%s", rName)),
 						resource.TestCheckResourceAttrSet(topic2ResourceName, "owner_user_group_id"),
+
+						// Topic config is not set when it is not defined by user
+						resource.TestCheckResourceAttr(topic2ResourceName, "config.#", "0"),
 					),
 				},
 			},
@@ -611,7 +615,7 @@ func TestFlattenKafkaTopicConfig(t *testing.T) {
 
 	for _, opt := range cases {
 		t.Run(opt.name, func(t *testing.T) {
-			result, err := kafkatopic.FlattenKafkaTopicConfig(&aiven.KafkaTopic{Config: opt.config})
+			result, err := kafkatopic.FlattenKafkaTopicConfig(&aiven.KafkaTopic{Config: opt.config}, false)
 			require.NoError(t, err)
 			assert.Empty(t, cmp.Diff([]map[string]any{opt.expect}, result))
 		})


### PR DESCRIPTION
Resolves NEX-1969.

Sets `nil` to topic.config if the configuration file doesn't have it. This prevents showing diffs in the Plugin Framework for optional+computed blocks, since the framework doesn't support them.

See: https://github.com/hashicorp/terraform-plugin-framework/issues/883

