### PR TITLE
chore: update schemas 11-12-2025

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,20 +12,19 @@ nav_order: 1
 
 ## [MAJOR.MINOR.PATCH] - YYYY-MM-DD
 
-- Change `aiven_billing_group`: migrate to the Plugin Framework
-- Change `aiven_billing_group`: add `billing_contact_emails` field
 - Add `aiven_organization_user_group_member_list` datasource: List members of a user group
-- Ignore 404 on client retries when deleting Plugin Framework resources: a 5xx on the first delete may be followed
-  by a 404 if the resource was already removed.
 - Add service user resources fields `password_wo` and `password_wo_version`: support for write-only passwords to manage
   them securely without storing them in state for `aiven_kafka_user`, `aiven_mysql_user`, `aiven_opensearch_user`,
   `aiven_pg_user`, `aiven_valkey_user`
-- Add `user_info` field to `aiven_organization_user_group_member` resource
-- Add `aiven_mysql` field `mysql_user_config.migration.dump_tool` (enum): Experimental! Tool to use for database dump
-  and restore during migration
 - Change service user resources and data sources: migrate to use generated client: `aiven_cassandra_user`,
   `aiven_influxdb_user`, `aiven_kafka_user`, `aiven_m3db_user`, `aiven_mysql_user`, `aiven_opensearch_user`,
   `aiven_pg_user`, `aiven_redis_user`
+- Change `aiven_billing_group`: migrate to the Plugin Framework
+- Change `aiven_billing_group`: add `billing_contact_emails` field
+- Warn 404 on client retries when deleting Plugin Framework resources: a 5xx on the first delete may be followed
+  by a 404 if the resource was already removed.
+- Add `aiven_mysql` field `mysql_user_config.migration.dump_tool` (enum): Experimental! Tool to use for database dump
+  and restore during migration
 - Add `aiven_kafka` field `kafka_user_config.letsencrypt_sasl`: Use a Let's Encrypt certificate authority (CA) for Kafka
   SASL authentication
 - Add `aiven_kafka` field `kafka_user_config.sasl_oauthbearer_allowed_urls`: List of allowed URLs for SASL OAUTHBEARER authentication
@@ -44,7 +43,7 @@ nav_order: 1
   threshold percentage for ML Commons
 - Add `aiven_opensearch` field `opensearch_user_config.opensearch.ml_commons_only_run_on_ml_node`: Enable or disable
   running ML Commons tasks only on ML nodes
-- Change `aiven_redis` resource field `redis_user_config`: deprecate: This property is deprecated
+- Change `aiven_kafka` field `kafka_user_config.kafka_version` (enum): add `4.1`
 
 ## [4.47.0] - 2025-11-12
 

--- a/docs/resources/kafka.md
+++ b/docs/resources/kafka.md
@@ -124,7 +124,7 @@ Optional:
 - `kafka_rest_authorization` (Boolean) Enable authorization in Kafka-REST service.
 - `kafka_rest_config` (Block List, Max: 1) Kafka REST configuration (see [below for nested schema](#nestedblock--kafka_user_config--kafka_rest_config))
 - `kafka_sasl_mechanisms` (Block List, Max: 1) Kafka SASL mechanisms (see [below for nested schema](#nestedblock--kafka_user_config--kafka_sasl_mechanisms))
-- `kafka_version` (String) Enum: `3.1`, `3.2`, `3.3`, `3.4`, `3.5`, `3.6`, `3.7`, `3.8`, `3.9`, `4.0`, and newer. Kafka major version.
+- `kafka_version` (String) Enum: `3.1`, `3.2`, `3.3`, `3.4`, `3.5`, `3.6`, `3.7`, `3.8`, `3.9`, `4.0`, `4.1`, and newer. Kafka major version.
 - `letsencrypt_sasl` (Boolean) Use a Let's Encrypt certificate authority (CA) for Kafka SASL authentication. (Default: False).
 - `letsencrypt_sasl_privatelink` (Boolean) Use a Let's Encrypt certificate authority (CA) for Kafka SASL authentication via Privatelink. (Default: False).
 - `private_access` (Block List, Max: 1) Allow access to selected service ports from private networks (see [below for nested schema](#nestedblock--kafka_user_config--private_access))

--- a/go.mod
+++ b/go.mod
@@ -269,7 +269,7 @@ require (
 
 require (
 	github.com/agext/levenshtein v1.2.3 // indirect
-	github.com/aiven/go-api-schemas v1.163.0
+	github.com/aiven/go-api-schemas v1.164.0
 	github.com/bgentry/go-netrc v0.0.0-20140422174119-9fd32a8b3d3d // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/fatih/color v1.18.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -76,8 +76,8 @@ github.com/agnivade/levenshtein v1.2.1 h1:EHBY3UOn1gwdy/VbFwgo4cxecRznFk7fKWN1KO
 github.com/agnivade/levenshtein v1.2.1/go.mod h1:QVVI16kDrtSuwcpd0p1+xMC6Z/VfhtCyDIjcwga4/DU=
 github.com/aiven/aiven-go-client/v2 v2.37.0 h1:bROOt9K5VJxacavzC/UrtDEZuI0KlDX/oP76W+DsxcM=
 github.com/aiven/aiven-go-client/v2 v2.37.0/go.mod h1:XHS4+7sseQk+GR4Wwre3IvVonWb6fGNk67WmAzs+qZk=
-github.com/aiven/go-api-schemas v1.163.0 h1:ZnMp2W4wa3zIL6RPrfeUUpskzSNA//b4KNugnn/5/gU=
-github.com/aiven/go-api-schemas v1.163.0/go.mod h1:APIzve1zu0BYXfbk9FBTqRwBiuT7++kEkbvZ0I1a4p0=
+github.com/aiven/go-api-schemas v1.164.0 h1:leuvRKY4jv6pmQkkQLl03TRJ/CIEfNajhC9nrnZsDFY=
+github.com/aiven/go-api-schemas v1.164.0/go.mod h1:APIzve1zu0BYXfbk9FBTqRwBiuT7++kEkbvZ0I1a4p0=
 github.com/aiven/go-client-codegen v0.136.0 h1:aMVt3bLgSjW7C8r0Xg9GZmBh06+/vtl9TEh2rWUxBRs=
 github.com/aiven/go-client-codegen v0.136.0/go.mod h1:+6eIsNIBB4KHMBTzy7maVAyoIZUyscTsL8ssHxrZZrU=
 github.com/aiven/go-utils/selproj v0.1.0 h1:ruqLwK4Y4FcMJyt/g9j8QZVDr9vrVO5Y0afM2APzKdE=

--- a/internal/sdkprovider/userconfig/service/kafka.go
+++ b/internal/sdkprovider/userconfig/service/kafka.go
@@ -658,7 +658,7 @@ func kafkaUserConfig() *schema.Schema {
 				Type:     schema.TypeList,
 			},
 			"kafka_version": {
-				Description: "Enum: `3.1`, `3.2`, `3.3`, `3.4`, `3.5`, `3.6`, `3.7`, `3.8`, `3.9`, `4.0`, and newer. Kafka major version.",
+				Description: "Enum: `3.1`, `3.2`, `3.3`, `3.4`, `3.5`, `3.6`, `3.7`, `3.8`, `3.9`, `4.0`, `4.1`, and newer. Kafka major version.",
 				Optional:    true,
 				Type:        schema.TypeString,
 			},


### PR DESCRIPTION
- Updates schemas
- Removes redis config deprecation (redis is deprecated)
- Removes `user_info` add: wasn't added
- Adds Kafka `4.1` version
