### PR TITLE
chore(ci): added issue comment workflow

### DIFF
--- a/.github/workflows/pr-test-command.yml
+++ b/.github/workflows/pr-test-command.yml
@@ -1,0 +1,121 @@
+name: PR Test Command
+
+on:
+  issue_comment:
+    types: [created]
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+
+jobs:
+  parse-and-discover:
+    name: Parse Command and Discover Tests
+    runs-on: ubuntu-latest
+    if: |
+      github.event.issue.pull_request &&
+      startsWith(github.event.comment.body, '/test')
+    outputs:
+      should_run: ${{ steps.check_permission.outputs.should_run }}
+      pr_sha: ${{ steps.parse.outputs.pr_sha }}
+      filter_services: ${{ steps.parse.outputs.filter_services }}
+      comment_id: ${{ steps.post_comment.outputs.comment_id }}
+    steps:
+      - name: Check user permissions
+        id: check_permission
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const association = context.payload.comment.author_association;
+            const allowedAssociations = ['OWNER', 'MEMBER', 'COLLABORATOR'];
+            const shouldRun = allowedAssociations.includes(association);
+
+            core.setOutput('should_run', shouldRun);
+
+      - name: Get PR details and parse command
+        id: parse
+        if: steps.check_permission.outputs.should_run == 'true'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const pr = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.issue.number
+            });
+
+            // Parse command
+            const comment = context.payload.comment.body;
+            const commandLine = comment.split('\n')[0].trim();
+
+            let serviceFilter = '';
+            if (commandLine.startsWith('/test ')) {
+              serviceFilter = commandLine.substring(6).trim();
+            } else if (commandLine === '/test') {
+              serviceFilter = ''; // Run all tests
+            }
+
+            // Convert spaces to commas for the Go program
+            const filterFormatted = serviceFilter.replace(/\s+/g, ',');
+
+            console.log(`Service filter: ${serviceFilter || 'all tests'}`);
+
+            core.setOutput('pr_sha', pr.data.head.sha);
+            core.setOutput('service_filter_display', serviceFilter);
+            core.setOutput('filter_services', filterFormatted);
+
+      - name: Post initial comment
+        id: post_comment
+        if: steps.check_permission.outputs.should_run == 'true'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const serviceFilter = '${{ steps.parse.outputs.service_filter_display }}';
+            const filterInfo = !serviceFilter
+              ? 'All acceptance tests'
+              : `Services: \`${serviceFilter}\``;
+
+            const comment = await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body: `## ⏳ Running Acceptance Tests\n\n**Triggered by:** @${context.actor}\n**Filter:** ${filterInfo}\n\n🔗 [View Progress](${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId})`
+            });
+
+            core.setOutput('comment_id', comment.data.id);
+
+  run-tests:
+    name: Run Acceptance Tests
+    needs: parse-and-discover
+    if: needs.parse-and-discover.outputs.should_run == 'true'
+    uses: ./.github/workflows/reusable-acceptance-tests.yml
+    with:
+      ref: ${{ needs.parse-and-discover.outputs.pr_sha }}
+      filter_services: ${{ needs.parse-and-discover.outputs.filter_services }}
+    secrets: inherit
+
+  update-comment:
+    name: Update PR Comment
+    runs-on: ubuntu-latest
+    if: always() && needs.parse-and-discover.outputs.comment_id != ''
+    needs: [parse-and-discover, run-tests]
+    permissions:
+      pull-requests: write
+      issues: write
+    steps:
+      - name: Update comment with results
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const testResult = '${{ needs.run-tests.result }}';
+            const success = testResult === 'success';
+            const emoji = success ? '✅' : '❌';
+            const status = success ? 'Passed' : 'Failed';
+
+            await github.rest.issues.updateComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              comment_id: ${{ needs.parse-and-discover.outputs.comment_id }},
+              body: `## ${emoji} Acceptance Tests ${status}\n\n**Result:** ${testResult}\n\n🔗 [View Details](${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId})`
+            });

--- a/.github/workflows/reusable-acceptance-tests.yml
+++ b/.github/workflows/reusable-acceptance-tests.yml
@@ -7,6 +7,11 @@ on:
         description: 'The git ref (branch, tag, or commit) to run tests against'
         required: true
         type: string
+      filter_services:
+        description: 'Optional comma-separated service names to filter tests (e.g., "kafka,pg,vpc"). Empty = all tests.'
+        required: false
+        type: string
+        default: ""
     secrets:
       AIVEN_TOKEN:
         required: true
@@ -67,7 +72,7 @@ jobs:
       - id: get_matrix
         name: Discover test matrix
         run: |
-          task ci:discover-test-matrix  SLOW_TESTS_CSV=sdk-service-vpc,sdk-service-kafka,sdk-service-kafkatopic | jq -cr '
+          task ci:discover-test-matrix SLOW_TESTS_CSV=sdk-service-vpc,sdk-service-kafka,sdk-service-kafkatopic FILTER_SERVICES="${{ inputs.filter_services }}" | jq -cr '
             # The input from the pipe is the correct JSON: {"slow":[...], "normal":[...]}
             {
               "matrix": tostring,

--- a/TaskInternal.yml
+++ b/TaskInternal.yml
@@ -245,11 +245,12 @@ tasks:
       - find ./examples -type f \( -name '*.tfstate' -o -name '*.tfstate.backup' \) -delete
 
   discover-test-matrix:
-    desc: "Finds Go tests, partitions them into normal/slow via SLOW_TESTS_CSV, and generates a JSON matrix for CI. Usage: task ci:discover-test-matrix SLOW_TESTS_CSV=slow_test1,slow_test2"
+    desc: "Finds Go tests, partitions them into normal/slow via SLOW_TESTS_CSV, optionally filters by FILTER_SERVICES, and generates a JSON matrix for CI. Usage: task ci:discover-test-matrix SLOW_TESTS_CSV=slow_test1,slow_test2 FILTER_SERVICES='kafka,pg'"
     vars:
       SLOW_TESTS_CSV: '{{.SLOW_TESTS_CSV}}'
+      FILTER_SERVICES: '{{.FILTER_SERVICES | default ""}}'
     cmds:
-        - "{{.GO_CMD}} run ./tools/main.go tests matrix --slow-tests-csv {{.SLOW_TESTS_CSV}}"
+        - "{{.GO_CMD}} run ./tools/main.go tests matrix --slow-tests-csv {{.SLOW_TESTS_CSV}}{{if .FILTER_SERVICES}} --filter {{.FILTER_SERVICES}}{{end}}"
     silent: true
 
   verify-version:

--- a/tools/cmd/tests.go
+++ b/tools/cmd/tests.go
@@ -19,6 +19,7 @@ var discoverTestMatrixCmd = &cobra.Command{
 	Long: `This command scans the './internal' directory for Go test files (*_test.go),
 identifies the unique directories containing them, and partitions them into two groups: 'normal' and 'slow'.
 The partitioning is based on a comma-separated list of test names provided via the --slow-tests-csv flag.
+Optionally filter tests by service names using --filter flag.
 The output is a JSON object suitable for use as a job matrix in GitHub Actions.`,
 	RunE: func(cmd *cobra.Command, _ []string) error {
 		slowTestsCSV, err := cmd.Flags().GetString("slow-tests-csv")
@@ -26,8 +27,13 @@ The output is a JSON object suitable for use as a job matrix in GitHub Actions.`
 			return fmt.Errorf("could not retrieve slow-tests-csv flag: %w", err)
 		}
 
+		filterCSV, err := cmd.Flags().GetString("filter")
+		if err != nil {
+			return fmt.Errorf("could not retrieve filter flag: %w", err)
+		}
+
 		// the root directory to scan for tests is hardcoded to "./internal"
-		matrix, err := test.GenerateMatrix("./internal", slowTestsCSV)
+		matrix, err := test.GenerateMatrix("./internal", slowTestsCSV, filterCSV)
 		if err != nil {
 			return fmt.Errorf("failed to generate test matrix: %w", err)
 		}
@@ -47,4 +53,5 @@ The output is a JSON object suitable for use as a job matrix in GitHub Actions.`
 func init() {
 	testsCmd.AddCommand(discoverTestMatrixCmd)
 	discoverTestMatrixCmd.Flags().String("slow-tests-csv", "", "A comma-separated list of test names to be considered slow.")
+	discoverTestMatrixCmd.Flags().String("filter", "", "Comma or space-separated list of service names to filter tests (e.g., 'kafka,pg,vpc' or 'kafka pg vpc').")
 }


### PR DESCRIPTION
<!-- All contributors, please complete these sections, including maintainers. -->

## About this change—what it does

<!-- Provide a small sentence that summarizes the change. -->

<!-- Provide the issue number below, if it exists. -->
Resolves: NEX-2039
- added GitHub workflow for triggering acceptance tests via PR comments
- added fuzzy matching with typo correction for service names using Levenshtein distance

**Examples:**
Comment on this PR to run acceptance tests:

- Run all tests: `/test`
- Run specific service(s): `/test kafka`, `/test postgres clickhouse` etc.
  
1. Auto-corrects typos (e.g., `kafk` → `kafka`)
2. Prefix matching: `kafka` runs all kafka-related tests

<!-- Provide a small explanation on why this is the approach you took for solving this problem. -->
