### PR TITLE
chore(update-schemas): adding enable_ha_replica_dns field

### DIFF
--- a/docs/resources/alloydbomni.md
+++ b/docs/resources/alloydbomni.md
@@ -163,7 +163,7 @@ Optional:
 - `backup_hour` (Number) The hour of day (in UTC) when backup for the service is started. New backup is only started if previous backup has already completed. Example: `3`.
 - `backup_minute` (Number) The minute of an hour when backup for the service is started. New backup is only started if previous backup has already completed. Example: `30`.
 - `enable_ipv6` (Boolean) Register AAAA DNS records for the service, and allow IPv6 packets to service ports.
-- `enable_ha_replica_dns` (Boolean) Enable DNS resolution for HA replica endpoints. Default: `false`.
+- `enable_ha_replica_dns` (Boolean) Creates a dedicated read-only DNS that automatically falls back to the primary if standby nodes are unavailable. It switches back when a standby recovers. Default: `false`.
 - `google_columnar_engine_enabled` (Boolean) Enables or disables the columnar engine. When enabled, it accelerates SQL query processing. Default: `true`.
 - `google_columnar_engine_memory_size_percentage` (Number) Allocate the amount of RAM to store columnar data. Default: `10`.
 - `ip_filter` (Set of String, Deprecated) Allow incoming connections from CIDR address block, e.g. `10.20.0.0/16`.

--- a/docs/resources/pg.md
+++ b/docs/resources/pg.md
@@ -140,7 +140,7 @@ Optional:
 - `backup_hour` (Number) The hour of day (in UTC) when backup for the service is started. New backup is only started if previous backup has already completed. Example: `3`.
 - `backup_minute` (Number) The minute of an hour when backup for the service is started. New backup is only started if previous backup has already completed. Example: `30`.
 - `enable_ipv6` (Boolean) Register AAAA DNS records for the service, and allow IPv6 packets to service ports.
-- `enable_ha_replica_dns` (Boolean) Enable DNS resolution for HA replica endpoints. Default: `false`.
+- `enable_ha_replica_dns` (Boolean) Creates a dedicated read-only DNS that automatically falls back to the primary if standby nodes are unavailable. It switches back when a standby recovers. Default: `false`.
 - `ip_filter` (Set of String, Deprecated) Allow incoming connections from CIDR address block, e.g. `10.20.0.0/16`.
 - `ip_filter_object` (Block Set, Max: 8000) Allow incoming connections from CIDR address block, e.g. `10.20.0.0/16` (see [below for nested schema](#nestedblock--pg_user_config--ip_filter_object))
 - `ip_filter_string` (Set of String) Allow incoming connections from CIDR address block, e.g. `10.20.0.0/16`.

--- a/internal/sdkprovider/userconfig/service/alloydbomni.go
+++ b/internal/sdkprovider/userconfig/service/alloydbomni.go
@@ -57,11 +57,6 @@ func alloydbomniUserConfig() *schema.Schema {
 				Optional:    true,
 				Type:        schema.TypeBool,
 			},
-			"enable_ha_replica_dns": {
-				Description: "Enable DNS resolution for HA replica endpoints. Default: `false`.",
-				Optional:    true,
-				Type:        schema.TypeBool,
-			},
 			"google_columnar_engine_enabled": {
 				Description: "Enables or disables the columnar engine. When enabled, it accelerates SQL query processing. Default: `true`.",
 				Optional:    true,

--- a/internal/sdkprovider/userconfig/service/pg.go
+++ b/internal/sdkprovider/userconfig/service/pg.go
@@ -52,11 +52,6 @@ func pgUserConfig() *schema.Schema {
 				Optional:    true,
 				Type:        schema.TypeBool,
 			},
-			"enable_ha_replica_dns": {
-				Description: "Enable DNS resolution for HA replica endpoints. Default: `false`.",
-				Optional:    true,
-				Type:        schema.TypeBool,
-			},
 			"ip_filter": {
 				Deprecated:  "Deprecated. Use `ip_filter_string` instead.",
 				Description: "Allow incoming connections from CIDR address block, e.g. `10.20.0.0/16`.",


### PR DESCRIPTION
<!-- All contributors, please complete these sections, including maintainers. -->

## Adds enable_ha_replica_dns configuration option to pg, alloydb

<!-- Provide a small sentence that summarizes the change. -->
Adds `enable_ha_replica_dns` configuration option to PostgreSQL and AlloyDB Omni services, allowing users to enable DNS resolution for HA replica endpoints.

<!-- Provide the issue number below, if it exists. -->
Resolves: #xxxxx.

## Why this way

<!-- Provide a small explanation on why this is the approach you took for solving this problem. -->
