### PR TITLE
fix(organization_project): retry `Not a project member` error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ nav_order: 1
 - Change `aiven_organization_address` field `address_lines` type from `Set` to `List` to preserve order of address lines
 - Fix `aiven_kafka_quota` added retry logic to handle API eventual consistency
 - Improve `aiven_organization`: added retries to `AccountList` for eventual consistency
+- Improve `aiven_organization_project`: added retries to the read operation to ensure eventual consistency after creating or updating the resource
 - Add `aiven_opensearch` field `opensearch_user_config.jwt`: OpenSearch JWT Configuration
 - Add `aiven_pg` field `pg_user_config.pg.io_combine_limit`: EXPERIMENTAL: Controls the largest I/O size in operations
   that combine I/O in 8kB units

--- a/internal/plugin/adapter/resource.go
+++ b/internal/plugin/adapter/resource.go
@@ -203,10 +203,10 @@ func (a *resourceAdapter[M, T]) Read(
 // In rare cases, the backend might return 404 after the resource is created or updated.
 func (a *resourceAdapter[M, T]) refreshState(ctx context.Context, plan M) diag.Diagnostics {
 	return errmsg.RetryDiags(
+		ctx,
 		func() diag.Diagnostics {
 			return a.resource.Read(ctx, a.client, plan.SharedModel())
 		},
-		retry.Context(ctx),
 		retry.RetryIf(avngen.IsNotFound),
 	)
 }

--- a/internal/plugin/errmsg/retry_test.go
+++ b/internal/plugin/errmsg/retry_test.go
@@ -70,10 +70,14 @@ func TestRetryDiags(t *testing.T) {
 			)
 
 			attempts := 0
-			_ = RetryDiags(func() diag.Diagnostics {
-				attempts++
-				return tc.diags
-			}, tc.opts...)
+			_ = RetryDiags(
+				t.Context(),
+				func() diag.Diagnostics {
+					attempts++
+					return tc.diags
+				},
+				tc.opts...,
+			)
 
 			assert.Equal(t, tc.expectRetried, attempts == maxAttempts)
 		})


### PR DESCRIPTION
Resolves NEX-2035.

- Retries the error after the resource was created or updated (moved to a different org).
- Makes the `ctx` required param in `RetryDiags`

