### PR TITLE
feat(plugin): support multi-purpose operationIDs

### DIFF
--- a/definitions/.schema.yml
+++ b/definitions/.schema.yml
@@ -124,8 +124,8 @@ definitions:
         $comment: The operation's unique identifier, e.g. "OrganizationCreate"
       type:
         type: string
-        enum: ["create", "read", "update", "delete", "upsert"]
-        $comment: The type of operation (create, read, update, delete, upsert)
+        enum: ["create", "read", "update", "delete"]
+        $comment: The type of operation (create, read, etc.)
       disableView:
         type: boolean
         $comment: Set to true to disable view generation for this specific operation

--- a/definitions/organization_permission.yml
+++ b/definitions/organization_permission.yml
@@ -20,7 +20,9 @@ resource:
 idAttributeComposed: [organization_id, resource_type, resource_id]
 operations:
   - id: PermissionsSet
-    type: upsert
+    type: create
+  - id: PermissionsSet
+    type: update
   - id: PermissionsGet
     type: read
 schema:

--- a/generators/plugin/item_test.go
+++ b/generators/plugin/item_test.go
@@ -164,7 +164,7 @@ func TestItemRemoveElements(t *testing.T) {
 			root := &Item{Name: "root", Type: SchemaTypeObject, Properties: make(map[string]*Item)}
 			scope := &Scope{Definition: &Definition{Remove: tt.remove}}
 
-			err := fromSchema(scope, "", root, tt.schema, ReadHandler)
+			err := fromSchema(scope, Operation{}, root, tt.schema, ReadHandler)
 			require.NoError(t, err)
 
 			if diff := cmp.Diff(tt.want, root.Properties, transformer); diff != "" {
@@ -189,7 +189,7 @@ func TestOperationsIDAppearsIn(t *testing.T) {
 	for _, op := range operations {
 		for i, source := range sources {
 			t.Run(fmt.Sprintf("%s_%d_source", op.ID, i), func(t *testing.T) {
-				this := operations.AppearsInID(op.ID, source)
+				this := operations.AppearsInID(op.ID, op.Type, source)
 				require.NotEqual(t, 0, this)
 				require.Positive(t, this&handlers[op.Type])
 				require.Positive(t, this&source)
@@ -197,13 +197,12 @@ func TestOperationsIDAppearsIn(t *testing.T) {
 				// Same as by handler type
 				require.Equal(t,
 					fmt.Sprintf("%b", this),
-					fmt.Sprintf("%b", operations.AppearsInHandler(handlers[op.Type], source)),
+					fmt.Sprintf("%b", operations.AppearsInHandler(op.Type, source)),
 				)
 
 				// Proves the mask doesn't contain other operations: create, update, etc
-				// OperationUpsert is a special case that combines Create and Update and has both flags set
-				for o, a := range handlers {
-					if o != op.Type && o != OperationUpsert {
+				for opType, a := range handlers {
+					if opType != op.Type {
 						require.EqualValues(t, 0, this&a)
 					}
 				}
@@ -220,5 +219,67 @@ func TestOperationsIDAppearsIn(t *testing.T) {
 				seen[this] = true
 			})
 		}
+	}
+}
+
+// TestOperationsIDAppearsInUpsert tests when the same operation ID is used for both create and update (upsert pattern)
+func TestOperationsIDAppearsInUpsert(t *testing.T) {
+	operations := Operations{
+		{ID: "FooUpsert", Type: OperationCreate},
+		{ID: "FooRead", Type: OperationRead},
+		{ID: "FooUpsert", Type: OperationUpdate}, // Same ID as create
+		{ID: "FooDelete", Type: OperationDelete},
+	}
+
+	sources := listSources()
+	handlers := operationToHandler()
+	seen := make(map[AppearsIn]bool)
+
+	for _, op := range operations {
+		for i, source := range sources {
+			t.Run(fmt.Sprintf("%s_%s_%d_source", op.ID, op.Type, i), func(t *testing.T) {
+				this := operations.AppearsInID(op.ID, op.Type, source)
+				require.NotEqual(t, 0, this)
+				require.Positive(t, this&handlers[op.Type])
+				require.Positive(t, this&source)
+
+				// Proves the mask doesn't contain other operations: create, update, etc
+				for opType, a := range handlers {
+					if opType != op.Type {
+						require.EqualValues(t, 0, this&a)
+					}
+				}
+
+				// Proves the mask doesn't contain other sources: RequestBody, ResponseBody, etc
+				for _, s := range sources {
+					if s != source {
+						require.EqualValues(t, 0, this&s)
+					}
+				}
+
+				// Stores to make sure all values are unique
+				require.False(t, seen[this])
+				seen[this] = true
+			})
+		}
+	}
+
+	// Test that AppearsInHandler merges both create and update when same ID is used
+	for _, source := range sources {
+		createMask := operations.AppearsInID("FooUpsert", OperationCreate, source)
+		updateMask := operations.AppearsInID("FooUpsert", OperationUpdate, source)
+
+		// Create and update masks should be different
+		require.NotEqual(t, createMask, updateMask)
+
+		// AppearsInHandler should return only the specific handler's mask
+		require.Equal(t,
+			fmt.Sprintf("%b", createMask),
+			fmt.Sprintf("%b", operations.AppearsInHandler(OperationCreate, source)),
+		)
+		require.Equal(t,
+			fmt.Sprintf("%b", updateMask),
+			fmt.Sprintf("%b", operations.AppearsInHandler(OperationUpdate, source)),
+		)
 	}
 }

--- a/generators/plugin/views.go
+++ b/generators/plugin/views.go
@@ -23,7 +23,7 @@ const (
 // genViews generates CRUD views for the resource, skips disabled or undefined operations.
 func genViews(item *Item, def *Definition) ([]jen.Code, error) {
 	codes := make([]jen.Code, 0)
-	for _, op := range listOperations() {
+	for _, op := range listOperationTypes() {
 		v, err := genGenericView(item, def, op)
 		if err != nil {
 			return nil, fmt.Errorf("%s view error: %w", op, err)
@@ -154,9 +154,9 @@ func genGenericView(item *Item, def *Definition, operation OperationType) (jen.C
 }
 
 func genGenericViewOperation(g *jen.Group, item *Item, def *Definition, operation Operation) error {
-	inPath := def.Operations.AppearsInID(operation.ID, PathParameter)
-	inRequest := def.Operations.AppearsInID(operation.ID, RequestBody)
-	inResponse := def.Operations.AppearsInID(operation.ID, ResponseBody)
+	inPath := def.Operations.AppearsInID(operation.ID, operation.Type, PathParameter)
+	inRequest := def.Operations.AppearsInID(operation.ID, operation.Type, RequestBody)
+	inResponse := def.Operations.AppearsInID(operation.ID, operation.Type, ResponseBody)
 
 	// Properties must be sorted for consistent output
 	properties := slices.Collect(maps.Values(item.Properties))


### PR DESCRIPTION
Resolves NEX-2168.

An `OperationID` can be used to create _and_ delete a resource.

- Removes hardcoded `upsert` operation
- Adds multi-purpose operationIDs support

