### PR TITLE
fix: handle 404 errors in read functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,10 @@ nav_order: 1
 - Deprecated `termination_protection` for `aiven_mysql_database`.
   Use [`prevent_destroy`](https://developer.hashicorp.com/terraform/tutorials/state/resource-lifecycle#prevent-resource-deletion) instead.
 - Add `aiven_mysql` field `mysql_user_config.migration.reestablish_replication`: Skip dump-restore part and start replication
+- Fix resources not properly removing from state when deleted externally or when delete fails with transient API errors:
+  `aiven_account_authentication`, `aiven_account_team_project`, `aiven_azure_privatelink`, `aiven_azure_privatelink_connection_approval`,
+  `aiven_flink_application_deployment`, `aiven_flink_application_version`, `aiven_gcp_privatelink`, `aiven_gcp_privatelink_connection_approval`,
+  `aiven_kafka_connector`, `aiven_kafka_native_acl`, `aiven_organization_vpc`
 
 ## [4.48.0] - 2025-12-11
 

--- a/internal/sdkprovider/service/account/account_authentication.go
+++ b/internal/sdkprovider/service/account/account_authentication.go
@@ -176,7 +176,7 @@ func resourceAccountAuthenticationRead(ctx context.Context, d *schema.ResourceDa
 
 	resp, err := client.AccountAuthenticationMethodGet(ctx, accountID, authID)
 	if err != nil {
-		return err
+		return schemautil.ResourceReadHandleNotFound(err, d)
 	}
 
 	if err = d.Set("account_id", resp.AccountId); err != nil {

--- a/internal/sdkprovider/service/account/account_team_project.go
+++ b/internal/sdkprovider/service/account/account_team_project.go
@@ -2,7 +2,6 @@ package account
 
 import (
 	"context"
-	"fmt"
 
 	avngen "github.com/aiven/go-client-codegen"
 	"github.com/aiven/go-client-codegen/handler/account"
@@ -100,7 +99,8 @@ func resourceAccountTeamProjectRead(ctx context.Context, d *schema.ResourceData,
 	}
 
 	if project.ProjectName == "" {
-		return fmt.Errorf("account team project %q not found", d.Id())
+		d.SetId("") // project not found in list, remove from state
+		return nil
 	}
 
 	if err = d.Set("account_id", accountID); err != nil {

--- a/internal/sdkprovider/service/flink/flink_application_deployment.go
+++ b/internal/sdkprovider/service/flink/flink_application_deployment.go
@@ -170,7 +170,7 @@ func resourceFlinkApplicationDeploymentRead(ctx context.Context, d *schema.Resou
 
 	r, err := client.FlinkApplicationDeployments.Get(ctx, project, serviceName, applicationID, deploymentID)
 	if err != nil {
-		return diag.Errorf("cannot get Flink Application Deployment: %v", err)
+		return diag.FromErr(schemautil.ResourceReadHandleNotFound(err, d))
 	}
 
 	if err := d.Set("project", project); err != nil {

--- a/internal/sdkprovider/service/flink/flink_application_version.go
+++ b/internal/sdkprovider/service/flink/flink_application_version.go
@@ -272,7 +272,7 @@ func resourceFlinkApplicationVersionRead(ctx context.Context, d *schema.Resource
 
 	r, err := client.FlinkApplicationVersions.Get(ctx, project, serviceName, applicationID, version)
 	if err != nil {
-		return diag.Errorf("cannot get Flink Application Version: %v", err)
+		return diag.FromErr(schemautil.ResourceReadHandleNotFound(err, d))
 	}
 
 	if err := d.Set("project", project); err != nil {

--- a/internal/sdkprovider/service/kafka/kafka_native_acl.go
+++ b/internal/sdkprovider/service/kafka/kafka_native_acl.go
@@ -131,7 +131,7 @@ func resourceKafkaNativeACLRead(ctx context.Context, d *schema.ResourceData, cli
 		aclID,
 	)
 	if err != nil {
-		return err
+		return schemautil.ResourceReadHandleNotFound(err, d)
 	}
 
 	err = schemautil.ResourceDataSet(

--- a/internal/sdkprovider/service/vpc/azure_privatelink.go
+++ b/internal/sdkprovider/service/vpc/azure_privatelink.go
@@ -112,7 +112,7 @@ func resourceAzurePrivatelinkRead(ctx context.Context, d *schema.ResourceData, m
 
 	pl, err := client.AzurePrivatelink.Get(ctx, project, serviceName)
 	if err != nil {
-		return diag.Errorf("Error getting Azure privatelink: %s", err)
+		return diag.FromErr(schemautil.ResourceReadHandleNotFound(err, d))
 	}
 
 	if err := d.Set("user_subscription_ids", pl.UserSubscriptionIDs); err != nil {

--- a/internal/sdkprovider/service/vpc/azure_privatelink_connection_approve.go
+++ b/internal/sdkprovider/service/vpc/azure_privatelink_connection_approve.go
@@ -183,12 +183,7 @@ func resourceAzurePrivatelinkConnectionApprovalRead(ctx context.Context, d *sche
 	plConnectionID := schemautil.OptionalStringPointer(d, "privatelink_connection_id")
 	plConnection, err := client.AzurePrivatelink.ConnectionGet(ctx, project, service, plConnectionID)
 	if err != nil {
-		if aiven.IsNotFound(err) {
-			if err := d.Set("privatelink_connection_id", ""); err != nil {
-				return diag.FromErr(err)
-			}
-		}
-		return diag.Errorf("Error getting Azure privatelink connection: %s", err)
+		return diag.FromErr(schemautil.ResourceReadHandleNotFound(err, d))
 	}
 
 	if err := d.Set("privatelink_connection_id", plConnection.PrivatelinkConnectionID); err != nil {

--- a/internal/sdkprovider/service/vpc/gcp_privatelink.go
+++ b/internal/sdkprovider/service/vpc/gcp_privatelink.go
@@ -87,7 +87,7 @@ func resourceGCPPrivatelinkRead(ctx context.Context, d *schema.ResourceData, m i
 
 	pl, err := client.GCPPrivatelink.Get(ctx, project, serviceName)
 	if err != nil {
-		return diag.Errorf("Error getting GCP privatelink: %s", err)
+		return diag.FromErr(schemautil.ResourceReadHandleNotFound(err, d))
 	}
 
 	if err := d.Set("project", project); err != nil {

--- a/internal/sdkprovider/service/vpc/gcp_privatelink_connection_approve.go
+++ b/internal/sdkprovider/service/vpc/gcp_privatelink_connection_approve.go
@@ -189,12 +189,7 @@ func resourceGCPPrivatelinkConnectionApprovalRead(
 	plConnectionID := schemautil.OptionalStringPointer(d, "privatelink_connection_id")
 	plConnection, err := client.GCPPrivatelink.ConnectionGet(ctx, project, service, plConnectionID)
 	if err != nil {
-		if aiven.IsNotFound(err) {
-			if err := d.Set("privatelink_connection_id", ""); err != nil {
-				return diag.FromErr(err)
-			}
-		}
-		return diag.Errorf("Error getting GCP privatelink connection: %s", err)
+		return diag.FromErr(schemautil.ResourceReadHandleNotFound(err, d))
 	}
 
 	if err := d.Set("privatelink_connection_id", plConnection.PrivatelinkConnectionID); err != nil {

--- a/internal/sdkprovider/service/vpc/organization_vpc.go
+++ b/internal/sdkprovider/service/vpc/organization_vpc.go
@@ -128,7 +128,7 @@ func resourceOrganizationVPCRead(ctx context.Context, d *schema.ResourceData, cl
 
 	resp, err := client.OrganizationVpcGet(ctx, orgID, vpcID)
 	if err != nil {
-		return err
+		return schemautil.ResourceReadHandleNotFound(err, d)
 	}
 
 	// currently we support only 1 cloud per VPC


### PR DESCRIPTION
<!-- All contributors, please complete these sections, including maintainers. -->

## About this change—what it does

<!-- Provide a small sentence that summarizes the change. -->

<!-- Provide the issue number below, if it exists. -->
**Issue:** When a resource is deleted outside of Terraform (e.g., via Aiven Console/API) or when a delete operation fails with transient errors, subsequent Terraform operations would fail with errors instead of detecting the drift.

This fix standardizes error handling to match:
  - Behavior of official providers ([AWS](https://github.com/hashicorp/terraform-provider-aws/blob/e27eff005293a6b5872a547cf4076b683807293e/internal/service/ec2/ec2_placement_group.go#L128), [Azure](https://github.com/hashicorp/terraform-provider-azurerm/blob/aaf98ac437f7f55699dbea91a8be06c3f6915aec/internal/services/batch/batch_account_resource.go#L313), etc.)
  - Existing Aiven provider resources

**kafka_connector**:
  - Create function now waits for connector to appear in list after creation
  - Read function simplified to just check existence and handle not found

Resolves: NEX-2213 && #2614 

## Why this way

<!-- Provide a small explanation on why this is the approach you took for solving this problem. -->
