### PR TITLE
refactor(plugin): rename `Datasource` to `DataSource`

### DIFF
--- a/generators/plugin/imports.go
+++ b/generators/plugin/imports.go
@@ -13,6 +13,23 @@ const (
 	datasourceType entityType = "datasource"
 )
 
+func (e entityType) isResource() bool {
+	return e == resourceType
+}
+
+func (e entityType) Title() string {
+	if e == resourceType {
+		return "Resource"
+	}
+
+	// In camelcase
+	return "DataSource"
+}
+
+func (e entityType) Import(importString entityImportType) string {
+	return fmt.Sprintf(string(importString), e)
+}
+
 func boolEntity(isResource bool) entityType {
 	if isResource {
 		return resourceType
@@ -22,6 +39,7 @@ func boolEntity(isResource bool) entityType {
 
 // Generic untyped imports
 const (
+	projectPackagePrefix  = "github.com/aiven/terraform-provider-aiven"
 	attrPackage           = "github.com/hashicorp/terraform-plugin-framework/attr"
 	diagPackage           = "github.com/hashicorp/terraform-plugin-framework/diag"
 	typesPackage          = "github.com/hashicorp/terraform-plugin-framework/types"
@@ -31,8 +49,6 @@ const (
 	adapterPackage        = "github.com/aiven/terraform-provider-aiven/internal/plugin/adapter"
 	legacyTimeoutsPackage = "github.com/aiven/terraform-provider-aiven/internal/plugin/legacytimeouts"
 	avnGenPackage         = "github.com/aiven/go-client-codegen"
-	resourcePackage       = "github.com/hashicorp/terraform-plugin-framework/resource"
-	datasourcePackage     = "github.com/hashicorp/terraform-plugin-framework/datasource"
 	errMsgPackage         = "github.com/aiven/terraform-provider-aiven/internal/plugin/errmsg"
 )
 
@@ -46,8 +62,6 @@ func getUntypedImports() []string {
 		utilPackage,
 		adapterPackage,
 		legacyTimeoutsPackage,
-		resourcePackage,
-		datasourcePackage,
 		errMsgPackage,
 	}
 }
@@ -56,6 +70,7 @@ func getUntypedImports() []string {
 type entityImportType string
 
 const (
+	entityPackage          entityImportType = "github.com/hashicorp/terraform-plugin-framework/%s"
 	schemaPackageFmt       entityImportType = "github.com/hashicorp/terraform-plugin-framework/%s/schema"
 	planmodifierPackageFmt entityImportType = "github.com/hashicorp/terraform-plugin-framework/%s/schema/planmodifier"
 	timeoutsPackageFmt     entityImportType = "github.com/hashicorp/terraform-plugin-framework-timeouts/%s/timeouts"

--- a/generators/plugin/item.go
+++ b/generators/plugin/item.go
@@ -21,6 +21,9 @@ const (
 	UpdateHandler
 	DeleteHandler
 	CreatePathParameter
+	UpdatePathParameter
+	ReadPathParameter
+	DeletePathParameter
 	CreateRequestBody
 	UpdateRequestBody
 	CreateResponseBody
@@ -59,6 +62,8 @@ type IDAttribute struct {
 }
 
 type Definition struct {
+	fileName       string               // e.g. organization_address.yaml
+	typeName       string               // e.g. aiven_organization_address, aiven_kafka_topic
 	Beta           bool                 `yaml:"beta"`
 	Location       string               `yaml:"location"`
 	Schema         map[string]*Item     `yaml:"schema,omitempty"`

--- a/generators/plugin/schemas.go
+++ b/generators/plugin/schemas.go
@@ -11,8 +11,8 @@ import (
 
 const schemaSuffix = "Schema"
 
-func genSchema(isResource bool, item *Item, def *Definition) (jen.Code, error) {
-	attrs, err := genAttributes(isResource, item, def)
+func genSchema(entity entityType, item *Item, def *Definition) (jen.Code, error) {
+	attrs, err := genAttributes(entity.isResource(), item, def)
 	if err != nil {
 		return nil, err
 	}
@@ -23,25 +23,25 @@ func genSchema(isResource bool, item *Item, def *Definition) (jen.Code, error) {
 		attrs[jen.Id("DeprecationMessage")] = jen.Lit(item.DeprecationMessage)
 	}
 
-	desc := fmtDescription(isResource, item)
+	desc := fmtDescription(entity.isResource(), item)
 	if def.Beta {
 		desc = userconfig.Desc(desc).AvailabilityType(userconfig.Beta).Build()
 	}
 	attrs[jen.Id("MarkdownDescription")] = jen.Lit(desc)
 
-	if isResource && def.Version != nil {
+	if entity.isResource() && def.Version != nil {
 		// Only resources have Version field
 		attrs[jen.Id("Version")] = jen.Lit(*def.Version)
 	}
 
-	example, err := exampleRoot(isResource, item)
+	example, err := exampleRoot(entity.isResource(), item)
 	if err != nil {
 		return nil, fmt.Errorf("example error: %w", err)
 	}
 
 	// Schema package depends on the entity type.
-	pkg := entityImport(isResource, schemaPackageFmt)
-	funcName := string(boolEntity(isResource)) + schemaSuffix
+	pkg := entityImport(entity.isResource(), schemaPackageFmt)
+	funcName := string(entity) + schemaSuffix
 	return jen.
 		Comment(funcName+":\n"+example).
 		Line().

--- a/internal/plugin/adapter/datasource.go
+++ b/internal/plugin/adapter/datasource.go
@@ -11,7 +11,7 @@ import (
 	"github.com/aiven/terraform-provider-aiven/internal/plugin/providerdata"
 )
 
-type DatasourceOptions[M Model[T], T any] struct {
+type DataSourceOptions[M Model[T], T any] struct {
 	// TypeName is the name of resource,
 	// for instance, "aiven_organization_address"
 	TypeName string
@@ -25,7 +25,7 @@ type DatasourceOptions[M Model[T], T any] struct {
 	ConfigValidators func(ctx context.Context, client avngen.Client) []datasource.ConfigValidator
 }
 
-func NewDatasource[M Model[T], T any](options DatasourceOptions[M, T]) datasource.DataSource {
+func NewDataSource[M Model[T], T any](options DataSourceOptions[M, T]) datasource.DataSource {
 	return &datasourceAdapter[M, T]{
 		datasource: options,
 	}
@@ -39,7 +39,7 @@ var (
 
 type datasourceAdapter[M Model[T], T any] struct {
 	client     avngen.Client
-	datasource DatasourceOptions[M, T]
+	datasource DataSourceOptions[M, T]
 }
 
 func (a *datasourceAdapter[M, T]) Configure(

--- a/internal/plugin/provider.go
+++ b/internal/plugin/provider.go
@@ -187,19 +187,19 @@ func (p *AivenProvider) Resources(context.Context) []func() resource.Resource {
 func (p *AivenProvider) DataSources(context.Context) []func() datasource.DataSource {
 	// List of data sources that are currently available in the provider.
 	dataSources := []func() datasource.DataSource{
-		organization.NewDatasource,
-		applicationuser.NewDatasource,
-		planlist.NewDatasource,
+		organization.NewDataSource,
+		applicationuser.NewDataSource,
+		planlist.NewDataSource,
 	}
 
 	// Add to a list of data sources that are currently in beta.
 	if util.IsBeta() {
 		betaDataSources := []func() datasource.DataSource{
-			externalidentity.NewDatasource,
-			address.NewDatasource,
-			billinggroup.NewDatasource,
-			billinggrouplist.NewDatasource,
-			project.NewDatasource,
+			externalidentity.NewDataSource,
+			address.NewDataSource,
+			billinggroup.NewDataSource,
+			billinggrouplist.NewDataSource,
+			project.NewDataSource,
 		}
 		dataSources = append(dataSources, betaDataSources...)
 	}

--- a/internal/plugin/service/externalidentity/external_identity_data_source.go
+++ b/internal/plugin/service/externalidentity/external_identity_data_source.go
@@ -21,7 +21,7 @@ var (
 	_ util.TypeNameable                  = &externalIdentityDataSource{}
 )
 
-func NewDatasource() datasource.DataSource {
+func NewDataSource() datasource.DataSource {
 	return &externalIdentityDataSource{}
 }
 

--- a/internal/plugin/service/organization/address/zz_view.go
+++ b/internal/plugin/service/organization/address/zz_view.go
@@ -29,8 +29,8 @@ func NewResource() resource.Resource {
 	})
 }
 
-func NewDatasource() datasource.DataSource {
-	return adapter.NewDatasource(adapter.DatasourceOptions[*datasourceModel, tfModel]{
+func NewDataSource() datasource.DataSource {
+	return adapter.NewDataSource(adapter.DataSourceOptions[*datasourceModel, tfModel]{
 		Read:     readView,
 		Schema:   datasourceSchema,
 		TypeName: typeName,

--- a/internal/plugin/service/organization/application_user/application_user.go
+++ b/internal/plugin/service/organization/application_user/application_user.go
@@ -25,8 +25,8 @@ func NewResource() resource.Resource {
 	})
 }
 
-func NewDatasource() datasource.DataSource {
-	return adapter.NewDatasource(adapter.DatasourceOptions[*datasourceModel, tfModel]{
+func NewDataSource() datasource.DataSource {
+	return adapter.NewDataSource(adapter.DataSourceOptions[*datasourceModel, tfModel]{
 		TypeName: typeName,
 		Schema:   datasourceSchema,
 		Read:     readApplicationUser,

--- a/internal/plugin/service/organization/billinggroup/billing_group.go
+++ b/internal/plugin/service/organization/billinggroup/billing_group.go
@@ -26,8 +26,8 @@ func NewResource() resource.Resource {
 	})
 }
 
-func NewDatasource() datasource.DataSource {
-	return adapter.NewDatasource(adapter.DatasourceOptions[*datasourceModel, tfModel]{
+func NewDataSource() datasource.DataSource {
+	return adapter.NewDataSource(adapter.DataSourceOptions[*datasourceModel, tfModel]{
 		TypeName: typeName,
 		Schema:   datasourceSchema,
 		Read:     readBillingGroup,

--- a/internal/plugin/service/organization/billinggrouplist/billing_group_list.go
+++ b/internal/plugin/service/organization/billinggrouplist/billing_group_list.go
@@ -14,8 +14,8 @@ import (
 	"github.com/aiven/terraform-provider-aiven/internal/plugin/util"
 )
 
-func NewDatasource() datasource.DataSource {
-	return adapter.NewDatasource(adapter.DatasourceOptions[*datasourceModel, tfModel]{
+func NewDataSource() datasource.DataSource {
+	return adapter.NewDataSource(adapter.DataSourceOptions[*datasourceModel, tfModel]{
 		TypeName: typeName,
 		Schema:   datasourceSchema,
 		Read:     readBillingGroupList,

--- a/internal/plugin/service/organization/organization/organization.go
+++ b/internal/plugin/service/organization/organization/organization.go
@@ -30,8 +30,8 @@ func NewResource() resource.Resource {
 	})
 }
 
-func NewDatasource() datasource.DataSource {
-	return adapter.NewDatasource(adapter.DatasourceOptions[*datasourceModel, tfModel]{
+func NewDataSource() datasource.DataSource {
+	return adapter.NewDataSource(adapter.DataSourceOptions[*datasourceModel, tfModel]{
 		TypeName:         typeName,
 		Schema:           datasourceSchemaPatched,
 		Read:             readOrganization,

--- a/internal/plugin/service/organization/project/project.go
+++ b/internal/plugin/service/organization/project/project.go
@@ -28,8 +28,8 @@ func NewResource() resource.Resource {
 	})
 }
 
-func NewDatasource() datasource.DataSource {
-	return adapter.NewDatasource(adapter.DatasourceOptions[*datasourceModel, tfModel]{
+func NewDataSource() datasource.DataSource {
+	return adapter.NewDataSource(adapter.DataSourceOptions[*datasourceModel, tfModel]{
 		TypeName: typeName,
 		Schema:   datasourceSchema,
 		Read:     readProject,

--- a/internal/plugin/service/planlist/plan_list.go
+++ b/internal/plugin/service/planlist/plan_list.go
@@ -14,8 +14,8 @@ import (
 	"github.com/aiven/terraform-provider-aiven/internal/plugin/util"
 )
 
-func NewDatasource() datasource.DataSource {
-	return adapter.NewDatasource(adapter.DatasourceOptions[*datasourceModel, tfModel]{
+func NewDataSource() datasource.DataSource {
+	return adapter.NewDataSource(adapter.DataSourceOptions[*datasourceModel, tfModel]{
 		TypeName: typeName,
 		Schema:   datasourceSchema,
 		Read:     readPlanList,


### PR DESCRIPTION
Resolves NEX-2011.

The correct naming for `Datasource` is `DataSource` (used by Terraform).
This simplifies the generation since we don't need to keep both names.
