### PR TITLE
refactor(kafka_topic): use generated client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ nav_order: 1
 
 ## [MAJOR.MINOR.PATCH] - YYYY-MM-DD
 
+- Migrate `aiven_kafka_topic` resource and data source to the generated Go client
 - Add `aiven_organization_application_user` field `create_time`: Time this application user was created.
 - Add `aiven_kafka_topic` field `config.message_timestamp_after_max_ms`: The maximum difference allowed between
   the timestamp when a broker receives a message and the timestamp specified in the message. Applies only for messages

--- a/internal/sdkprovider/kafkatopicrepository/create.go
+++ b/internal/sdkprovider/kafkatopicrepository/create.go
@@ -5,13 +5,14 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/aiven/aiven-go-client/v2"
+	avngen "github.com/aiven/go-client-codegen"
+	"github.com/aiven/go-client-codegen/handler/kafkatopic"
 )
 
 // Create creates a topic.
 // First checks if the topic does not exist for the safety
 // Then calls creates topic.
-func (rep *repository) Create(ctx context.Context, project, service string, req aiven.CreateKafkaTopicRequest) error {
+func (rep *repository) Create(ctx context.Context, project, service string, req *kafkatopic.ServiceKafkaTopicCreateIn) error {
 	// aiven.KafkaTopics.Create() function may return 501 on create
 	// Second call might say that topic already exists, and we have retries in aiven client
 	// So to be sure, better check it before create
@@ -25,8 +26,8 @@ func (rep *repository) Create(ctx context.Context, project, service string, req 
 		return err
 	}
 
-	err = rep.client.Create(ctx, project, service, req)
-	if err != nil && !aiven.IsAlreadyExists(err) {
+	err = rep.client.ServiceKafkaTopicCreate(ctx, project, service, req)
+	if err != nil && !avngen.IsAlreadyExists(err) {
 		return fmt.Errorf("topic create error: %w", err)
 	}
 

--- a/internal/sdkprovider/kafkatopicrepository/create_test.go
+++ b/internal/sdkprovider/kafkatopicrepository/create_test.go
@@ -9,7 +9,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/aiven/aiven-go-client/v2"
+	avngen "github.com/aiven/go-client-codegen"
+	"github.com/aiven/go-client-codegen/handler/kafkatopic"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -24,7 +25,7 @@ func TestCreateConflict(t *testing.T) {
 	var wg sync.WaitGroup
 	for range 100 {
 		wg.Go(func() {
-			err := rep.Create(ctx, "a", "b", aiven.CreateKafkaTopicRequest{TopicName: "c"})
+			err := rep.Create(ctx, "a", "b", &kafkatopic.ServiceKafkaTopicCreateIn{TopicName: "c"})
 			if errors.Is(err, errAlreadyExists) {
 				atomic.AddInt32(&conflictErr, 1)
 			}
@@ -47,7 +48,7 @@ func TestCreateRecreateMissing(t *testing.T) {
 	ctx := context.Background()
 
 	// Creates topic
-	err := rep.Create(ctx, "a", "b", aiven.CreateKafkaTopicRequest{TopicName: "c"})
+	err := rep.Create(ctx, "a", "b", &kafkatopic.ServiceKafkaTopicCreateIn{TopicName: "c"})
 	require.NoError(t, err)
 	assert.EqualValues(t, 1, client.createCalled)
 	assert.EqualValues(t, 1, client.v1ListCalled)
@@ -62,7 +63,7 @@ func TestCreateRecreateMissing(t *testing.T) {
 	assert.False(t, rep.seenTopics["a/b/c"]) // not cached, missing
 
 	// Recreates topic
-	err = rep.Create(ctx, "a", "b", aiven.CreateKafkaTopicRequest{TopicName: "c"})
+	err = rep.Create(ctx, "a", "b", &kafkatopic.ServiceKafkaTopicCreateIn{TopicName: "c"})
 	require.NoError(t, err)
 	assert.EqualValues(t, 2, client.createCalled) // Updated
 	assert.EqualValues(t, 1, client.v1ListCalled)
@@ -87,7 +88,7 @@ func TestCreateRetries(t *testing.T) {
 		{
 			name: "emulates case when 501 retried in client and then 409 received (ignores 409)",
 			createErr: []error{
-				aiven.Error{Status: 409, Message: "already exists"},
+				avngen.Error{Status: 409, Message: "already exists"},
 			},
 			expectCalled: 1, // exists on the first call as it means the topic is created
 		},
@@ -103,7 +104,7 @@ func TestCreateRetries(t *testing.T) {
 			rep := newRepository(client)
 			rep.workerCallInterval = time.Millisecond
 
-			req := aiven.CreateKafkaTopicRequest{
+			req := &kafkatopic.ServiceKafkaTopicCreateIn{
 				TopicName: "my-topic",
 			}
 			err := rep.Create(ctx, "foo", "bar", req)

--- a/internal/sdkprovider/kafkatopicrepository/delete.go
+++ b/internal/sdkprovider/kafkatopicrepository/delete.go
@@ -3,7 +3,7 @@ package kafkatopicrepository
 import (
 	"context"
 
-	"github.com/aiven/aiven-go-client/v2"
+	avngen "github.com/aiven/go-client-codegen"
 )
 
 func (rep *repository) Delete(ctx context.Context, project, service, topic string) error {
@@ -11,8 +11,8 @@ func (rep *repository) Delete(ctx context.Context, project, service, topic strin
 	// because 404 is also returned for "unknown" topic.
 	// But it speedups things a lot (no "read" performed),
 	// and if kafka has been off, it will make it easier to remove topics from state
-	err := rep.client.Delete(ctx, project, service, topic)
-	if err != nil && !aiven.IsNotFound(err) {
+	err := rep.client.ServiceKafkaTopicDelete(ctx, project, service, topic)
+	if err != nil && !avngen.IsNotFound(err) {
 		return err
 	}
 

--- a/internal/sdkprovider/kafkatopicrepository/delete_test.go
+++ b/internal/sdkprovider/kafkatopicrepository/delete_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"testing"
 
-	"github.com/aiven/aiven-go-client/v2"
+	"github.com/aiven/go-client-codegen/handler/kafkatopic"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -27,7 +27,7 @@ func TestDeleteDoesNotExist(t *testing.T) {
 func TestDeletesAfterRetry(t *testing.T) {
 	client := &fakeTopicClient{
 		deleteErr: errNotFound,
-		storage: map[string]*aiven.KafkaListTopic{
+		storage: map[string]kafkatopic.TopicOut{
 			"a/b/c": {TopicName: "c"},
 		},
 	}

--- a/internal/sdkprovider/kafkatopicrepository/read.go
+++ b/internal/sdkprovider/kafkatopicrepository/read.go
@@ -4,12 +4,13 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/aiven/aiven-go-client/v2"
+	avngen "github.com/aiven/go-client-codegen"
+	"github.com/aiven/go-client-codegen/handler/kafkatopic"
 	"github.com/avast/retry-go"
 	"github.com/samber/lo"
 )
 
-func (rep *repository) Read(ctx context.Context, project, service, topic string) (*aiven.KafkaTopic, error) {
+func (rep *repository) Read(ctx context.Context, project, service, topic string) (*kafkatopic.ServiceKafkaTopicGetOut, error) {
 	// We have quick methods to determine that topic does not exist
 	err := rep.exists(ctx, project, service, topic, false)
 	if err != nil {
@@ -42,7 +43,7 @@ func (rep *repository) Read(ctx context.Context, project, service, topic string)
 // Exists omits service not found
 func (rep *repository) Exists(ctx context.Context, project, service, topic string) (bool, error) {
 	err := rep.exists(ctx, project, service, topic, false)
-	if aiven.IsNotFound(err) {
+	if avngen.IsNotFound(err) {
 		// Either topic or service or project does not exist
 		return false, nil
 	}
@@ -54,7 +55,6 @@ func (rep *repository) Exists(ctx context.Context, project, service, topic strin
 // 2. calls v1List for the remote state for the given service and marks it in repository.seenServices
 // 3. saves topic names to repository.seenTopics, so its result can be reused
 // 4. when acquire true, then saves topic to repository.seenTopics (for creating)
-// todo: use context with the new client
 func (rep *repository) exists(ctx context.Context, project, service, topic string, acquire bool) error {
 	rep.Lock()
 	defer rep.Unlock()
@@ -69,7 +69,7 @@ func (rep *repository) exists(ctx context.Context, project, service, topic strin
 
 	// Goes for v1List
 	if !rep.seenServices[serviceKey] {
-		list, err := rep.client.List(ctx, project, service)
+		list, err := rep.client.ServiceKafkaTopicList(ctx, project, service)
 		if err != nil {
 			return err
 		}
@@ -129,15 +129,15 @@ func (rep *repository) fetch(ctx context.Context, queue map[string]*request) {
 		for _, chunk := range lo.Chunk(topicNames, rep.v2ListBatchSize) {
 			// V2List() and Get() do not get info immediately
 			// Some retries should be applied if result is not equal to requested values
-			var list []*aiven.KafkaTopic
+			var list []kafkatopic.ServiceKafkaTopicGetOut
 			err := retry.Do(func() error {
-				rspList, err := rep.client.V2List(ctx, project, service, chunk)
+				rspList, err := rep.client.ServiceKafkaTopicListV2(ctx, project, service, &kafkatopic.ServiceKafkaTopicListV2In{TopicNames: chunk})
 
 				// A 404 means that the "chunk" contains a topic not found on the backend,
 				// even though repository.exists confirmed the topic exists.
 				// The backend uses a cache, and the two endpoints might be inconsistent.
 				// Keeps retrying.
-				if aiven.IsNotFound(err) {
+				if avngen.IsNotFound(err) {
 					return fmt.Errorf("topic list is inconsistent: %w", err)
 				}
 
@@ -167,7 +167,7 @@ func (rep *repository) fetch(ctx context.Context, queue map[string]*request) {
 
 			// Sends topics
 			for _, t := range list {
-				queue[newKey(project, service, t.TopicName)].send(t, nil)
+				queue[newKey(project, service, t.TopicName)].send(&t, nil)
 			}
 		}
 	}

--- a/internal/sdkprovider/kafkatopicrepository/repository.go
+++ b/internal/sdkprovider/kafkatopicrepository/repository.go
@@ -7,17 +7,18 @@ import (
 	"sync"
 	"time"
 
-	"github.com/aiven/aiven-go-client/v2"
+	avngen "github.com/aiven/go-client-codegen"
+	"github.com/aiven/go-client-codegen/handler/kafkatopic"
 )
 
 var (
 	initOnce sync.Once
 	// singleRep a singleton for repository to share it across running goroutines
 	singleRep = &repository{}
-	// errNotFound mimics Aiven "not found" error. Never wrap it, so it can be determined by aiven.IsNotFound
-	errNotFound = aiven.Error{Status: http.StatusNotFound, Message: "Topic not found"}
-	// errAlreadyExists mimics Aiven "conflict" error. Never wrap it, so it can be determined by aiven.IsAlreadyExists
-	errAlreadyExists = aiven.Error{Status: http.StatusConflict, Message: "Topic conflict, already exists"}
+	// errNotFound mimics Aiven "not found" error. Never wrap it, so it can be determined by avngen.IsNotFound
+	errNotFound = avngen.Error{Status: http.StatusNotFound, Message: "Topic not found"}
+	// errAlreadyExists mimics Aiven "conflict" error. Never wrap it, so it can be determined by avngen.IsAlreadyExists
+	errAlreadyExists = avngen.Error{Status: http.StatusConflict, Message: "Topic conflict, already exists"}
 )
 
 const (
@@ -44,20 +45,20 @@ func New(client topicsClient) Repository {
 
 // Repository CRUD interface for topics
 type Repository interface {
-	Create(ctx context.Context, project, service string, req aiven.CreateKafkaTopicRequest) error
-	Read(ctx context.Context, project, service, topic string) (*aiven.KafkaTopic, error)
-	Update(ctx context.Context, project, service, topic string, req aiven.UpdateKafkaTopicRequest) error
+	Create(ctx context.Context, project, service string, req *kafkatopic.ServiceKafkaTopicCreateIn) error
+	Read(ctx context.Context, project, service, topic string) (*kafkatopic.ServiceKafkaTopicGetOut, error)
+	Update(ctx context.Context, project, service, topic string, req *kafkatopic.ServiceKafkaTopicUpdateIn) error
 	Delete(ctx context.Context, project, service, topic string) error
 	Exists(ctx context.Context, project, service, topic string) (bool, error)
 }
 
 // topicsClient interface for unit tests
 type topicsClient interface {
-	List(ctx context.Context, project, service string) ([]*aiven.KafkaListTopic, error)
-	V2List(ctx context.Context, project, service string, topicNames []string) ([]*aiven.KafkaTopic, error)
-	Create(ctx context.Context, project, service string, req aiven.CreateKafkaTopicRequest) error
-	Update(ctx context.Context, project, service, topic string, req aiven.UpdateKafkaTopicRequest) error
-	Delete(ctx context.Context, project, service, topic string) error
+	ServiceKafkaTopicList(ctx context.Context, project, serviceName string) ([]kafkatopic.TopicOut, error)
+	ServiceKafkaTopicListV2(ctx context.Context, project, serviceName string, in *kafkatopic.ServiceKafkaTopicListV2In) ([]kafkatopic.ServiceKafkaTopicGetOut, error)
+	ServiceKafkaTopicCreate(ctx context.Context, project, serviceName string, in *kafkatopic.ServiceKafkaTopicCreateIn) error
+	ServiceKafkaTopicUpdate(ctx context.Context, project, serviceName string, topicName string, in *kafkatopic.ServiceKafkaTopicUpdateIn) error
+	ServiceKafkaTopicDelete(ctx context.Context, project, serviceName string, topicName string) error
 }
 
 func newRepository(client topicsClient) *repository {
@@ -153,7 +154,7 @@ func (rep *repository) forgetService(project, service string) {
 }
 
 type response struct {
-	topic *aiven.KafkaTopic
+	topic *kafkatopic.ServiceKafkaTopicGetOut
 	err   error
 }
 
@@ -168,7 +169,7 @@ func (r *request) key() string {
 	return newKey(r.project, r.service, r.topic)
 }
 
-func (r *request) send(topic *aiven.KafkaTopic, err error) {
+func (r *request) send(topic *kafkatopic.ServiceKafkaTopicGetOut, err error) {
 	r.rsp <- &response{topic: topic, err: err}
 }
 

--- a/internal/sdkprovider/kafkatopicrepository/repository_test.go
+++ b/internal/sdkprovider/kafkatopicrepository/repository_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/aiven/aiven-go-client/v2"
+	"github.com/aiven/go-client-codegen/handler/kafkatopic"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -19,7 +19,7 @@ func TestRepositoryContextWithDeadline(t *testing.T) {
 	defer cancel()
 
 	rep := newRepository(&fakeTopicClient{
-		storage: map[string]*aiven.KafkaListTopic{
+		storage: map[string]kafkatopic.TopicOut{
 			"a/b/c": {TopicName: "c"},
 		},
 	})
@@ -36,7 +36,7 @@ func TestRepositoryRead(t *testing.T) {
 		requests  []request  // to call Read()
 		responses []response // to get from Read()
 		// fakeTopicClient params
-		storage         map[string]*aiven.KafkaListTopic
+		storage         map[string]kafkatopic.TopicOut
 		v1ListErr       error
 		v1ListCalled    int32
 		v2ListErr       error
@@ -51,7 +51,7 @@ func TestRepositoryRead(t *testing.T) {
 			responses: []response{
 				{err: errNotFound},
 			},
-			storage:         make(map[string]*aiven.KafkaListTopic),
+			storage:         make(map[string]kafkatopic.TopicOut),
 			v1ListCalled:    1,
 			v2ListCalled:    0, // doesn't reach V2List, because "storage" doesn't return the topic
 			v2ListBatchSize: defaultV2ListBatchSize,
@@ -62,9 +62,9 @@ func TestRepositoryRead(t *testing.T) {
 				{project: "a", service: "b", topic: "c"},
 			},
 			responses: []response{
-				{topic: &aiven.KafkaTopic{TopicName: "c"}},
+				{topic: &kafkatopic.ServiceKafkaTopicGetOut{TopicName: "c"}},
 			},
-			storage: map[string]*aiven.KafkaListTopic{
+			storage: map[string]kafkatopic.TopicOut{
 				"a/b/c": {TopicName: "c"},
 			},
 			v1ListCalled:    1,
@@ -78,10 +78,10 @@ func TestRepositoryRead(t *testing.T) {
 				{project: "a", service: "b", topic: "d"},
 			},
 			responses: []response{
-				{topic: &aiven.KafkaTopic{TopicName: "c"}},
+				{topic: &kafkatopic.ServiceKafkaTopicGetOut{TopicName: "c"}},
 				{err: errNotFound},
 			},
-			storage: map[string]*aiven.KafkaListTopic{
+			storage: map[string]kafkatopic.TopicOut{
 				"a/b/c": {TopicName: "c"},
 			},
 			v1ListCalled:    1, // called once
@@ -95,10 +95,10 @@ func TestRepositoryRead(t *testing.T) {
 				{project: "a", service: "d", topic: "e"},
 			},
 			responses: []response{
-				{topic: &aiven.KafkaTopic{TopicName: "c"}},
+				{topic: &kafkatopic.ServiceKafkaTopicGetOut{TopicName: "c"}},
 				{err: errNotFound},
 			},
-			storage: map[string]*aiven.KafkaListTopic{
+			storage: map[string]kafkatopic.TopicOut{
 				"a/b/c": {TopicName: "c"},
 			},
 			v1ListCalled:    2, // called once for each service
@@ -112,10 +112,10 @@ func TestRepositoryRead(t *testing.T) {
 				{project: "a", service: "d", topic: "e"},
 			},
 			responses: []response{
-				{topic: &aiven.KafkaTopic{TopicName: "c"}},
-				{topic: &aiven.KafkaTopic{TopicName: "e"}},
+				{topic: &kafkatopic.ServiceKafkaTopicGetOut{TopicName: "c"}},
+				{topic: &kafkatopic.ServiceKafkaTopicGetOut{TopicName: "e"}},
 			},
-			storage: map[string]*aiven.KafkaListTopic{
+			storage: map[string]kafkatopic.TopicOut{
 				"a/b/c": {TopicName: "c"},
 				"a/d/e": {TopicName: "e"},
 			},
@@ -139,16 +139,16 @@ func TestRepositoryRead(t *testing.T) {
 				{project: "b", service: "a", topic: "b"},
 			},
 			responses: []response{
-				{topic: &aiven.KafkaTopic{TopicName: "a"}},
-				{topic: &aiven.KafkaTopic{TopicName: "b"}},
-				{topic: &aiven.KafkaTopic{TopicName: "c"}},
-				{topic: &aiven.KafkaTopic{TopicName: "a"}},
-				{topic: &aiven.KafkaTopic{TopicName: "b"}},
-				{topic: &aiven.KafkaTopic{TopicName: "c"}},
-				{topic: &aiven.KafkaTopic{TopicName: "a"}},
-				{topic: &aiven.KafkaTopic{TopicName: "b"}},
+				{topic: &kafkatopic.ServiceKafkaTopicGetOut{TopicName: "a"}},
+				{topic: &kafkatopic.ServiceKafkaTopicGetOut{TopicName: "b"}},
+				{topic: &kafkatopic.ServiceKafkaTopicGetOut{TopicName: "c"}},
+				{topic: &kafkatopic.ServiceKafkaTopicGetOut{TopicName: "a"}},
+				{topic: &kafkatopic.ServiceKafkaTopicGetOut{TopicName: "b"}},
+				{topic: &kafkatopic.ServiceKafkaTopicGetOut{TopicName: "c"}},
+				{topic: &kafkatopic.ServiceKafkaTopicGetOut{TopicName: "a"}},
+				{topic: &kafkatopic.ServiceKafkaTopicGetOut{TopicName: "b"}},
 			},
-			storage: map[string]*aiven.KafkaListTopic{
+			storage: map[string]kafkatopic.TopicOut{
 				"a/a/a": {TopicName: "a"},
 				"a/a/b": {TopicName: "b"},
 				"a/a/c": {TopicName: "c"},
@@ -187,7 +187,7 @@ func TestRepositoryRead(t *testing.T) {
 			responses: []response{
 				{err: fmt.Errorf("topic read error: All attempts fail:\n#1: bla bla bla")},
 			},
-			storage: map[string]*aiven.KafkaListTopic{
+			storage: map[string]kafkatopic.TopicOut{
 				"a/b/c": {TopicName: "c"},
 			},
 			v2ListErr:       fmt.Errorf("bla bla bla"),
@@ -243,7 +243,7 @@ var _ topicsClient = &fakeTopicClient{}
 type fakeTopicClient struct {
 	// stores topics as if they stored at Aiven
 	// key format: project/service/topic
-	storage map[string]*aiven.KafkaListTopic
+	storage map[string]kafkatopic.TopicOut
 	// errors to return
 	createErr []error
 	deleteErr error
@@ -256,7 +256,7 @@ type fakeTopicClient struct {
 	v2ListCalled int32
 }
 
-func (f *fakeTopicClient) Create(context.Context, string, string, aiven.CreateKafkaTopicRequest) error {
+func (f *fakeTopicClient) ServiceKafkaTopicCreate(_ context.Context, _, _ string, _ *kafkatopic.ServiceKafkaTopicCreateIn) error {
 	time.Sleep(time.Millisecond * 100) // we need some lag to simulate races
 	attempt := atomic.AddInt32(&f.createCalled, 1) - 1
 	if int(attempt) >= len(f.createErr) {
@@ -265,19 +265,19 @@ func (f *fakeTopicClient) Create(context.Context, string, string, aiven.CreateKa
 	return f.createErr[attempt]
 }
 
-func (f *fakeTopicClient) Update(context.Context, string, string, string, aiven.UpdateKafkaTopicRequest) error {
+func (f *fakeTopicClient) ServiceKafkaTopicUpdate(context.Context, string, string, string, *kafkatopic.ServiceKafkaTopicUpdateIn) error {
 	panic("implement me")
 }
 
-func (f *fakeTopicClient) Delete(context.Context, string, string, string) error {
+func (f *fakeTopicClient) ServiceKafkaTopicDelete(context.Context, string, string, string) error {
 	atomic.AddInt32(&f.deleteCalled, 1)
 	return f.deleteErr
 }
 
-func (f *fakeTopicClient) List(_ context.Context, project, service string) ([]*aiven.KafkaListTopic, error) {
+func (f *fakeTopicClient) ServiceKafkaTopicList(_ context.Context, project, service string) ([]kafkatopic.TopicOut, error) {
 	atomic.AddInt32(&f.v1ListCalled, 1)
 	key := newKey(project, service) + "/"
-	result := make([]*aiven.KafkaListTopic, 0)
+	result := make([]kafkatopic.TopicOut, 0)
 	for k, v := range f.storage {
 		if strings.HasPrefix(k, key) {
 			result = append(result, v)
@@ -286,13 +286,13 @@ func (f *fakeTopicClient) List(_ context.Context, project, service string) ([]*a
 	return result, f.v1ListErr
 }
 
-func (f *fakeTopicClient) V2List(_ context.Context, project, service string, topicNames []string) ([]*aiven.KafkaTopic, error) {
+func (f *fakeTopicClient) ServiceKafkaTopicListV2(_ context.Context, project, service string, in *kafkatopic.ServiceKafkaTopicListV2In) ([]kafkatopic.ServiceKafkaTopicGetOut, error) {
 	atomic.AddInt32(&f.v2ListCalled, 1)
-	result := make([]*aiven.KafkaTopic, 0)
-	for _, n := range topicNames {
+	result := make([]kafkatopic.ServiceKafkaTopicGetOut, 0)
+	for _, n := range in.TopicNames {
 		v, ok := f.storage[newKey(project, service, n)]
 		if ok {
-			result = append(result, &aiven.KafkaTopic{TopicName: v.TopicName})
+			result = append(result, kafkatopic.ServiceKafkaTopicGetOut{TopicName: v.TopicName})
 		}
 	}
 	return result, f.v2ListErr

--- a/internal/sdkprovider/kafkatopicrepository/update.go
+++ b/internal/sdkprovider/kafkatopicrepository/update.go
@@ -3,9 +3,9 @@ package kafkatopicrepository
 import (
 	"context"
 
-	"github.com/aiven/aiven-go-client/v2"
+	"github.com/aiven/go-client-codegen/handler/kafkatopic"
 )
 
-func (rep *repository) Update(ctx context.Context, project, service, topic string, req aiven.UpdateKafkaTopicRequest) error {
-	return rep.client.Update(ctx, project, service, topic, req)
+func (rep *repository) Update(ctx context.Context, project, service, topic string, req *kafkatopic.ServiceKafkaTopicUpdateIn) error {
+	return rep.client.ServiceKafkaTopicUpdate(ctx, project, service, topic, req)
 }

--- a/internal/sdkprovider/service/kafkatopic/kafka_topic.go
+++ b/internal/sdkprovider/service/kafkatopic/kafka_topic.go
@@ -9,7 +9,7 @@ import (
 	"log"
 	"strconv"
 
-	"github.com/aiven/aiven-go-client/v2"
+	avngen "github.com/aiven/go-client-codegen"
 	"github.com/aiven/go-client-codegen/handler/kafkatopic"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -263,10 +263,10 @@ var aivenKafkaTopicSchema = map[string]*schema.Schema{
 func ResourceKafkaTopic() *schema.Resource {
 	return &schema.Resource{
 		Description:   "Creates and manages an Aiven for Apache Kafka® [topic](https://aiven.io/docs/products/kafka/concepts).",
-		CreateContext: resourceKafkaTopicCreate,
-		ReadContext:   resourceKafkaTopicReadResource,
-		UpdateContext: resourceKafkaTopicUpdate,
-		DeleteContext: resourceKafkaTopicDelete,
+		CreateContext: common.WithGenClientDiag(resourceKafkaTopicCreate),
+		ReadContext:   common.WithGenClientDiag(resourceKafkaTopicReadResource),
+		UpdateContext: common.WithGenClientDiag(resourceKafkaTopicUpdate),
+		DeleteContext: common.WithGenClientDiag(resourceKafkaTopicDelete),
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},
@@ -274,7 +274,7 @@ func ResourceKafkaTopic() *schema.Resource {
 		Schema:         aivenKafkaTopicSchema,
 		SchemaVersion:  1,
 		StateUpgraders: stateupgrader.KafkaTopic(),
-		CustomizeDiff: func(ctx context.Context, d *schema.ResourceDiff, m any) error {
+		CustomizeDiff: func(ctx context.Context, d *schema.ResourceDiff, _ any) error {
 			oldPartitions, newPartitions := d.GetChange("partitions")
 
 			assertedOldPartitions, ok := oldPartitions.(int)
@@ -319,12 +319,15 @@ func ResourceKafkaTopic() *schema.Resource {
 				return nil
 			}
 
-			// A new topic
-			client := m.(*aiven.Client)
+			client, err := common.GenClient()
+			if err != nil {
+				return err
+			}
+
 			project := d.Get("project").(string)
 			serviceName := d.Get("service_name").(string)
 			topicName := d.Get("topic_name").(string)
-			exists, err := kafkatopicrepository.New(client.KafkaTopics).Exists(ctx, project, serviceName, topicName)
+			exists, err := kafkatopicrepository.New(client).Exists(ctx, project, serviceName, topicName)
 			if err != nil {
 				return err
 			}
@@ -338,7 +341,7 @@ func ResourceKafkaTopic() *schema.Resource {
 	}
 }
 
-func resourceKafkaTopicCreate(ctx context.Context, d *schema.ResourceData, m any) diag.Diagnostics {
+func resourceKafkaTopicCreate(ctx context.Context, d *schema.ResourceData, client avngen.Client) diag.Diagnostics {
 	project := d.Get("project").(string)
 	serviceName := d.Get("service_name").(string)
 	topicName := d.Get("topic_name").(string)
@@ -352,7 +355,7 @@ func resourceKafkaTopicCreate(ctx context.Context, d *schema.ResourceData, m any
 		return diag.Errorf("config to json error: %s", err)
 	}
 
-	createRequest := aiven.CreateKafkaTopicRequest{
+	createRequest := &kafkatopic.ServiceKafkaTopicCreateIn{
 		Partitions:  &partitions,
 		Replication: &replication,
 		TopicName:   topicName,
@@ -368,8 +371,7 @@ func resourceKafkaTopicCreate(ctx context.Context, d *schema.ResourceData, m any
 		createRequest.OwnerUserGroupId = &ownerUserGroupID
 	}
 
-	client := m.(*aiven.Client)
-	err = kafkatopicrepository.New(client.KafkaTopics).Create(ctx, project, serviceName, createRequest)
+	err = kafkatopicrepository.New(client).Create(ctx, project, serviceName, createRequest)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -382,29 +384,28 @@ func resourceKafkaTopicCreate(ctx context.Context, d *schema.ResourceData, m any
 	return nil
 }
 
-func getTags(d *schema.ResourceData) []aiven.KafkaTopicTag {
+func getTags(d *schema.ResourceData) *[]kafkatopic.TagIn {
 	tagSet := d.Get("tag").(*schema.Set)
-	tags := make([]aiven.KafkaTopicTag, tagSet.Len())
+	if tagSet.Len() == 0 {
+		return nil
+	}
+	tags := make([]kafkatopic.TagIn, tagSet.Len())
 	for i, tagD := range tagSet.List() {
 		tagM := tagD.(map[string]any)
-		tag := aiven.KafkaTopicTag{
+		tags[i] = kafkatopic.TagIn{
 			Key:   tagM["key"].(string),
 			Value: tagM["value"].(string),
 		}
-
-		tags[i] = tag
 	}
-
-	return tags
+	return &tags
 }
 
-// getKafkaTopicConfig converts schema.ResourceData into aiven.KafkaTopicConfig
+// getKafkaTopicConfig converts schema.ResourceData into kafkatopic.ConfigIn
 // Takes manifest values only
-func getKafkaTopicConfig(d *schema.ResourceData) (aiven.KafkaTopicConfig, error) {
-	empty := aiven.KafkaTopicConfig{}
+func getKafkaTopicConfig(d *schema.ResourceData) (*kafkatopic.ConfigIn, error) {
 	configs := d.GetRawConfig().AsValueMap()[configField]
 	if configs.IsNull() || len(configs.AsValueSlice()) == 0 {
-		return empty, nil
+		return nil, nil
 	}
 
 	config := make(map[string]any)
@@ -416,7 +417,7 @@ func getKafkaTopicConfig(d *schema.ResourceData) (aiven.KafkaTopicConfig, error)
 		key := fmt.Sprintf("%s.0.%s", configField, k)
 		value, err := typedConfigValue(k, d.Get(key))
 		if err != nil {
-			return empty, fmt.Errorf("error converting config field %q: %w", k, err)
+			return nil, fmt.Errorf("error converting config field %q: %w", k, err)
 		}
 		config[k] = value
 	}
@@ -424,24 +425,26 @@ func getKafkaTopicConfig(d *schema.ResourceData) (aiven.KafkaTopicConfig, error)
 	// Converts to json and loads values to the struct
 	b, err := json.Marshal(config)
 	if err != nil {
-		return empty, err
+		return nil, err
 	}
 
-	var result aiven.KafkaTopicConfig
+	var result kafkatopic.ConfigIn
 	dec := json.NewDecoder(bytes.NewReader(b))
 	dec.UseNumber()
 	err = dec.Decode(&result)
-	return result, err
+	if err != nil {
+		return nil, err
+	}
+	return &result, nil
 }
 
-func resourceKafkaTopicRead(ctx context.Context, d *schema.ResourceData, m any, isResource bool) diag.Diagnostics {
+func resourceKafkaTopicRead(ctx context.Context, d *schema.ResourceData, client avngen.Client, isResource bool) diag.Diagnostics {
 	project, serviceName, topicName, err := schemautil.SplitResourceID3(d.Id())
 	if err != nil {
 		return diag.FromErr(err)
 	}
 
-	client := m.(*aiven.Client)
-	topic, err := kafkatopicrepository.New(client.KafkaTopics).Read(ctx, project, serviceName, topicName)
+	topic, err := kafkatopicrepository.New(client).Read(ctx, project, serviceName, topicName)
 	// Topics are destroyed when kafka is off
 	// https://aiven.io/docs/platform/concepts/service-power-cycle
 	// So it's better to recreate them, than make user to clear the state manually
@@ -504,15 +507,15 @@ func resourceKafkaTopicRead(ctx context.Context, d *schema.ResourceData, m any, 
 	return nil
 }
 
-func resourceKafkaTopicReadResource(ctx context.Context, d *schema.ResourceData, m any) diag.Diagnostics {
-	return resourceKafkaTopicRead(ctx, d, m, true)
+func resourceKafkaTopicReadResource(ctx context.Context, d *schema.ResourceData, client avngen.Client) diag.Diagnostics {
+	return resourceKafkaTopicRead(ctx, d, client, true)
 }
 
-func resourceKafkaTopicReadDatasource(ctx context.Context, d *schema.ResourceData, m any) diag.Diagnostics {
-	return resourceKafkaTopicRead(ctx, d, m, false)
+func resourceKafkaTopicReadDatasource(ctx context.Context, d *schema.ResourceData, client avngen.Client) diag.Diagnostics {
+	return resourceKafkaTopicRead(ctx, d, client, false)
 }
 
-func flattenKafkaTopicTags(list []aiven.KafkaTopicTag) []map[string]any {
+func flattenKafkaTopicTags(list []kafkatopic.TagOut) []map[string]any {
 	tags := make([]map[string]any, 0, len(list))
 	for _, tagS := range list {
 		tags = append(tags, map[string]any{
@@ -524,7 +527,7 @@ func flattenKafkaTopicTags(list []aiven.KafkaTopicTag) []map[string]any {
 	return tags
 }
 
-func resourceKafkaTopicUpdate(ctx context.Context, d *schema.ResourceData, m any) diag.Diagnostics {
+func resourceKafkaTopicUpdate(ctx context.Context, d *schema.ResourceData, client avngen.Client) diag.Diagnostics {
 	partitions := d.Get("partitions").(int)
 	projectName, serviceName, topicName, err := schemautil.SplitResourceID3(d.Id())
 	if err != nil {
@@ -539,7 +542,7 @@ func resourceKafkaTopicUpdate(ctx context.Context, d *schema.ResourceData, m any
 	topicDescription := d.Get("topic_description").(string)
 	ownerUserGroupID := d.Get("owner_user_group_id").(string)
 
-	updateRequest := aiven.UpdateKafkaTopicRequest{
+	updateRequest := &kafkatopic.ServiceKafkaTopicUpdateIn{
 		Partitions:  &partitions,
 		Replication: schemautil.OptionalIntPointer(d, "replication"),
 		Config:      config,
@@ -554,8 +557,7 @@ func resourceKafkaTopicUpdate(ctx context.Context, d *schema.ResourceData, m any
 		updateRequest.OwnerUserGroupId = &ownerUserGroupID
 	}
 
-	client := m.(*aiven.Client)
-	err = kafkatopicrepository.New(client.KafkaTopics).Update(
+	err = kafkatopicrepository.New(client).Update(
 		ctx,
 		projectName,
 		serviceName,
@@ -569,7 +571,7 @@ func resourceKafkaTopicUpdate(ctx context.Context, d *schema.ResourceData, m any
 	return nil
 }
 
-func resourceKafkaTopicDelete(ctx context.Context, d *schema.ResourceData, m any) diag.Diagnostics {
+func resourceKafkaTopicDelete(ctx context.Context, d *schema.ResourceData, client avngen.Client) diag.Diagnostics {
 	projectName, serviceName, topicName, err := schemautil.SplitResourceID3(d.Id())
 	if err != nil {
 		return diag.FromErr(err)
@@ -579,7 +581,7 @@ func resourceKafkaTopicDelete(ctx context.Context, d *schema.ResourceData, m any
 		return diag.Errorf("cannot delete kafka topic when termination_protection is enabled")
 	}
 
-	err = kafkatopicrepository.New(m.(*aiven.Client).KafkaTopics).Delete(ctx, projectName, serviceName, topicName)
+	err = kafkatopicrepository.New(client).Delete(ctx, projectName, serviceName, topicName)
 	if err != nil {
 		return diag.Errorf("error waiting for Aiven Kafka Topic to be DELETED: %s", err)
 	}
@@ -587,7 +589,7 @@ func resourceKafkaTopicDelete(ctx context.Context, d *schema.ResourceData, m any
 	return nil
 }
 
-func FlattenKafkaTopicConfig(t *aiven.KafkaTopic, isResource bool) ([]map[string]any, error) {
+func FlattenKafkaTopicConfig(t *kafkatopic.ServiceKafkaTopicGetOut, isResource bool) ([]map[string]any, error) {
 	source := make(map[string]struct {
 		Source kafkatopic.SourceType `json:"source"`
 		Value  any                   `json:"value"`

--- a/internal/sdkprovider/service/kafkatopic/kafka_topic_data_source.go
+++ b/internal/sdkprovider/service/kafkatopic/kafka_topic_data_source.go
@@ -3,26 +3,28 @@ package kafkatopic
 import (
 	"context"
 
+	avngen "github.com/aiven/go-client-codegen"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
+	"github.com/aiven/terraform-provider-aiven/internal/common"
 	"github.com/aiven/terraform-provider-aiven/internal/schemautil"
 )
 
 func DatasourceKafkaTopic() *schema.Resource {
 	return &schema.Resource{
-		ReadContext: datasourceKafkaTopicRead,
+		ReadContext: common.WithGenClientDiag(datasourceKafkaTopicRead),
 		Description: "Gets information about an Aiven for Apache Kafka® topic.",
 		Schema: schemautil.ResourceSchemaAsDatasourceSchema(aivenKafkaTopicSchema,
 			"project", "service_name", "topic_name"),
 	}
 }
 
-func datasourceKafkaTopicRead(ctx context.Context, d *schema.ResourceData, m any) diag.Diagnostics {
+func datasourceKafkaTopicRead(ctx context.Context, d *schema.ResourceData, client avngen.Client) diag.Diagnostics {
 	projectName := d.Get("project").(string)
 	serviceName := d.Get("service_name").(string)
 	topicName := d.Get("topic_name").(string)
 
 	d.SetId(schemautil.BuildResourceID(projectName, serviceName, topicName))
-	return resourceKafkaTopicReadDatasource(ctx, d, m)
+	return resourceKafkaTopicReadDatasource(ctx, d, client)
 }

--- a/internal/sdkprovider/service/kafkatopic/kafka_topic_test.go
+++ b/internal/sdkprovider/service/kafkatopic/kafka_topic_test.go
@@ -8,9 +8,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/aiven/aiven-go-client/v2"
 	avngen "github.com/aiven/go-client-codegen"
-	kafkatopic2 "github.com/aiven/go-client-codegen/handler/kafkatopic"
+	kafkatopichandler "github.com/aiven/go-client-codegen/handler/kafkatopic"
 	"github.com/avast/retry-go"
 	"github.com/google/go-cmp/cmp"
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
@@ -163,7 +162,7 @@ func TestAccAivenKafkaTopic(t *testing.T) {
 							func() error {
 								topic, err := client.ServiceKafkaTopicGet(ctx, projectName, kafkaName, topicName)
 								if topic != nil {
-									assert.Equal(t, kafkatopic2.TopicStateTypeActive, topic.State)
+									assert.Equal(t, kafkatopichandler.TopicStateTypeActive, topic.State)
 								}
 								return err
 							},
@@ -195,7 +194,7 @@ func TestAccAivenKafkaTopic(t *testing.T) {
 								func() error {
 									topic, err := client.ServiceKafkaTopicGet(ctx, projectName, kafkaName, topicName)
 									if topic != nil {
-										assert.Equal(t, kafkatopic2.TopicStateTypeActive, topic.State)
+										assert.Equal(t, kafkatopichandler.TopicStateTypeActive, topic.State)
 									}
 									return err
 								},
@@ -566,7 +565,7 @@ func TestFlattenKafkaTopicConfig(t *testing.T) {
 	cases := []struct {
 		name   string
 		expect map[string]any
-		config aiven.KafkaTopicConfigResponse
+		config kafkatopichandler.ConfigOut
 	}{
 		{
 			name: "all fields",
@@ -584,6 +583,8 @@ func TestFlattenKafkaTopicConfig(t *testing.T) {
 				"max_message_bytes":                   "8",
 				"message_downconversion_enable":       false,
 				"message_format_version":              "",
+				"message_timestamp_after_max_ms":      "1000",
+				"message_timestamp_before_max_ms":     "1000",
 				"message_timestamp_difference_max_ms": "0",
 				"message_timestamp_type":              "",
 				"min_cleanable_dirty_ratio":           0.2,
@@ -599,34 +600,36 @@ func TestFlattenKafkaTopicConfig(t *testing.T) {
 				"segment_ms":                          "0",
 				"unclean_leader_election_enable":      true,
 			},
-			config: aiven.KafkaTopicConfigResponse{
-				CleanupPolicy:                   &aiven.KafkaTopicConfigResponseString{Value: "foo"},
-				CompressionType:                 &aiven.KafkaTopicConfigResponseString{Value: "bar"},
-				DeleteRetentionMs:               &aiven.KafkaTopicConfigResponseInt{Value: 0},
-				FileDeleteDelayMs:               &aiven.KafkaTopicConfigResponseInt{Value: 1},
-				FlushMessages:                   &aiven.KafkaTopicConfigResponseInt{Value: 2},
-				FlushMs:                         &aiven.KafkaTopicConfigResponseInt{Value: 3},
-				IndexIntervalBytes:              &aiven.KafkaTopicConfigResponseInt{Value: 4},
-				LocalRetentionBytes:             &aiven.KafkaTopicConfigResponseInt{Value: 5},
-				LocalRetentionMs:                &aiven.KafkaTopicConfigResponseInt{Value: 6},
-				MaxCompactionLagMs:              &aiven.KafkaTopicConfigResponseInt{Value: 7},
-				MaxMessageBytes:                 &aiven.KafkaTopicConfigResponseInt{Value: 8},
-				MessageDownconversionEnable:     &aiven.KafkaTopicConfigResponseBool{Value: false},
-				MessageFormatVersion:            &aiven.KafkaTopicConfigResponseString{Value: ""},
-				MessageTimestampDifferenceMaxMs: &aiven.KafkaTopicConfigResponseInt{Value: 0},
-				MessageTimestampType:            &aiven.KafkaTopicConfigResponseString{Value: ""},
-				MinCleanableDirtyRatio:          &aiven.KafkaTopicConfigResponseFloat{Value: 0.2},
-				MinCompactionLagMs:              &aiven.KafkaTopicConfigResponseInt{Value: 0},
-				MinInsyncReplicas:               &aiven.KafkaTopicConfigResponseInt{Value: 0},
-				Preallocate:                     &aiven.KafkaTopicConfigResponseBool{Value: true},
-				RemoteStorageEnable:             &aiven.KafkaTopicConfigResponseBool{Value: false},
-				RetentionBytes:                  &aiven.KafkaTopicConfigResponseInt{Value: 0},
-				RetentionMs:                     &aiven.KafkaTopicConfigResponseInt{Value: 0},
-				SegmentBytes:                    &aiven.KafkaTopicConfigResponseInt{Value: 0},
-				SegmentIndexBytes:               &aiven.KafkaTopicConfigResponseInt{Value: 0},
-				SegmentJitterMs:                 &aiven.KafkaTopicConfigResponseInt{Value: 0},
-				SegmentMs:                       &aiven.KafkaTopicConfigResponseInt{Value: 0},
-				UncleanLeaderElectionEnable:     &aiven.KafkaTopicConfigResponseBool{Value: true},
+			config: kafkatopichandler.ConfigOut{
+				CleanupPolicy:                   &kafkatopichandler.CleanupPolicyOut{Value: "foo"},
+				CompressionType:                 &kafkatopichandler.CompressionTypeOut{Value: "bar"},
+				DeleteRetentionMs:               &kafkatopichandler.DeleteRetentionMsOut{Value: 0},
+				FileDeleteDelayMs:               &kafkatopichandler.FileDeleteDelayMsOut{Value: 1},
+				FlushMessages:                   &kafkatopichandler.FlushMessagesOut{Value: 2},
+				FlushMs:                         &kafkatopichandler.FlushMsOut{Value: 3},
+				IndexIntervalBytes:              &kafkatopichandler.IndexIntervalBytesOut{Value: 4},
+				LocalRetentionBytes:             &kafkatopichandler.LocalRetentionBytesOut{Value: 5},
+				LocalRetentionMs:                &kafkatopichandler.LocalRetentionMsOut{Value: 6},
+				MaxCompactionLagMs:              &kafkatopichandler.MaxCompactionLagMsOut{Value: 7},
+				MaxMessageBytes:                 &kafkatopichandler.MaxMessageBytesOut{Value: 8},
+				MessageDownconversionEnable:     &kafkatopichandler.MessageDownconversionEnableOut{Value: false},
+				MessageFormatVersion:            &kafkatopichandler.MessageFormatVersionOut{Value: ""},
+				MessageTimestampAfterMaxMs:      &kafkatopichandler.MessageTimestampAfterMaxMsOut{Value: 1000},
+				MessageTimestampBeforeMaxMs:     &kafkatopichandler.MessageTimestampBeforeMaxMsOut{Value: 1000},
+				MessageTimestampDifferenceMaxMs: &kafkatopichandler.MessageTimestampDifferenceMaxMsOut{Value: 0},
+				MessageTimestampType:            &kafkatopichandler.MessageTimestampTypeOut{Value: ""},
+				MinCleanableDirtyRatio:          &kafkatopichandler.MinCleanableDirtyRatioOut{Value: 0.2},
+				MinCompactionLagMs:              &kafkatopichandler.MinCompactionLagMsOut{Value: 0},
+				MinInsyncReplicas:               &kafkatopichandler.MinInsyncReplicasOut{Value: 0},
+				Preallocate:                     &kafkatopichandler.PreallocateOut{Value: true},
+				RemoteStorageEnable:             &kafkatopichandler.RemoteStorageEnableOut{Value: false},
+				RetentionBytes:                  &kafkatopichandler.RetentionBytesOut{Value: 0},
+				RetentionMs:                     &kafkatopichandler.RetentionMsOut{Value: 0},
+				SegmentBytes:                    &kafkatopichandler.SegmentBytesOut{Value: 0},
+				SegmentIndexBytes:               &kafkatopichandler.SegmentIndexBytesOut{Value: 0},
+				SegmentJitterMs:                 &kafkatopichandler.SegmentJitterMsOut{Value: 0},
+				SegmentMs:                       &kafkatopichandler.SegmentMsOut{Value: 0},
+				UncleanLeaderElectionEnable:     &kafkatopichandler.UncleanLeaderElectionEnableOut{Value: true},
 			},
 		},
 		{
@@ -636,17 +639,17 @@ func TestFlattenKafkaTopicConfig(t *testing.T) {
 				"retention_bytes":       "2",
 				"segment_bytes":         "10",
 			},
-			config: aiven.KafkaTopicConfigResponse{
-				LocalRetentionBytes: &aiven.KafkaTopicConfigResponseInt{Value: 1},
-				RetentionBytes:      &aiven.KafkaTopicConfigResponseInt{Value: 2},
-				SegmentBytes:        &aiven.KafkaTopicConfigResponseInt{Value: 10},
+			config: kafkatopichandler.ConfigOut{
+				LocalRetentionBytes: &kafkatopichandler.LocalRetentionBytesOut{Value: 1},
+				RetentionBytes:      &kafkatopichandler.RetentionBytesOut{Value: 2},
+				SegmentBytes:        &kafkatopichandler.SegmentBytesOut{Value: 10},
 			},
 		},
 	}
 
 	for _, opt := range cases {
 		t.Run(opt.name, func(t *testing.T) {
-			result, err := kafkatopic.FlattenKafkaTopicConfig(&aiven.KafkaTopic{Config: opt.config}, false)
+			result, err := kafkatopic.FlattenKafkaTopicConfig(&kafkatopichandler.ServiceKafkaTopicGetOut{Config: opt.config}, false)
 			require.NoError(t, err)
 			assert.Empty(t, cmp.Diff([]map[string]any{opt.expect}, result))
 		})


### PR DESCRIPTION
Resolves NEX-2459.
    
Uses the generated client in `aiven_kafka_topic` handlers.