### PR TITLE
fix(kafka/kafka_connect): marked env config as sensitive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ nav_order: 1
 - Add `aiven_kafka_connect` field `kafka_connect_user_config.secret_providers.vault.server_pem`: PEM encoded certificate
   of the Vault server
 - Change `aiven_service_integration` field `integration_type` (enum): remove `cassandra_cross_service_cluster`
+- Mark `env.secrets` field as sensitive in user config schemas for `kafka` and `kafka_connect` resources
 
 ## [4.55.2] - 2026-04-22
 

--- a/docs/resources/kafka.md
+++ b/docs/resources/kafka.md
@@ -300,7 +300,7 @@ Optional:
 
 Required:
 
-- `secrets` (Map of String) Key/value map of secrets for ENV secret provider.
+- `secrets` (Map of String, Sensitive) Key/value map of secrets for ENV secret provider.
 
 
 <a id="nestedblock--kafka_user_config--kafka_connect_secret_providers--vault"></a>

--- a/docs/resources/kafka_connect.md
+++ b/docs/resources/kafka_connect.md
@@ -234,7 +234,7 @@ Optional:
 
 Required:
 
-- `secrets` (Map of String) Key/value map of secrets for ENV secret provider.
+- `secrets` (Map of String, Sensitive) Key/value map of secrets for ENV secret provider.
 
 
 <a id="nestedblock--kafka_connect_user_config--secret_providers--vault"></a>

--- a/generators/userconfig/main.go
+++ b/generators/userconfig/main.go
@@ -254,11 +254,11 @@ func getSchemaValues(o *object) (jen.Dict, error) {
 		}
 	}
 
-	if o.isScalar() {
-		if o.IsSensitive {
-			values[jen.Id("Sensitive")] = jen.True()
-		}
+	if o.IsSensitive {
+		values[jen.Id("Sensitive")] = jen.True()
+	}
 
+	if o.isScalar() {
 		if o.Enum != nil {
 			args := make([]jen.Code, 0)
 			for _, v := range o.Enum {

--- a/internal/sdkprovider/userconfig/service/kafka.go
+++ b/internal/sdkprovider/userconfig/service/kafka.go
@@ -545,6 +545,7 @@ func kafkaUserConfig() *schema.Schema {
 						Elem: &schema.Resource{Schema: map[string]*schema.Schema{"secrets": {
 							Description: "Key/value map of secrets for ENV secret provider.",
 							Required:    true,
+							Sensitive:   true,
 							Type:        schema.TypeMap,
 						}}},
 						MaxItems: 1,

--- a/internal/sdkprovider/userconfig/service/kafka_connect.go
+++ b/internal/sdkprovider/userconfig/service/kafka_connect.go
@@ -287,6 +287,7 @@ func kafkaConnectUserConfig() *schema.Schema {
 						Elem: &schema.Resource{Schema: map[string]*schema.Schema{"secrets": {
 							Description: "Key/value map of secrets for ENV secret provider.",
 							Required:    true,
+							Sensitive:   true,
 							Type:        schema.TypeMap,
 						}}},
 						MaxItems: 1,


### PR DESCRIPTION
<!-- All contributors, please complete these sections, including maintainers. -->

## About this change—what it does

<!-- Provide a small sentence that summarizes the change. -->

<!-- Provide the issue number below, if it exists. -->
- fixed `userconfig` generator to apply `Sensitive` flag to non-scalar fields
- marked `env` config as sensitive in `kafka` and `kafka_connect` resources

Resolves: NEX-2466

<!-- Provide a small explanation on why this is the approach you took for solving this problem. -->
