### PR TITLE
fix(aiven_kafka_schema): handle error when Kafka Schema Registry disabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ nav_order: 1
 
 ## [4.49.0] - 2026-01-08
 
+- Fix `aiven_kafka_schema`: handle 403 Forbidden error when Schema Registry is disabled by verifying service state
 - Fix `aiven_kafka_schema_configuration`: handle 403 Forbidden error when Schema Registry is disabled by verifying service state
 - Add `aiven_service_list` data source: list all services in a project
 - Fix `aiven_kafka_topic`: retry 404 errors from `KafkaTopicListV2` endpoint

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/Masterminds/semver/v3 v3.4.0
 	github.com/agnivade/levenshtein v1.2.1
 	github.com/aiven/aiven-go-client/v2 v2.37.0
-	github.com/aiven/go-client-codegen v0.142.0
+	github.com/aiven/go-client-codegen v0.144.0
 	github.com/avast/retry-go v3.0.0+incompatible
 	github.com/dave/jennifer v1.7.1
 	github.com/docker/go-units v0.5.0

--- a/go.sum
+++ b/go.sum
@@ -78,8 +78,8 @@ github.com/aiven/aiven-go-client/v2 v2.37.0 h1:bROOt9K5VJxacavzC/UrtDEZuI0KlDX/o
 github.com/aiven/aiven-go-client/v2 v2.37.0/go.mod h1:XHS4+7sseQk+GR4Wwre3IvVonWb6fGNk67WmAzs+qZk=
 github.com/aiven/go-api-schemas v1.165.0 h1:4PUIa5g6ucp3zlO8cD3AAPcam4ls+EZlWfPgOg1wnuI=
 github.com/aiven/go-api-schemas v1.165.0/go.mod h1:APIzve1zu0BYXfbk9FBTqRwBiuT7++kEkbvZ0I1a4p0=
-github.com/aiven/go-client-codegen v0.142.0 h1:CukRLL1BkYpb/4X2EYDgypqXj6QBXdVkteXt4egiqqc=
-github.com/aiven/go-client-codegen v0.142.0/go.mod h1:+6eIsNIBB4KHMBTzy7maVAyoIZUyscTsL8ssHxrZZrU=
+github.com/aiven/go-client-codegen v0.144.0 h1:Cye5doUbu9gCLPWdy/pdJIuLLcZvOBoSWAGvTcWc2JY=
+github.com/aiven/go-client-codegen v0.144.0/go.mod h1:+6eIsNIBB4KHMBTzy7maVAyoIZUyscTsL8ssHxrZZrU=
 github.com/aiven/go-utils/selproj v0.1.0 h1:ruqLwK4Y4FcMJyt/g9j8QZVDr9vrVO5Y0afM2APzKdE=
 github.com/aiven/go-utils/selproj v0.1.0/go.mod h1:Tc71RJ7tPJ5V0IsVxSrXbAJQICGLpe5iMXS+rq8aLqg=
 github.com/alecthomas/assert/v2 v2.11.0 h1:2Q9r3ki8+JYXvGsDyBXwH3LcJ+WK5D0gc5E8vS6K3D0=

--- a/internal/sdkprovider/service/kafkaschema/kafka_schema.go
+++ b/internal/sdkprovider/service/kafkaschema/kafka_schema.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/aiven/aiven-go-client/v2"
+	avngen "github.com/aiven/go-client-codegen"
 	"github.com/aiven/go-client-codegen/handler/kafkaschemaregistry"
 	"github.com/hamba/avro/v2"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -122,10 +122,10 @@ func normalizeJSONOrProtobufString(i any) string {
 func ResourceKafkaSchema() *schema.Resource {
 	return &schema.Resource{
 		Description:   "The Kafka Schema resource allows the creation and management of Aiven Kafka Schemas.",
-		CreateContext: resourceKafkaSchemaUpsert,
-		UpdateContext: resourceKafkaSchemaUpsert,
-		ReadContext:   resourceKafkaSchemaRead,
-		DeleteContext: resourceKafkaSchemaDelete,
+		CreateContext: common.WithGenClientDiag(resourceKafkaSchemaUpsert),
+		UpdateContext: common.WithGenClientDiag(resourceKafkaSchemaUpsert),
+		ReadContext:   common.WithGenClientDiag(resourceKafkaSchemaRead),
+		DeleteContext: common.WithGenClientDiag(resourceKafkaSchemaDelete),
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},
@@ -136,22 +136,21 @@ func ResourceKafkaSchema() *schema.Resource {
 	}
 }
 
-func resourceKafkaSchemaUpsert(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+func resourceKafkaSchemaUpsert(ctx context.Context, d *schema.ResourceData, client avngen.Client) diag.Diagnostics {
 	project := d.Get("project").(string)
 	serviceName := d.Get("service_name").(string)
 	subjectName := d.Get("subject_name").(string)
 
-	client := m.(*aiven.Client)
 	if d.HasChange("schema") {
 		// This call returns Schema ID, not its version
-		s, err := client.KafkaSubjectSchemas.Add(
+		schemaId, err := client.ServiceSchemaRegistrySubjectVersionPost(
 			ctx,
 			project,
 			serviceName,
 			subjectName,
-			aiven.KafkaSchemaSubject{
+			&kafkaschemaregistry.ServiceSchemaRegistrySubjectVersionPostIn{
 				Schema:     d.Get("schema").(string),
-				SchemaType: d.Get("schema_type").(string),
+				SchemaType: kafkaschemaregistry.SchemaType(d.Get("schema_type").(string)),
 			},
 		)
 		if err != nil {
@@ -159,7 +158,7 @@ func resourceKafkaSchemaUpsert(ctx context.Context, d *schema.ResourceData, m in
 		}
 
 		// Gets Schema's version by its ID
-		version, err := getSchemaVersion(ctx, client, project, serviceName, subjectName, s.Id)
+		version, err := getSchemaVersion(ctx, client, project, serviceName, subjectName, schemaId)
 		if err != nil {
 			return diag.Errorf("unable to get schema version: %s", err)
 		}
@@ -171,12 +170,14 @@ func resourceKafkaSchemaUpsert(ctx context.Context, d *schema.ResourceData, m in
 
 	// if compatibility_level has changed and the new value is not empty
 	if compatibility, ok := d.GetOk("compatibility_level"); ok {
-		_, err := client.KafkaSubjectSchemas.UpdateConfiguration(
+		_, err := client.ServiceSchemaRegistrySubjectConfigPut(
 			ctx,
 			project,
 			serviceName,
 			subjectName,
-			compatibility.(string),
+			&kafkaschemaregistry.ServiceSchemaRegistrySubjectConfigPutIn{
+				Compatibility: kafkaschemaregistry.CompatibilityType(compatibility.(string)),
+			},
 		)
 		if err != nil {
 			return diag.Errorf("unable to update configuration: %s", err)
@@ -184,61 +185,70 @@ func resourceKafkaSchemaUpsert(ctx context.Context, d *schema.ResourceData, m in
 	}
 
 	d.SetId(schemautil.BuildResourceID(project, serviceName, subjectName))
-	return resourceKafkaSchemaRead(ctx, d, m)
+	return resourceKafkaSchemaRead(ctx, d, client)
 }
 
 // getSchemaVersion polls until the version with given Schema ID appears in the version list
-func getSchemaVersion(ctx context.Context, client *aiven.Client, project, serviceName, subjectName string, id int) (int, error) {
+func getSchemaVersion(ctx context.Context, client avngen.Client, project, serviceName, subjectName string, id int) (int, error) {
 	for {
 		select {
 		case <-ctx.Done():
 			return 0, ctx.Err()
 		case <-time.After(time.Second):
-			versions, err := client.KafkaSubjectSchemas.GetVersions(ctx, project, serviceName, subjectName)
+			versions, err := client.ServiceSchemaRegistrySubjectVersionsGet(ctx, project, serviceName, subjectName)
 			if err != nil {
 				return 0, err
 			}
 
-			for _, v := range versions.Versions {
-				s, err := client.KafkaSubjectSchemas.Get(ctx, project, serviceName, subjectName, v)
+			for _, v := range versions {
+				s, err := client.ServiceSchemaRegistrySubjectVersionGet(ctx, project, serviceName, subjectName, v)
 				if err != nil {
 					return 0, err
 				}
 
-				if s.Version.Id == id {
-					return s.Version.Version, nil
+				if s.Id == id {
+					return s.Version, nil
 				}
 			}
 		}
 	}
 }
 
-func resourceKafkaSchemaRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+func resourceKafkaSchemaRead(ctx context.Context, d *schema.ResourceData, client avngen.Client) diag.Diagnostics {
 	project, serviceName, subjectName, err := schemautil.SplitResourceID3(d.Id())
 	if err != nil {
 		return diag.FromErr(err)
 	}
 
-	client := m.(*aiven.Client)
+	// if Schema Registry is disabled, the resource is considered deleted
+	enabled, err := isSchemaRegistryEnabled(ctx, client, project, serviceName)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	if !enabled {
+		d.SetId("")
+		return nil
+	}
+
 	version := d.Get("version").(int)
 	if version == 0 {
 		// For data source type and "import"
-		r, err := client.KafkaSubjectSchemas.GetVersions(ctx, project, serviceName, subjectName)
+		versions, err := client.ServiceSchemaRegistrySubjectVersionsGet(ctx, project, serviceName, subjectName)
 		if err != nil {
 			return diag.FromErr(schemautil.ResourceReadHandleNotFound(err, d))
 		}
-		version = slices.Max(r.Versions)
+		version = slices.Max(versions)
 		if err := d.Set("version", version); err != nil {
 			return diag.FromErr(err)
 		}
 	}
 
-	s, err := client.KafkaSubjectSchemas.Get(ctx, project, serviceName, subjectName, version)
+	s, err := client.ServiceSchemaRegistrySubjectVersionGet(ctx, project, serviceName, subjectName, version)
 	if err != nil {
 		return diag.FromErr(schemautil.ResourceReadHandleNotFound(err, d))
 	}
 
-	if err := d.Set("schema", s.Version.Schema); err != nil {
+	if err := d.Set("schema", s.Schema); err != nil {
 		return diag.FromErr(err)
 	}
 
@@ -252,29 +262,47 @@ func resourceKafkaSchemaRead(ctx context.Context, d *schema.ResourceData, m inte
 		return diag.FromErr(err)
 	}
 
-	c, err := client.KafkaSubjectSchemas.GetConfiguration(ctx, project, serviceName, subjectName)
+	compatibilityLevel, err := client.ServiceSchemaRegistrySubjectConfigGet(
+		ctx,
+		project,
+		serviceName,
+		subjectName,
+		kafkaschemaregistry.ServiceSchemaRegistrySubjectConfigGetGlobalDefaultFallback(false),
+	)
 	if err != nil {
-		if !aiven.IsNotFound(err) {
-			return diag.FromErr(err)
+		if avngen.IsNotFound(err) {
+			return nil
 		}
-	} else {
-		if err := d.Set("compatibility_level", c.CompatibilityLevel); err != nil {
-			return diag.FromErr(err)
-		}
+
+		return diag.FromErr(err)
+	}
+
+	if err := d.Set("compatibility_level", string(compatibilityLevel)); err != nil {
+		return diag.FromErr(err)
 	}
 
 	return nil
 }
 
-func resourceKafkaSchemaDelete(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+func resourceKafkaSchemaDelete(ctx context.Context, d *schema.ResourceData, client avngen.Client) diag.Diagnostics {
 	project, serviceName, schemaName, err := schemautil.SplitResourceID3(d.Id())
 	if err != nil {
 		return diag.FromErr(err)
 	}
 
-	err = m.(*aiven.Client).KafkaSubjectSchemas.Delete(ctx, project, serviceName, schemaName)
-	if common.IsCritical(err) {
+	enabled, err := isSchemaRegistryEnabled(ctx, client, project, serviceName)
+	if err != nil {
 		return diag.FromErr(err)
+	}
+	if !enabled {
+		return nil
+	}
+
+	err = client.ServiceSchemaRegistrySubjectDelete(ctx, project, serviceName, schemaName)
+	if err != nil {
+		if common.IsCritical(err) {
+			return diag.FromErr(err)
+		}
 	}
 
 	return nil
@@ -312,6 +340,16 @@ func resourceKafkaSchemaCustomizeDiff(ctx context.Context, d *schema.ResourceDif
 		},
 	)
 	if err != nil {
+		// if Schema Registry is disabled, skip compatibility check
+		project := d.Get("project").(string)
+		serviceName := d.Get("service_name").(string)
+		enabled, checkErr := isSchemaRegistryEnabled(ctx, client, project, serviceName)
+		if checkErr != nil {
+			return fmt.Errorf("unable to check schema registry status: %w", checkErr)
+		}
+		if !enabled {
+			return nil
+		}
 		return fmt.Errorf("unable to check schema validity: %w", err)
 	}
 

--- a/internal/sdkprovider/service/kafkaschema/kafka_schema_data_source.go
+++ b/internal/sdkprovider/service/kafkaschema/kafka_schema_data_source.go
@@ -3,37 +3,37 @@ package kafkaschema
 import (
 	"context"
 
-	"github.com/aiven/aiven-go-client/v2"
+	avngen "github.com/aiven/go-client-codegen"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"golang.org/x/exp/slices"
 
+	"github.com/aiven/terraform-provider-aiven/internal/common"
 	"github.com/aiven/terraform-provider-aiven/internal/schemautil"
 )
 
 func DatasourceKafkaSchema() *schema.Resource {
 	return &schema.Resource{
-		ReadContext: datasourceKafkaSchemaRead,
+		ReadContext: common.WithGenClientDiag(datasourceKafkaSchemaRead),
 		Description: "The Kafka Schema data source provides information about the existing Aiven Kafka Schema.",
 		Schema: schemautil.ResourceSchemaAsDatasourceSchema(aivenKafkaSchemaSchema,
 			"project", "service_name", "subject_name"),
 	}
 }
 
-func datasourceKafkaSchemaRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+func datasourceKafkaSchemaRead(ctx context.Context, d *schema.ResourceData, client avngen.Client) diag.Diagnostics {
 	projectName := d.Get("project").(string)
 	serviceName := d.Get("service_name").(string)
 	subjectName := d.Get("subject_name").(string)
 
-	subjects, err := m.(*aiven.Client).KafkaSubjectSchemas.List(ctx, projectName, serviceName)
+	subjects, err := client.ServiceSchemaRegistrySubjects(ctx, projectName, serviceName)
 	if err != nil {
 		return diag.FromErr(err)
 	}
 
-	for _, subject := range subjects.Subjects {
-		if subject == subjectName {
-			d.SetId(schemautil.BuildResourceID(projectName, serviceName, subjectName))
-			return resourceKafkaSchemaRead(ctx, d, m)
-		}
+	if slices.Contains(subjects, subjectName) {
+		d.SetId(schemautil.BuildResourceID(projectName, serviceName, subjectName))
+		return resourceKafkaSchemaRead(ctx, d, client)
 	}
 
 	return diag.Errorf("kafka schema subject %s/%s/%s not found",


### PR DESCRIPTION
<!-- All contributors, please complete these sections, including maintainers. -->

## About this change—what it does

<!-- Provide a small sentence that summarizes the change. -->

<!-- Provide the issue number below, if it exists. -->
- updated the `aiven_kafka_schema` resource to catch `403` errors during Read and Delete operations. When a 403 error occurs, the provider now fetches the parent Kafka service configuration to verify if the Schema Registry is disabled
- updated acceptance tests to include lifecycle verification: enabling the feature, disabling it and re-enabling it
- replaced old client with a new genclient in `aiven_kafka_schema`

Resolves: NEX-2251
<!-- Provide a small explanation on why this is the approach you took for solving this problem. -->
