### PR TITLE
test: lock free shared resources

### DIFF
--- a/internal/acctest/backward_compat.go
+++ b/internal/acctest/backward_compat.go
@@ -82,6 +82,9 @@ type BackwardCompatConfig struct {
 	// Checks are the test checks to run in both steps
 	Checks resource.TestCheckFunc
 
+	// PreConfig Same as resource.TestStep.PreConfig but for the first step only
+	PreConfig func()
+
 	// OldProviderVersion is the version to test against (defaults to latest stable)
 	OldProviderVersion string
 
@@ -119,8 +122,9 @@ func BackwardCompatibilitySteps(t *testing.T, config BackwardCompatConfig) []res
 			ExternalProviders: map[string]resource.ExternalProvider{
 				"aiven": ExternalAivenProvider(t, version),
 			},
-			Config: config.TFConfig,
-			Check:  config.Checks,
+			Config:    config.TFConfig,
+			Check:     config.Checks,
+			PreConfig: config.PreConfig,
 		},
 		// switch to new provider and verify plan is empty
 		{

--- a/internal/sdkprovider/service/kafkatopic/kafka_topic_test.go
+++ b/internal/sdkprovider/service/kafkatopic/kafka_topic_test.go
@@ -36,17 +36,15 @@ func TestAccAivenKafkaTopic(t *testing.T) {
 	kafkaName := acc.RandName("kafka")
 
 	// Creates shared Kafka
-	cleanup, err := acc.CreateTestService(
-		t.Context(),
+	serviceIsReady := acc.CreateTestService(
+		t,
 		projectName,
 		kafkaName,
 		acc.WithServiceType("kafka"),
 		acc.WithPlan("startup-4"),
 		acc.WithCloud("google-europe-west1"),
 	)
-
-	require.NoError(t, err)
-	defer cleanup()
+	require.NoError(t, <-serviceIsReady)
 
 	t.Run("basic", func(t *testing.T) {
 		defer kafkatopicrepository.ForgetService(projectName, kafkaName)


### PR DESCRIPTION
Resolves NEX-2212.

Speeds up backward compatibility tests with a shared resource.

- `BackwardCompatibilitySteps` can download providers while a shared service is created
- `acc.CreateTestService` can take an existing service name, but won't delete it
- `acc.CreateTestService` registers service removal as `t.Cleanup`
