### PR TITLE
feat(plugin): add `RefreshState`

### DIFF
--- a/definitions/.schema.yml
+++ b/definitions/.schema.yml
@@ -80,6 +80,11 @@ properties:
     $comment: |
       Disables generation of specific CRUD views for this resource.
       Example: disableViews: ["delete"]
+  refreshState:
+    type: boolean
+    $comment: |
+      Set to true to refresh the state after the resource is created/updated/deleted.
+      Example: refreshState: true
 required:
   - location
   - idAttribute

--- a/generators/plugin/imports.go
+++ b/generators/plugin/imports.go
@@ -33,6 +33,7 @@ const (
 	avnGenPackage         = "github.com/aiven/go-client-codegen"
 	resourcePackage       = "github.com/hashicorp/terraform-plugin-framework/resource"
 	datasourcePackage     = "github.com/hashicorp/terraform-plugin-framework/datasource"
+	errMsgPackage         = "github.com/aiven/terraform-provider-aiven/internal/plugin/errmsg"
 )
 
 func getUntypedImports() []string {
@@ -47,6 +48,7 @@ func getUntypedImports() []string {
 		legacyTimeoutsPackage,
 		resourcePackage,
 		datasourcePackage,
+		errMsgPackage,
 	}
 }
 

--- a/generators/plugin/item.go
+++ b/generators/plugin/item.go
@@ -73,6 +73,7 @@ type Definition struct {
 	Version        *int                 `yaml:"version"`
 	ClientHandler  string               `yaml:"clientHandler,omitempty"`
 	DisableViews   []Operation          `yaml:"disableViews,omitempty"`
+	RefreshState   bool                 `yaml:"refreshState,omitempty"`
 }
 
 type Item struct {

--- a/internal/plugin/errmsg/errmsg.go
+++ b/internal/plugin/errmsg/errmsg.go
@@ -1,6 +1,10 @@
 // Package errmsg is the package that contains all the error messages in the provider.
 package errmsg
 
+import (
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+)
+
 // All error messages in the provider should be defined in this package.
 // This is to ensure that all error messages are consistent and not duplicated, and follow the same style.
 // This is also to ensure that all error messages are defined in one place, and are easy to find and update:
@@ -146,3 +150,17 @@ var (
 	// UnableToSetValueFrom is the error message for when a Set cannot be created from a value.
 	UnableToSetValueFrom = "unable to set value from %v"
 )
+
+// DiagError wraps diag.Diagnostic with original error for error.Is()
+type DiagError struct {
+	diag.ErrorDiagnostic
+	Error error
+}
+
+// FromError creates a DiagError that wraps the original error.
+func FromError(summary string, err error) diag.Diagnostic {
+	return DiagError{
+		ErrorDiagnostic: diag.NewErrorDiagnostic(summary, err.Error()),
+		Error:           err,
+	}
+}

--- a/internal/plugin/errmsg/retry.go
+++ b/internal/plugin/errmsg/retry.go
@@ -1,0 +1,29 @@
+package errmsg
+
+import (
+	"github.com/avast/retry-go"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+)
+
+// RetryDiags detects DiagError in diagnostics and retries it.
+// Use FromError to create a DiagError from diag.Diagnostic.
+func RetryDiags(
+	retryableFunc func() diag.Diagnostics,
+	opts ...retry.Option,
+) diag.Diagnostics {
+	var diags diag.Diagnostics
+	_ = retry.Do(func() error {
+		diags = retryableFunc()
+		for _, d := range diags {
+			if o, ok := d.(DiagError); ok {
+				// Use retry.RetryIf to control which error to retry.
+				// By default, retries all errors.
+				return o.Error
+			}
+		}
+
+		// No DiagError found, exit.
+		return nil
+	}, opts...)
+	return diags
+}

--- a/internal/plugin/errmsg/retry_test.go
+++ b/internal/plugin/errmsg/retry_test.go
@@ -1,0 +1,81 @@
+package errmsg
+
+import (
+	"net/http"
+	"testing"
+	"time"
+
+	avngen "github.com/aiven/go-client-codegen"
+	"github.com/avast/retry-go"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRetryDiags(t *testing.T) {
+	testcases := []struct {
+		name          string
+		diags         diag.Diagnostics
+		expectRetried bool
+		opts          []retry.Option
+	}{
+		{
+			name:          "no error",
+			expectRetried: false,
+		},
+		{
+			name:          "doesn't retry unknown errors",
+			expectRetried: false,
+			diags: diag.Diagnostics{
+				diag.NewErrorDiagnostic("test", "test"),
+			},
+		},
+		{
+			name:          "retries 404",
+			expectRetried: true,
+			diags: diag.Diagnostics{
+				FromError("test", avngen.Error{Status: http.StatusNotFound}),
+			},
+			opts: []retry.Option{
+				retry.RetryIf(avngen.IsNotFound),
+			},
+		},
+		{
+			name:          "doesn't retry 400",
+			expectRetried: false,
+			diags: diag.Diagnostics{
+				FromError("test", avngen.Error{Status: http.StatusBadRequest}),
+			},
+			opts: []retry.Option{
+				retry.RetryIf(avngen.IsNotFound),
+			},
+		},
+		{
+			name:          "retries 400, because no RetryIf specified",
+			expectRetried: true,
+			diags: diag.Diagnostics{
+				FromError("test", avngen.Error{Status: http.StatusBadRequest}),
+			},
+		},
+	}
+
+	// We set maxAttempts so test doesn't run forever
+	const maxAttempts = 2
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			tc.opts = append(
+				tc.opts,
+				retry.Attempts(maxAttempts),
+				retry.Delay(time.Millisecond),
+			)
+
+			attempts := 0
+			_ = RetryDiags(func() diag.Diagnostics {
+				attempts++
+				return tc.diags
+			}, tc.opts...)
+
+			assert.Equal(t, tc.expectRetried, attempts == maxAttempts)
+		})
+	}
+}


### PR DESCRIPTION
Resolves NEX-1998.

- Adds `RefreshState` option that calls Read after Create and Update, allowing resources to use generated Create/Update with custom Read. Default `false`.
- Retries 404 errors during state refresh to handle backend races where resources aren't immediately queryable after creation. See `RetryDiags`.
- Removes Read call generation in Create and Update.
- Removes state refresh for `aiven_organization_address`, Create and Update responses have all the fields.