### PR TITLE
refactor(plugin): turn 404 DELETE into warning

### DIFF
--- a/internal/plugin/errmsg/retry.go
+++ b/internal/plugin/errmsg/retry.go
@@ -43,14 +43,12 @@ func RetryIfAivenStatus(codes ...int) retry.Option {
 	})
 }
 
-func RemoveDiagError(diags diag.Diagnostics, f func(error) bool) diag.Diagnostics {
-	i := 0
-	for _, d := range diags {
+// WarnDiagError turns errors into warnings if they match the filter function.
+func WarnDiagError(diags diag.Diagnostics, f func(error) bool) diag.Diagnostics {
+	for i, d := range diags {
 		if e, ok := d.(DiagError); ok && f(e.Error) {
-			continue
+			diags[i] = diag.NewWarningDiagnostic(d.Summary(), d.Detail())
 		}
-		diags[i] = d
-		i++
 	}
-	return diags[:i]
+	return diags
 }


### PR DESCRIPTION
Resolves NEX-2183.

"Not Found" error is completely ignored on DELETE. This might omit real issues, better turn it into a warning: this won't fail the operation, but might help with debugging.
