### PR TITLE
fix(plugin/adapter): return empty-but-known value for empty list/set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ nav_order: 1
 - Fix plugin-framework adapter decoding map attributes as objects
 - Change `aiven_byoc_aws_entity` resource field `deployment_model` (enum): add `hipaa`, `pci_dss`
 - Change `aiven_service_integration` field `integration_type` (enum): add `datahub_metadata_ingestion`
+- Fix plugin-framework adapter encoding empty lists and sets as null
 
 ## [4.55.2] - 2026-04-22
 

--- a/internal/plugin/adapter/marshalling.go
+++ b/internal/plugin/adapter/marshalling.go
@@ -179,7 +179,7 @@ func toTFValue(sch *Schema, value any) (tftypes.Value, error) {
 		}
 
 		if len(list) == 0 {
-			return tftypes.NewValue(listType, nil), nil
+			return tftypes.NewValue(listType, []tftypes.Value{}), nil
 		}
 
 		result := make([]tftypes.Value, len(list))
@@ -209,7 +209,7 @@ func toTFValue(sch *Schema, value any) (tftypes.Value, error) {
 		}
 
 		if len(set) == 0 {
-			return tftypes.NewValue(setType, nil), nil
+			return tftypes.NewValue(setType, []tftypes.Value{}), nil
 		}
 
 		result := make([]tftypes.Value, len(set))

--- a/internal/plugin/adapter/marshalling_test.go
+++ b/internal/plugin/adapter/marshalling_test.go
@@ -9,6 +9,82 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// TestToTFValue_EmptyCollectionsAreKnown covers the encode path for empty
+// List/Set values. Regression for a bug where
+// `tftypes.NewValue(<type>, nil)` was returned, which produces a null value.
+// When a resource's schema declares the attribute as Required (e.g.
+// `accounts` on aiven_byoc_permissions) and the user supplies an empty
+// collection, TF rejects the apply with
+// `Provider produced inconsistent result after apply ... was
+// cty.SetValEmpty(<type>), but now null`.
+func TestToTFValue_EmptyCollectionsAreKnown(t *testing.T) {
+	t.Parallel()
+
+	strSch := &Schema{Type: SchemaTypeString}
+
+	t.Run("empty list encodes as empty known value, not null", func(t *testing.T) {
+		sch := &Schema{Type: SchemaTypeList, Items: strSch}
+
+		got, err := toTFValue(sch, []any{})
+		require.NoError(t, err)
+		require.False(t, got.IsNull(), "empty list must not be null")
+		require.True(t, got.IsKnown(), "empty list must be known")
+
+		// Round-trip: decoding the encoded value must give back []any{}.
+		decoded, err := fromTFValueAny(sch, got)
+		require.NoError(t, err)
+		require.Equal(t, []any{}, decoded)
+	})
+
+	t.Run("empty set encodes as empty known value, not null", func(t *testing.T) {
+		sch := &Schema{Type: SchemaTypeSet, Items: strSch}
+
+		got, err := toTFValue(sch, []any{})
+		require.NoError(t, err)
+		require.False(t, got.IsNull(), "empty set must not be null")
+		require.True(t, got.IsKnown(), "empty set must be known")
+
+		decoded, err := fromTFValueAny(sch, got)
+		require.NoError(t, err)
+		require.Equal(t, []any{}, decoded)
+	})
+
+	t.Run("non-empty list preserves elements", func(t *testing.T) {
+		sch := &Schema{Type: SchemaTypeList, Items: strSch}
+
+		got, err := toTFValue(sch, []any{"a", "b"})
+		require.NoError(t, err)
+		require.False(t, got.IsNull())
+
+		decoded, err := fromTFValueAny(sch, got)
+		require.NoError(t, err)
+		require.Equal(t, []any{"a", "b"}, decoded)
+	})
+
+	t.Run("non-empty set preserves elements", func(t *testing.T) {
+		sch := &Schema{Type: SchemaTypeSet, Items: strSch}
+
+		got, err := toTFValue(sch, []any{"a", "b"})
+		require.NoError(t, err)
+		require.False(t, got.IsNull())
+
+		decoded, err := fromTFValueAny(sch, got)
+		require.NoError(t, err)
+		require.Equal(t, []any{"a", "b"}, decoded)
+	})
+
+	t.Run("nil value stays null", func(t *testing.T) {
+		// Distinct from an empty collection: when the Go-side value is nil,
+		// the attribute is unset and we want a null tftypes value. Empty
+		// collections (above) and unset (here) are semantically different.
+		sch := &Schema{Type: SchemaTypeList, Items: strSch}
+
+		got, err := toTFValue(sch, nil)
+		require.NoError(t, err)
+		require.True(t, got.IsNull(), "nil input must encode as null")
+	})
+}
+
 // TestFromTFValueAny_Map covers the decode path for SchemaTypeMap.
 // Regression for a bug where SchemaTypeMap and SchemaTypeObject shared
 // one case, causing user-supplied map keys to be looked up in sch.Properties

--- a/internal/plugin/adapter/resourcedata.go
+++ b/internal/plugin/adapter/resourcedata.go
@@ -253,6 +253,22 @@ func (d *resourceData) Flatten(in any, modifiers ...MapModifier) error {
 
 	// todo: remove stale data
 	state := d.currentState()
+
+	// Drop empty-collection fields the API returned by default when the user
+	// (in plan/prior-state) never set them. Overlaying would encode
+	// empty-known tftypes, causing TF to reject the apply with
+	// `was null, but now cty.SetValEmpty(...)`. Existing keys — including
+	// explicit `attr = []` — are preserved to keep the Required-empty case
+	// working (see marshalling.go toTFValue SchemaTypeList/Set branches).
+	for k, v := range norm {
+		if !isEmptyCollection(v) {
+			continue
+		}
+		if _, existed := state[k]; !existed {
+			delete(norm, k)
+		}
+	}
+
 	maps.Copy(state, norm)
 
 	id := make([]string, len(d.idFields))
@@ -535,6 +551,16 @@ func normalizeAny(sch *Schema, value any, ignoreUnknown bool, setFlow bool) (any
 	default:
 		return nil, fmt.Errorf("can't normalize type: %T", value)
 	}
+}
+
+func isEmptyCollection(v any) bool {
+	switch x := v.(type) {
+	case []any:
+		return len(x) == 0
+	case map[string]any:
+		return len(x) == 0
+	}
+	return false
 }
 
 func zeroValue(kind SchemaType) any {

--- a/internal/plugin/adapter/resourcedata_test.go
+++ b/internal/plugin/adapter/resourcedata_test.go
@@ -5,6 +5,7 @@ package adapter
 import (
 	"testing"
 
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
 	"github.com/stretchr/testify/require"
 )
 
@@ -46,4 +47,125 @@ func TestDereference(t *testing.T) {
 			require.Equal(t, tt.want, got)
 		})
 	}
+}
+
+// TestFlatten_EmptyCollectionOverlay covers the Flatten rule that drops
+// empty-collection fields from an API response when the user (plan in
+// Create/Update, prior state in Read) never set them. Without the rule,
+// overlaying produces encoded `SetValEmpty` for attrs that were null in
+// plan, which TF rejects as "inconsistent result after apply".
+//
+// Symmetric to TestToTFValue_EmptyCollectionsAreKnown (marshalling_test.go):
+// that test covers the Required-empty encode; this one covers the
+// Optional-omitted filter so both cases work together.
+func TestFlatten_EmptyCollectionOverlay(t *testing.T) {
+	t.Parallel()
+
+	strSch := &Schema{Type: SchemaTypeString}
+	sch := &Schema{
+		Type: SchemaTypeObject,
+		Properties: map[string]*Schema{
+			"id":     strSch,
+			"tags":   {Type: SchemaTypeList, Items: strSch},
+			"labels": {Type: SchemaTypeMap, Items: strSch},
+		},
+	}
+
+	attr := func(t *testing.T, v tftypes.Value, name string) tftypes.Value {
+		t.Helper()
+		var m map[string]tftypes.Value
+		require.NoError(t, v.As(&m))
+		got, ok := m[name]
+		require.True(t, ok, "attribute %q missing", name)
+		return got
+	}
+
+	t.Run("API empty, plan omitted → dropped, encodes null", func(t *testing.T) {
+		plan := map[string]any{"id": "x"}
+		rd, err := NewResourceDataFromMaps(sch, []string{"id"}, plan, nil, nil)
+		require.NoError(t, err)
+
+		require.NoError(t, rd.(*resourceData).Flatten(map[string]any{
+			"id":   "x",
+			"tags": []any{},
+		}))
+
+		v := rd.(*resourceData).tfValue()
+		require.True(t, attr(t, v, "tags").IsNull())
+	})
+
+	t.Run("API empty, plan has explicit [] → preserved, encodes empty-known", func(t *testing.T) {
+		plan := map[string]any{"id": "x", "tags": []any{}}
+		rd, err := NewResourceDataFromMaps(sch, []string{"id"}, plan, nil, nil)
+		require.NoError(t, err)
+
+		require.NoError(t, rd.(*resourceData).Flatten(map[string]any{
+			"id":   "x",
+			"tags": []any{},
+		}))
+
+		v := rd.(*resourceData).tfValue()
+		got := attr(t, v, "tags")
+		require.False(t, got.IsNull())
+		require.True(t, got.IsKnown())
+	})
+
+	t.Run("Read path: API empty, prior state omitted → dropped", func(t *testing.T) {
+		state := map[string]any{"id": "x"}
+		rd, err := NewResourceDataFromMaps(sch, []string{"id"}, nil, state, nil)
+		require.NoError(t, err)
+
+		require.NoError(t, rd.(*resourceData).Flatten(map[string]any{
+			"id":   "x",
+			"tags": []any{},
+		}))
+
+		v := rd.(*resourceData).tfValue()
+		require.True(t, attr(t, v, "tags").IsNull())
+	})
+
+	t.Run("Read path: API empty, prior state has [] → preserved", func(t *testing.T) {
+		state := map[string]any{"id": "x", "tags": []any{}}
+		rd, err := NewResourceDataFromMaps(sch, []string{"id"}, nil, state, nil)
+		require.NoError(t, err)
+
+		require.NoError(t, rd.(*resourceData).Flatten(map[string]any{
+			"id":   "x",
+			"tags": []any{},
+		}))
+
+		v := rd.(*resourceData).tfValue()
+		require.False(t, attr(t, v, "tags").IsNull())
+	})
+
+	t.Run("empty map follows same rule", func(t *testing.T) {
+		plan := map[string]any{"id": "x"}
+		rd, err := NewResourceDataFromMaps(sch, []string{"id"}, plan, nil, nil)
+		require.NoError(t, err)
+
+		require.NoError(t, rd.(*resourceData).Flatten(map[string]any{
+			"id":     "x",
+			"labels": map[string]any{},
+		}))
+
+		v := rd.(*resourceData).tfValue()
+		require.True(t, attr(t, v, "labels").IsNull())
+	})
+
+	t.Run("non-empty API response always preserved", func(t *testing.T) {
+		plan := map[string]any{"id": "x"}
+		rd, err := NewResourceDataFromMaps(sch, []string{"id"}, plan, nil, nil)
+		require.NoError(t, err)
+
+		require.NoError(t, rd.(*resourceData).Flatten(map[string]any{
+			"id":   "x",
+			"tags": []any{"a"},
+		}))
+
+		v := rd.(*resourceData).tfValue()
+		got := attr(t, v, "tags")
+		var list []tftypes.Value
+		require.NoError(t, got.As(&list))
+		require.Len(t, list, 1)
+	})
 }

--- a/internal/plugin/service/billinggroup/billinggroup_test.go
+++ b/internal/plugin/service/billinggroup/billinggroup_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/aiven/aiven-go-client/v2"
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 
 	acc "github.com/aiven/terraform-provider-aiven/internal/acctest"
@@ -46,6 +47,24 @@ func TestAccAivenBillingGroup_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckNoResourceAttr(resourceName, "billing_contact_emails"),
 				),
+			},
+			{
+				Config: testAccBillingGroupBasicResource(rName, ""),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{plancheck.ExpectEmptyPlan()},
+				},
+			},
+			{
+				Config: testAccBillingGroupBasicResource(rName, `billing_contact_emails = []`),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "billing_contact_emails.#", "0"),
+				),
+			},
+			{
+				Config: testAccBillingGroupBasicResource(rName, `billing_contact_emails = []`),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{plancheck.ExpectEmptyPlan()},
+				},
 			},
 		},
 	})

--- a/internal/plugin/service/byoc/permissions/permissions_test.go
+++ b/internal/plugin/service/byoc/permissions/permissions_test.go
@@ -86,6 +86,12 @@ resource "aiven_byoc_permissions" "example" {
 				),
 			},
 			{
+				Config: updatedConfig,
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{plancheck.ExpectEmptyPlan()},
+				},
+			},
+			{
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,


### PR DESCRIPTION
Resolves: IP-925.

Encodes empty collections as `NewValue(<type>, []tftypes.Value{})`. This preserves the semantic distinction between "unset" (nil Go input -> null tftypes value) and "empty" (empty Go input -> empty-but-known tftypes value) and fixes the inconsistent result error.

toTFValue encoded empty List and Set collections as
  `tftypes.NewValue(<type>, nil)`, which produces a null value rather
  than an empty-but-known one. For resources with a Required Set or List
  attribute that the user supplies as empty (e.g.
  `aiven_byoc_permissions.accounts = []`), Terraform rejects the apply
  result with:

    Provider produced inconsistent result after apply
    ... .accounts: was cty.SetValEmpty(cty.String), but now null.

  The Aiven API call itself succeeds, but the provider fails the
  post-apply consistency check, so the resource ends up tainted in state
  while the backend holds the intended configuration -- blocking every
  subsequent plan/apply.