### PR TITLE
feat(changelog): add format command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,9 +23,9 @@ nav_order: 1
   Use [`prevent_destroy`](https://developer.hashicorp.com/terraform/tutorials/state/resource-lifecycle#prevent-resource-deletion) instead.
 - Add `aiven_mysql` field `mysql_user_config.migration.reestablish_replication`: Skip dump-restore part and start replication
 - Fix resources not properly removing from state when deleted externally or when delete fails with transient API errors:
-  `aiven_account_authentication`, `aiven_account_team_project`, `aiven_azure_privatelink`, `aiven_azure_privatelink_connection_approval`,
-  `aiven_flink_application_deployment`, `aiven_flink_application_version`, `aiven_gcp_privatelink`, `aiven_gcp_privatelink_connection_approval`,
-  `aiven_kafka_connector`, `aiven_kafka_native_acl`, `aiven_organization_vpc`
+  `aiven_account_authentication`, `aiven_account_team_project`, `aiven_azure_privatelink`,
+  `aiven_azure_privatelink_connection_approval`, `aiven_flink_application_deployment`, `aiven_flink_application_version`,
+  `aiven_gcp_privatelink`, `aiven_gcp_privatelink_connection_approval`, `aiven_kafka_connector`, `aiven_kafka_native_acl`, `aiven_organization_vpc`
 
 ## [4.48.0] - 2025-12-11
 

--- a/TaskInternal.yml
+++ b/TaskInternal.yml
@@ -39,6 +39,7 @@ vars:
   SWEEP: global                          # Default scope for resource sweeper
   OLD_SCHEMA: .oldSchema.json            # Temp file to store previous provider schema for diffing
   CHANGELOG_CMD: "{{.GO_CMD}} run ./generators/changelog/..." # Command to run the internal changelog generation tool
+  CHANGELOG_FILE: CHANGELOG.md
 
   # --- Docs ---
   DEPRECATED_RESOURCES: "influxdb m3 redis"   # List of deprecated resources and data sources to exclude from docs
@@ -62,8 +63,6 @@ tasks:
 
   lint-docs:
     desc: "Validate provider documentation consistency"
-    env:
-      PROVIDER_AIVEN_ENABLE_BETA: 1
     cmds:
       - "{{.TFPLUGINDOCS}} generate --rendered-website-dir tmp"
       - mkdir -p docs/data-sources docs/resources
@@ -125,6 +124,11 @@ tasks:
       - find docs -name "*.md" -type f -exec sed -i'' -e 's/[[:space:]]*$//' {} +
       - find docs -name "*.md" -type f -exec sed -i'' -e '${/^$/d}' {} +
 
+  fmt-changelog:
+    desc: "Format CHANGELOG.md using changelog generator"
+    cmds:
+      - "{{.CHANGELOG_CMD}} -format -changelog={{.CHANGELOG_FILE}}"
+
   #-------------------------------------
   # Generate Sub-Tasks
   #-------------------------------------
@@ -164,8 +168,6 @@ tasks:
 
   gen-docs:
     desc: "Generate Terraform provider documentation"
-    env:
-      PROVIDER_AIVEN_ENABLE_BETA: 1
     cmds:
       - rm -f docs/.DS_Store
       - "{{.TFPLUGINDOCS}} generate --provider-name terraform-provider-aiven"
@@ -180,8 +182,6 @@ tasks:
     desc: "Run all code generation tasks"
     vars:
       no_spec: '{{.no_spec | default "false"}}'
-    env:
-      PROVIDER_AIVEN_ENABLE_BETA: 1
     cmds:
       - task: gen-go
       - task: gen-plugin
@@ -195,21 +195,17 @@ tasks:
   #-------------------------------------
   dump-schemas:
     desc: "Save current provider schemas to {{.OLD_SCHEMA}} for later diffing"
-    env:
-      PROVIDER_AIVEN_ENABLE_BETA: 1
     cmds:
       - "{{.CHANGELOG_CMD}} -save -schema={{.OLD_SCHEMA}}"
     generates: ["{{.OLD_SCHEMA}}"]
 
   diff-schemas:
     desc: "Compare current schemas against {{.OLD_SCHEMA}} and update CHANGELOG.md"
-    env:
-      PROVIDER_AIVEN_ENABLE_BETA: 1
     cmds:
-      - "{{.CHANGELOG_CMD}} -diff -schema={{.OLD_SCHEMA}} -changelog=CHANGELOG.md"
+      - "{{.CHANGELOG_CMD}} -diff -schema={{.OLD_SCHEMA}} -changelog={{.CHANGELOG_FILE}}"
       - rm {{.OLD_SCHEMA}}
     sources: ["**/*.go"]
-    generates: ["CHANGELOG.md"]
+    generates: ["{{.CHANGELOG_FILE}}"]
 
   load-codegen:
     desc: "Update go-client-codegen module dependency"

--- a/Taskfile.dist.yml
+++ b/Taskfile.dist.yml
@@ -10,6 +10,9 @@ vars:
   CHANGELOG_BACKUP: CHANGELOG.md.bak
   VERSION_PATTERN: '^[0-9]+\.[0-9]+\.[0-9]+(-.*)?$'
 
+env:
+  PROVIDER_AIVEN_ENABLE_BETA: true
+
 tasks:
   default:
     desc: Lists available tasks defined in this file
@@ -22,6 +25,8 @@ tasks:
   #################################################
   build:
     desc: Build the provider binary
+    env:
+      PROVIDER_AIVEN_ENABLE_BETA: false
     cmds:
       - "{{.GO_CMD}} build"
 
@@ -51,7 +56,6 @@ tasks:
       - unit
     env:
       TF_ACC: 0
-      PROVIDER_AIVEN_ENABLE_BETA: 1
     cmds:
       - env -u AIVEN_TOKEN
         {{.TESTSUM}}
@@ -66,7 +70,6 @@ tasks:
     desc: "Run acceptance tests (e.g., task test-acc -- -run TestAccResourceMyThing)"
     env:
       TF_ACC: 1
-      PROVIDER_AIVEN_ENABLE_BETA: 1
     vars:
       EFFECTIVE_PKG_PATH: '{{env "PKG_PATH" | default .PKG_PATH}}'
       TAGS: '{{.TAGS | default (env "GO_BUILD_TAGS")}}'
@@ -81,7 +84,6 @@ tasks:
       - internal:clean-examples
     env:
       AIVEN_PROVIDER_PATH: "{{.BUILD_DEV_DIR}}"
-      PROVIDER_AIVEN_ENABLE_BETA: 1
     cmds:
       - "{{.TESTSUM}}
         --format testname
@@ -122,6 +124,7 @@ tasks:
           task: internal:fmt-imports
       - task: internal:fmt-go
       - task: internal:fmt-test
+      - task: internal:fmt-changelog
       - task: '{{if ne .FAST_FORMAT "true"}}internal:fmt-precommit{{else}}internal:fmt-fast{{end}}'
 
   #################################################

--- a/generators/changelog/formatter.go
+++ b/generators/changelog/formatter.go
@@ -30,10 +30,6 @@ var (
 // Soft-wraps lines to the given lineLength
 // When reformat is true, reformats the whole given content
 func updateChangelog(content string, lineLength int, reformat bool, addLines ...string) (string, error) {
-	if len(addLines) == 0 && !reformat {
-		return content, nil
-	}
-
 	lines := strings.Split(reTrailingSpace.ReplaceAllString(content, ""), "\n")
 	items, start, end := parseItems(lines)
 	addText := strings.Join(addLines, "\n")

--- a/generators/plugin/report.go
+++ b/generators/plugin/report.go
@@ -16,10 +16,8 @@ const reportFileName = "PLUGIN_MIGRATION.md"
 
 // genReport writes a table with: resource name, plugin indicator, count to reportFileName.
 func genReport() error {
-	// Needs to enable beta to load all resources.
-	err := os.Setenv(util.AivenEnableBeta, "true")
-	if err != nil {
-		return err
+	if !util.IsBeta() {
+		return fmt.Errorf("please enable beta mode, i.e. set %s=1", util.AivenEnableBeta)
 	}
 
 	sdkProvider, err := provider.Provider("foo")


### PR DESCRIPTION
Resolves NEX-2225.

The `CHANGELOG.md` is currently reformatted during schema updates, which overwrites manually added lines and makes `git blame` harder to use.

- Sets `PROVIDER_AIVEN_ENABLE_BETA=true` globally in `Taskfile.dist`
- Sets `PROVIDER_AIVEN_ENABLE_BETA=false` explictly for `task build`
