### PR TITLE
feat: MM2 follower fetching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ nav_order: 1
 - Add `aiven_pg` field `pg_user_config.backup_interval_hours`: Interval in hours between automatic backups. Minimum value is 3 hours
 - Add `aiven_pg` field `pg_user_config.backup_retention_days`: Number of days to retain automatic backups. Backups older
   than this value will be automatically deleted
+- Add `follower_fetching_enabled` field to `aiven_mirrormaker_replication_flow`: Assigns a Rack ID based on the availability-zone to enable follower fetching and rack awareness per replication flow
 
 ## [4.49.0] - 2026-01-08
 

--- a/TaskInternal.yml
+++ b/TaskInternal.yml
@@ -226,6 +226,11 @@ tasks:
       - "{{.GO_CMD}} get github.com/aiven/go-api-schemas@latest"
       - "{{.GO_CMD}} mod tidy"
 
+  dump-mockery:
+    desc: "Generate mocks after client updates"
+    cmds:
+      - task: mockery
+
   mockery:
     desc: "Generate mocks for interfaces"
     preconditions:

--- a/docs/data-sources/mirrormaker_replication_flow.md
+++ b/docs/data-sources/mirrormaker_replication_flow.md
@@ -38,6 +38,7 @@ data "aiven_mirrormaker_replication_flow" "example_replication_flow" {
 - `emit_heartbeats_enabled` (Boolean) Enables emitting heartbeats to the target cluster. The default value is `false`.
 - `enable` (Boolean) Enables replication flow for a service.
 - `exactly_once_delivery_enabled` (Boolean) Enables exactly-once message delivery. Set this to `enabled` for new replications. The default value is `false`.
+- `follower_fetching_enabled` (Boolean) Assigns a Rack ID based on the availability-zone to enable follower fetching and rack awareness per replication flow. Defaults to enabled by the service for new flows, but is left unchanged for existing ones when not set.
 - `id` (String) The ID of this resource.
 - `offset_syncs_topic_location` (String) Offset syncs topic location. The possible values are `source` and `target`.
 - `replication_factor` (Number) Replication factor, `>= 1`.

--- a/docs/resources/mirrormaker_replication_flow.md
+++ b/docs/resources/mirrormaker_replication_flow.md
@@ -60,6 +60,7 @@ resource "aiven_mirrormaker_replication_flow" "example_replication_flow" {
 - `emit_backward_heartbeats_enabled` (Boolean) Enables emitting heartbeats to the direction opposite to the flow, i.e. to the source cluster. The default value is `false`.
 - `emit_heartbeats_enabled` (Boolean) Enables emitting heartbeats to the target cluster. The default value is `false`.
 - `exactly_once_delivery_enabled` (Boolean) Enables exactly-once message delivery. Set this to `enabled` for new replications. The default value is `false`.
+- `follower_fetching_enabled` (Boolean) Assigns a Rack ID based on the availability-zone to enable follower fetching and rack awareness per replication flow. Defaults to enabled by the service for new flows, but is left unchanged for existing ones when not set.
 - `replication_factor` (Number) Replication factor, `>= 1`.
 - `sync_group_offsets_enabled` (Boolean) Sync consumer group offsets. The default value is `false`.
 - `sync_group_offsets_interval_seconds` (Number) Frequency of consumer group offset sync. The default value is `1`.

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/Masterminds/semver/v3 v3.4.0
 	github.com/agnivade/levenshtein v1.2.1
 	github.com/aiven/aiven-go-client/v2 v2.37.0
-	github.com/aiven/go-client-codegen v0.145.0
+	github.com/aiven/go-client-codegen v0.146.0
 	github.com/avast/retry-go v3.0.0+incompatible
 	github.com/dave/jennifer v1.7.1
 	github.com/docker/go-units v0.5.0
@@ -268,7 +268,7 @@ require (
 
 require (
 	github.com/agext/levenshtein v1.2.3 // indirect
-	github.com/aiven/go-api-schemas v1.166.0
+	github.com/aiven/go-api-schemas v1.167.0
 	github.com/bgentry/go-netrc v0.0.0-20140422174119-9fd32a8b3d3d // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/fatih/color v1.18.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -76,10 +76,10 @@ github.com/agnivade/levenshtein v1.2.1 h1:EHBY3UOn1gwdy/VbFwgo4cxecRznFk7fKWN1KO
 github.com/agnivade/levenshtein v1.2.1/go.mod h1:QVVI16kDrtSuwcpd0p1+xMC6Z/VfhtCyDIjcwga4/DU=
 github.com/aiven/aiven-go-client/v2 v2.37.0 h1:bROOt9K5VJxacavzC/UrtDEZuI0KlDX/oP76W+DsxcM=
 github.com/aiven/aiven-go-client/v2 v2.37.0/go.mod h1:XHS4+7sseQk+GR4Wwre3IvVonWb6fGNk67WmAzs+qZk=
-github.com/aiven/go-api-schemas v1.166.0 h1:J24YwFqHHWU5x3bNKBWk63Efp+g2BTrT5/Hk+kOh/E4=
-github.com/aiven/go-api-schemas v1.166.0/go.mod h1:WTWdlammndlBvINEUP2F8JDmOef6rEWkpNVhJS33GcQ=
-github.com/aiven/go-client-codegen v0.145.0 h1:UmwRa3w4vpGdSeiKvbWZFLKmDLUO06B1ZtIxDuDyLFU=
-github.com/aiven/go-client-codegen v0.145.0/go.mod h1:+6eIsNIBB4KHMBTzy7maVAyoIZUyscTsL8ssHxrZZrU=
+github.com/aiven/go-api-schemas v1.167.0 h1:jDSZRqKkf1zrprOGfZ8MF7Aq3c9qWlOYLnWe4W29+Jk=
+github.com/aiven/go-api-schemas v1.167.0/go.mod h1:WTWdlammndlBvINEUP2F8JDmOef6rEWkpNVhJS33GcQ=
+github.com/aiven/go-client-codegen v0.146.0 h1:cAcZT/36zRDGhNBVCA2QcPvN0g3A1Qbj2ikRAJOCLfc=
+github.com/aiven/go-client-codegen v0.146.0/go.mod h1:+6eIsNIBB4KHMBTzy7maVAyoIZUyscTsL8ssHxrZZrU=
 github.com/aiven/go-utils/selproj v0.1.0 h1:ruqLwK4Y4FcMJyt/g9j8QZVDr9vrVO5Y0afM2APzKdE=
 github.com/aiven/go-utils/selproj v0.1.0/go.mod h1:Tc71RJ7tPJ5V0IsVxSrXbAJQICGLpe5iMXS+rq8aLqg=
 github.com/alecthomas/assert/v2 v2.11.0 h1:2Q9r3ki8+JYXvGsDyBXwH3LcJ+WK5D0gc5E8vS6K3D0=

--- a/internal/sdkprovider/service/kafka/mirrormaker_replication_flow.go
+++ b/internal/sdkprovider/service/kafka/mirrormaker_replication_flow.go
@@ -131,6 +131,12 @@ var aivenMirrorMakerReplicationFlowSchema = map[string]*schema.Schema{
 			"Enables exactly-once message delivery. Set this to `enabled` for new replications.",
 		).DefaultValue(false).Build(),
 	},
+	"follower_fetching_enabled": {
+		Type:        schema.TypeBool,
+		Optional:    true,
+		Computed:    true,
+		Description: userconfig.Desc("Assigns a Rack ID based on the availability-zone to enable follower fetching and rack awareness per replication flow. Defaults to enabled by the service for new flows, but is left unchanged for existing ones when not set.").Build(),
+	},
 }
 
 func ResourceMirrorMakerReplicationFlow() *schema.Resource {

--- a/internal/sdkprovider/service/kafka/mirrormaker_replication_flow_test.go
+++ b/internal/sdkprovider/service/kafka/mirrormaker_replication_flow_test.go
@@ -42,6 +42,7 @@ func TestAccAivenMirrorMakerReplicationFlow_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "topics_blacklist.2", "__.*"),
 					resource.TestCheckResourceAttr(resourceName, "config_properties_exclude.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "exactly_once_delivery_enabled", "true"),
+					resource.TestCheckResourceAttr(resourceName, "follower_fetching_enabled", "true"),
 				),
 			},
 			{
@@ -226,6 +227,7 @@ resource "aiven_mirrormaker_replication_flow" "foo" {
   emit_backward_heartbeats_enabled    = true
   offset_syncs_topic_location         = "source"
   exactly_once_delivery_enabled       = true
+  follower_fetching_enabled           = true
 
   topics = [
     ".*",


### PR DESCRIPTION
## About this change—what it does
We update the `aivenMirrorMakerReplicationFlowSchema` with `follower_fetching_enabled` configured per replication flow and enabled by default.

See related aiven [docs](https://aiven.io/docs/products/kafka/kafka-mirrormaker/howto/mm2-rack-awareness).

[FLEET-6349]

[FLEET-6349]: https://aiven.atlassian.net/browse/FLEET-6349?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ