### PR TITLE
refactor(plugin): use conventional naming

### DIFF
--- a/generators/plugin/examples.go
+++ b/generators/plugin/examples.go
@@ -19,7 +19,7 @@ func exampleRoot(isResource bool, item *Item) (string, error) {
 	}
 
 	f := hclwrite.NewEmptyFile()
-	rootBody := f.Body().AppendNewBlock(t, []string{aivenNamePrefix + item.Name, "example"}).Body()
+	rootBody := f.Body().AppendNewBlock(t, []string{typeNamePrefix + item.Name, "example"}).Body()
 	err := exampleObjectItem(isResource, item, rootBody)
 	if err != nil {
 		return "", err

--- a/generators/plugin/main.go
+++ b/generators/plugin/main.go
@@ -61,15 +61,15 @@ func exec() error {
 }
 
 const (
-	// aivenNameConst resource and datasource name, e.g. aivenName = "aiven_foo_bar"
-	aivenNameConst = "aivenName"
+	// typeName resource and datasource name, e.g. typeName = "aiven_foo_bar"
+	typeName = "typeName"
 
-	// aivenNamePrefix is a prefix for the resource and datasource names: aiven_pg, aiven_kafka, etc.
-	aivenNamePrefix = "aiven_"
+	// typeNamePrefix is a prefix for the resource and datasource names: aiven_pg, aiven_kafka, etc.
+	typeNamePrefix = "aiven_"
 
-	// convertersFileName contains expandData and flattenData functions
-	convertersFileName = "converters"
-	viewFileName       = "view"
+	// converterFileName contains expandData and flattenData functions
+	converterFileName = "converter"
+	viewFileName      = "view"
 )
 
 // genDefinition generates zz_datasource.go, zz_resource.go, and zz_converters.go files
@@ -139,8 +139,8 @@ func genDefinition(doc *OpenAPIDoc, defPath string) error {
 			var codes []jen.Code
 
 			// Renders the resourceName constant
-			avnName := aivenNamePrefix + resName
-			codes = append(codes, jen.Const().Id(aivenNameConst).Op("=").Lit(avnName))
+			avnName := typeNamePrefix + resName
+			codes = append(codes, jen.Const().Id(typeName).Op("=").Lit(avnName))
 
 			// Generates TF and API models
 			models, err := genModels(root)
@@ -171,7 +171,7 @@ func genDefinition(doc *OpenAPIDoc, defPath string) error {
 				convertersFile.Add(c).Line()
 			}
 
-			convertersPath := genFilePath(def.Location, convertersFileName)
+			convertersPath := genFilePath(def.Location, converterFileName)
 			err = convertersFile.Save(convertersPath)
 			if err != nil {
 				return fmt.Errorf("could not save file %s: %w", convertersPath, err)

--- a/generators/plugin/schemas.go
+++ b/generators/plugin/schemas.go
@@ -9,6 +9,8 @@ import (
 	"github.com/aiven/terraform-provider-aiven/internal/schemautil/userconfig"
 )
 
+const schemaSuffix = "Schema"
+
 func genSchema(isResource bool, item *Item, def *Definition) (jen.Code, error) {
 	attrs, err := genAttributes(isResource, item, def)
 	if err != nil {
@@ -39,7 +41,7 @@ func genSchema(isResource bool, item *Item, def *Definition) (jen.Code, error) {
 
 	// Schema package depends on the entity type.
 	pkg := entityImport(isResource, schemaPackageFmt)
-	funcName := "new" + firstUpper(boolEntity(isResource)) + "Schema"
+	funcName := string(boolEntity(isResource)) + schemaSuffix
 	return jen.
 		Comment(funcName+":\n"+example).
 		Line().

--- a/generators/plugin/views.go
+++ b/generators/plugin/views.go
@@ -58,8 +58,8 @@ func genViews(item *Item, def *Definition) ([]jen.Code, error) {
 func genNewResource(entity entityType, def *Definition) jen.Code {
 	entityTitle := firstUpper(entity)
 	values := jen.Dict{
-		jen.Id("TypeName"): jen.Id(aivenNameConst),
-		jen.Id("Schema"):   jen.Id(fmt.Sprintf("new%sSchema", entityTitle)),
+		jen.Id("TypeName"): jen.Id(typeName),
+		jen.Id("Schema"):   jen.Id(string(entity) + schemaSuffix),
 	}
 
 	for _, v := range def.Operations {

--- a/internal/plugin/service/governance/access/access.go
+++ b/internal/plugin/service/governance/access/access.go
@@ -14,9 +14,9 @@ import (
 
 func NewResource() resource.Resource {
 	return adapter.NewResource(adapter.ResourceOptions[*resourceModel, tfModel]{
-		TypeName: aivenName,
+		TypeName: typeName,
 		IDFields: idFields(),
-		Schema:   newResourceSchema,
+		Schema:   resourceSchema,
 		Read:     readAccess,
 		Create:   createAccess,
 		Delete:   deleteAccess,

--- a/internal/plugin/service/governance/access/zz_converter.go
+++ b/internal/plugin/service/governance/access/zz_converter.go
@@ -16,7 +16,7 @@ import (
 	"github.com/aiven/terraform-provider-aiven/internal/plugin/util"
 )
 
-const aivenName = "aiven_governance_access"
+const typeName = "aiven_governance_access"
 
 type tfModel struct {
 	ID               types.String `tfsdk:"id"`

--- a/internal/plugin/service/governance/access/zz_resource.go
+++ b/internal/plugin/service/governance/access/zz_resource.go
@@ -32,7 +32,7 @@ func (tf *resourceModel) TimeoutsObject() types.Object {
 }
 
 /*
-newResourceSchema:
+resourceSchema:
 
 	resource "aiven_governance_access" "example" {
 	  access_data {
@@ -59,7 +59,7 @@ newResourceSchema:
 	  susbcription_id = "foo"
 	}
 */
-func newResourceSchema(ctx context.Context) schema.Schema {
+func resourceSchema(ctx context.Context) schema.Schema {
 	return schema.Schema{
 		Attributes: map[string]schema.Attribute{
 			"access_name": schema.StringAttribute{

--- a/internal/plugin/service/organization/address/zz_converter.go
+++ b/internal/plugin/service/organization/address/zz_converter.go
@@ -15,7 +15,7 @@ import (
 	"github.com/aiven/terraform-provider-aiven/internal/plugin/util"
 )
 
-const aivenName = "aiven_organization_address"
+const typeName = "aiven_organization_address"
 
 type tfModel struct {
 	ID             types.String `tfsdk:"id"`

--- a/internal/plugin/service/organization/address/zz_datasource.go
+++ b/internal/plugin/service/organization/address/zz_datasource.go
@@ -28,7 +28,7 @@ func (tf *datasourceModel) TimeoutsObject() types.Object {
 }
 
 /*
-newDatasourceSchema:
+datasourceSchema:
 
 	data "aiven_organization_address" "example" {
 	  organization_id = "org1a23f456789"
@@ -45,7 +45,7 @@ newDatasourceSchema:
 	  zip_code      = "foo"
 	}
 */
-func newDatasourceSchema(ctx context.Context) schema.Schema {
+func datasourceSchema(ctx context.Context) schema.Schema {
 	return schema.Schema{
 		Attributes: map[string]schema.Attribute{
 			"address_id": schema.StringAttribute{

--- a/internal/plugin/service/organization/address/zz_resource.go
+++ b/internal/plugin/service/organization/address/zz_resource.go
@@ -31,7 +31,7 @@ func (tf *resourceModel) TimeoutsObject() types.Object {
 }
 
 /*
-newResourceSchema:
+resourceSchema:
 
 	resource "aiven_organization_address" "example" {
 	  organization_id = "org1a23f456789" // Force new
@@ -48,7 +48,7 @@ newResourceSchema:
 	  address_id  = "foo"
 	}
 */
-func newResourceSchema(ctx context.Context) schema.Schema {
+func resourceSchema(ctx context.Context) schema.Schema {
 	return schema.Schema{
 		Attributes: map[string]schema.Attribute{
 			"address_id": schema.StringAttribute{

--- a/internal/plugin/service/organization/address/zz_view.go
+++ b/internal/plugin/service/organization/address/zz_view.go
@@ -23,8 +23,8 @@ func NewResource() resource.Resource {
 		IDFields:     idFields(),
 		Read:         readView,
 		RefreshState: false,
-		Schema:       newResourceSchema,
-		TypeName:     aivenName,
+		Schema:       resourceSchema,
+		TypeName:     typeName,
 		Update:       updateView,
 	})
 }
@@ -32,8 +32,8 @@ func NewResource() resource.Resource {
 func NewDatasource() datasource.DataSource {
 	return adapter.NewDatasource(adapter.DatasourceOptions[*datasourceModel, tfModel]{
 		Read:     readView,
-		Schema:   newDatasourceSchema,
-		TypeName: aivenName,
+		Schema:   datasourceSchema,
+		TypeName: typeName,
 	})
 }
 

--- a/internal/plugin/service/organization/application_user/application_user.go
+++ b/internal/plugin/service/organization/application_user/application_user.go
@@ -15,9 +15,9 @@ import (
 
 func NewResource() resource.Resource {
 	return adapter.NewResource(adapter.ResourceOptions[*resourceModel, tfModel]{
-		TypeName: aivenName,
+		TypeName: typeName,
 		IDFields: idFields(),
-		Schema:   newResourceSchema,
+		Schema:   resourceSchema,
 		Read:     readApplicationUser,
 		Create:   createApplicationUser,
 		Update:   updateApplicationUser,
@@ -27,8 +27,8 @@ func NewResource() resource.Resource {
 
 func NewDatasource() datasource.DataSource {
 	return adapter.NewDatasource(adapter.DatasourceOptions[*datasourceModel, tfModel]{
-		TypeName: aivenName,
-		Schema:   newDatasourceSchema,
+		TypeName: typeName,
+		Schema:   datasourceSchema,
 		Read:     readApplicationUser,
 	})
 }

--- a/internal/plugin/service/organization/application_user/zz_converter.go
+++ b/internal/plugin/service/organization/application_user/zz_converter.go
@@ -15,7 +15,7 @@ import (
 	"github.com/aiven/terraform-provider-aiven/internal/plugin/util"
 )
 
-const aivenName = "aiven_organization_application_user"
+const typeName = "aiven_organization_application_user"
 
 type tfModel struct {
 	ID             types.String `tfsdk:"id"`

--- a/internal/plugin/service/organization/application_user/zz_datasource.go
+++ b/internal/plugin/service/organization/application_user/zz_datasource.go
@@ -26,7 +26,7 @@ func (tf *datasourceModel) TimeoutsObject() types.Object {
 }
 
 /*
-newDatasourceSchema:
+datasourceSchema:
 
 	data "aiven_organization_application_user" "example" {
 	  organization_id = "org1a23f456789"
@@ -38,7 +38,7 @@ newDatasourceSchema:
 	  name           = "test"
 	}
 */
-func newDatasourceSchema(ctx context.Context) schema.Schema {
+func datasourceSchema(ctx context.Context) schema.Schema {
 	return schema.Schema{
 		Attributes: map[string]schema.Attribute{
 			"email": schema.StringAttribute{

--- a/internal/plugin/service/organization/application_user/zz_resource.go
+++ b/internal/plugin/service/organization/application_user/zz_resource.go
@@ -29,7 +29,7 @@ func (tf *resourceModel) TimeoutsObject() types.Object {
 }
 
 /*
-newResourceSchema:
+resourceSchema:
 
 	resource "aiven_organization_application_user" "example" {
 	  organization_id = "org1a23f456789" // Force new
@@ -41,7 +41,7 @@ newResourceSchema:
 	  user_id = "foo"
 	}
 */
-func newResourceSchema(ctx context.Context) schema.Schema {
+func resourceSchema(ctx context.Context) schema.Schema {
 	return schema.Schema{
 		Attributes: map[string]schema.Attribute{
 			"email": schema.StringAttribute{

--- a/internal/plugin/service/organization/application_user_token/application_user_token.go
+++ b/internal/plugin/service/organization/application_user_token/application_user_token.go
@@ -16,9 +16,9 @@ import (
 
 func NewResource() resource.Resource {
 	return adapter.NewResource(adapter.ResourceOptions[*resourceModel, tfModel]{
-		TypeName: aivenName,
+		TypeName: typeName,
 		IDFields: idFields(),
-		Schema:   newResourceSchema,
+		Schema:   resourceSchema,
 		Read:     readApplicationUserToken,
 		Create:   createApplicationUserToken,
 		Delete:   deleteApplicationUserToken,

--- a/internal/plugin/service/organization/application_user_token/zz_converter.go
+++ b/internal/plugin/service/organization/application_user_token/zz_converter.go
@@ -15,7 +15,7 @@ import (
 	"github.com/aiven/terraform-provider-aiven/internal/plugin/util"
 )
 
-const aivenName = "aiven_organization_application_user_token"
+const typeName = "aiven_organization_application_user_token"
 
 type tfModel struct {
 	ID                         types.String `tfsdk:"id"`

--- a/internal/plugin/service/organization/application_user_token/zz_resource.go
+++ b/internal/plugin/service/organization/application_user_token/zz_resource.go
@@ -36,7 +36,7 @@ func (tf *resourceModel) TimeoutsObject() types.Object {
 }
 
 /*
-newResourceSchema:
+resourceSchema:
 
 	resource "aiven_organization_application_user_token" "example" {
 	  description      = "test" // Force new
@@ -60,7 +60,7 @@ newResourceSchema:
 	  token_prefix                   = "foo"
 	}
 */
-func newResourceSchema(ctx context.Context) schema.Schema {
+func resourceSchema(ctx context.Context) schema.Schema {
 	return schema.Schema{
 		Attributes: map[string]schema.Attribute{
 			"create_time": schema.StringAttribute{

--- a/internal/plugin/service/organization/billinggroup/billing_group.go
+++ b/internal/plugin/service/organization/billinggroup/billing_group.go
@@ -16,9 +16,9 @@ import (
 
 func NewResource() resource.Resource {
 	return adapter.NewResource(adapter.ResourceOptions[*resourceModel, tfModel]{
-		TypeName: aivenName,
+		TypeName: typeName,
 		IDFields: idFields(),
-		Schema:   newResourceSchema,
+		Schema:   resourceSchema,
 		Read:     readBillingGroup,
 		Create:   createBillingGroup,
 		Update:   updateBillingGroup,
@@ -28,8 +28,8 @@ func NewResource() resource.Resource {
 
 func NewDatasource() datasource.DataSource {
 	return adapter.NewDatasource(adapter.DatasourceOptions[*datasourceModel, tfModel]{
-		TypeName: aivenName,
-		Schema:   newDatasourceSchema,
+		TypeName: typeName,
+		Schema:   datasourceSchema,
 		Read:     readBillingGroup,
 	})
 }

--- a/internal/plugin/service/organization/billinggroup/zz_converter.go
+++ b/internal/plugin/service/organization/billinggroup/zz_converter.go
@@ -15,7 +15,7 @@ import (
 	"github.com/aiven/terraform-provider-aiven/internal/plugin/util"
 )
 
-const aivenName = "aiven_organization_billing_group"
+const typeName = "aiven_organization_billing_group"
 
 type tfModel struct {
 	ID                   types.String `tfsdk:"id"`

--- a/internal/plugin/service/organization/billinggroup/zz_datasource.go
+++ b/internal/plugin/service/organization/billinggroup/zz_datasource.go
@@ -28,7 +28,7 @@ func (tf *datasourceModel) TimeoutsObject() types.Object {
 }
 
 /*
-newDatasourceSchema:
+datasourceSchema:
 
 	data "aiven_organization_billing_group" "example" {
 	  organization_id  = "org1a23f456789"
@@ -46,7 +46,7 @@ newDatasourceSchema:
 	  vat_id                 = "foo"
 	}
 */
-func newDatasourceSchema(ctx context.Context) schema.Schema {
+func datasourceSchema(ctx context.Context) schema.Schema {
 	return schema.Schema{
 		Attributes: map[string]schema.Attribute{
 			"billing_address_id": schema.StringAttribute{

--- a/internal/plugin/service/organization/billinggroup/zz_resource.go
+++ b/internal/plugin/service/organization/billinggroup/zz_resource.go
@@ -30,7 +30,7 @@ func (tf *resourceModel) TimeoutsObject() types.Object {
 }
 
 /*
-newResourceSchema:
+resourceSchema:
 
 	resource "aiven_organization_billing_group" "example" {
 	  organization_id        = "org1a23f456789" // Force new
@@ -48,7 +48,7 @@ newResourceSchema:
 	  billing_group_id = "foo"
 	}
 */
-func newResourceSchema(ctx context.Context) schema.Schema {
+func resourceSchema(ctx context.Context) schema.Schema {
 	return schema.Schema{
 		Attributes: map[string]schema.Attribute{
 			"billing_address_id": schema.StringAttribute{

--- a/internal/plugin/service/organization/billinggrouplist/billing_group_list.go
+++ b/internal/plugin/service/organization/billinggrouplist/billing_group_list.go
@@ -16,8 +16,8 @@ import (
 
 func NewDatasource() datasource.DataSource {
 	return adapter.NewDatasource(adapter.DatasourceOptions[*datasourceModel, tfModel]{
-		TypeName: aivenName,
-		Schema:   newDatasourceSchema,
+		TypeName: typeName,
+		Schema:   datasourceSchema,
 		Read:     readBillingGroupList,
 	})
 }

--- a/internal/plugin/service/organization/billinggrouplist/zz_converter.go
+++ b/internal/plugin/service/organization/billinggrouplist/zz_converter.go
@@ -16,7 +16,7 @@ import (
 	"github.com/aiven/terraform-provider-aiven/internal/plugin/util"
 )
 
-const aivenName = "aiven_organization_billing_group_list"
+const typeName = "aiven_organization_billing_group_list"
 
 type tfModel struct {
 	ID             types.String `tfsdk:"id"`

--- a/internal/plugin/service/organization/billinggrouplist/zz_datasource.go
+++ b/internal/plugin/service/organization/billinggrouplist/zz_datasource.go
@@ -26,7 +26,7 @@ func (tf *datasourceModel) TimeoutsObject() types.Object {
 }
 
 /*
-newDatasourceSchema:
+datasourceSchema:
 
 	data "aiven_organization_billing_group_list" "example" {
 	  organization_id = "org1a23f456789"
@@ -47,7 +47,7 @@ newDatasourceSchema:
 	  }
 	}
 */
-func newDatasourceSchema(ctx context.Context) schema.Schema {
+func datasourceSchema(ctx context.Context) schema.Schema {
 	return schema.Schema{
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{

--- a/internal/plugin/service/organization/organization/organization.go
+++ b/internal/plugin/service/organization/organization/organization.go
@@ -20,9 +20,9 @@ import (
 
 func NewResource() resource.Resource {
 	return adapter.NewResource(adapter.ResourceOptions[*resourceModel, tfModel]{
-		TypeName: aivenName,
+		TypeName: typeName,
 		IDFields: idFields(),
-		Schema:   newResourceSchema,
+		Schema:   resourceSchema,
 		Read:     readOrganization,
 		Create:   createOrganization,
 		Update:   updateOrganization,
@@ -32,7 +32,7 @@ func NewResource() resource.Resource {
 
 func NewDatasource() datasource.DataSource {
 	return adapter.NewDatasource(adapter.DatasourceOptions[*datasourceModel, tfModel]{
-		TypeName:         aivenName,
+		TypeName:         typeName,
 		Schema:           datasourceSchemaPatched,
 		Read:             readOrganization,
 		ConfigValidators: datasourceConfigValidators,
@@ -53,7 +53,7 @@ func datasourceSchemaPatched(ctx context.Context) dataschema.Schema {
 			},
 		},
 	}
-	result := newDatasourceSchema(ctx)
+	result := datasourceSchema(ctx)
 	for k, v := range patch.Attributes {
 		result.Attributes[k] = v
 	}

--- a/internal/plugin/service/organization/organization/zz_converter.go
+++ b/internal/plugin/service/organization/organization/zz_converter.go
@@ -14,7 +14,7 @@ import (
 	"github.com/aiven/terraform-provider-aiven/internal/plugin/util"
 )
 
-const aivenName = "aiven_organization"
+const typeName = "aiven_organization"
 
 type tfModel struct {
 	ID         types.String `tfsdk:"id"`

--- a/internal/plugin/service/organization/organization/zz_datasource.go
+++ b/internal/plugin/service/organization/organization/zz_datasource.go
@@ -26,7 +26,7 @@ func (tf *datasourceModel) TimeoutsObject() types.Object {
 }
 
 /*
-newDatasourceSchema:
+datasourceSchema:
 
 	data "aiven_organization" "example" {
 	  id = "foo"
@@ -38,7 +38,7 @@ newDatasourceSchema:
 	  update_time = "foo"
 	}
 */
-func newDatasourceSchema(ctx context.Context) schema.Schema {
+func datasourceSchema(ctx context.Context) schema.Schema {
 	return schema.Schema{
 		Attributes: map[string]schema.Attribute{
 			"create_time": schema.StringAttribute{

--- a/internal/plugin/service/organization/organization/zz_resource.go
+++ b/internal/plugin/service/organization/organization/zz_resource.go
@@ -30,7 +30,7 @@ func (tf *resourceModel) TimeoutsObject() types.Object {
 }
 
 /*
-newResourceSchema:
+resourceSchema:
 
 	resource "aiven_organization" "example" {
 	  name = "test"
@@ -42,7 +42,7 @@ newResourceSchema:
 	  update_time = "foo"
 	}
 */
-func newResourceSchema(ctx context.Context) schema.Schema {
+func resourceSchema(ctx context.Context) schema.Schema {
 	return schema.Schema{
 		Attributes: map[string]schema.Attribute{
 			"create_time": schema.StringAttribute{

--- a/internal/plugin/service/organization/permission/permission.go
+++ b/internal/plugin/service/organization/permission/permission.go
@@ -30,7 +30,7 @@ const (
 
 func NewResource() resource.Resource {
 	return adapter.NewResource(adapter.ResourceOptions[*resourceModel, tfModel]{
-		TypeName: aivenName,
+		TypeName: typeName,
 		IDFields: idFields(),
 		Schema:   patchedSchema,
 		Read:     readPermission,
@@ -43,7 +43,7 @@ func NewResource() resource.Resource {
 // patchedSchema adds "permissions" enum values that are not yet in OpenAPI spec.
 // They are exactly the same as for teams.
 func patchedSchema(ctx context.Context) schema.Schema {
-	s := newResourceSchema(ctx)
+	s := resourceSchema(ctx)
 	b := s.Blocks["permissions"].(schema.SetNestedBlock)
 	v := b.NestedObject.Attributes["permissions"].(schema.SetAttribute)
 	v.MarkdownDescription = userconfig.

--- a/internal/plugin/service/organization/permission/zz_converter.go
+++ b/internal/plugin/service/organization/permission/zz_converter.go
@@ -16,7 +16,7 @@ import (
 	"github.com/aiven/terraform-provider-aiven/internal/plugin/util"
 )
 
-const aivenName = "aiven_organization_permission"
+const typeName = "aiven_organization_permission"
 
 type tfModel struct {
 	ID             types.String `tfsdk:"id"`

--- a/internal/plugin/service/organization/permission/zz_resource.go
+++ b/internal/plugin/service/organization/permission/zz_resource.go
@@ -31,7 +31,7 @@ func (tf *resourceModel) TimeoutsObject() types.Object {
 }
 
 /*
-newResourceSchema:
+resourceSchema:
 
 	resource "aiven_organization_permission" "example" {
 	  organization_id = "org1a23f456789" // Force new
@@ -46,7 +46,7 @@ newResourceSchema:
 	  }
 	}
 */
-func newResourceSchema(ctx context.Context) schema.Schema {
+func resourceSchema(ctx context.Context) schema.Schema {
 	return schema.Schema{
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{

--- a/internal/plugin/service/organization/project/project.go
+++ b/internal/plugin/service/organization/project/project.go
@@ -18,9 +18,9 @@ import (
 
 func NewResource() resource.Resource {
 	return adapter.NewResource(adapter.ResourceOptions[*resourceModel, tfModel]{
-		TypeName: aivenName,
+		TypeName: typeName,
 		IDFields: idFields(),
-		Schema:   newResourceSchema,
+		Schema:   resourceSchema,
 		Read:     readProject,
 		Create:   createProject,
 		Update:   updateProject,
@@ -30,8 +30,8 @@ func NewResource() resource.Resource {
 
 func NewDatasource() datasource.DataSource {
 	return adapter.NewDatasource(adapter.DatasourceOptions[*datasourceModel, tfModel]{
-		TypeName: aivenName,
-		Schema:   newDatasourceSchema,
+		TypeName: typeName,
+		Schema:   datasourceSchema,
 		Read:     readProject,
 	})
 }

--- a/internal/plugin/service/organization/project/zz_converter.go
+++ b/internal/plugin/service/organization/project/zz_converter.go
@@ -16,7 +16,7 @@ import (
 	"github.com/aiven/terraform-provider-aiven/internal/plugin/util"
 )
 
-const aivenName = "aiven_organization_project"
+const typeName = "aiven_organization_project"
 
 type tfModel struct {
 	ID              types.String `tfsdk:"id"`

--- a/internal/plugin/service/organization/project/zz_datasource.go
+++ b/internal/plugin/service/organization/project/zz_datasource.go
@@ -28,7 +28,7 @@ func (tf *datasourceModel) TimeoutsObject() types.Object {
 }
 
 /*
-newDatasourceSchema:
+datasourceSchema:
 
 	data "aiven_organization_project" "example" {
 	  organization_id = "org1a23f456789"
@@ -46,7 +46,7 @@ newDatasourceSchema:
 	  technical_emails = ["test@example.com"]
 	}
 */
-func newDatasourceSchema(ctx context.Context) schema.Schema {
+func datasourceSchema(ctx context.Context) schema.Schema {
 	return schema.Schema{
 		Attributes: map[string]schema.Attribute{
 			"base_port": schema.Int64Attribute{

--- a/internal/plugin/service/organization/project/zz_resource.go
+++ b/internal/plugin/service/organization/project/zz_resource.go
@@ -31,7 +31,7 @@ func (tf *resourceModel) TimeoutsObject() types.Object {
 }
 
 /*
-newResourceSchema:
+resourceSchema:
 
 	resource "aiven_organization_project" "example" {
 	  organization_id  = "org1a23f456789"
@@ -49,7 +49,7 @@ newResourceSchema:
 	  ca_cert = "foo"
 	}
 */
-func newResourceSchema(ctx context.Context) schema.Schema {
+func resourceSchema(ctx context.Context) schema.Schema {
 	return schema.Schema{
 		Attributes: map[string]schema.Attribute{
 			"base_port": schema.Int64Attribute{


### PR DESCRIPTION
Resolves NEX-2006.

- converters.go → converter.go (go convention)
- aivenName → typeName (tf convention)
- newResourceSchema → resourceSchema (naming consistency)
