### PR TITLE
fix(kafka_schema_configuration): handle error when Kafka Schema Registry is disabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ nav_order: 1
 
 ## [4.49.0] - 2026-01-08
 
+- Fix `aiven_kafka_schema_configuration`: handle 403 Forbidden error when Schema Registry is disabled by verifying service state
 - Add `aiven_service_list` data source: list all services in a project
 - Fix `aiven_kafka_topic`: retry 404 errors from `KafkaTopicListV2` endpoint
 - Fix services: previously, if `ServiceGet` returned an error, the update could have been skipped

--- a/internal/sdkprovider/service/kafkaschema/kafka_schema_configuration.go
+++ b/internal/sdkprovider/service/kafkaschema/kafka_schema_configuration.go
@@ -2,15 +2,24 @@ package kafkaschema
 
 import (
 	"context"
+	"errors"
+	"path/filepath"
+	"sync"
 
-	"github.com/aiven/aiven-go-client/v2"
+	avngen "github.com/aiven/go-client-codegen"
 	"github.com/aiven/go-client-codegen/handler/kafkaschemaregistry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 
+	"github.com/aiven/terraform-provider-aiven/internal/common"
 	"github.com/aiven/terraform-provider-aiven/internal/schemautil"
 	"github.com/aiven/terraform-provider-aiven/internal/schemautil/userconfig"
+)
+
+var (
+	schemaRegistryAvailabilityCache schemautil.DoOnce
+	schemaRegistryState             sync.Map
 )
 
 var aivenKafkaSchemaConfigurationSchema = map[string]*schema.Schema{
@@ -33,10 +42,10 @@ var aivenKafkaSchemaConfigurationSchema = map[string]*schema.Schema{
 func ResourceKafkaSchemaConfiguration() *schema.Resource {
 	return &schema.Resource{
 		Description:   "The Kafka Schema Configuration resource allows the creation and management of Aiven Kafka Schema Configurations.",
-		CreateContext: resourceKafkaSchemaConfigurationCreate,
-		UpdateContext: resourceKafkaSchemaConfigurationUpdate,
-		ReadContext:   resourceKafkaSchemaConfigurationRead,
-		DeleteContext: resourceKafkaSchemaConfigurationDelete,
+		CreateContext: common.WithGenClientDiag(resourceKafkaSchemaConfigurationCreate),
+		UpdateContext: common.WithGenClientDiag(resourceKafkaSchemaConfigurationUpdate),
+		ReadContext:   common.WithGenClientDiag(resourceKafkaSchemaConfigurationRead),
+		DeleteContext: common.WithGenClientDiag(resourceKafkaSchemaConfigurationDelete),
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},
@@ -46,37 +55,37 @@ func ResourceKafkaSchemaConfiguration() *schema.Resource {
 	}
 }
 
-func resourceKafkaSchemaConfigurationUpdate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+func resourceKafkaSchemaConfigurationUpdate(ctx context.Context, d *schema.ResourceData, client avngen.Client) diag.Diagnostics {
 	project, serviceName, err := schemautil.SplitResourceID2(d.Id())
 	if err != nil {
 		return diag.FromErr(err)
 	}
 
-	_, err = m.(*aiven.Client).KafkaGlobalSchemaConfig.Update(
+	_, err = client.ServiceSchemaRegistryGlobalConfigPut(
 		ctx,
 		project,
 		serviceName,
-		aiven.KafkaSchemaConfig{
-			CompatibilityLevel: d.Get("compatibility_level").(string),
+		&kafkaschemaregistry.ServiceSchemaRegistryGlobalConfigPutIn{
+			Compatibility: kafkaschemaregistry.CompatibilityType(d.Get("compatibility_level").(string)),
 		})
 	if err != nil {
 		return diag.FromErr(err)
 	}
 
-	return resourceKafkaSchemaConfigurationRead(ctx, d, m)
+	return resourceKafkaSchemaConfigurationRead(ctx, d, client)
 }
 
 // resourceKafkaSchemaConfigurationCreate Kafka Schemas global configuration cannot be created but only updated
-func resourceKafkaSchemaConfigurationCreate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+func resourceKafkaSchemaConfigurationCreate(ctx context.Context, d *schema.ResourceData, client avngen.Client) diag.Diagnostics {
 	project := d.Get("project").(string)
 	serviceName := d.Get("service_name").(string)
 
-	_, err := m.(*aiven.Client).KafkaGlobalSchemaConfig.Update(
+	_, err := client.ServiceSchemaRegistryGlobalConfigPut(
 		ctx,
 		project,
 		serviceName,
-		aiven.KafkaSchemaConfig{
-			CompatibilityLevel: d.Get("compatibility_level").(string),
+		&kafkaschemaregistry.ServiceSchemaRegistryGlobalConfigPutIn{
+			Compatibility: kafkaschemaregistry.CompatibilityType(d.Get("compatibility_level").(string)),
 		})
 	if err != nil {
 		return diag.FromErr(err)
@@ -84,17 +93,25 @@ func resourceKafkaSchemaConfigurationCreate(ctx context.Context, d *schema.Resou
 
 	d.SetId(schemautil.BuildResourceID(project, serviceName))
 
-	return resourceKafkaSchemaConfigurationRead(ctx, d, m)
+	return resourceKafkaSchemaConfigurationRead(ctx, d, client)
 }
 
-func resourceKafkaSchemaConfigurationRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+func resourceKafkaSchemaConfigurationRead(ctx context.Context, d *schema.ResourceData, client avngen.Client) diag.Diagnostics {
 	project, serviceName, err := schemautil.SplitResourceID2(d.Id())
 	if err != nil {
 		return diag.FromErr(err)
 	}
 
-	r, err := m.(*aiven.Client).KafkaGlobalSchemaConfig.Get(ctx, project, serviceName)
+	compatibilityLevel, err := client.ServiceSchemaRegistryGlobalConfigGet(ctx, project, serviceName)
 	if err != nil {
+		if isSchemaRegistryAPIError(err) {
+			enabled, checkErr := isSchemaRegistryEnabled(ctx, client, project, serviceName)
+			if checkErr == nil && !enabled {
+				d.SetId("")
+				return nil
+			}
+		}
+
 		return diag.FromErr(schemautil.ResourceReadHandleNotFound(err, d))
 	}
 
@@ -104,7 +121,7 @@ func resourceKafkaSchemaConfigurationRead(ctx context.Context, d *schema.Resourc
 	if err := d.Set("service_name", serviceName); err != nil {
 		return diag.FromErr(err)
 	}
-	if err := d.Set("compatibility_level", r.CompatibilityLevel); err != nil {
+	if err := d.Set("compatibility_level", string(compatibilityLevel)); err != nil {
 		return diag.FromErr(err)
 	}
 
@@ -113,22 +130,73 @@ func resourceKafkaSchemaConfigurationRead(ctx context.Context, d *schema.Resourc
 
 // resourceKafkaSchemaConfigurationDelete Kafka Schemas configuration cannot be deleted, therefore
 // on delete event configuration will be set to the default setting
-func resourceKafkaSchemaConfigurationDelete(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+func resourceKafkaSchemaConfigurationDelete(ctx context.Context, d *schema.ResourceData, client avngen.Client) diag.Diagnostics {
 	project, serviceName, err := schemautil.SplitResourceID2(d.Id())
 	if err != nil {
 		return diag.FromErr(err)
 	}
 
-	_, err = m.(*aiven.Client).KafkaGlobalSchemaConfig.Update(
+	_, err = client.ServiceSchemaRegistryGlobalConfigPut(
 		ctx,
 		project,
 		serviceName,
-		aiven.KafkaSchemaConfig{
-			CompatibilityLevel: "BACKWARD",
+		&kafkaschemaregistry.ServiceSchemaRegistryGlobalConfigPutIn{
+			Compatibility: kafkaschemaregistry.CompatibilityTypeBackward,
 		})
 	if err != nil {
+		if isSchemaRegistryAPIError(err) {
+			enabled, checkErr := isSchemaRegistryEnabled(ctx, client, project, serviceName)
+			if checkErr == nil && !enabled {
+				return nil
+			}
+		}
 		return diag.FromErr(err)
 	}
 
 	return nil
+}
+
+// isSchemaRegistryEnabled checks if the Schema Registry is enabled in the parent Kafka service.
+// This is used to verify if a 403 Forbidden error from the Schema Registry API is due to the feature
+// being intentionally disabled, allowing the provider to handle it gracefully.
+func isSchemaRegistryEnabled(ctx context.Context, client avngen.Client, project, serviceName string) (bool, error) {
+	key := filepath.Join(project, serviceName)
+
+	err := schemaRegistryAvailabilityCache.Do(key, func() error {
+		service, err := client.ServiceGet(ctx, project, serviceName)
+		if err != nil {
+			return err
+		}
+
+		var enabled bool
+		if v, ok := service.UserConfig["schema_registry"]; ok {
+			if val, ok := v.(bool); ok {
+				enabled = val
+			}
+		}
+
+		schemaRegistryState.Store(key, enabled)
+
+		return nil
+	})
+	if err != nil {
+		return false, err
+	}
+
+	if v, ok := schemaRegistryState.Load(key); ok {
+		return v.(bool), nil
+	}
+
+	return false, nil
+}
+
+// isSchemaRegistryAPIError checks if the error is a 403 Forbidden error.
+// The Aiven API returns 403 when an optional feature (like Schema Registry) is disabled.
+func isSchemaRegistryAPIError(err error) bool {
+	var avngenErr avngen.Error
+	if errors.As(err, &avngenErr) {
+		return avngenErr.Status == 403
+	}
+
+	return false
 }

--- a/internal/sdkprovider/service/kafkaschema/kafka_schema_configuration_data_source.go
+++ b/internal/sdkprovider/service/kafkaschema/kafka_schema_configuration_data_source.go
@@ -3,32 +3,33 @@ package kafkaschema
 import (
 	"context"
 
-	"github.com/aiven/aiven-go-client/v2"
+	avngen "github.com/aiven/go-client-codegen"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
+	"github.com/aiven/terraform-provider-aiven/internal/common"
 	"github.com/aiven/terraform-provider-aiven/internal/schemautil"
 )
 
 func DatasourceKafkaSchemaConfiguration() *schema.Resource {
 	return &schema.Resource{
-		ReadContext: datasourceKafkaSchemasConfigurationRead,
+		ReadContext: common.WithGenClientDiag(datasourceKafkaSchemasConfigurationRead),
 		Description: "The Kafka Schema Configuration data source provides information about the existing Aiven Kafka Schema Configuration.",
 		Schema: schemautil.ResourceSchemaAsDatasourceSchema(aivenKafkaSchemaSchema,
 			"project", "service_name"),
 	}
 }
 
-func datasourceKafkaSchemasConfigurationRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+func datasourceKafkaSchemasConfigurationRead(ctx context.Context, d *schema.ResourceData, client avngen.Client) diag.Diagnostics {
 	projectName := d.Get("project").(string)
 	serviceName := d.Get("service_name").(string)
 
-	_, err := m.(*aiven.Client).KafkaGlobalSchemaConfig.Get(ctx, projectName, serviceName)
+	_, err := client.ServiceSchemaRegistryGlobalConfigGet(ctx, projectName, serviceName)
 	if err != nil {
 		return diag.FromErr(err)
 	}
 
 	d.SetId(schemautil.BuildResourceID(projectName, serviceName))
 
-	return resourceKafkaSchemaConfigurationRead(ctx, d, m)
+	return resourceKafkaSchemaConfigurationRead(ctx, d, client)
 }


### PR DESCRIPTION
<!-- All contributors, please complete these sections, including maintainers. -->

## About this change—what it does

<!-- Provide a small sentence that summarizes the change. -->

<!-- Provide the issue number below, if it exists. -->
-  updated the `aiven_kafka_schema_configuration` resource to catch 403 errors during `Read` and `Delete` operations.
-  when a 403 error occurs, the provider now fetches the parent Kafka service configuration to verify if the Schema Registry is disabled
- updated acceptance tests to include lifecycle verification: enabling the feature, disabling it and re-enabling it.

Resolves: NEX-2245

<!-- Provide a small explanation on why this is the approach you took for solving this problem. -->
