### PR TITLE
feat(service_user): added new field to the `aiven_service_component` DS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ nav_order: 1
 ## [MAJOR.MINOR.PATCH] - YYYY-MM-DD
 
 - Migrate `aiven_organizational_unit` to the Plugin Framework
+- Added field `kafka_ssl_ca` to `aiven_service_component` data source
 
 ## [4.48.0] - 2025-12-11
 

--- a/docs/data-sources/service_component.md
+++ b/docs/data-sources/service_component.md
@@ -30,6 +30,7 @@ data "aiven_service_component" "sc1" {
 ### Optional
 
 - `kafka_authentication_method` (String) Kafka authentication method. This is a value specific to the 'kafka' service component. The possible values are `certificate` and `sasl`.
+- `kafka_ssl_ca` (String) Kafka certificate used. The possible values are `letsencrypt` and `project_ca`.
 - `route` (String) Network access route. The possible values are `dynamic`, `private`, `privatelink` and `public`.
 - `service_name` (String) Service name
 - `ssl` (Boolean) Whether the endpoint is encrypted or accepts plaintext. By default endpoints are always encrypted and this property is only included for service components that may disable encryption
@@ -39,5 +40,4 @@ data "aiven_service_component" "sc1" {
 
 - `host` (String) DNS name for connecting to the service component
 - `id` (String) The ID of this resource.
-- `kafka_ssl_ca` (String) Kafka certificate used. The possible values are `letsencrypt` and `project_ca`.
 - `port` (Number) Port number for connecting to the service component


### PR DESCRIPTION
<!-- All contributors, please complete these sections, including maintainers. -->

## About this change—what it does

<!-- Provide a small sentence that summarizes the change. -->

<!-- Provide the issue number below, if it exists. -->
Resolves: NEX-2204
-  added `kafka_ssl_ca` field to `aiven_service_component` data source for filtering and output
- replaced old `go-client` with `avngen` for `aiven_service_component`

<!-- Provide a small explanation on why this is the approach you took for solving this problem. -->
