### PR TITLE
refactor(plugin): rename `resultListToKey` -> `resultToKey`

### DIFF
--- a/definitions/.schema.yml
+++ b/definitions/.schema.yml
@@ -138,10 +138,10 @@ definitions:
           type: string
         $comment: |
           When the response returns a list, these keys are used to locate the item within the response
-      resultListToKey:
+      resultToKey:
         type: string
         $comment: |
-          Specifies the key to map list responses into a single object for flatten/expand logic
+          When the API response is not an object (e.g., a primitive or array), wrap it into a map using this key.
     required:
       - id
       - type

--- a/definitions/organization_billing_group_list.yml
+++ b/definitions/organization_billing_group_list.yml
@@ -9,7 +9,7 @@ idAttribute:
 operations:
   - id: OrganizationBillingGroupList
     type: read
-    resultListToKey: billing_groups
+    resultToKey: billing_groups
 schema:
   billing_groups:
     items:

--- a/definitions/organization_user_group_list.yml
+++ b/definitions/organization_user_group_list.yml
@@ -8,5 +8,5 @@ idAttribute:
 operations:
   - id: UserGroupsList
     type: read
-    resultListToKey: user_groups
+    resultToKey: user_groups
 clientHandler: usergroup

--- a/definitions/service_plan_list.yml
+++ b/definitions/service_plan_list.yml
@@ -13,7 +13,7 @@ clientHandler: project
 operations:
   - id: ProjectServicePlanList
     type: read
-    resultListToKey: service_plans
+    resultToKey: service_plans
 schema:
   service_plans:
     type: arrayOrdered

--- a/generators/plugin/item.go
+++ b/generators/plugin/item.go
@@ -71,8 +71,8 @@ type Operation struct {
 	DisableView          bool          `yaml:"disableView"`
 	ResultKey            string        `yaml:"resultKey"`            // E.g.: {errors: [], result: {}} - extract "result"
 	ResultListLookupKeys []string      `yaml:"resultListLookupKeys"` // When the response is a list, these keys are used to locate the correct item
-	// Specifies the key to map list responses into a single object for flatten/expand logic
-	ResultListToKey string `yaml:"resultListToKey"`
+	// When the API response is not an object (e.g., a primitive or array), wrap it into a map using this key.
+	ResultToKey string `yaml:"resultToKey"`
 }
 
 type Operations []Operation

--- a/generators/plugin/views.go
+++ b/generators/plugin/views.go
@@ -255,10 +255,10 @@ func viewResponse(g *jen.Group, item *Item, def *Definition, operation Operation
 		)
 	}
 
-	// Wraps the list into a map by the specified key
-	if operation.ResultListToKey != "" {
+	// Wraps the result into a map by the specified key
+	if operation.ResultToKey != "" {
 		m := jen.Op("&").Map(jen.String()).Any()
-		g.Add(flatten(m.Values(jen.Dict{jen.Lit(operation.ResultListToKey): jen.Id("rsp")})))
+		g.Add(flatten(m.Values(jen.Dict{jen.Lit(operation.ResultToKey): jen.Id("rsp")})))
 		return nil
 	}
 


### PR DESCRIPTION
Resolves NEX-2100.

Some client handlers return scalar types, for instance, `ProjectKmsGetCA`. At the moment, `resultListToKey` name is confusing.
