### PR TITLE
feat(plugin): ignore 404 on DELETE

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ nav_order: 1
 ## [MAJOR.MINOR.PATCH] - YYYY-MM-DD
 
 - Add `aiven_organization_user_group_member_list` datasource: List members of a user group
+- Ignore 404 on client retries when deleting Plugin Framework resources: a 5xx on the first delete may be followed by a 404 if the resource was already removed.
 - Add service user resources fields `password_wo` and `password_wo_version`: support for write-only passwords to manage
   them securely without storing them in state for `aiven_kafka_user`, `aiven_mysql_user`, `aiven_opensearch_user`,
   `aiven_pg_user`, `aiven_valkey_user`

--- a/definitions/organization_user_group_member.yml
+++ b/definitions/organization_user_group_member.yml
@@ -2,9 +2,9 @@
 location: internal/plugin/service/organization/usergroupmember
 resource:
   description: |
-    Adds and manages users in a [user group](https://registry.terraform.io/providers/aiven/aiven/latest/docs/resources/organization_user_group). 
+    Adds and manages users in a [user group](https://registry.terraform.io/providers/aiven/aiven/latest/docs/resources/organization_user_group).
     You can add organization users and application users to groups.
-    Organization users must be [managed in the Aiven Console](https://aiven.io/docs/platform/howto/manage-org-users). 
+    Organization users must be [managed in the Aiven Console](https://aiven.io/docs/platform/howto/manage-org-users).
     Application users can be created and managed using the `aiven_organization_application_user` resource.
     Groups are granted roles and permissions using the `aiven_organization_permission` resource.
 idAttributeComposed: [organization_id, group_id, user_id]

--- a/internal/plugin/adapter/resource.go
+++ b/internal/plugin/adapter/resource.go
@@ -57,6 +57,7 @@ type ResourceOptions[M Model[T], T any] struct {
 	// Each CRUD operation should return diag.Diagnostics (rather than taking it as an argument)
 	// This design allows internal retry logic for operations that can fail transiently.
 	// NOTE: Create and Update must NOT invoke Read themselves; set RefreshState=true to trigger a post-operation Read.
+	// NOTE2: Delete ignores 404 errors since resources may already be deleted after client retries.
 	Read   func(ctx context.Context, client avngen.Client, state *T) diag.Diagnostics
 	Delete func(ctx context.Context, client avngen.Client, state *T) diag.Diagnostics
 	Create func(ctx context.Context, client avngen.Client, plan *T) diag.Diagnostics
@@ -290,7 +291,10 @@ func (a *resourceAdapter[M, T]) Delete(
 	}
 	defer cancel()
 
-	diags.Append(a.resource.Delete(ctx, a.client, state.SharedModel())...)
+	// The Aiven client might receive 5xx errors from the backend, causing it to retry the delete operation.
+	// However, the resource may have already been deleted, in which case a 404 error can be safely ignored.
+	d = a.resource.Delete(ctx, a.client, state.SharedModel())
+	diags.Append(errmsg.RemoveDiagError(d, avngen.IsNotFound)...)
 }
 
 func (a *resourceAdapter[M, T]) ImportState(

--- a/internal/plugin/errmsg/retry.go
+++ b/internal/plugin/errmsg/retry.go
@@ -42,3 +42,15 @@ func RetryIfAivenStatus(codes ...int) retry.Option {
 		return slices.Contains(codes, e.Status)
 	})
 }
+
+func RemoveDiagError(diags diag.Diagnostics, f func(error) bool) diag.Diagnostics {
+	i := 0
+	for _, d := range diags {
+		if e, ok := d.(DiagError); ok && f(e.Error) {
+			continue
+		}
+		diags[i] = d
+		i++
+	}
+	return diags[:i]
+}

--- a/internal/plugin/errmsg/retry_test.go
+++ b/internal/plugin/errmsg/retry_test.go
@@ -8,6 +8,7 @@ import (
 	avngen "github.com/aiven/go-client-codegen"
 	"github.com/avast/retry-go"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/samber/lo"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -80,6 +81,54 @@ func TestRetryDiags(t *testing.T) {
 			)
 
 			assert.Equal(t, tc.expectRetried, attempts == maxAttempts)
+		})
+	}
+}
+
+func TestRemoveDiagErrorNotFound(t *testing.T) {
+	type testcase struct {
+		name         string
+		diags        diag.Diagnostics
+		expectTitles []string
+	}
+
+	testcases := []testcase{
+		{
+			name: "removes matching error",
+			diags: diag.Diagnostics{
+				FromError("should be filtered out", avngen.Error{Status: http.StatusNotFound}),
+				FromError("should remain", avngen.Error{Status: http.StatusInternalServerError}),
+			},
+			expectTitles: []string{"should remain"},
+		},
+		{
+			name: "retains non-matching errors",
+			diags: diag.Diagnostics{
+				FromError("error1", avngen.Error{Status: http.StatusInternalServerError}),
+				FromError("error2", avngen.Error{Status: http.StatusBadRequest}),
+			},
+			expectTitles: []string{"error1", "error2"},
+		},
+		{
+			name: "removes all matching errors",
+			diags: diag.Diagnostics{
+				FromError("err a", avngen.Error{Status: http.StatusNotFound}),
+				FromError("err b", avngen.Error{Status: http.StatusNotFound}),
+			},
+		},
+		{
+			name:  "no errors",
+			diags: diag.Diagnostics{},
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := RemoveDiagError(tc.diags, avngen.IsNotFound)
+			titles := lo.Map(result.Errors(), func(d diag.Diagnostic, _ int) string {
+				return d.Summary()
+			})
+			assert.ElementsMatch(t, tc.expectTitles, titles)
 		})
 	}
 }


### PR DESCRIPTION
Resolves NEX-2171.

Ignore 404 on client retries when deleting Plugin Framework resources: a 5xx on the first delete may be followed by a 404 if the resource was already removed.
