### PR TITLE
fix(kafka_topic): retry `ListV2` 404 error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ nav_order: 1
 ## [MAJOR.MINOR.PATCH] - YYYY-MM-DD
 
 - Add `aiven_service_list` data source: list all services in a project
+- Fix `aiven_kafka_topic`: retry 404 errors from `KafkaTopicListV2` endpoint
 - Change `aiven_kafka_connector` resource: migrate to use generated client
 - Migrate `aiven_organizational_unit` to the Plugin Framework
 - Migrate `aiven_mysql_database` to the Plugin Framework

--- a/internal/sdkprovider/kafkatopicrepository/repository_test.go
+++ b/internal/sdkprovider/kafkatopicrepository/repository_test.go
@@ -195,22 +195,6 @@ func TestRepositoryRead(t *testing.T) {
 			v2ListCalled:    1,
 			v2ListBatchSize: defaultV2ListBatchSize,
 		},
-		{
-			name: "emulates v2List 404 error",
-			requests: []request{
-				{project: "a", service: "b", topic: "c"},
-			},
-			responses: []response{
-				{err: fmt.Errorf("topic read error: All attempts fail:\n#1: topic list has changed")},
-			},
-			storage: map[string]*aiven.KafkaListTopic{
-				"a/b/c": {TopicName: "c"},
-			},
-			v2ListErr:       aiven.Error{Status: 404},
-			v1ListCalled:    1,
-			v2ListCalled:    1,
-			v2ListBatchSize: defaultV2ListBatchSize,
-		},
 	}
 
 	for _, opt := range cases {


### PR DESCRIPTION
Resolves NEX-2229.

The `KafkaTopicListV2` might return 404 for a topic list returned by `KafkaTopicList`. This might happen because of aggressive caching on the V2 endpoint.

- Ignores 404 errors for `KafkaTopicListV2`
- Removes 404 repository test (incompatible with the given mock)

