### PR TITLE
feat(plugin): set values to all computed fields values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ nav_order: 1
 - Fix `aiven_kafka_quota` added retry logic to handle API eventual consistency
 - Improve `aiven_organization`: added retries to `AccountList` for eventual consistency
 - Improve `aiven_organization_project`: added retries to the read operation to ensure eventual consistency after creating or updating the resource
+- Fix `aiven_organization_application_user_token`: prevent `full_token` from being lost after running `terraform refresh`
 - Add `aiven_opensearch` field `opensearch_user_config.jwt`: OpenSearch JWT Configuration
 - Add `aiven_pg` field `pg_user_config.pg.io_combine_limit`: EXPERIMENTAL: Controls the largest I/O size in operations
   that combine I/O in 8kB units

--- a/internal/plugin/service/governance/access/zz_converter.go
+++ b/internal/plugin/service/governance/access/zz_converter.go
@@ -185,20 +185,20 @@ func flattenData[R any](ctx context.Context, state *tfModel, rsp *R, modifiers .
 		}
 		state.AccessData = vAccessData
 	}
-	if api.AccessName != nil && (*api.AccessName != "" || !state.AccessName.IsNull()) {
-		state.AccessName = types.StringPointerValue(api.AccessName)
+	if api.AccessName != nil {
+		state.AccessName = util.StringPointerValue(api.AccessName)
 	}
-	if api.AccessType != nil && (*api.AccessType != "" || !state.AccessType.IsNull()) {
-		state.AccessType = types.StringPointerValue(api.AccessType)
+	if api.AccessType != nil {
+		state.AccessType = util.StringPointerValue(api.AccessType)
 	}
-	if api.OrganizationID != nil && (*api.OrganizationID != "" || !state.OrganizationID.IsNull()) {
-		state.OrganizationID = types.StringPointerValue(api.OrganizationID)
+	if api.OrganizationID != nil {
+		state.OrganizationID = util.StringPointerValue(api.OrganizationID)
 	}
-	if api.OwnerUserGroupID != nil && (*api.OwnerUserGroupID != "" || !state.OwnerUserGroupID.IsNull()) {
-		state.OwnerUserGroupID = types.StringPointerValue(api.OwnerUserGroupID)
+	if api.OwnerUserGroupID != nil {
+		state.OwnerUserGroupID = util.StringPointerValue(api.OwnerUserGroupID)
 	}
-	if api.SusbcriptionID != nil && (*api.SusbcriptionID != "" || !state.SusbcriptionID.IsNull()) {
-		state.SusbcriptionID = types.StringPointerValue(api.SusbcriptionID)
+	if api.SusbcriptionID != nil || state.SusbcriptionID.IsUnknown() {
+		state.SusbcriptionID = util.StringPointerValue(api.SusbcriptionID)
 	}
 	// Response may not contain ID fields.
 	// In that case, `terraform import` won't be able to set them. Gets values from the ID.
@@ -228,13 +228,13 @@ func flattenAccessData(ctx context.Context, api *apiModelAccessData) (*tfModelAc
 		state.Acls = vAcls
 	}
 	if api.Project != nil {
-		state.Project = types.StringPointerValue(api.Project)
+		state.Project = util.StringPointerValue(api.Project)
 	}
 	if api.ServiceName != nil {
-		state.ServiceName = types.StringPointerValue(api.ServiceName)
+		state.ServiceName = util.StringPointerValue(api.ServiceName)
 	}
 	if api.Username != nil {
-		state.Username = types.StringPointerValue(api.Username)
+		state.Username = util.StringPointerValue(api.Username)
 	}
 	return state, nil
 }
@@ -242,28 +242,28 @@ func flattenAccessData(ctx context.Context, api *apiModelAccessData) (*tfModelAc
 func flattenAccessDataAcls(ctx context.Context, api *apiModelAccessDataAcls) (*tfModelAccessDataAcls, diag.Diagnostics) {
 	state := new(tfModelAccessDataAcls)
 	if api.Host != nil {
-		state.Host = types.StringPointerValue(api.Host)
+		state.Host = util.StringPointerValue(api.Host)
 	}
 	if api.ID != nil {
-		state.ID = types.StringPointerValue(api.ID)
+		state.ID = util.StringPointerValue(api.ID)
 	}
 	if api.Operation != nil {
-		state.Operation = types.StringPointerValue(api.Operation)
+		state.Operation = util.StringPointerValue(api.Operation)
 	}
 	if api.PatternType != nil {
-		state.PatternType = types.StringPointerValue(api.PatternType)
+		state.PatternType = util.StringPointerValue(api.PatternType)
 	}
 	if api.PermissionType != nil {
-		state.PermissionType = types.StringPointerValue(api.PermissionType)
+		state.PermissionType = util.StringPointerValue(api.PermissionType)
 	}
 	if api.Principal != nil {
-		state.Principal = types.StringPointerValue(api.Principal)
+		state.Principal = util.StringPointerValue(api.Principal)
 	}
 	if api.ResourceName != nil {
-		state.ResourceName = types.StringPointerValue(api.ResourceName)
+		state.ResourceName = util.StringPointerValue(api.ResourceName)
 	}
 	if api.ResourceType != nil {
-		state.ResourceType = types.StringPointerValue(api.ResourceType)
+		state.ResourceType = util.StringPointerValue(api.ResourceType)
 	}
 	return state, nil
 }

--- a/internal/plugin/service/organization/address/zz_converter.go
+++ b/internal/plugin/service/organization/address/zz_converter.go
@@ -109,39 +109,39 @@ func flattenData[R any](ctx context.Context, state *tfModel, rsp *R, modifiers .
 		diags.AddError("Remarshal error", fmt.Sprintf("Failed to remarshal Response to dtoModel: %s", err.Error()))
 		return diags
 	}
-	if api.AddressLines != nil && (len(*api.AddressLines) > 0 || !state.AddressLines.IsNull()) {
-		vAddressLines, diags := types.ListValueFrom(ctx, types.StringType, api.AddressLines)
+	if api.AddressLines != nil {
+		vAddressLines, diags := util.ListValueFrom(ctx, types.StringType, api.AddressLines)
 		if diags.HasError() {
 			return diags
 		}
 		state.AddressLines = vAddressLines
 	}
-	if api.AddressID != nil && (*api.AddressID != "" || !state.AddressID.IsNull()) {
-		state.AddressID = types.StringPointerValue(api.AddressID)
+	if api.AddressID != nil || state.AddressID.IsUnknown() {
+		state.AddressID = util.StringPointerValue(api.AddressID)
 	}
-	if api.City != nil && (*api.City != "" || !state.City.IsNull()) {
-		state.City = types.StringPointerValue(api.City)
+	if api.City != nil {
+		state.City = util.StringPointerValue(api.City)
 	}
-	if api.CountryCode != nil && (*api.CountryCode != "" || !state.CountryCode.IsNull()) {
-		state.CountryCode = types.StringPointerValue(api.CountryCode)
+	if api.CountryCode != nil {
+		state.CountryCode = util.StringPointerValue(api.CountryCode)
 	}
-	if api.CreateTime != nil && (*api.CreateTime != "" || !state.CreateTime.IsNull()) {
-		state.CreateTime = types.StringPointerValue(api.CreateTime)
+	if api.CreateTime != nil || state.CreateTime.IsUnknown() {
+		state.CreateTime = util.StringPointerValue(api.CreateTime)
 	}
-	if api.Name != nil && (*api.Name != "" || !state.Name.IsNull()) {
-		state.Name = types.StringPointerValue(api.Name)
+	if api.Name != nil {
+		state.Name = util.StringPointerValue(api.Name)
 	}
-	if api.OrganizationID != nil && (*api.OrganizationID != "" || !state.OrganizationID.IsNull()) {
-		state.OrganizationID = types.StringPointerValue(api.OrganizationID)
+	if api.OrganizationID != nil {
+		state.OrganizationID = util.StringPointerValue(api.OrganizationID)
 	}
-	if api.State != nil && (*api.State != "" || !state.State.IsNull()) {
-		state.State = types.StringPointerValue(api.State)
+	if api.State != nil {
+		state.State = util.StringPointerValue(api.State)
 	}
-	if api.UpdateTime != nil && (*api.UpdateTime != "" || !state.UpdateTime.IsNull()) {
-		state.UpdateTime = types.StringPointerValue(api.UpdateTime)
+	if api.UpdateTime != nil || state.UpdateTime.IsUnknown() {
+		state.UpdateTime = util.StringPointerValue(api.UpdateTime)
 	}
-	if api.ZipCode != nil && (*api.ZipCode != "" || !state.ZipCode.IsNull()) {
-		state.ZipCode = types.StringPointerValue(api.ZipCode)
+	if api.ZipCode != nil {
+		state.ZipCode = util.StringPointerValue(api.ZipCode)
 	}
 	// Response may not contain ID fields.
 	// In that case, `terraform import` won't be able to set them. Gets values from the ID.

--- a/internal/plugin/service/organization/application_user/zz_converter.go
+++ b/internal/plugin/service/organization/application_user/zz_converter.go
@@ -79,20 +79,20 @@ func flattenData[R any](ctx context.Context, state *tfModel, rsp *R, modifiers .
 		diags.AddError("Remarshal error", fmt.Sprintf("Failed to remarshal Response to dtoModel: %s", err.Error()))
 		return diags
 	}
-	if api.Email != nil && (*api.Email != "" || !state.Email.IsNull()) {
-		state.Email = types.StringPointerValue(api.Email)
+	if api.Email != nil || state.Email.IsUnknown() {
+		state.Email = util.StringPointerValue(api.Email)
 	}
-	if api.IsSuperAdmin != nil {
+	if api.IsSuperAdmin != nil || state.IsSuperAdmin.IsUnknown() {
 		state.IsSuperAdmin = types.BoolPointerValue(api.IsSuperAdmin)
 	}
-	if api.Name != nil && (*api.Name != "" || !state.Name.IsNull()) {
-		state.Name = types.StringPointerValue(api.Name)
+	if api.Name != nil {
+		state.Name = util.StringPointerValue(api.Name)
 	}
-	if api.OrganizationID != nil && (*api.OrganizationID != "" || !state.OrganizationID.IsNull()) {
-		state.OrganizationID = types.StringPointerValue(api.OrganizationID)
+	if api.OrganizationID != nil {
+		state.OrganizationID = util.StringPointerValue(api.OrganizationID)
 	}
-	if api.UserID != nil && (*api.UserID != "" || !state.UserID.IsNull()) {
-		state.UserID = types.StringPointerValue(api.UserID)
+	if api.UserID != nil || state.UserID.IsUnknown() {
+		state.UserID = util.StringPointerValue(api.UserID)
 	}
 	// Response may not contain ID fields.
 	// In that case, `terraform import` won't be able to set them. Gets values from the ID.

--- a/internal/plugin/service/organization/application_user_token/application_user_token.go
+++ b/internal/plugin/service/organization/application_user_token/application_user_token.go
@@ -43,15 +43,6 @@ func createApplicationUserToken(ctx context.Context, client avngen.Client, plan 
 
 	// FullToken is only available at creation time
 	plan.FullToken = types.StringValue(rsp.FullToken)
-
-	// This information is not available at creation time.
-	// Terraform state requires all fields to be set:
-	// "After the apply operation, the provider still indicated an unknown value for"
-	plan.LastUsedTime = types.StringValue("")
-	plan.LastIP = types.StringValue("")
-	plan.LastUserAgent = types.StringValue("")
-	plan.LastUserAgentHumanReadable = types.StringValue("")
-	plan.ExpiryTime = types.StringValue("") // Is nil if `max_age_seconds` is not set
 	return readApplicationUserToken(ctx, client, plan)
 }
 

--- a/internal/plugin/service/organization/application_user_token/application_user_token_test.go
+++ b/internal/plugin/service/organization/application_user_token/application_user_token_test.go
@@ -44,8 +44,6 @@ resource "aiven_organization_application_user_token" "bar" {
   organization_id = aiven_organization_application_user.foo.organization_id
   user_id         = aiven_organization_application_user.foo.user_id
 }
-
-
 `, acc.RandStr(), org),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(tokenFoo, "description", "Terraform acceptance tests"),
@@ -58,6 +56,22 @@ resource "aiven_organization_application_user_token" "bar" {
 					resource.TestCheckResourceAttr(tokenBar, "extend_when_used", "false"),
 				),
 			},
+			{
+				// The token must survive the refresh command
+				RefreshState: true,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrWith(tokenFoo, "full_token", validToken),
+					resource.TestCheckResourceAttrWith(tokenBar, "full_token", validToken),
+				),
+			},
 		},
 	})
+}
+
+func validToken(s string) error {
+	// Not "", "nil" or some other invalid value
+	if len(s) < 100 {
+		return fmt.Errorf("expected full_token to have value, got length %d", len(s))
+	}
+	return nil
 }

--- a/internal/plugin/service/organization/application_user_token/zz_converter.go
+++ b/internal/plugin/service/organization/application_user_token/zz_converter.go
@@ -128,64 +128,64 @@ func flattenData[R any](ctx context.Context, state *tfModel, rsp *R, modifiers .
 		diags.AddError("Remarshal error", fmt.Sprintf("Failed to remarshal Response to dtoModel: %s", err.Error()))
 		return diags
 	}
-	if api.IpAllowlist != nil && (len(*api.IpAllowlist) > 0 || !state.IpAllowlist.IsNull()) {
-		vIpAllowlist, diags := types.SetValueFrom(ctx, types.StringType, api.IpAllowlist)
+	if api.IpAllowlist != nil {
+		vIpAllowlist, diags := util.SetValueFrom(ctx, types.StringType, api.IpAllowlist)
 		if diags.HasError() {
 			return diags
 		}
 		state.IpAllowlist = vIpAllowlist
 	}
-	if api.Scopes != nil && (len(*api.Scopes) > 0 || !state.Scopes.IsNull()) {
-		vScopes, diags := types.SetValueFrom(ctx, types.StringType, api.Scopes)
+	if api.Scopes != nil {
+		vScopes, diags := util.SetValueFrom(ctx, types.StringType, api.Scopes)
 		if diags.HasError() {
 			return diags
 		}
 		state.Scopes = vScopes
 	}
-	if api.CreateTime != nil && (*api.CreateTime != "" || !state.CreateTime.IsNull()) {
-		state.CreateTime = types.StringPointerValue(api.CreateTime)
+	if api.CreateTime != nil || state.CreateTime.IsUnknown() {
+		state.CreateTime = util.StringPointerValue(api.CreateTime)
 	}
-	if api.CreatedManually != nil {
+	if api.CreatedManually != nil || state.CreatedManually.IsUnknown() {
 		state.CreatedManually = types.BoolPointerValue(api.CreatedManually)
 	}
-	if api.CurrentlyActive != nil {
+	if api.CurrentlyActive != nil || state.CurrentlyActive.IsUnknown() {
 		state.CurrentlyActive = types.BoolPointerValue(api.CurrentlyActive)
 	}
-	if api.Description != nil && (*api.Description != "" || !state.Description.IsNull()) {
-		state.Description = types.StringPointerValue(api.Description)
+	if api.Description != nil {
+		state.Description = util.StringPointerValue(api.Description)
 	}
-	if api.ExpiryTime != nil && (*api.ExpiryTime != "" || !state.ExpiryTime.IsNull()) {
-		state.ExpiryTime = types.StringPointerValue(api.ExpiryTime)
+	if api.ExpiryTime != nil || state.ExpiryTime.IsUnknown() {
+		state.ExpiryTime = util.StringPointerValue(api.ExpiryTime)
 	}
-	if api.ExtendWhenUsed != nil {
+	if api.ExtendWhenUsed != nil || state.ExtendWhenUsed.IsUnknown() {
 		state.ExtendWhenUsed = types.BoolPointerValue(api.ExtendWhenUsed)
 	}
-	if api.FullToken != nil && (*api.FullToken != "" || !state.FullToken.IsNull()) {
-		state.FullToken = types.StringPointerValue(api.FullToken)
+	if api.FullToken != nil || state.FullToken.IsUnknown() {
+		state.FullToken = util.StringPointerValue(api.FullToken)
 	}
-	if api.LastIP != nil && (*api.LastIP != "" || !state.LastIP.IsNull()) {
-		state.LastIP = types.StringPointerValue(api.LastIP)
+	if api.LastIP != nil || state.LastIP.IsUnknown() {
+		state.LastIP = util.StringPointerValue(api.LastIP)
 	}
-	if api.LastUsedTime != nil && (*api.LastUsedTime != "" || !state.LastUsedTime.IsNull()) {
-		state.LastUsedTime = types.StringPointerValue(api.LastUsedTime)
+	if api.LastUsedTime != nil || state.LastUsedTime.IsUnknown() {
+		state.LastUsedTime = util.StringPointerValue(api.LastUsedTime)
 	}
-	if api.LastUserAgent != nil && (*api.LastUserAgent != "" || !state.LastUserAgent.IsNull()) {
-		state.LastUserAgent = types.StringPointerValue(api.LastUserAgent)
+	if api.LastUserAgent != nil || state.LastUserAgent.IsUnknown() {
+		state.LastUserAgent = util.StringPointerValue(api.LastUserAgent)
 	}
-	if api.LastUserAgentHumanReadable != nil && (*api.LastUserAgentHumanReadable != "" || !state.LastUserAgentHumanReadable.IsNull()) {
-		state.LastUserAgentHumanReadable = types.StringPointerValue(api.LastUserAgentHumanReadable)
+	if api.LastUserAgentHumanReadable != nil || state.LastUserAgentHumanReadable.IsUnknown() {
+		state.LastUserAgentHumanReadable = util.StringPointerValue(api.LastUserAgentHumanReadable)
 	}
 	if api.MaxAgeSeconds != nil {
 		state.MaxAgeSeconds = types.Int64PointerValue(api.MaxAgeSeconds)
 	}
-	if api.OrganizationID != nil && (*api.OrganizationID != "" || !state.OrganizationID.IsNull()) {
-		state.OrganizationID = types.StringPointerValue(api.OrganizationID)
+	if api.OrganizationID != nil {
+		state.OrganizationID = util.StringPointerValue(api.OrganizationID)
 	}
-	if api.TokenPrefix != nil && (*api.TokenPrefix != "" || !state.TokenPrefix.IsNull()) {
-		state.TokenPrefix = types.StringPointerValue(api.TokenPrefix)
+	if api.TokenPrefix != nil || state.TokenPrefix.IsUnknown() {
+		state.TokenPrefix = util.StringPointerValue(api.TokenPrefix)
 	}
-	if api.UserID != nil && (*api.UserID != "" || !state.UserID.IsNull()) {
-		state.UserID = types.StringPointerValue(api.UserID)
+	if api.UserID != nil {
+		state.UserID = util.StringPointerValue(api.UserID)
 	}
 	// Response may not contain ID fields.
 	// In that case, `terraform import` won't be able to set them. Gets values from the ID.

--- a/internal/plugin/service/organization/billinggroup/zz_converter.go
+++ b/internal/plugin/service/organization/billinggroup/zz_converter.go
@@ -127,46 +127,46 @@ func flattenData[R any](ctx context.Context, state *tfModel, rsp *R, modifiers .
 		diags.AddError("Remarshal error", fmt.Sprintf("Failed to remarshal Response to dtoModel: %s", err.Error()))
 		return diags
 	}
-	if api.BillingContactEmails != nil && (len(*api.BillingContactEmails) > 0 || !state.BillingContactEmails.IsNull()) {
-		vBillingContactEmails, diags := types.SetValueFrom(ctx, types.StringType, api.BillingContactEmails)
+	if api.BillingContactEmails != nil {
+		vBillingContactEmails, diags := util.SetValueFrom(ctx, types.StringType, api.BillingContactEmails)
 		if diags.HasError() {
 			return diags
 		}
 		state.BillingContactEmails = vBillingContactEmails
 	}
-	if api.BillingEmails != nil && (len(*api.BillingEmails) > 0 || !state.BillingEmails.IsNull()) {
-		vBillingEmails, diags := types.SetValueFrom(ctx, types.StringType, api.BillingEmails)
+	if api.BillingEmails != nil {
+		vBillingEmails, diags := util.SetValueFrom(ctx, types.StringType, api.BillingEmails)
 		if diags.HasError() {
 			return diags
 		}
 		state.BillingEmails = vBillingEmails
 	}
-	if api.BillingAddressID != nil && (*api.BillingAddressID != "" || !state.BillingAddressID.IsNull()) {
-		state.BillingAddressID = types.StringPointerValue(api.BillingAddressID)
+	if api.BillingAddressID != nil {
+		state.BillingAddressID = util.StringPointerValue(api.BillingAddressID)
 	}
-	if api.BillingGroupID != nil && (*api.BillingGroupID != "" || !state.BillingGroupID.IsNull()) {
-		state.BillingGroupID = types.StringPointerValue(api.BillingGroupID)
+	if api.BillingGroupID != nil || state.BillingGroupID.IsUnknown() {
+		state.BillingGroupID = util.StringPointerValue(api.BillingGroupID)
 	}
-	if api.BillingGroupName != nil && (*api.BillingGroupName != "" || !state.BillingGroupName.IsNull()) {
-		state.BillingGroupName = types.StringPointerValue(api.BillingGroupName)
+	if api.BillingGroupName != nil {
+		state.BillingGroupName = util.StringPointerValue(api.BillingGroupName)
 	}
-	if api.Currency != nil && (*api.Currency != "" || !state.Currency.IsNull()) {
-		state.Currency = types.StringPointerValue(api.Currency)
+	if api.Currency != nil {
+		state.Currency = util.StringPointerValue(api.Currency)
 	}
-	if api.CustomInvoiceText != nil && (*api.CustomInvoiceText != "" || !state.CustomInvoiceText.IsNull()) {
-		state.CustomInvoiceText = types.StringPointerValue(api.CustomInvoiceText)
+	if api.CustomInvoiceText != nil {
+		state.CustomInvoiceText = util.StringPointerValue(api.CustomInvoiceText)
 	}
-	if api.OrganizationID != nil && (*api.OrganizationID != "" || !state.OrganizationID.IsNull()) {
-		state.OrganizationID = types.StringPointerValue(api.OrganizationID)
+	if api.OrganizationID != nil {
+		state.OrganizationID = util.StringPointerValue(api.OrganizationID)
 	}
-	if api.PaymentMethodID != nil && (*api.PaymentMethodID != "" || !state.PaymentMethodID.IsNull()) {
-		state.PaymentMethodID = types.StringPointerValue(api.PaymentMethodID)
+	if api.PaymentMethodID != nil {
+		state.PaymentMethodID = util.StringPointerValue(api.PaymentMethodID)
 	}
-	if api.ShippingAddressID != nil && (*api.ShippingAddressID != "" || !state.ShippingAddressID.IsNull()) {
-		state.ShippingAddressID = types.StringPointerValue(api.ShippingAddressID)
+	if api.ShippingAddressID != nil {
+		state.ShippingAddressID = util.StringPointerValue(api.ShippingAddressID)
 	}
-	if api.VatID != nil && (*api.VatID != "" || !state.VatID.IsNull()) {
-		state.VatID = types.StringPointerValue(api.VatID)
+	if api.VatID != nil {
+		state.VatID = util.StringPointerValue(api.VatID)
 	}
 	// Response may not contain ID fields.
 	// In that case, `terraform import` won't be able to set them. Gets values from the ID.

--- a/internal/plugin/service/organization/billinggrouplist/zz_converter.go
+++ b/internal/plugin/service/organization/billinggrouplist/zz_converter.go
@@ -78,8 +78,8 @@ func flattenData[R any](ctx context.Context, state *tfModel, rsp *R, modifiers .
 		}
 		state.BillingGroups = vBillingGroups
 	}
-	if api.OrganizationID != nil && (*api.OrganizationID != "" || !state.OrganizationID.IsNull()) {
-		state.OrganizationID = types.StringPointerValue(api.OrganizationID)
+	if api.OrganizationID != nil {
+		state.OrganizationID = util.StringPointerValue(api.OrganizationID)
 	}
 	// Response may not contain ID fields.
 	// In that case, `terraform import` won't be able to set them. Gets values from the ID.
@@ -99,45 +99,45 @@ func flattenData[R any](ctx context.Context, state *tfModel, rsp *R, modifiers .
 func flattenBillingGroups(ctx context.Context, api *apiModelBillingGroups) (*tfModelBillingGroups, diag.Diagnostics) {
 	state := new(tfModelBillingGroups)
 	if api.BillingContactEmails != nil {
-		vBillingContactEmails, diags := types.SetValueFrom(ctx, types.StringType, api.BillingContactEmails)
+		vBillingContactEmails, diags := util.SetValueFrom(ctx, types.StringType, api.BillingContactEmails)
 		if diags.HasError() {
 			return nil, diags
 		}
 		state.BillingContactEmails = vBillingContactEmails
 	}
 	if api.BillingEmails != nil {
-		vBillingEmails, diags := types.SetValueFrom(ctx, types.StringType, api.BillingEmails)
+		vBillingEmails, diags := util.SetValueFrom(ctx, types.StringType, api.BillingEmails)
 		if diags.HasError() {
 			return nil, diags
 		}
 		state.BillingEmails = vBillingEmails
 	}
 	if api.BillingAddressID != nil {
-		state.BillingAddressID = types.StringPointerValue(api.BillingAddressID)
+		state.BillingAddressID = util.StringPointerValue(api.BillingAddressID)
 	}
 	if api.BillingGroupID != nil {
-		state.BillingGroupID = types.StringPointerValue(api.BillingGroupID)
+		state.BillingGroupID = util.StringPointerValue(api.BillingGroupID)
 	}
 	if api.BillingGroupName != nil {
-		state.BillingGroupName = types.StringPointerValue(api.BillingGroupName)
+		state.BillingGroupName = util.StringPointerValue(api.BillingGroupName)
 	}
 	if api.Currency != nil {
-		state.Currency = types.StringPointerValue(api.Currency)
+		state.Currency = util.StringPointerValue(api.Currency)
 	}
 	if api.CustomInvoiceText != nil {
-		state.CustomInvoiceText = types.StringPointerValue(api.CustomInvoiceText)
+		state.CustomInvoiceText = util.StringPointerValue(api.CustomInvoiceText)
 	}
 	if api.OrganizationID != nil {
-		state.OrganizationID = types.StringPointerValue(api.OrganizationID)
+		state.OrganizationID = util.StringPointerValue(api.OrganizationID)
 	}
 	if api.PaymentMethodID != nil {
-		state.PaymentMethodID = types.StringPointerValue(api.PaymentMethodID)
+		state.PaymentMethodID = util.StringPointerValue(api.PaymentMethodID)
 	}
 	if api.ShippingAddressID != nil {
-		state.ShippingAddressID = types.StringPointerValue(api.ShippingAddressID)
+		state.ShippingAddressID = util.StringPointerValue(api.ShippingAddressID)
 	}
 	if api.VatID != nil {
-		state.VatID = types.StringPointerValue(api.VatID)
+		state.VatID = util.StringPointerValue(api.VatID)
 	}
 	return state, nil
 }

--- a/internal/plugin/service/organization/organization/zz_converter.go
+++ b/internal/plugin/service/organization/organization/zz_converter.go
@@ -67,20 +67,20 @@ func flattenData[R any](ctx context.Context, state *tfModel, rsp *R, modifiers .
 		diags.AddError("Remarshal error", fmt.Sprintf("Failed to remarshal Response to dtoModel: %s", err.Error()))
 		return diags
 	}
-	if api.CreateTime != nil && (*api.CreateTime != "" || !state.CreateTime.IsNull()) {
-		state.CreateTime = types.StringPointerValue(api.CreateTime)
+	if api.CreateTime != nil || state.CreateTime.IsUnknown() {
+		state.CreateTime = util.StringPointerValue(api.CreateTime)
 	}
-	if api.ID != nil && (*api.ID != "" || !state.ID.IsNull()) {
-		state.ID = types.StringPointerValue(api.ID)
+	if api.ID != nil || state.ID.IsUnknown() {
+		state.ID = util.StringPointerValue(api.ID)
 	}
-	if api.Name != nil && (*api.Name != "" || !state.Name.IsNull()) {
-		state.Name = types.StringPointerValue(api.Name)
+	if api.Name != nil {
+		state.Name = util.StringPointerValue(api.Name)
 	}
-	if api.TenantID != nil && (*api.TenantID != "" || !state.TenantID.IsNull()) {
-		state.TenantID = types.StringPointerValue(api.TenantID)
+	if api.TenantID != nil || state.TenantID.IsUnknown() {
+		state.TenantID = util.StringPointerValue(api.TenantID)
 	}
-	if api.UpdateTime != nil && (*api.UpdateTime != "" || !state.UpdateTime.IsNull()) {
-		state.UpdateTime = types.StringPointerValue(api.UpdateTime)
+	if api.UpdateTime != nil || state.UpdateTime.IsUnknown() {
+		state.UpdateTime = util.StringPointerValue(api.UpdateTime)
 	}
 	return nil
 }

--- a/internal/plugin/service/organization/permission/permission_test.go
+++ b/internal/plugin/service/organization/permission/permission_test.go
@@ -71,17 +71,17 @@ func TestAccAivenOrganizationPermission_basic(t *testing.T) {
 func testAccOrganizationPermissionResource(name, permission string) string {
 	config := fmt.Sprintf(`
 resource "aiven_organization" "org" {
-  name = "test-org-permissions-%[1]s"
+  name = "test-acc-permissions-%[1]s"
 }
 
 resource "aiven_project" "project" {
   parent_id = aiven_organization.org.id
-  project   = "test-proj-permissions-%[1]s"
+  project   = "test-acc-permissions-%[1]s"
 }
 
 resource "aiven_organization_user_group" "group" {
   organization_id = aiven_organization.org.id
-  name            = "test-group-%[1]s"
+  name            = "test-acc-%[1]s"
   description     = "test group description"
 }
 `, name)
@@ -119,12 +119,12 @@ data "aiven_organization" "org" {
 
 resource "aiven_project" "project" {
   parent_id = data.aiven_organization.org.id
-  project   = "test-proj-%[2]s"
+  project   = "test-acc-%[2]s"
 }
 
 resource "aiven_organization_user_group" "group" {
   organization_id = data.aiven_organization.org.id
-  name            = "test-group-%[2]s"
+  name            = "test-acc-%[2]s"
   description     = "test group description"
 }
 

--- a/internal/plugin/service/organization/permission/zz_converter.go
+++ b/internal/plugin/service/organization/permission/zz_converter.go
@@ -130,14 +130,14 @@ func flattenData[R any](ctx context.Context, state *tfModel, rsp *R, modifiers .
 		}
 		state.Permissions = vPermissions
 	}
-	if api.OrganizationID != nil && (*api.OrganizationID != "" || !state.OrganizationID.IsNull()) {
-		state.OrganizationID = types.StringPointerValue(api.OrganizationID)
+	if api.OrganizationID != nil {
+		state.OrganizationID = util.StringPointerValue(api.OrganizationID)
 	}
-	if api.ResourceID != nil && (*api.ResourceID != "" || !state.ResourceID.IsNull()) {
-		state.ResourceID = types.StringPointerValue(api.ResourceID)
+	if api.ResourceID != nil {
+		state.ResourceID = util.StringPointerValue(api.ResourceID)
 	}
-	if api.ResourceType != nil && (*api.ResourceType != "" || !state.ResourceType.IsNull()) {
-		state.ResourceType = types.StringPointerValue(api.ResourceType)
+	if api.ResourceType != nil {
+		state.ResourceType = util.StringPointerValue(api.ResourceType)
 	}
 	// Response may not contain ID fields.
 	// In that case, `terraform import` won't be able to set them. Gets values from the ID.
@@ -163,23 +163,23 @@ func flattenData[R any](ctx context.Context, state *tfModel, rsp *R, modifiers .
 func flattenPermissions(ctx context.Context, api *apiModelPermissions) (*tfModelPermissions, diag.Diagnostics) {
 	state := new(tfModelPermissions)
 	if api.Permissions != nil {
-		vPermissions, diags := types.SetValueFrom(ctx, types.StringType, api.Permissions)
+		vPermissions, diags := util.SetValueFrom(ctx, types.StringType, api.Permissions)
 		if diags.HasError() {
 			return nil, diags
 		}
 		state.Permissions = vPermissions
 	}
 	if api.CreateTime != nil {
-		state.CreateTime = types.StringPointerValue(api.CreateTime)
+		state.CreateTime = util.StringPointerValue(api.CreateTime)
 	}
 	if api.PrincipalID != nil {
-		state.PrincipalID = types.StringPointerValue(api.PrincipalID)
+		state.PrincipalID = util.StringPointerValue(api.PrincipalID)
 	}
 	if api.PrincipalType != nil {
-		state.PrincipalType = types.StringPointerValue(api.PrincipalType)
+		state.PrincipalType = util.StringPointerValue(api.PrincipalType)
 	}
 	if api.UpdateTime != nil {
-		state.UpdateTime = types.StringPointerValue(api.UpdateTime)
+		state.UpdateTime = util.StringPointerValue(api.UpdateTime)
 	}
 	return state, nil
 }

--- a/internal/plugin/service/organization/project/zz_converter.go
+++ b/internal/plugin/service/organization/project/zz_converter.go
@@ -139,30 +139,30 @@ func flattenData[R any](ctx context.Context, state *tfModel, rsp *R, modifiers .
 		}
 		state.Tag = vTag
 	}
-	if api.TechnicalEmails != nil && (len(*api.TechnicalEmails) > 0 || !state.TechnicalEmails.IsNull()) {
-		vTechnicalEmails, diags := types.SetValueFrom(ctx, types.StringType, api.TechnicalEmails)
+	if api.TechnicalEmails != nil {
+		vTechnicalEmails, diags := util.SetValueFrom(ctx, types.StringType, api.TechnicalEmails)
 		if diags.HasError() {
 			return diags
 		}
 		state.TechnicalEmails = vTechnicalEmails
 	}
-	if api.BasePort != nil {
+	if api.BasePort != nil || state.BasePort.IsUnknown() {
 		state.BasePort = types.Int64PointerValue(api.BasePort)
 	}
-	if api.BillingGroupID != nil && (*api.BillingGroupID != "" || !state.BillingGroupID.IsNull()) {
-		state.BillingGroupID = types.StringPointerValue(api.BillingGroupID)
+	if api.BillingGroupID != nil {
+		state.BillingGroupID = util.StringPointerValue(api.BillingGroupID)
 	}
-	if api.CaCert != nil && (*api.CaCert != "" || !state.CaCert.IsNull()) {
-		state.CaCert = types.StringPointerValue(api.CaCert)
+	if api.CaCert != nil || state.CaCert.IsUnknown() {
+		state.CaCert = util.StringPointerValue(api.CaCert)
 	}
-	if api.OrganizationID != nil && (*api.OrganizationID != "" || !state.OrganizationID.IsNull()) {
-		state.OrganizationID = types.StringPointerValue(api.OrganizationID)
+	if api.OrganizationID != nil {
+		state.OrganizationID = util.StringPointerValue(api.OrganizationID)
 	}
-	if api.ParentID != nil && (*api.ParentID != "" || !state.ParentID.IsNull()) {
-		state.ParentID = types.StringPointerValue(api.ParentID)
+	if api.ParentID != nil {
+		state.ParentID = util.StringPointerValue(api.ParentID)
 	}
-	if api.ProjectID != nil && (*api.ProjectID != "" || !state.ProjectID.IsNull()) {
-		state.ProjectID = types.StringPointerValue(api.ProjectID)
+	if api.ProjectID != nil {
+		state.ProjectID = util.StringPointerValue(api.ProjectID)
 	}
 	// Response may not contain ID fields.
 	// In that case, `terraform import` won't be able to set them. Gets values from the ID.
@@ -185,10 +185,10 @@ func flattenData[R any](ctx context.Context, state *tfModel, rsp *R, modifiers .
 func flattenTag(ctx context.Context, api *apiModelTag) (*tfModelTag, diag.Diagnostics) {
 	state := new(tfModelTag)
 	if api.Key != nil {
-		state.Key = types.StringPointerValue(api.Key)
+		state.Key = util.StringPointerValue(api.Key)
 	}
 	if api.Value != nil {
-		state.Value = types.StringPointerValue(api.Value)
+		state.Value = util.StringPointerValue(api.Value)
 	}
 	return state, nil
 }

--- a/internal/plugin/service/plan/zz_converter.go
+++ b/internal/plugin/service/plan/zz_converter.go
@@ -95,40 +95,40 @@ func flattenData[R any](ctx context.Context, state *tfModel, rsp *R, modifiers .
 		}
 		state.BackupConfig = vBackupConfig
 	}
-	if api.BasePriceUsd != nil && (*api.BasePriceUsd != "" || !state.BasePriceUsd.IsNull()) {
-		state.BasePriceUsd = types.StringPointerValue(api.BasePriceUsd)
+	if api.BasePriceUsd != nil || state.BasePriceUsd.IsUnknown() {
+		state.BasePriceUsd = util.StringPointerValue(api.BasePriceUsd)
 	}
-	if api.CloudName != nil && (*api.CloudName != "" || !state.CloudName.IsNull()) {
-		state.CloudName = types.StringPointerValue(api.CloudName)
+	if api.CloudName != nil {
+		state.CloudName = util.StringPointerValue(api.CloudName)
 	}
-	if api.DiskSpaceCapMb != nil {
+	if api.DiskSpaceCapMb != nil || state.DiskSpaceCapMb.IsUnknown() {
 		state.DiskSpaceCapMb = types.Int64PointerValue(api.DiskSpaceCapMb)
 	}
-	if api.DiskSpaceMb != nil {
+	if api.DiskSpaceMb != nil || state.DiskSpaceMb.IsUnknown() {
 		state.DiskSpaceMb = types.Int64PointerValue(api.DiskSpaceMb)
 	}
-	if api.DiskSpaceStepMb != nil {
+	if api.DiskSpaceStepMb != nil || state.DiskSpaceStepMb.IsUnknown() {
 		state.DiskSpaceStepMb = types.Int64PointerValue(api.DiskSpaceStepMb)
 	}
-	if api.MaxMemoryPercent != nil {
+	if api.MaxMemoryPercent != nil || state.MaxMemoryPercent.IsUnknown() {
 		state.MaxMemoryPercent = types.Int64PointerValue(api.MaxMemoryPercent)
 	}
-	if api.NodeCount != nil {
+	if api.NodeCount != nil || state.NodeCount.IsUnknown() {
 		state.NodeCount = types.Int64PointerValue(api.NodeCount)
 	}
-	if api.ObjectStorageGbPriceUsd != nil && (*api.ObjectStorageGbPriceUsd != "" || !state.ObjectStorageGbPriceUsd.IsNull()) {
-		state.ObjectStorageGbPriceUsd = types.StringPointerValue(api.ObjectStorageGbPriceUsd)
+	if api.ObjectStorageGbPriceUsd != nil || state.ObjectStorageGbPriceUsd.IsUnknown() {
+		state.ObjectStorageGbPriceUsd = util.StringPointerValue(api.ObjectStorageGbPriceUsd)
 	}
-	if api.Project != nil && (*api.Project != "" || !state.Project.IsNull()) {
-		state.Project = types.StringPointerValue(api.Project)
+	if api.Project != nil {
+		state.Project = util.StringPointerValue(api.Project)
 	}
-	if api.ServicePlan != nil && (*api.ServicePlan != "" || !state.ServicePlan.IsNull()) {
-		state.ServicePlan = types.StringPointerValue(api.ServicePlan)
+	if api.ServicePlan != nil {
+		state.ServicePlan = util.StringPointerValue(api.ServicePlan)
 	}
-	if api.ServiceType != nil && (*api.ServiceType != "" || !state.ServiceType.IsNull()) {
-		state.ServiceType = types.StringPointerValue(api.ServiceType)
+	if api.ServiceType != nil || state.ServiceType.IsUnknown() {
+		state.ServiceType = util.StringPointerValue(api.ServiceType)
 	}
-	if api.ShardCount != nil {
+	if api.ShardCount != nil || state.ShardCount.IsUnknown() {
 		state.ShardCount = types.Int64PointerValue(api.ShardCount)
 	}
 	// Response may not contain ID fields.
@@ -176,7 +176,7 @@ func flattenBackupConfig(ctx context.Context, api *apiModelBackupConfig) (*tfMod
 		state.MaxCount = types.Int64PointerValue(api.MaxCount)
 	}
 	if api.RecoveryMode != nil {
-		state.RecoveryMode = types.StringPointerValue(api.RecoveryMode)
+		state.RecoveryMode = util.StringPointerValue(api.RecoveryMode)
 	}
 	return state, nil
 }

--- a/internal/plugin/service/planlist/zz_converter.go
+++ b/internal/plugin/service/planlist/zz_converter.go
@@ -63,11 +63,11 @@ func flattenData[R any](ctx context.Context, state *tfModel, rsp *R, modifiers .
 		}
 		state.ServicePlans = vServicePlans
 	}
-	if api.Project != nil && (*api.Project != "" || !state.Project.IsNull()) {
-		state.Project = types.StringPointerValue(api.Project)
+	if api.Project != nil {
+		state.Project = util.StringPointerValue(api.Project)
 	}
-	if api.ServiceType != nil && (*api.ServiceType != "" || !state.ServiceType.IsNull()) {
-		state.ServiceType = types.StringPointerValue(api.ServiceType)
+	if api.ServiceType != nil {
+		state.ServiceType = util.StringPointerValue(api.ServiceType)
 	}
 	// Response may not contain ID fields.
 	// In that case, `terraform import` won't be able to set them. Gets values from the ID.
@@ -90,14 +90,14 @@ func flattenData[R any](ctx context.Context, state *tfModel, rsp *R, modifiers .
 func flattenServicePlans(ctx context.Context, api *apiModelServicePlans) (*tfModelServicePlans, diag.Diagnostics) {
 	state := new(tfModelServicePlans)
 	if api.CloudNames != nil {
-		vCloudNames, diags := types.ListValueFrom(ctx, types.StringType, api.CloudNames)
+		vCloudNames, diags := util.ListValueFrom(ctx, types.StringType, api.CloudNames)
 		if diags.HasError() {
 			return nil, diags
 		}
 		state.CloudNames = vCloudNames
 	}
 	if api.ServicePlan != nil {
-		state.ServicePlan = types.StringPointerValue(api.ServicePlan)
+		state.ServicePlan = util.StringPointerValue(api.ServicePlan)
 	}
 	return state, nil
 }


### PR DESCRIPTION
Resolves NEX-2036.

Terraform requires all computed fields to have a value. Either "a real one" or at least "nil".

- When there is an API value uses it
- If computed field remains "unknown" sets "nil"
- Treats empty string, map and array as "nil" to avoid state drift (see `util` package changes)
- Removes hardcoded "computed" values in `application_user_token`, which are now handled by this very feature
- Fixes `aiven_organization_application_user_token`: prevents `full_token` from being lost after running `terraform refresh` (also fixed by this feature)
- Fixes "permission" test: uses `test-acc` prefix for resource names

