### PR TITLE
chore(ci): remove redundant slack statuses from CI

### DIFF
--- a/.github/workflows/acceptance-tests.yml
+++ b/.github/workflows/acceptance-tests.yml
@@ -63,7 +63,11 @@ jobs:
 
   notify-slack-success:
     needs: [call-tests, gatekeeper]
-    if: success() && needs.gatekeeper.outputs.should_run == 'true'
+    if: |
+      always() &&
+      success() &&
+      needs.gatekeeper.outputs.should_run == 'true' &&
+      (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch')
     uses: ./.github/workflows/slack-notify.yml
     with:
       status: 'success'
@@ -74,7 +78,11 @@ jobs:
 
   notify-slack-failure:
     needs: [call-tests, gatekeeper]
-    if: failure() && needs.gatekeeper.outputs.should_run == 'true'
+    if: |
+      always() &&
+      failure() &&
+      needs.gatekeeper.outputs.should_run == 'true' &&
+      (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch')
     uses: ./.github/workflows/slack-notify.yml
     with:
       status: 'failure'


### PR DESCRIPTION
<!-- All contributors, please complete these sections, including maintainers. -->

## About this change—what it does

<!-- Provide a small sentence that summarizes the change. -->

<!-- Provide the issue number below, if it exists. -->
Contributes to: NEX-2039
- remove redundant slack notification statuses from PR checks

## Why this way

<!-- Provide a small explanation on why this is the approach you took for solving this problem. -->
