### PR TITLE
feat(plugin): turn `resultListLookupKeys` into a map

### DIFF
--- a/definitions/.schema.yml
+++ b/definitions/.schema.yml
@@ -140,11 +140,12 @@ definitions:
           The key to extract the result object from the response (if the API nests result under a property)
           E.g.: resultKey: "result" retrieves response.result
       resultListLookupKeys:
-        type: array
-        items:
+        type: object
+        additionalProperties:
           type: string
         $comment: |
-          When the response returns a list, these keys are used to locate the item within the response
+          Used to find the correct item in a list response.
+          Maps client response field names (key) to Terraform schema attributes (value).
       resultToKey:
         type: string
         $comment: |

--- a/definitions/mysql_database.yml
+++ b/definitions/mysql_database.yml
@@ -21,4 +21,5 @@ operations:
   - id: ServiceDatabaseList
     type: read
     resultKey: databases
-    resultListLookupKeys: [database_name]
+    resultListLookupKeys:
+      DatabaseName: database_name

--- a/definitions/organization_application_user_token.yml
+++ b/definitions/organization_application_user_token.yml
@@ -15,7 +15,8 @@ operations:
   - id: ApplicationUserAccessTokensList
     type: read
     resultKey: tokens
-    resultListLookupKeys: [token_prefix]
+    resultListLookupKeys:
+      TokenPrefix: token_prefix
 schema:
   full_token:
     sensitive: true

--- a/definitions/organization_user_group_member.yml
+++ b/definitions/organization_user_group_member.yml
@@ -18,7 +18,8 @@ operations:
   - id: UserGroupMemberList
     type: read
     resultKey: members
-    resultListLookupKeys: [user_id]
+    resultListLookupKeys:
+      UserId: user_id
 refreshState: true # create and update operations have no response.
 clientHandler: usergroup
 rename:

--- a/generators/plugin/examples.go
+++ b/generators/plugin/examples.go
@@ -218,5 +218,5 @@ func exampleScalarItem(item *Item) (cty.Value, error) {
 		}
 		return cty.NumberFloatVal(anyValue.(float64)), nil
 	}
-	return cty.NilVal, fmt.Errorf("unknown scalar type %s for %s", item.Type, item.Path())
+	return cty.NilVal, fmt.Errorf("unknown scalar type %q for %q", item.Type, item.Path())
 }

--- a/generators/plugin/item.go
+++ b/generators/plugin/item.go
@@ -64,11 +64,11 @@ func operationToHandler() map[OperationType]AppearsIn {
 type OperationID string
 
 type Operation struct {
-	ID                   OperationID   `yaml:"id"`
-	Type                 OperationType `yaml:"type"`
-	DisableView          bool          `yaml:"disableView"`
-	ResultKey            string        `yaml:"resultKey"`            // E.g.: {errors: [], result: {}} - extract "result"
-	ResultListLookupKeys []string      `yaml:"resultListLookupKeys"` // When the response is a list, these keys are used to locate the correct item
+	ID                   OperationID       `yaml:"id"`
+	Type                 OperationType     `yaml:"type"`
+	DisableView          bool              `yaml:"disableView"`
+	ResultKey            string            `yaml:"resultKey"`            // E.g.: {errors: [], result: {}} - extract "result"
+	ResultListLookupKeys map[string]string `yaml:"resultListLookupKeys"` // When the response is a list, these keys are used to locate the correct item
 	// When the API response is not an object (e.g., a primitive or array), wrap it into a map using this key.
 	ResultToKey string `yaml:"resultToKey"`
 }


### PR DESCRIPTION
Resolves NEX-2211.

When Request and Response name a field differently, we need a mapping. This also solves naming issues between the go client and Terraform generator.

