### PR TITLE
refactor: use gen client to manage services

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,11 +13,14 @@ nav_order: 1
 ## [MAJOR.MINOR.PATCH] - YYYY-MM-DD
 
 - Migrate `aiven_pg_database` to the Plugin Framework
+- Fix `aiven_kafka_schema`: handle 403 Forbidden error when Schema Registry is disabled by verifying service state
+- Fix `aiven_kafka_schema_configuration`: handle 403 Forbidden error when Schema Registry is disabled by verifying service state
+- Change all service types to use generated client: `aiven_alloydbomni`, `aiven_cassandra`, `aiven_clickhouse`,
+  `aiven_dragonfly`, `aiven_flink`, `aiven_grafana`, `aiven_kafka`, `aiven_kafka_connect`, `aiven_kafka_mirrormaker`,
+  `aiven_m3aggregator`, `aiven_mysql`, `aiven_opensearch`, `aiven_pg`, `aiven_thanos`, `aiven_valkey`
 
 ## [4.49.0] - 2026-01-08
 
-- Fix `aiven_kafka_schema`: handle 403 Forbidden error when Schema Registry is disabled by verifying service state
-- Fix `aiven_kafka_schema_configuration`: handle 403 Forbidden error when Schema Registry is disabled by verifying service state
 - Add `aiven_service_list` data source: list all services in a project
 - Fix `aiven_kafka_topic`: retry 404 errors from `KafkaTopicListV2` endpoint
 - Fix services: previously, if `ServiceGet` returned an error, the update could have been skipped

--- a/internal/schemautil/userconfig/stateupgrader/v0/kafka/kafka.go
+++ b/internal/schemautil/userconfig/stateupgrader/v0/kafka/kafka.go
@@ -2,10 +2,8 @@ package kafka
 
 import (
 	"context"
-	"strconv"
 	"time"
 
-	"github.com/aiven/aiven-go-client/v2"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
@@ -117,28 +115,6 @@ func ResourceKafka() *schema.Resource {
 				schemautil.CustomizeDiffCheckPlanAndStaticIpsCannotBeModifiedTogether,
 				schemautil.CustomizeDiffCheckStaticIPDisassociation,
 			),
-
-			// if a kafka_version is >= 3.0 then this schema field is not applicable
-			customdiff.ComputedIf("karapace", func(ctx context.Context, d *schema.ResourceDiff, m any) bool {
-				project := d.Get("project").(string)
-				serviceName := d.Get("service_name").(string)
-				client := m.(*aiven.Client)
-
-				kafka, err := client.Services.Get(ctx, project, serviceName)
-				if err != nil {
-					return false
-				}
-
-				if v, ok := kafka.UserConfig["kafka_version"]; ok {
-					if version, err := strconv.ParseFloat(v.(string), 64); err == nil {
-						if version >= 3 {
-							return true
-						}
-					}
-				}
-
-				return false
-			}),
 		),
 	}
 }

--- a/internal/sdkprovider/service/flink/flink.go
+++ b/internal/sdkprovider/service/flink/flink.go
@@ -3,10 +3,11 @@ package flink
 import (
 	"context"
 
-	"github.com/aiven/aiven-go-client/v2"
+	avngen "github.com/aiven/go-client-codegen"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
+	"github.com/aiven/terraform-provider-aiven/internal/common"
 	"github.com/aiven/terraform-provider-aiven/internal/schemautil"
 	"github.com/aiven/terraform-provider-aiven/internal/schemautil/userconfig/stateupgrader"
 )
@@ -46,7 +47,7 @@ func ResourceFlink() *schema.Resource {
 		CreateContext: schemautil.ResourceServiceCreateWrapper(schemautil.ServiceTypeFlink),
 		ReadContext:   schemautil.ResourceServiceRead,
 		UpdateContext: schemautil.ResourceServiceUpdate,
-		DeleteContext: FlinkServiceDelete,
+		DeleteContext: common.WithGenClientDiag(flinkServiceDelete),
 		CustomizeDiff: schemautil.CustomizeDiffGenericService(schemautil.ServiceTypeFlink),
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
@@ -58,35 +59,33 @@ func ResourceFlink() *schema.Resource {
 	}
 }
 
-func FlinkServiceDelete(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	client := m.(*aiven.Client)
-
+func flinkServiceDelete(ctx context.Context, d *schema.ResourceData, client avngen.Client) diag.Diagnostics {
 	projectName, serviceName, err := schemautil.SplitResourceID2(d.Id())
 	if err != nil {
 		return diag.Errorf("error splitting service ID: %s", err)
 	}
 
-	apps, err := client.FlinkApplications.List(ctx, projectName, serviceName)
-	if err != nil && !aiven.IsNotFound(err) {
+	apps, err := client.ServiceFlinkListApplications(ctx, projectName, serviceName)
+	if err != nil && !avngen.IsNotFound(err) {
 		return diag.Errorf("error listing Flink service applications: %s", err)
 	}
 
-	for _, app := range apps.Applications {
-		deployments, err := client.FlinkApplicationDeployments.List(ctx, projectName, serviceName, app.ID)
-		if err != nil && !aiven.IsNotFound(err) {
+	for _, app := range apps {
+		deployments, err := client.ServiceFlinkListApplicationDeployments(ctx, projectName, serviceName, app.Id)
+		if err != nil && !avngen.IsNotFound(err) {
 			return diag.Errorf("error listing Flink service deployments: %s", err)
 		}
 
-		for _, deployment := range deployments.Deployments {
+		for _, deployment := range deployments {
 			if deployment.Status != "CANCELED" {
 				return diag.Errorf(
 					"cannot delete Flink service while there are running deployments: %s in state: %s; "+
 						"please delete the deployment first and try again",
-					deployment.ID,
+					deployment.Id,
 					deployment.Status)
 			}
 		}
 	}
 
-	return schemautil.ResourceServiceDelete(ctx, d, m)
+	return schemautil.ResourceServiceDelete(ctx, d, client)
 }


### PR DESCRIPTION
Resolves NEX-2231.

Change all service types to use generated client: `aiven_alloydbomni`, `aiven_cassandra`, `aiven_clickhouse`,
  `aiven_dragonfly`, `aiven_flink`, `aiven_grafana`, `aiven_kafka`, `aiven_kafka_connect`, `aiven_kafka_mirrormaker`,
  `aiven_m3aggregator`, `aiven_mysql`, `aiven_opensearch`, `aiven_pg`, `aiven_thanos`, `aiven_valkey`
