### PR TITLE
chore(service_user): replaced old client with new

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ nav_order: 1
 
 - Add `aiven_mysql` field `mysql_user_config.migration.dump_tool` (enum): Experimental! Tool to use for database dump
   and restore during migration
+- Change service user resources and data sources: migrate to use generated client: `aiven_cassandra_user`, `aiven_influxdb_user`, `aiven_kafka_user`, `aiven_m3db_user`, `aiven_mysql_user`, `aiven_opensearch_user`, `aiven_pg_user`, `aiven_redis_user`
 
 ## [4.47.0] - 2025-11-12
 

--- a/internal/schemautil/schemautil.go
+++ b/internal/schemautil/schemautil.go
@@ -10,7 +10,6 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/aiven/aiven-go-client/v2"
 	"github.com/aiven/go-client-codegen/handler/service"
 	"github.com/docker/go-units"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -286,42 +285,6 @@ func FlattenToString[T any](a []T) []string {
 }
 
 func CopyServiceUserPropertiesFromAPIResponseToTerraform(
-	d ResourceData,
-	user *aiven.ServiceUser,
-	projectName string,
-	serviceName string,
-) error {
-	if err := d.Set("project", projectName); err != nil {
-		return err
-	}
-	if err := d.Set("service_name", serviceName); err != nil {
-		return err
-	}
-	if err := d.Set("username", user.Username); err != nil {
-		return err
-	}
-	if err := d.Set("password", user.Password); err != nil {
-		return err
-	}
-	if err := d.Set("type", user.Type); err != nil {
-		return err
-	}
-
-	if len(user.AccessCert) > 0 {
-		if err := d.Set("access_cert", user.AccessCert); err != nil {
-			return err
-		}
-	}
-	if len(user.AccessKey) > 0 {
-		if err := d.Set("access_key", user.AccessKey); err != nil {
-			return err
-		}
-	}
-
-	return nil
-}
-
-func CopyServiceUserGenPropertiesFromAPIResponseToTerraform(
 	d ResourceData,
 	user *service.ServiceUserGetOut,
 	projectName string,

--- a/internal/sdkprovider/service/cassandra/cassandra_user.go
+++ b/internal/sdkprovider/service/cassandra/cassandra_user.go
@@ -3,6 +3,7 @@ package cassandra
 import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
+	"github.com/aiven/terraform-provider-aiven/internal/common"
 	"github.com/aiven/terraform-provider-aiven/internal/schemautil"
 	"github.com/aiven/terraform-provider-aiven/internal/schemautil/userconfig"
 )
@@ -51,9 +52,9 @@ func ResourceCassandraUser() *schema.Resource {
 	return &schema.Resource{
 		Description:        "Creates and manages an Aiven for Apache Cassandra® service user.",
 		DeprecationMessage: deprecationMessage,
-		CreateContext:      schemautil.ResourceServiceUserCreate,
-		UpdateContext:      schemautil.ResourceServiceUserUpdate,
-		ReadContext:        schemautil.ResourceServiceUserRead,
+		CreateContext:      common.WithGenClientDiag(schemautil.ResourceServiceUserCreate),
+		UpdateContext:      common.WithGenClientDiag(schemautil.ResourceServiceUserUpdate),
+		ReadContext:        common.WithGenClientDiag(schemautil.ResourceServiceUserRead),
 		DeleteContext:      schemautil.WithResourceData(schemautil.ResourceServiceUserDelete),
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,

--- a/internal/sdkprovider/service/cassandra/cassandra_user_data_source.go
+++ b/internal/sdkprovider/service/cassandra/cassandra_user_data_source.go
@@ -3,12 +3,13 @@ package cassandra
 import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
+	"github.com/aiven/terraform-provider-aiven/internal/common"
 	"github.com/aiven/terraform-provider-aiven/internal/schemautil"
 )
 
 func DatasourceCassandraUser() *schema.Resource {
 	return &schema.Resource{
-		ReadContext: schemautil.DatasourceServiceUserRead,
+		ReadContext: common.WithGenClientDiag(schemautil.DatasourceServiceUserRead),
 		Description: "Gets information about an Aiven for Apache Cassandra® service user.",
 		Schema: schemautil.ResourceSchemaAsDatasourceSchema(aivenCassandraUserSchema,
 			"project", "service_name", "username"),

--- a/internal/sdkprovider/service/clickhouse/clickhouse_user_backward_compat_test.go
+++ b/internal/sdkprovider/service/clickhouse/clickhouse_user_backward_compat_test.go
@@ -1,0 +1,67 @@
+//go:build backwardcompat
+
+package clickhouse_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+
+	acc "github.com/aiven/terraform-provider-aiven/internal/acctest"
+)
+
+// TestAccAivenClickhouseUserBackwardCompatibility verifies that the ClickHouse user resource
+// maintains backward compatibility with previous provider versions.
+func TestAccAivenClickhouseUserBackwardCompatibility(t *testing.T) {
+	var (
+		projectName = acc.ProjectName()
+		rName       = acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
+		serviceName = fmt.Sprintf("test-ch-bc-%s", rName)
+		userName    = fmt.Sprintf("user-bc-%s", rName)
+	)
+
+	config := fmt.Sprintf(`
+resource "aiven_clickhouse" "ch" {
+  project                 = %[1]q
+  cloud_name              = "google-europe-west1"
+  plan                    = "startup-16"
+  service_name            = %[2]q
+  maintenance_window_dow  = "monday"
+  maintenance_window_time = "10:00:00"
+}
+
+resource "aiven_clickhouse_user" "test" {
+  project      = aiven_clickhouse.ch.project
+  service_name = aiven_clickhouse.ch.service_name
+  username     = %[3]q
+}
+
+data "aiven_clickhouse_user" "test" {
+  project      = aiven_clickhouse_user.test.project
+  service_name = aiven_clickhouse_user.test.service_name
+  username     = aiven_clickhouse_user.test.username
+}`, projectName, serviceName, userName)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() { acc.TestAccPreCheck(t) },
+		Steps: acc.BackwardCompatibilitySteps(t, acc.BackwardCompatConfig{
+			TFConfig:           config,
+			OldProviderVersion: "4.47.0",
+			Checks: resource.ComposeTestCheckFunc(
+				resource.TestCheckResourceAttr("aiven_clickhouse.ch", "state", "RUNNING"),
+				resource.TestCheckResourceAttrSet("aiven_clickhouse.ch", "id"),
+
+				resource.TestCheckResourceAttrSet("aiven_clickhouse_user.test", "id"),
+				resource.TestCheckResourceAttr("aiven_clickhouse_user.test", "username", userName),
+				resource.TestCheckResourceAttrSet("aiven_clickhouse_user.test", "password"),
+				resource.TestCheckResourceAttrSet("aiven_clickhouse_user.test", "uuid"),
+				resource.TestCheckResourceAttrSet("aiven_clickhouse_user.test", "required"),
+
+				resource.TestCheckResourceAttr("data.aiven_clickhouse_user.test", "username", userName),
+				resource.TestCheckResourceAttrSet("data.aiven_clickhouse_user.test", "uuid"),
+			),
+		}),
+	})
+}

--- a/internal/sdkprovider/service/influxdb/influxdb_user.go
+++ b/internal/sdkprovider/service/influxdb/influxdb_user.go
@@ -3,6 +3,7 @@ package influxdb
 import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
+	"github.com/aiven/terraform-provider-aiven/internal/common"
 	"github.com/aiven/terraform-provider-aiven/internal/schemautil"
 	"github.com/aiven/terraform-provider-aiven/internal/schemautil/userconfig"
 )
@@ -51,9 +52,9 @@ func ResourceInfluxDBUser() *schema.Resource {
 	return &schema.Resource{
 		DeprecationMessage: deprecationMessage,
 		Description:        "The InfluxDB User resource allows the creation and management of Aiven InfluxDB Users.",
-		CreateContext:      schemautil.ResourceServiceUserCreate,
-		UpdateContext:      schemautil.ResourceServiceUserUpdate,
-		ReadContext:        schemautil.ResourceServiceUserRead,
+		CreateContext:      common.WithGenClientDiag(schemautil.ResourceServiceUserCreate),
+		UpdateContext:      common.WithGenClientDiag(schemautil.ResourceServiceUserUpdate),
+		ReadContext:        common.WithGenClientDiag(schemautil.ResourceServiceUserRead),
 		DeleteContext:      schemautil.WithResourceData(schemautil.ResourceServiceUserDelete),
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,

--- a/internal/sdkprovider/service/influxdb/influxdb_user_data_source.go
+++ b/internal/sdkprovider/service/influxdb/influxdb_user_data_source.go
@@ -3,13 +3,14 @@ package influxdb
 import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
+	"github.com/aiven/terraform-provider-aiven/internal/common"
 	"github.com/aiven/terraform-provider-aiven/internal/schemautil"
 )
 
 func DatasourceInfluxDBUser() *schema.Resource {
 	return &schema.Resource{
 		DeprecationMessage: deprecationMessage,
-		ReadContext:        schemautil.DatasourceServiceUserRead,
+		ReadContext:        common.WithGenClientDiag(schemautil.DatasourceServiceUserRead),
 		Description:        "The InfluxDB User data source provides information about the existing Aiven InfluxDB User.",
 		Schema: schemautil.ResourceSchemaAsDatasourceSchema(aivenInfluxDBUserSchema,
 			"project", "service_name", "username"),

--- a/internal/sdkprovider/service/kafka/kafka_user.go
+++ b/internal/sdkprovider/service/kafka/kafka_user.go
@@ -3,6 +3,7 @@ package kafka
 import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
+	"github.com/aiven/terraform-provider-aiven/internal/common"
 	"github.com/aiven/terraform-provider-aiven/internal/schemautil"
 	"github.com/aiven/terraform-provider-aiven/internal/schemautil/userconfig"
 )
@@ -50,9 +51,9 @@ var aivenKafkaUserSchema = map[string]*schema.Schema{
 func ResourceKafkaUser() *schema.Resource {
 	return &schema.Resource{
 		Description:   "Creates and manages an Aiven for Apache Kafka® service user.",
-		CreateContext: schemautil.ResourceServiceUserCreate,
-		UpdateContext: schemautil.ResourceServiceUserUpdate,
-		ReadContext:   schemautil.ResourceServiceUserRead,
+		CreateContext: common.WithGenClientDiag(schemautil.ResourceServiceUserCreate),
+		UpdateContext: common.WithGenClientDiag(schemautil.ResourceServiceUserUpdate),
+		ReadContext:   common.WithGenClientDiag(schemautil.ResourceServiceUserRead),
 		DeleteContext: schemautil.WithResourceData(schemautil.ResourceServiceUserDelete),
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,

--- a/internal/sdkprovider/service/kafka/kafka_user_backward_compat_test.go
+++ b/internal/sdkprovider/service/kafka/kafka_user_backward_compat_test.go
@@ -1,0 +1,68 @@
+//go:build backwardcompat
+
+package kafka_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+
+	acc "github.com/aiven/terraform-provider-aiven/internal/acctest"
+)
+
+// TestAccAivenKafkaUserBackwardCompatibility verifies that the Kafka user resource
+// maintains backward compatibility with previous provider versions.
+func TestAccAivenKafkaUserBackwardCompatibility(t *testing.T) {
+	var (
+		projectName = acc.ProjectName()
+		rName       = acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
+		serviceName = fmt.Sprintf("test-kafka-bc-%s", rName)
+		userName    = fmt.Sprintf("user-bc-%s", rName)
+	)
+
+	config := fmt.Sprintf(`
+resource "aiven_kafka" "kafka" {
+  project                 = %[1]q
+  cloud_name              = "google-europe-west1"
+  plan                    = "startup-4"
+  service_name            = %[2]q
+  maintenance_window_dow  = "monday"
+  maintenance_window_time = "10:00:00"
+}
+
+resource "aiven_kafka_user" "test" {
+  project      = aiven_kafka.kafka.project
+  service_name = aiven_kafka.kafka.service_name
+  username     = %[3]q
+}
+
+data "aiven_kafka_user" "test" {
+  project      = aiven_kafka_user.test.project
+  service_name = aiven_kafka_user.test.service_name
+  username     = aiven_kafka_user.test.username
+}`, projectName, serviceName, userName)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() { acc.TestAccPreCheck(t) },
+		Steps: acc.BackwardCompatibilitySteps(t, acc.BackwardCompatConfig{
+			TFConfig:           config,
+			OldProviderVersion: "4.47.0",
+			Checks: resource.ComposeTestCheckFunc(
+				resource.TestCheckResourceAttr("aiven_kafka.kafka", "state", "RUNNING"),
+				resource.TestCheckResourceAttrSet("aiven_kafka.kafka", "id"),
+
+				resource.TestCheckResourceAttrSet("aiven_kafka_user.test", "id"),
+				resource.TestCheckResourceAttr("aiven_kafka_user.test", "username", userName),
+				resource.TestCheckResourceAttrSet("aiven_kafka_user.test", "password"),
+				resource.TestCheckResourceAttr("aiven_kafka_user.test", "type", "normal"),
+				resource.TestCheckResourceAttrSet("aiven_kafka_user.test", "access_cert"),
+				resource.TestCheckResourceAttrSet("aiven_kafka_user.test", "access_key"),
+
+				resource.TestCheckResourceAttr("data.aiven_kafka_user.test", "username", userName),
+				resource.TestCheckResourceAttrSet("data.aiven_kafka_user.test", "password"),
+			),
+		}),
+	})
+}

--- a/internal/sdkprovider/service/kafka/kafka_user_data_source.go
+++ b/internal/sdkprovider/service/kafka/kafka_user_data_source.go
@@ -3,12 +3,13 @@ package kafka
 import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
+	"github.com/aiven/terraform-provider-aiven/internal/common"
 	"github.com/aiven/terraform-provider-aiven/internal/schemautil"
 )
 
 func DatasourceKafkaUser() *schema.Resource {
 	return &schema.Resource{
-		ReadContext: schemautil.DatasourceServiceUserRead,
+		ReadContext: common.WithGenClientDiag(schemautil.DatasourceServiceUserRead),
 		Description: "Gets information about an Aiven for Apache Kafka® service user.",
 		Schema: schemautil.ResourceSchemaAsDatasourceSchema(aivenKafkaUserSchema,
 			"project", "service_name", "username"),

--- a/internal/sdkprovider/service/kafka/kafka_user_test.go
+++ b/internal/sdkprovider/service/kafka/kafka_user_test.go
@@ -2,11 +2,10 @@ package kafka_test
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"testing"
 
-	"github.com/aiven/aiven-go-client/v2"
+	avngen "github.com/aiven/go-client-codegen"
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
@@ -25,7 +24,7 @@ func TestAccAivenKafkaUser_basic(t *testing.T) {
 		CheckDestroy:             testAccCheckAivenKafkaUserResourceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccKafkaUserResource(rName),
+				Config: testAccKafkaUserResource(rName, "Test$1234"),
 				Check: resource.ComposeTestCheckFunc(
 					schemautil.TestAccCheckAivenServiceUserAttributes("data.aiven_kafka_user.user"),
 					resource.TestCheckResourceAttr(resourceName, "service_name", fmt.Sprintf("test-acc-sr-%s", rName)),
@@ -34,12 +33,25 @@ func TestAccAivenKafkaUser_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "password", "Test$1234"),
 				),
 			},
+			{
+				Config: testAccKafkaUserResource(rName, "UpdatedP@ss5678"),
+				Check: resource.ComposeTestCheckFunc(
+					schemautil.TestAccCheckAivenServiceUserAttributes("data.aiven_kafka_user.user"),
+					resource.TestCheckResourceAttr(resourceName, "service_name", fmt.Sprintf("test-acc-sr-%s", rName)),
+					resource.TestCheckResourceAttr(resourceName, "project", acc.ProjectName()),
+					resource.TestCheckResourceAttr(resourceName, "username", fmt.Sprintf("user-%s", rName)),
+					resource.TestCheckResourceAttr(resourceName, "password", "UpdatedP@ss5678"),
+				),
+			},
 		},
 	})
 }
 
 func testAccCheckAivenKafkaUserResourceDestroy(s *terraform.State) error {
-	c := acc.GetTestAivenClient()
+	c, err := acc.GetTestGenAivenClient()
+	if err != nil {
+		return fmt.Errorf("error instantiating client: %w", err)
+	}
 
 	ctx := context.Background()
 
@@ -54,23 +66,22 @@ func testAccCheckAivenKafkaUserResourceDestroy(s *terraform.State) error {
 			return err
 		}
 
-		p, err := c.ServiceUsers.Get(ctx, projectName, serviceName, username)
-		if err != nil {
-			var e aiven.Error
-			if errors.As(err, &e) && e.Status != 404 {
-				return err
-			}
+		_, err = c.ServiceUserGet(ctx, projectName, serviceName, username)
+		if err == nil {
+			return fmt.Errorf("kafka user (%s) still exists", rs.Primary.ID)
 		}
 
-		if p != nil {
-			return fmt.Errorf("common user (%s) still exists", rs.Primary.ID)
+		if !avngen.IsNotFound(err) {
+			return fmt.Errorf("error checking if user was destroyed: %w", err)
 		}
+
+		return nil
 	}
 
 	return nil
 }
 
-func testAccKafkaUserResource(name string) string {
+func testAccKafkaUserResource(name, password string) string {
 	return fmt.Sprintf(`
 data "aiven_project" "foo" {
   project = "%s"
@@ -89,12 +100,12 @@ resource "aiven_kafka_user" "foo" {
   service_name = aiven_kafka.bar.service_name
   project      = data.aiven_project.foo.project
   username     = "user-%s"
-  password     = "Test$1234"
+  password     = "%s"
 }
 
 data "aiven_kafka_user" "user" {
   service_name = aiven_kafka_user.foo.service_name
   project      = aiven_kafka_user.foo.project
   username     = aiven_kafka_user.foo.username
-}`, acc.ProjectName(), name, name)
+}`, acc.ProjectName(), name, name, password)
 }

--- a/internal/sdkprovider/service/m3db/m3db_user.go
+++ b/internal/sdkprovider/service/m3db/m3db_user.go
@@ -3,6 +3,7 @@ package m3db
 import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
+	"github.com/aiven/terraform-provider-aiven/internal/common"
 	"github.com/aiven/terraform-provider-aiven/internal/schemautil"
 	"github.com/aiven/terraform-provider-aiven/internal/schemautil/userconfig"
 )
@@ -39,9 +40,9 @@ func ResourceM3DBUser() *schema.Resource {
 	return &schema.Resource{
 		Description:        "Creates and manages an Aiven for M3 service user.",
 		DeprecationMessage: deprecationMessage,
-		CreateContext:      schemautil.ResourceServiceUserCreate,
-		UpdateContext:      schemautil.ResourceServiceUserUpdate,
-		ReadContext:        schemautil.ResourceServiceUserRead,
+		CreateContext:      common.WithGenClientDiag(schemautil.ResourceServiceUserCreate),
+		UpdateContext:      common.WithGenClientDiag(schemautil.ResourceServiceUserUpdate),
+		ReadContext:        common.WithGenClientDiag(schemautil.ResourceServiceUserRead),
 		DeleteContext:      schemautil.WithResourceData(schemautil.ResourceServiceUserDelete),
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,

--- a/internal/sdkprovider/service/m3db/m3db_user_data_source.go
+++ b/internal/sdkprovider/service/m3db/m3db_user_data_source.go
@@ -3,12 +3,13 @@ package m3db
 import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
+	"github.com/aiven/terraform-provider-aiven/internal/common"
 	"github.com/aiven/terraform-provider-aiven/internal/schemautil"
 )
 
 func DatasourceM3DBUser() *schema.Resource {
 	return &schema.Resource{
-		ReadContext: schemautil.DatasourceServiceUserRead,
+		ReadContext: common.WithGenClientDiag(schemautil.DatasourceServiceUserRead),
 		Description: "Gets information about an Aiven for M3DB service user.",
 		Schema: schemautil.ResourceSchemaAsDatasourceSchema(aivenM3DBUserSchema,
 			"project", "service_name", "username"),

--- a/internal/sdkprovider/service/mysql/mysql_user_backward_compat_test.go
+++ b/internal/sdkprovider/service/mysql/mysql_user_backward_compat_test.go
@@ -1,0 +1,66 @@
+//go:build backwardcompat
+
+package mysql_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+
+	acc "github.com/aiven/terraform-provider-aiven/internal/acctest"
+)
+
+// TestAccAivenMySQLUserBackwardCompatibility verifies that the MySQL user resource
+// maintains backward compatibility with previous provider versions.
+func TestAccAivenMySQLUserBackwardCompatibility(t *testing.T) {
+	var (
+		projectName = acc.ProjectName()
+		rName       = acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
+		serviceName = fmt.Sprintf("test-mysql-bc-%s", rName)
+		userName    = fmt.Sprintf("user-bc-%s", rName)
+	)
+
+	config := fmt.Sprintf(`
+resource "aiven_mysql" "mysql" {
+  project                 = %[1]q
+  cloud_name              = "google-europe-west1"
+  plan                    = "startup-4"
+  service_name            = %[2]q
+  maintenance_window_dow  = "monday"
+  maintenance_window_time = "10:00:00"
+}
+
+resource "aiven_mysql_user" "test" {
+  project      = aiven_mysql.mysql.project
+  service_name = aiven_mysql.mysql.service_name
+  username     = %[3]q
+}
+
+data "aiven_mysql_user" "test" {
+  project      = aiven_mysql_user.test.project
+  service_name = aiven_mysql_user.test.service_name
+  username     = aiven_mysql_user.test.username
+}`, projectName, serviceName, userName)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() { acc.TestAccPreCheck(t) },
+		Steps: acc.BackwardCompatibilitySteps(t, acc.BackwardCompatConfig{
+			TFConfig:           config,
+			OldProviderVersion: "4.47.0",
+			Checks: resource.ComposeTestCheckFunc(
+				resource.TestCheckResourceAttr("aiven_mysql.mysql", "state", "RUNNING"),
+				resource.TestCheckResourceAttrSet("aiven_mysql.mysql", "id"),
+
+				resource.TestCheckResourceAttrSet("aiven_mysql_user.test", "id"),
+				resource.TestCheckResourceAttr("aiven_mysql_user.test", "username", userName),
+				resource.TestCheckResourceAttrSet("aiven_mysql_user.test", "password"),
+				resource.TestCheckResourceAttr("aiven_mysql_user.test", "type", "normal"),
+
+				resource.TestCheckResourceAttr("data.aiven_mysql_user.test", "username", userName),
+				resource.TestCheckResourceAttrSet("data.aiven_mysql_user.test", "password"),
+			),
+		}),
+	})
+}

--- a/internal/sdkprovider/service/mysql/mysql_user_data_source.go
+++ b/internal/sdkprovider/service/mysql/mysql_user_data_source.go
@@ -3,12 +3,13 @@ package mysql
 import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
+	"github.com/aiven/terraform-provider-aiven/internal/common"
 	"github.com/aiven/terraform-provider-aiven/internal/schemautil"
 )
 
 func DatasourceMySQLUser() *schema.Resource {
 	return &schema.Resource{
-		ReadContext: schemautil.DatasourceServiceUserRead,
+		ReadContext: common.WithGenClientDiag(schemautil.DatasourceServiceUserRead),
 		Description: "Gets information about an Aiven for MySQL® service user.",
 		Schema: schemautil.ResourceSchemaAsDatasourceSchema(aivenMySQLUserSchema,
 			"project", "service_name", "username"),

--- a/internal/sdkprovider/service/opensearch/opensearch_user_backward_compat_test.go
+++ b/internal/sdkprovider/service/opensearch/opensearch_user_backward_compat_test.go
@@ -1,0 +1,67 @@
+//go:build backwardcompat
+
+package opensearch_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+
+	acc "github.com/aiven/terraform-provider-aiven/internal/acctest"
+)
+
+// TestAccAivenOpenSearchUserBackwardCompatibility verifies that the OpenSearch user resource
+// maintains backward compatibility with previous provider versions.
+func TestAccAivenOpenSearchUserBackwardCompatibility(t *testing.T) {
+	var (
+		projectName     = acc.ProjectName()
+		rName           = acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
+		serviceName     = fmt.Sprintf("test-os-bc-%s", rName)
+		userName        = fmt.Sprintf("user-bc-%s", rName)
+		providerVersion = "4.47.0"
+	)
+
+	config := fmt.Sprintf(`
+resource "aiven_opensearch" "os" {
+  project                 = %[1]q
+  cloud_name              = "google-europe-west1"
+  plan                    = "startup-4"
+  service_name            = %[2]q
+  maintenance_window_dow  = "monday"
+  maintenance_window_time = "10:00:00"
+}
+
+resource "aiven_opensearch_user" "test" {
+  project      = aiven_opensearch.os.project
+  service_name = aiven_opensearch.os.service_name
+  username     = %[3]q
+}
+
+data "aiven_opensearch_user" "test" {
+  project      = aiven_opensearch_user.test.project
+  service_name = aiven_opensearch_user.test.service_name
+  username     = aiven_opensearch_user.test.username
+}`, projectName, serviceName, userName)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() { acc.TestAccPreCheck(t) },
+		Steps: acc.BackwardCompatibilitySteps(t, acc.BackwardCompatConfig{
+			TFConfig:           config,
+			OldProviderVersion: providerVersion,
+			Checks: resource.ComposeTestCheckFunc(
+				resource.TestCheckResourceAttr("aiven_opensearch.os", "state", "RUNNING"),
+				resource.TestCheckResourceAttrSet("aiven_opensearch.os", "id"),
+
+				resource.TestCheckResourceAttrSet("aiven_opensearch_user.test", "id"),
+				resource.TestCheckResourceAttr("aiven_opensearch_user.test", "username", userName),
+				resource.TestCheckResourceAttrSet("aiven_opensearch_user.test", "password"),
+				resource.TestCheckResourceAttr("aiven_opensearch_user.test", "type", "normal"),
+
+				resource.TestCheckResourceAttr("data.aiven_opensearch_user.test", "username", userName),
+				resource.TestCheckResourceAttrSet("data.aiven_opensearch_user.test", "password"),
+			),
+		}),
+	})
+}

--- a/internal/sdkprovider/service/opensearch/opensearch_user_data_source.go
+++ b/internal/sdkprovider/service/opensearch/opensearch_user_data_source.go
@@ -3,12 +3,13 @@ package opensearch
 import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
+	"github.com/aiven/terraform-provider-aiven/internal/common"
 	"github.com/aiven/terraform-provider-aiven/internal/schemautil"
 )
 
 func DatasourceOpenSearchUser() *schema.Resource {
 	return &schema.Resource{
-		ReadContext: schemautil.DatasourceServiceUserRead,
+		ReadContext: common.WithGenClientDiag(schemautil.DatasourceServiceUserRead),
 		Description: "Gets information about an Aiven for OpenSearch® service user.",
 		Schema: schemautil.ResourceSchemaAsDatasourceSchema(aivenOpenSearchUserSchema,
 			"project", "service_name", "username"),

--- a/internal/sdkprovider/service/redis/redis_user_data_source.go
+++ b/internal/sdkprovider/service/redis/redis_user_data_source.go
@@ -3,38 +3,37 @@ package redis
 import (
 	"context"
 
-	"github.com/aiven/aiven-go-client/v2"
+	avngen "github.com/aiven/go-client-codegen"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
+	"github.com/aiven/terraform-provider-aiven/internal/common"
 	"github.com/aiven/terraform-provider-aiven/internal/schemautil"
 )
 
 func DatasourceRedisUser() *schema.Resource {
 	return &schema.Resource{
-		ReadContext: datasourceRedisUserRead,
+		ReadContext: common.WithGenClientDiag(datasourceRedisUserRead),
 		Description: "The Redis User data source provides information about the existing Aiven Redis User.",
 		Schema: schemautil.ResourceSchemaAsDatasourceSchema(aivenRedisUserSchema,
 			"project", "service_name", "username"),
 	}
 }
 
-func datasourceRedisUserRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	client := m.(*aiven.Client)
-
+func datasourceRedisUserRead(ctx context.Context, d *schema.ResourceData, client avngen.Client) diag.Diagnostics {
 	projectName := d.Get("project").(string)
 	serviceName := d.Get("service_name").(string)
 	userName := d.Get("username").(string)
 
-	list, err := client.ServiceUsers.List(ctx, projectName, serviceName)
+	svc, err := client.ServiceGet(ctx, projectName, serviceName)
 	if err != nil {
 		return diag.FromErr(err)
 	}
 
-	for _, u := range list {
+	for _, u := range svc.Users {
 		if u.Username == userName {
 			d.SetId(schemautil.BuildResourceID(projectName, serviceName, userName))
-			return resourceRedisUserRead(ctx, d, m)
+			return resourceRedisUserRead(ctx, d, client)
 		}
 	}
 

--- a/internal/sdkprovider/service/valkey/valkey_user.go
+++ b/internal/sdkprovider/service/valkey/valkey_user.go
@@ -166,7 +166,7 @@ func resourceValkeyUserRead(ctx context.Context, d *schema.ResourceData, client 
 		return schemautil.ResourceReadHandleNotFound(err, d)
 	}
 
-	err = schemautil.CopyServiceUserGenPropertiesFromAPIResponseToTerraform(d, user, projectName, serviceName)
+	err = schemautil.CopyServiceUserPropertiesFromAPIResponseToTerraform(d, user, projectName, serviceName)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
<!-- All contributors, please complete these sections, including maintainers. -->

## About this change—what it does

<!-- Provide a small sentence that summarizes the change. -->

<!-- Provide the issue number below, if it exists. -->
Resolves: NEX-2077
-   migrated service user resources and data sources from legacy `aiven-go-client/v2` to autogenerated `go-client-codegen` client.
- added password update test steps to MySQL, Kafka, and PostgreSQL user tests
- added backward compatibility tests for service_users

<!-- Provide a small explanation on why this is the approach you took for solving this problem. -->
