### PR TITLE
fix(kafka): `kafka_diskless` being sent empty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,10 @@ nav_order: 1
 - Change `aiven_influxdb` resource field `influxdb_user_config`: deprecate: This property is deprecated
 - Upgraded `go` version to `1.25`
 
+## [4.46.1] - 2025-10-27
+
+- Fix `aiven_kafka` user config field `kafka_diskless` being sent empty to the API
+
 ## [4.46.0] - 2025-10-09
 
 - Added `maintenance_window_enabled` field to service resources: Indicates whether the maintenance window is currently enabled for this service.

--- a/internal/sdkprovider/userconfig/converters/converters.go
+++ b/internal/sdkprovider/userconfig/converters/converters.go
@@ -309,21 +309,23 @@ func expandList(s *stateCompose) (any, error) {
 	states := s.listItems()
 	items := make([]any, 0, len(states))
 	for i := range states {
-		var exp any
-		var err error
 		if isObjList {
-			exp, err = expandObj(states[i])
+			v, err := expandObj(states[i])
+			if err != nil {
+				return nil, err
+			}
+			if len(v) > 0 {
+				// Avoids sending empty objects
+				items = append(items, v)
+			}
 		} else {
-			exp, err = expandScalar(states[i])
-		}
-
-		if err != nil {
-			return nil, err
-		}
-
-		// If an object is not empty
-		if exp != nil {
-			items = append(items, exp)
+			v, err := expandScalar(states[i])
+			if err != nil {
+				return nil, err
+			}
+			if v != nil {
+				items = append(items, v)
+			}
 		}
 	}
 


### PR DESCRIPTION
Resolves NEX-1999.

Cherry-pick 2917ee33b5e8e263bf268c1d26c566d5a6c7b20f.