### PR TITLE
docs: fix billing contact email descriptions

### DIFF
--- a/definitions/organization_billing_group.yml
+++ b/definitions/organization_billing_group.yml
@@ -21,8 +21,10 @@ operations:
     resultKey: billing_group
 schema:
   billing_contact_emails:
+    description: Aiven contacts these email addresses when there are billing issues or questions.
     items:
       type: string
   billing_emails:
+    description: PDF invoices are sent to these email addresses.
     items:
       type: string

--- a/docs/data-sources/organization_billing_group.md
+++ b/docs/data-sources/organization_billing_group.md
@@ -32,8 +32,8 @@ the `PROVIDER_AIVEN_ENABLE_BETA` environment variable to use the resource.
 ### Read-Only
 
 - `billing_address_id` (String) Billing address ID.
-- `billing_contact_emails` (Set of String) List of billing contact emails.
-- `billing_emails` (Set of String) List of billing contact emails.
+- `billing_contact_emails` (Set of String) Aiven contacts these email addresses when there are billing issues or questions.
+- `billing_emails` (Set of String) PDF invoices are sent to these email addresses.
 - `billing_group_name` (String) Billing Group Name.
 - `currency` (String) Acceptable currencies for a billing group. The possible values are `AUD`, `CAD`, `CHF`, `DKK`, `EUR`, `GBP`, `JPY`, `NOK`, `NZD`, `SEK`, `SGD` and `USD`.
 - `custom_invoice_text` (String) Extra billing text.

--- a/docs/resources/organization_billing_group.md
+++ b/docs/resources/organization_billing_group.md
@@ -23,8 +23,8 @@ the `PROVIDER_AIVEN_ENABLE_BETA` environment variable to use the resource.
 ### Required
 
 - `billing_address_id` (String) Billing address ID. Maximum length: `36`.
-- `billing_contact_emails` (Set of String) List of billing contact emails.
-- `billing_emails` (Set of String) List of billing contact emails.
+- `billing_contact_emails` (Set of String) Aiven contacts these email addresses when there are billing issues or questions.
+- `billing_emails` (Set of String) PDF invoices are sent to these email addresses.
 - `billing_group_name` (String) Billing Group Name. Maximum length: `128`.
 - `organization_id` (String) ID of an organization. Maximum length: `36`. Changing this property forces recreation of the resource.
 - `payment_method_id` (String) Payment method ID.

--- a/internal/plugin/service/organization/billinggroup/zz_datasource.go
+++ b/internal/plugin/service/organization/billinggroup/zz_datasource.go
@@ -56,12 +56,12 @@ func datasourceSchema(ctx context.Context) schema.Schema {
 			"billing_contact_emails": schema.SetAttribute{
 				Computed:            true,
 				ElementType:         types.StringType,
-				MarkdownDescription: "List of billing contact emails.",
+				MarkdownDescription: "Aiven contacts these email addresses when there are billing issues or questions.",
 			},
 			"billing_emails": schema.SetAttribute{
 				Computed:            true,
 				ElementType:         types.StringType,
-				MarkdownDescription: "List of billing contact emails.",
+				MarkdownDescription: "PDF invoices are sent to these email addresses.",
 			},
 			"billing_group_id": schema.StringAttribute{
 				MarkdownDescription: "Billing group ID.",

--- a/internal/plugin/service/organization/billinggroup/zz_resource.go
+++ b/internal/plugin/service/organization/billinggroup/zz_resource.go
@@ -58,12 +58,12 @@ func resourceSchema(ctx context.Context) schema.Schema {
 			},
 			"billing_contact_emails": schema.SetAttribute{
 				ElementType:         types.StringType,
-				MarkdownDescription: "List of billing contact emails.",
+				MarkdownDescription: "Aiven contacts these email addresses when there are billing issues or questions.",
 				Required:            true,
 			},
 			"billing_emails": schema.SetAttribute{
 				ElementType:         types.StringType,
-				MarkdownDescription: "List of billing contact emails.",
+				MarkdownDescription: "PDF invoices are sent to these email addresses.",
 				Required:            true,
 			},
 			"billing_group_id": schema.StringAttribute{


### PR DESCRIPTION
<!-- All contributors, please complete these sections, including maintainers. -->

## About this change—what it does

Updates the descriptions of the billing contact email fields for billing groups to distinguish between the two.
