### PR TITLE
docs(kafka): enable SASL auth example

### DIFF
--- a/examples/kafka/kafka_sasl_authentication/README.md
+++ b/examples/kafka/kafka_sasl_authentication/README.md
@@ -1,0 +1,7 @@
+# Enable and configure SASL authentication for Aiven for Apache Kafka®
+
+Aiven for Apache Kafka lets you use Simple Authentication and Security Layer (SASL) over SSL [to secure your data in transit](https://aiven.io/docs/products/kafka/concepts/auth-types).
+
+This example creates a Kafka service with the SASL authentication method enabled and configures SCRAM-SHA-256 as the SASL mechanism. It outputs the port number for SASL authentication using a public CA.
+
+You can also enable the public CA over a PivateLink connection by setting `letsencrypt_sasl_privatelink` to true in the `kafka_user_config`.

--- a/examples/kafka/kafka_sasl_authentication/provider.tf
+++ b/examples/kafka/kafka_sasl_authentication/provider.tf
@@ -1,0 +1,12 @@
+terraform {
+  required_providers {
+    aiven = {
+      source  = "aiven/aiven"
+      version = ">=4.0.0, <5.0.0"
+    }
+  }
+}
+
+provider "aiven" {
+  api_token = var.aiven_token
+}

--- a/examples/kafka/kafka_sasl_authentication/service.tf
+++ b/examples/kafka/kafka_sasl_authentication/service.tf
@@ -1,0 +1,31 @@
+resource "aiven_kafka" "example_kafka" {
+  project      = var.aiven_project
+  cloud_name   = var.cloud
+  plan         = var.plan
+  service_name = var.kafka_service_name
+
+  kafka_user_config {
+    kafka_authentication_methods {
+      certificate = true
+      sasl        = true # Enable SASL authentication
+    }
+    kafka_sasl_mechanisms {
+      scram_sha_256 = true
+    }
+
+  }
+}
+
+data "aiven_service_component" "public_ca" {
+  project                     = aiven_kafka.example_kafka.project
+  service_name                = aiven_kafka.example_kafka.service_name
+  component                   = "kafka"
+  route                       = "dynamic"
+  kafka_authentication_method = "sasl"
+  kafka_ssl_ca                = "letsencrypt"
+}
+
+output "port_number_public_ca" {
+  value       = data.aiven_service_component.public_ca.port
+  description = "Kafka service port for SASL authentication with public CA"
+}

--- a/examples/kafka/kafka_sasl_authentication/variables.tf
+++ b/examples/kafka/kafka_sasl_authentication/variables.tf
@@ -1,0 +1,27 @@
+variable "aiven_token" {
+  description = "Aiven token"
+  type        = string
+  sensitive   = true
+}
+
+variable "aiven_project" {
+  description = "Aiven project name"
+  type        = string
+}
+
+variable "cloud" {
+  description = "Cloud provider and region"
+  type        = string
+  default     = "google-europe-west1"
+}
+
+variable "plan" {
+  description = "Service plan name"
+  type        = string
+  default     = "business-4"
+}
+variable "kafka_service_name" {
+  description = "Name of the Kafka service"
+  type        = string
+  default     = "example-kafka-sasl-enabled"
+}


### PR DESCRIPTION
## About this change—what it does

Adds an example for using SASL auth for a Kafka service to be included in the Aiven docs.