### PR TITLE
refactor(plugin): rename definition fields

### DIFF
--- a/definitions/.schema.yml
+++ b/definitions/.schema.yml
@@ -24,11 +24,11 @@ properties:
     $comment: |
       Documentation and configuration specific to this datasource.
       Use this to provide clear descriptions for your datasource in the Terraform registry.
-  delete:
-    $ref: '#/definitions/Delete'
+  remove:
+    $ref: '#/definitions/Remove'
     $comment: |
-      List of attributes to delete from the resource/datasource.
-      Example: delete: ["openapi_name1", "openapi_name2"]
+      List of attributes to remove from the resource/datasource.
+      Example: remove: ["openapi_name1", "openapi_name2"]
   idAttribute:
     $ref: '#/definitions/IDAttribute'
     $comment: |
@@ -71,21 +71,20 @@ required:
   - location
   - idAttribute
   - operations
-$comment: These fields must be specified for every resource/datasource
 additionalProperties: false
 
 definitions:
-  Delete:
+  Remove:
     type: array
     items:
       type: string
-      $comment: The attribute to delete
+      $comment: The attribute to remove
 
   IDAttribute:
     type: object
     $comment: Configuration for how resource IDs are structured and managed
     properties:
-      compose:
+      fields:
         type: array
         items:
           type: string
@@ -105,7 +104,7 @@ definitions:
           Most resources should not set this.
           When set to true, it doesn't generate the `UseStateForUnknown` plan modifier. 
     required:
-      - compose
+      - fields
     additionalProperties: false
 
   Operation:

--- a/definitions/governance_access.yml
+++ b/definitions/governance_access.yml
@@ -12,13 +12,13 @@ resource:
     [Governance](https://aiven.io/docs/products/kafka/howto/governance) helps you manage your Kafka clusters securely and efficiently through structured policies, roles, and processes.
     You can [manage approval workflows using Terraform and GitHub Actions](https://aiven.io/docs/products/kafka/howto/terraform-governance-approvals).
 idAttribute:
-  compose:
+  fields:
     - organization_id
     - susbcription_id
 rename:
   access_id: susbcription_id
   access_data/project_name: project
-delete:
+remove:
   - credentials_user_id
   - credentials_consumed
   - created_by

--- a/definitions/organization.yml
+++ b/definitions/organization.yml
@@ -11,10 +11,10 @@ resource:
 datasource:
   description: Gets information about an organization.
 idAttribute:
-  compose:
+  fields:
     - id
   description: The organization ID.
-delete:
+remove:
   - features
   - access_source
   - account_owner_team_id

--- a/definitions/organization_address.yml
+++ b/definitions/organization_address.yml
@@ -6,7 +6,7 @@ resource:
 datasource:
   description: Gets information about an organization address.
 idAttribute:
-  compose:
+  fields:
     - organization_id
     - address_id
 operations:

--- a/definitions/organization_application_user.yml
+++ b/definitions/organization_application_user.yml
@@ -9,7 +9,7 @@ resource:
 datasource:
   description: Gets information about an application user.
 idAttribute:
-  compose:
+  fields:
     - organization_id
     - user_id
 operations:

--- a/definitions/organization_application_user_token.yml
+++ b/definitions/organization_application_user_token.yml
@@ -5,7 +5,7 @@ resource:
     Creates and manages an application user token.
     Review the [best practices](https://aiven.io/docs/platform/concepts/application-users#security-best-practices) for securing application users and their tokens.
 idAttribute:
-  compose:
+  fields:
     - organization_id
     - user_id
     - token_prefix

--- a/definitions/organization_billing_group.yml
+++ b/definitions/organization_billing_group.yml
@@ -7,7 +7,7 @@ resource:
 datasource:
   description: Gets information about a billing group.
 idAttribute:
-  compose:
+  fields:
     - organization_id
     - billing_group_id
 operations:

--- a/definitions/organization_billing_group_list.yml
+++ b/definitions/organization_billing_group_list.yml
@@ -4,7 +4,7 @@ location: internal/plugin/service/organization/billinggrouplist
 datasource:
   description: Lists billing groups for an organization.
 idAttribute:
-  compose:
+  fields:
     - organization_id
 operations:
   OrganizationBillingGroupList: read

--- a/definitions/organization_permission.yml
+++ b/definitions/organization_permission.yml
@@ -18,7 +18,7 @@ resource:
     Alternatively, you can disable this validation by setting the `AIVEN_ORGANIZATION_PERMISSION_VALIDATE_CONFLICT` environment variable to `false`,
     which will cause Terraform to override the remote state.
 idAttribute:
-  compose:
+  fields:
     - organization_id
     - resource_type
     - resource_id

--- a/definitions/organization_project.yml
+++ b/definitions/organization_project.yml
@@ -11,11 +11,11 @@ operations:
   OrganizationProjectsUpdate: update
   ProjectKmsGetCA: read
 idAttribute:
-  compose:
+  fields:
     - organization_id
     - project_id
   mutable: true
-delete:
+remove:
   - end_of_life_extension
   - features
   - account_id

--- a/generators/plugin/item.go
+++ b/generators/plugin/item.go
@@ -50,7 +50,7 @@ type SchemaMeta struct {
 }
 
 type IDAttribute struct {
-	Compose     []string `yaml:"compose"`
+	Fields      []string `yaml:"fields"`
 	Description string   `yaml:"description,omitempty"`
 	Mutable     bool     `yaml:"mutable,omitempty"` // Negative for UseStateForUnknown
 }
@@ -59,7 +59,7 @@ type Definition struct {
 	Beta           bool                 `yaml:"beta"`
 	Location       string               `yaml:"location"`
 	Schema         map[string]*Item     `yaml:"schema,omitempty"`
-	Delete         []string             `yaml:"delete,omitempty"`
+	Remove         []string             `yaml:"remove,omitempty"`
 	Rename         map[string]string    `yaml:"rename,omitempty"`
 	ObjectKey      string               `yaml:"objectKey,omitempty"`
 	Resource       *SchemaMeta          `yaml:"resource,omitempty"`

--- a/generators/plugin/main.go
+++ b/generators/plugin/main.go
@@ -147,9 +147,9 @@ func genDefinition(doc *OpenAPIDoc, defPath string) error {
 			}
 			codes = append(codes, models...)
 
-			// Resources need composeID and expander
+			// Resources need idFields and expander
 			if hasResource {
-				codes = append(codes, genComposeID(avnName, def.IDAttribute.Compose))
+				codes = append(codes, genIDFields(avnName, def.IDAttribute.Fields))
 				expand, err := genExpand(root)
 				if err != nil {
 					return fmt.Errorf("could not generate expand: %w", err)
@@ -284,7 +284,7 @@ func createRootItem(scope *Scope) (*Item, error) {
 	}
 
 	// Marks ID fields
-	for i, v := range pkg.IDAttribute.Compose {
+	for i, v := range pkg.IDAttribute.Fields {
 		if _, ok := root.Properties[v]; !ok {
 			keys := sortedKeys(root.Properties)
 			return nil, fmt.Errorf("ID field %q not found in: %s", v, strings.Join(keys, ", "))
@@ -494,7 +494,7 @@ func getOperationID(scope *Scope, operationID string) (*OAPath, error) {
 }
 
 func addProperty(scope *Scope, parent, prop *Item) error {
-	if slices.Contains(scope.Definition.Delete, prop.JSONPath()) {
+	if slices.Contains(scope.Definition.Remove, prop.JSONPath()) {
 		return nil
 	}
 

--- a/generators/plugin/models.go
+++ b/generators/plugin/models.go
@@ -154,18 +154,18 @@ func genFieldTag(kv ...string) map[string]string {
 	return m
 }
 
-const funcComposeID = "composeID"
+const funcIDFields = "idFields"
 
-func genComposeID(avnName string, fields []string) jen.Code {
+func genIDFields(avnName string, fields []string) jen.Code {
 	codes := make([]jen.Code, 0)
 	for _, v := range fields {
 		codes = append(codes, jen.Lit(v))
 	}
 
 	return jen.
-		Commentf("%s the ID attribute fields, i.e.:", funcComposeID).Line().
+		Commentf("%s the ID attribute fields, i.e.:", funcIDFields).Line().
 		Commentf("terraform import %s.foo %s", avnName, strings.ToUpper(filepath.Join(fields...))).Line().
-		Func().Id(funcComposeID).Params().Index().String().
+		Func().Id(funcIDFields).Params().Index().String().
 		Block(jen.Return().Index().String().Values(codes...))
 }
 

--- a/generators/plugin/schemas.go
+++ b/generators/plugin/schemas.go
@@ -69,10 +69,10 @@ func genTimeoutsField(isResource bool, def *Definition) jen.Code {
 func genIDField(isResource bool, idField *IDAttribute) jen.Code {
 	description := idField.Description
 	if description == "" {
-		fields := lo.Map(idField.Compose, func(v string, _ int) string {
+		fields := lo.Map(idField.Fields, func(v string, _ int) string {
 			return fmt.Sprintf("`%s`", v)
 		})
-		switch len(idField.Compose) {
+		switch len(idField.Fields) {
 		case 0:
 		case 1:
 			description = fmt.Sprintf("Resource ID, equal to %s.", fields[0])
@@ -85,7 +85,7 @@ func genIDField(isResource bool, idField *IDAttribute) jen.Code {
 		jen.Id("MarkdownDescription"): jen.Lit(description),
 	}
 
-	if !isResource && len(idField.Compose) == 1 && idField.Compose[0] == "id" {
+	if !isResource && len(idField.Fields) == 1 && idField.Fields[0] == "id" {
 		// If datasource id is literally "id", it is required.
 		attrs[jen.Id("Required")] = jen.True()
 	} else {

--- a/internal/plugin/service/governance/access/access.go
+++ b/internal/plugin/service/governance/access/access.go
@@ -15,7 +15,7 @@ import (
 func NewResource() resource.Resource {
 	return adapter.NewResource(adapter.ResourceOptions[*resourceModel, tfModel]{
 		TypeName: aivenName,
-		IDFields: composeID(),
+		IDFields: idFields(),
 		Schema:   newResourceSchema,
 		Read:     readAccess,
 		Create:   createAccess,

--- a/internal/plugin/service/governance/access/zz_converters.go
+++ b/internal/plugin/service/governance/access/zz_converters.go
@@ -79,9 +79,9 @@ type apiModelAccessDataAcls struct {
 	ResourceType   *string `json:"resource_type,omitempty"`
 }
 
-// composeID the ID attribute fields, i.e.:
+// idFields the ID attribute fields, i.e.:
 // terraform import aiven_governance_access.foo ORGANIZATION_ID/SUSBCRIPTION_ID
-func composeID() []string {
+func idFields() []string {
 	return []string{"organization_id", "susbcription_id"}
 }
 

--- a/internal/plugin/service/organization/address/address.go
+++ b/internal/plugin/service/organization/address/address.go
@@ -16,7 +16,7 @@ import (
 func NewResource() resource.Resource {
 	return adapter.NewResource(adapter.ResourceOptions[*resourceModel, tfModel]{
 		TypeName: aivenName,
-		IDFields: composeID(),
+		IDFields: idFields(),
 		Schema:   newResourceSchema,
 		Read:     readAddress,
 		Create:   createAddress,

--- a/internal/plugin/service/organization/address/zz_converters.go
+++ b/internal/plugin/service/organization/address/zz_converters.go
@@ -50,9 +50,9 @@ type apiModel struct {
 	ZipCode        *string   `json:"zip_code,omitempty"`
 }
 
-// composeID the ID attribute fields, i.e.:
+// idFields the ID attribute fields, i.e.:
 // terraform import aiven_organization_address.foo ORGANIZATION_ID/ADDRESS_ID
-func composeID() []string {
+func idFields() []string {
 	return []string{"organization_id", "address_id"}
 }
 

--- a/internal/plugin/service/organization/application_user/application_user.go
+++ b/internal/plugin/service/organization/application_user/application_user.go
@@ -16,7 +16,7 @@ import (
 func NewResource() resource.Resource {
 	return adapter.NewResource(adapter.ResourceOptions[*resourceModel, tfModel]{
 		TypeName: aivenName,
-		IDFields: composeID(),
+		IDFields: idFields(),
 		Schema:   newResourceSchema,
 		Read:     readApplicationUser,
 		Create:   createApplicationUser,

--- a/internal/plugin/service/organization/application_user/zz_converters.go
+++ b/internal/plugin/service/organization/application_user/zz_converters.go
@@ -40,9 +40,9 @@ type apiModel struct {
 	UserID         *string `json:"user_id,omitempty"`
 }
 
-// composeID the ID attribute fields, i.e.:
+// idFields the ID attribute fields, i.e.:
 // terraform import aiven_organization_application_user.foo ORGANIZATION_ID/USER_ID
-func composeID() []string {
+func idFields() []string {
 	return []string{"organization_id", "user_id"}
 }
 

--- a/internal/plugin/service/organization/application_user_token/application_user_token.go
+++ b/internal/plugin/service/organization/application_user_token/application_user_token.go
@@ -17,7 +17,7 @@ import (
 func NewResource() resource.Resource {
 	return adapter.NewResource(adapter.ResourceOptions[*resourceModel, tfModel]{
 		TypeName: aivenName,
-		IDFields: composeID(),
+		IDFields: idFields(),
 		Schema:   newResourceSchema,
 		Read:     readApplicationUserToken,
 		Create:   createApplicationUserToken,

--- a/internal/plugin/service/organization/application_user_token/zz_converters.go
+++ b/internal/plugin/service/organization/application_user_token/zz_converters.go
@@ -65,9 +65,9 @@ type apiModel struct {
 	UserID                     *string   `json:"user_id,omitempty"`
 }
 
-// composeID the ID attribute fields, i.e.:
+// idFields the ID attribute fields, i.e.:
 // terraform import aiven_organization_application_user_token.foo ORGANIZATION_ID/USER_ID/TOKEN_PREFIX
-func composeID() []string {
+func idFields() []string {
 	return []string{"organization_id", "user_id", "token_prefix"}
 }
 

--- a/internal/plugin/service/organization/billinggroup/billing_group.go
+++ b/internal/plugin/service/organization/billinggroup/billing_group.go
@@ -17,7 +17,7 @@ import (
 func NewResource() resource.Resource {
 	return adapter.NewResource(adapter.ResourceOptions[*resourceModel, tfModel]{
 		TypeName: aivenName,
-		IDFields: composeID(),
+		IDFields: idFields(),
 		Schema:   newResourceSchema,
 		Read:     readBillingGroup,
 		Create:   createBillingGroup,

--- a/internal/plugin/service/organization/billinggroup/zz_converters.go
+++ b/internal/plugin/service/organization/billinggroup/zz_converters.go
@@ -52,9 +52,9 @@ type apiModel struct {
 	VatID                *string   `json:"vat_id,omitempty"`
 }
 
-// composeID the ID attribute fields, i.e.:
+// idFields the ID attribute fields, i.e.:
 // terraform import aiven_organization_billing_group.foo ORGANIZATION_ID/BILLING_GROUP_ID
-func composeID() []string {
+func idFields() []string {
 	return []string{"organization_id", "billing_group_id"}
 }
 

--- a/internal/plugin/service/organization/organization/organization.go
+++ b/internal/plugin/service/organization/organization/organization.go
@@ -21,7 +21,7 @@ import (
 func NewResource() resource.Resource {
 	return adapter.NewResource(adapter.ResourceOptions[*resourceModel, tfModel]{
 		TypeName: aivenName,
-		IDFields: composeID(),
+		IDFields: idFields(),
 		Schema:   newResourceSchema,
 		Read:     readOrganization,
 		Create:   createOrganization,

--- a/internal/plugin/service/organization/organization/zz_converters.go
+++ b/internal/plugin/service/organization/organization/zz_converters.go
@@ -36,9 +36,9 @@ type apiModel struct {
 	UpdateTime *string `json:"update_time,omitempty"`
 }
 
-// composeID the ID attribute fields, i.e.:
+// idFields the ID attribute fields, i.e.:
 // terraform import aiven_organization.foo ID
-func composeID() []string {
+func idFields() []string {
 	return []string{"id"}
 }
 

--- a/internal/plugin/service/organization/permission/permission.go
+++ b/internal/plugin/service/organization/permission/permission.go
@@ -31,7 +31,7 @@ const (
 func NewResource() resource.Resource {
 	return adapter.NewResource(adapter.ResourceOptions[*resourceModel, tfModel]{
 		TypeName: aivenName,
-		IDFields: composeID(),
+		IDFields: idFields(),
 		Schema:   patchedSchema,
 		Read:     readPermission,
 		Create:   createPermission,

--- a/internal/plugin/service/organization/permission/zz_converters.go
+++ b/internal/plugin/service/organization/permission/zz_converters.go
@@ -56,9 +56,9 @@ type apiModelPermissions struct {
 	UpdateTime    *string   `json:"update_time,omitempty"`
 }
 
-// composeID the ID attribute fields, i.e.:
+// idFields the ID attribute fields, i.e.:
 // terraform import aiven_organization_permission.foo ORGANIZATION_ID/RESOURCE_TYPE/RESOURCE_ID
-func composeID() []string {
+func idFields() []string {
 	return []string{"organization_id", "resource_type", "resource_id"}
 }
 

--- a/internal/plugin/service/organization/project/project.go
+++ b/internal/plugin/service/organization/project/project.go
@@ -19,7 +19,7 @@ import (
 func NewResource() resource.Resource {
 	return adapter.NewResource(adapter.ResourceOptions[*resourceModel, tfModel]{
 		TypeName: aivenName,
-		IDFields: composeID(),
+		IDFields: idFields(),
 		Schema:   newResourceSchema,
 		Read:     readProject,
 		Create:   createProject,

--- a/internal/plugin/service/organization/project/zz_converters.go
+++ b/internal/plugin/service/organization/project/zz_converters.go
@@ -57,9 +57,9 @@ type apiModelTag struct {
 	Value *string `json:"value,omitempty"`
 }
 
-// composeID the ID attribute fields, i.e.:
+// idFields the ID attribute fields, i.e.:
 // terraform import aiven_organization_project.foo ORGANIZATION_ID/PROJECT_ID
-func composeID() []string {
+func idFields() []string {
 	return []string{"organization_id", "project_id"}
 }
 


### PR DESCRIPTION
Resolves NEX-1988.

- Renames “delete” list of fields to “remove” (might clash with “delete” operation semantically)
- Renames composeID to idFields (the function itself does not “compose”)
