### PR TITLE
fix(plugin): normalize empty containers in tfValue

### DIFF
--- a/internal/plugin/adapter/marshalling.go
+++ b/internal/plugin/adapter/marshalling.go
@@ -127,7 +127,7 @@ func fromTFValueAny(sch *Schema, value tftypes.Value) (any, error) {
 	}
 }
 
-func toTFValue(sch *Schema, value any) (tftypes.Value, error) {
+func toTFValue(sch *Schema, value any, keepEmpty bool) (tftypes.Value, error) {
 	if sch == nil {
 		return tftypes.Value{}, fmt.Errorf("schema is nil")
 	}
@@ -165,7 +165,7 @@ func toTFValue(sch *Schema, value any) (tftypes.Value, error) {
 		if sch.Items == nil {
 			return tftypes.Value{}, fmt.Errorf("list items is nil")
 		}
-		nullItem, err := toTFValue(sch.Items, nil)
+		nullItem, err := toTFValue(sch.Items, nil, keepEmpty)
 		if err != nil {
 			return tftypes.Value{}, fmt.Errorf("failed to build list item type: %w", err)
 		}
@@ -178,13 +178,13 @@ func toTFValue(sch *Schema, value any) (tftypes.Value, error) {
 			return tftypes.Value{}, fmt.Errorf("expected []any, got %T", value)
 		}
 
-		if len(list) == 0 {
+		if len(list) == 0 && !keepEmpty {
 			return tftypes.NewValue(listType, nil), nil
 		}
 
 		result := make([]tftypes.Value, len(list))
 		for i, item := range list {
-			converted, err := toTFValue(sch.Items, item)
+			converted, err := toTFValue(sch.Items, item, keepEmpty)
 			if err != nil {
 				return tftypes.Value{}, fmt.Errorf("invalid item at index %d: %w", i, err)
 			}
@@ -195,7 +195,7 @@ func toTFValue(sch *Schema, value any) (tftypes.Value, error) {
 		if sch.Items == nil {
 			return tftypes.Value{}, fmt.Errorf("set items is nil")
 		}
-		nullItem, err := toTFValue(sch.Items, nil)
+		nullItem, err := toTFValue(sch.Items, nil, keepEmpty)
 		if err != nil {
 			return tftypes.Value{}, fmt.Errorf("failed to build set item type: %w", err)
 		}
@@ -208,13 +208,13 @@ func toTFValue(sch *Schema, value any) (tftypes.Value, error) {
 			return tftypes.Value{}, fmt.Errorf("expected []any, got %T", value)
 		}
 
-		if len(set) == 0 {
+		if len(set) == 0 && !keepEmpty {
 			return tftypes.NewValue(setType, nil), nil
 		}
 
 		result := make([]tftypes.Value, len(set))
 		for i, item := range set {
-			converted, err := toTFValue(sch.Items, item)
+			converted, err := toTFValue(sch.Items, item, keepEmpty)
 			if err != nil {
 				return tftypes.Value{}, fmt.Errorf("invalid item at index %d: %w", i, err)
 			}
@@ -225,7 +225,7 @@ func toTFValue(sch *Schema, value any) (tftypes.Value, error) {
 		if sch.Items == nil {
 			return tftypes.Value{}, fmt.Errorf("map items is nil")
 		}
-		nullItem, err := toTFValue(sch.Items, nil)
+		nullItem, err := toTFValue(sch.Items, nil, keepEmpty)
 		if err != nil {
 			return tftypes.Value{}, fmt.Errorf("failed to build map item type: %w", err)
 		}
@@ -240,7 +240,7 @@ func toTFValue(sch *Schema, value any) (tftypes.Value, error) {
 
 		result := make(map[string]tftypes.Value, len(m))
 		for k, item := range m {
-			converted, err := toTFValue(sch.Items, item)
+			converted, err := toTFValue(sch.Items, item, keepEmpty)
 			if err != nil {
 				return tftypes.Value{}, fmt.Errorf("invalid map value for key %q: %w", k, err)
 			}
@@ -250,7 +250,7 @@ func toTFValue(sch *Schema, value any) (tftypes.Value, error) {
 	case SchemaTypeObject:
 		attrs := make(map[string]tftypes.Type, len(sch.Properties))
 		for key, prop := range sch.Properties {
-			nullProp, err := toTFValue(prop, nil)
+			nullProp, err := toTFValue(prop, nil, keepEmpty)
 			if err != nil {
 				return tftypes.Value{}, fmt.Errorf("failed to build object property %q type: %w", key, err)
 			}
@@ -271,7 +271,7 @@ func toTFValue(sch *Schema, value any) (tftypes.Value, error) {
 		for key, prop := range sch.Properties {
 			item, exists := m[key]
 			if !exists {
-				nullValue, err := toTFValue(prop, nil)
+				nullValue, err := toTFValue(prop, nil, keepEmpty)
 				if err != nil {
 					return tftypes.Value{}, fmt.Errorf("invalid object property %q: %w", key, err)
 				}
@@ -279,7 +279,7 @@ func toTFValue(sch *Schema, value any) (tftypes.Value, error) {
 				continue
 			}
 
-			converted, err := toTFValue(prop, item)
+			converted, err := toTFValue(prop, item, keepEmpty)
 			if err != nil {
 				return tftypes.Value{}, fmt.Errorf("invalid object property %q: %w", key, err)
 			}

--- a/internal/plugin/adapter/marshalling.go
+++ b/internal/plugin/adapter/marshalling.go
@@ -127,7 +127,7 @@ func fromTFValueAny(sch *Schema, value tftypes.Value) (any, error) {
 	}
 }
 
-func toTFValue(sch *Schema, value any, keepEmpty bool) (tftypes.Value, error) {
+func toTFValue(sch *Schema, value any, dropEmpty bool) (tftypes.Value, error) {
 	if sch == nil {
 		return tftypes.Value{}, fmt.Errorf("schema is nil")
 	}
@@ -161,71 +161,48 @@ func toTFValue(sch *Schema, value any, keepEmpty bool) (tftypes.Value, error) {
 			return tftypes.Value{}, fmt.Errorf("expected bool, got %T", value)
 		}
 		return tftypes.NewValue(tftypes.Bool, v), nil
-	case SchemaTypeList:
+	case SchemaTypeSet, SchemaTypeList:
 		if sch.Items == nil {
-			return tftypes.Value{}, fmt.Errorf("list items is nil")
+			return tftypes.Value{}, fmt.Errorf("%s items is nil", sch.Type)
 		}
-		nullItem, err := toTFValue(sch.Items, nil, keepEmpty)
+		nullItem, err := toTFValue(sch.Items, nil, dropEmpty)
 		if err != nil {
-			return tftypes.Value{}, fmt.Errorf("failed to build list item type: %w", err)
+			return tftypes.Value{}, fmt.Errorf("failed to build %s item type: %w", sch.Type, err)
 		}
-		listType := tftypes.List{ElementType: nullItem.Type()}
+
+		var arrayType tftypes.Type
+		if sch.Type == SchemaTypeSet {
+			arrayType = tftypes.Set{ElementType: nullItem.Type()}
+		} else {
+			arrayType = tftypes.List{ElementType: nullItem.Type()}
+		}
+
 		if value == nil {
-			return tftypes.NewValue(listType, nil), nil
+			return tftypes.NewValue(arrayType, nil), nil
 		}
-		list, ok := value.([]any)
+		array, ok := value.([]any)
 		if !ok {
 			return tftypes.Value{}, fmt.Errorf("expected []any, got %T", value)
 		}
 
-		if len(list) == 0 && !keepEmpty {
-			return tftypes.NewValue(listType, nil), nil
+		if len(array) == 0 && dropEmpty {
+			return tftypes.NewValue(arrayType, nil), nil
 		}
 
-		result := make([]tftypes.Value, len(list))
-		for i, item := range list {
-			converted, err := toTFValue(sch.Items, item, keepEmpty)
+		result := make([]tftypes.Value, len(array))
+		for i, item := range array {
+			converted, err := toTFValue(sch.Items, item, dropEmpty)
 			if err != nil {
 				return tftypes.Value{}, fmt.Errorf("invalid item at index %d: %w", i, err)
 			}
 			result[i] = converted
 		}
-		return tftypes.NewValue(listType, result), nil
-	case SchemaTypeSet:
-		if sch.Items == nil {
-			return tftypes.Value{}, fmt.Errorf("set items is nil")
-		}
-		nullItem, err := toTFValue(sch.Items, nil, keepEmpty)
-		if err != nil {
-			return tftypes.Value{}, fmt.Errorf("failed to build set item type: %w", err)
-		}
-		setType := tftypes.Set{ElementType: nullItem.Type()}
-		if value == nil {
-			return tftypes.NewValue(setType, nil), nil
-		}
-		set, ok := value.([]any)
-		if !ok {
-			return tftypes.Value{}, fmt.Errorf("expected []any, got %T", value)
-		}
-
-		if len(set) == 0 && !keepEmpty {
-			return tftypes.NewValue(setType, nil), nil
-		}
-
-		result := make([]tftypes.Value, len(set))
-		for i, item := range set {
-			converted, err := toTFValue(sch.Items, item, keepEmpty)
-			if err != nil {
-				return tftypes.Value{}, fmt.Errorf("invalid item at index %d: %w", i, err)
-			}
-			result[i] = converted
-		}
-		return tftypes.NewValue(setType, result), nil
+		return tftypes.NewValue(arrayType, result), nil
 	case SchemaTypeMap:
 		if sch.Items == nil {
 			return tftypes.Value{}, fmt.Errorf("map items is nil")
 		}
-		nullItem, err := toTFValue(sch.Items, nil, keepEmpty)
+		nullItem, err := toTFValue(sch.Items, nil, dropEmpty)
 		if err != nil {
 			return tftypes.Value{}, fmt.Errorf("failed to build map item type: %w", err)
 		}
@@ -240,7 +217,7 @@ func toTFValue(sch *Schema, value any, keepEmpty bool) (tftypes.Value, error) {
 
 		result := make(map[string]tftypes.Value, len(m))
 		for k, item := range m {
-			converted, err := toTFValue(sch.Items, item, keepEmpty)
+			converted, err := toTFValue(sch.Items, item, dropEmpty)
 			if err != nil {
 				return tftypes.Value{}, fmt.Errorf("invalid map value for key %q: %w", k, err)
 			}
@@ -250,7 +227,7 @@ func toTFValue(sch *Schema, value any, keepEmpty bool) (tftypes.Value, error) {
 	case SchemaTypeObject:
 		attrs := make(map[string]tftypes.Type, len(sch.Properties))
 		for key, prop := range sch.Properties {
-			nullProp, err := toTFValue(prop, nil, keepEmpty)
+			nullProp, err := toTFValue(prop, nil, dropEmpty)
 			if err != nil {
 				return tftypes.Value{}, fmt.Errorf("failed to build object property %q type: %w", key, err)
 			}
@@ -271,7 +248,7 @@ func toTFValue(sch *Schema, value any, keepEmpty bool) (tftypes.Value, error) {
 		for key, prop := range sch.Properties {
 			item, exists := m[key]
 			if !exists {
-				nullValue, err := toTFValue(prop, nil, keepEmpty)
+				nullValue, err := toTFValue(prop, nil, dropEmpty)
 				if err != nil {
 					return tftypes.Value{}, fmt.Errorf("invalid object property %q: %w", key, err)
 				}
@@ -279,7 +256,7 @@ func toTFValue(sch *Schema, value any, keepEmpty bool) (tftypes.Value, error) {
 				continue
 			}
 
-			converted, err := toTFValue(prop, item, keepEmpty)
+			converted, err := toTFValue(prop, item, dropEmpty)
 			if err != nil {
 				return tftypes.Value{}, fmt.Errorf("invalid object property %q: %w", key, err)
 			}

--- a/internal/plugin/adapter/resourcedata.go
+++ b/internal/plugin/adapter/resourcedata.go
@@ -269,11 +269,73 @@ func (d *resourceData) Flatten(in any, modifiers ...MapModifier) error {
 
 // tfValue converts the current state to tftypes.Value to write it to the user's state.
 func (d *resourceData) tfValue() tftypes.Value {
-	v, err := toTFValue(d.schema, d.currentState())
+	state := d.currentState()
+	keepEmpty := d.plan != nil && d.config != nil
+	if keepEmpty {
+		// Plan and config must agree on which empty containers (`[]`, `{}`)
+		// exist; otherwise toTFValue produces a state that Terraform rejects
+		// as inconsistent with config.
+		normalizeEmpties(d.schema, state, d.config)
+	}
+
+	v, err := toTFValue(d.schema, state, keepEmpty)
 	if err != nil {
 		panic(fmt.Errorf("failed to convert state to tftypes.Value: %w", err))
 	}
 	return v
+}
+
+func normalizeEmpties(sch *Schema, state, config map[string]any) {
+	if state == nil || config == nil {
+		return
+	}
+
+	for k, childSch := range sch.Properties {
+		if childSch.Type.IsPrimitive() {
+			// We process containers only.
+			continue
+		}
+
+		cv, cOk := config[k]
+		sv, sOk := state[k]
+
+		// Treat an explicit nil value the same as a missing key — both mean
+		// "user did not set this".
+		sOk = sOk && sv != nil
+		cOk = cOk && cv != nil
+
+		switch {
+		case sOk == cOk:
+		case sOk:
+			if isEmpty(sv) {
+				// State has an empty [] or {}, but user hasn't defined it in the config.
+				// Need to delete it, so terraform won't complain.
+				delete(state, k)
+			}
+		case cOk:
+			if isEmpty(cv) {
+				// Config has an empty [] or {}, but state doesn't, e.g.:
+				// resource "foo" "foo" {
+				//   foo = []
+				// }
+				// The state value probably has been omitted by the backend or the go-client struct.
+				state[k] = zeroValue(childSch.Type)
+			}
+		}
+	}
+}
+
+func isEmpty(v any) bool {
+	if v == nil {
+		return true
+	}
+
+	val := reflect.ValueOf(v)
+	switch val.Kind() {
+	case reflect.String, reflect.Slice, reflect.Map, reflect.Array:
+		return val.Len() == 0
+	}
+	return false
 }
 
 // getOk returns a value by a path:

--- a/internal/plugin/adapter/resourcedata.go
+++ b/internal/plugin/adapter/resourcedata.go
@@ -270,15 +270,18 @@ func (d *resourceData) Flatten(in any, modifiers ...MapModifier) error {
 // tfValue converts the current state to tftypes.Value to write it to the user's state.
 func (d *resourceData) tfValue() tftypes.Value {
 	state := d.currentState()
-	keepEmpty := d.plan != nil && d.config != nil
-	if keepEmpty {
+	if d.config != nil {
 		// Plan and config must agree on which empty containers (`[]`, `{}`)
 		// exist; otherwise toTFValue produces a state that Terraform rejects
 		// as inconsistent with config.
 		normalizeEmpties(d.schema, state, d.config)
 	}
 
-	v, err := toTFValue(d.schema, state, keepEmpty)
+	if _, ok := state["technical_emails"]; ok {
+		println(";ad")
+	}
+
+	v, err := toTFValue(d.schema, state, d.config == nil)
 	if err != nil {
 		panic(fmt.Errorf("failed to convert state to tftypes.Value: %w", err))
 	}

--- a/internal/plugin/adapter/resourcedata_test.go
+++ b/internal/plugin/adapter/resourcedata_test.go
@@ -5,6 +5,7 @@ package adapter
 import (
 	"testing"
 
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
 	"github.com/stretchr/testify/require"
 )
 
@@ -46,4 +47,170 @@ func TestDereference(t *testing.T) {
 			require.Equal(t, tt.want, got)
 		})
 	}
+}
+
+// TestTFValue_NormalizeEmpties verifies the two symmetric rules applied by
+// tfValue() to keep plan and config in agreement on empty containers:
+//
+//  1. Lift: config has [] or {}, plan is missing/nil → encoded as empty.
+//  2. Drop: plan has [] or {}, config is missing/nil → encoded as null.
+//
+// Without these rules, Terraform rejects the apply with "produced
+// inconsistent result after apply".
+func TestTFValue_NormalizeEmpties(t *testing.T) {
+	t.Parallel()
+
+	strSch := &Schema{Type: SchemaTypeString}
+	nestedSch := &Schema{
+		Type: SchemaTypeObject,
+		Properties: map[string]*Schema{
+			"name": strSch,
+			"tags": {Type: SchemaTypeList, Items: strSch},
+		},
+	}
+	rootSch := &Schema{
+		Type: SchemaTypeObject,
+		Properties: map[string]*Schema{
+			"id":     strSch,
+			"tags":   {Type: SchemaTypeList, Items: strSch},
+			"set":    {Type: SchemaTypeSet, Items: strSch},
+			"labels": {Type: SchemaTypeMap, Items: strSch},
+			"nested": nestedSch,
+		},
+	}
+
+	encode := func(t *testing.T, plan, config map[string]any) tftypes.Value {
+		t.Helper()
+		rd, err := NewResourceDataFromMaps(rootSch, []string{"id"}, plan, nil, config)
+		require.NoError(t, err)
+		return rd.(*resourceData).tfValue()
+	}
+
+	attr := func(t *testing.T, v tftypes.Value, name string) tftypes.Value {
+		t.Helper()
+		var m map[string]tftypes.Value
+		require.NoError(t, v.As(&m))
+		got, ok := m[name]
+		require.True(t, ok, "attribute %q missing", name)
+		return got
+	}
+
+	t.Run("lift: empty list in config, missing in plan, encodes as empty", func(t *testing.T) {
+		plan := map[string]any{"id": "x"}
+		config := map[string]any{"id": "x", "tags": []any{}}
+
+		got := attr(t, encode(t, plan, config), "tags")
+		require.False(t, got.IsNull())
+		require.True(t, got.IsKnown())
+
+		var list []tftypes.Value
+		require.NoError(t, got.As(&list))
+		require.Empty(t, list)
+	})
+
+	t.Run("lift: empty set in config, missing in plan, encodes as empty", func(t *testing.T) {
+		plan := map[string]any{"id": "x"}
+		config := map[string]any{"id": "x", "set": []any{}}
+
+		got := attr(t, encode(t, plan, config), "set")
+		require.False(t, got.IsNull())
+
+		var s []tftypes.Value
+		require.NoError(t, got.As(&s))
+		require.Empty(t, s)
+	})
+
+	t.Run("lift: empty map in config, missing in plan, encodes as empty", func(t *testing.T) {
+		plan := map[string]any{"id": "x"}
+		config := map[string]any{"id": "x", "labels": map[string]any{}}
+
+		got := attr(t, encode(t, plan, config), "labels")
+		require.False(t, got.IsNull())
+
+		var m map[string]tftypes.Value
+		require.NoError(t, got.As(&m))
+		require.Empty(t, m)
+	})
+
+	t.Run("lift: empty list in config, nil in plan, encodes as empty", func(t *testing.T) {
+		plan := map[string]any{"id": "x", "tags": nil}
+		config := map[string]any{"id": "x", "tags": []any{}}
+
+		got := attr(t, encode(t, plan, config), "tags")
+		require.False(t, got.IsNull(), "nil in plan must be treated like a missing key")
+
+		var list []tftypes.Value
+		require.NoError(t, got.As(&list))
+		require.Empty(t, list)
+	})
+
+	t.Run("lift: empty set in config, nil in plan, encodes as empty", func(t *testing.T) {
+		plan := map[string]any{"id": "x", "set": nil}
+		config := map[string]any{"id": "x", "set": []any{}}
+
+		got := attr(t, encode(t, plan, config), "set")
+		require.False(t, got.IsNull())
+
+		var s []tftypes.Value
+		require.NoError(t, got.As(&s))
+		require.Empty(t, s)
+	})
+
+	t.Run("lift: empty map in config, nil in plan, encodes as empty", func(t *testing.T) {
+		plan := map[string]any{"id": "x", "labels": nil}
+		config := map[string]any{"id": "x", "labels": map[string]any{}}
+
+		got := attr(t, encode(t, plan, config), "labels")
+		require.False(t, got.IsNull())
+
+		var m map[string]tftypes.Value
+		require.NoError(t, got.As(&m))
+		require.Empty(t, m)
+	})
+
+	t.Run("drop: empty list in plan, missing in config, encodes as null", func(t *testing.T) {
+		plan := map[string]any{"id": "x", "tags": []any{}}
+		config := map[string]any{"id": "x"}
+
+		got := attr(t, encode(t, plan, config), "tags")
+		require.True(t, got.IsNull(), "empty plan list must be dropped when config does not declare it")
+	})
+
+	t.Run("drop: empty map in plan, missing in config, encodes as null", func(t *testing.T) {
+		plan := map[string]any{"id": "x", "labels": map[string]any{}}
+		config := map[string]any{"id": "x"}
+
+		got := attr(t, encode(t, plan, config), "labels")
+		require.True(t, got.IsNull(), "empty plan map must be dropped when config does not declare it")
+	})
+
+	t.Run("non-empty plan list survives empty config", func(t *testing.T) {
+		plan := map[string]any{"id": "x", "tags": []any{"a", "b"}}
+		config := map[string]any{"id": "x", "tags": []any{}}
+
+		got := attr(t, encode(t, plan, config), "tags")
+		var list []tftypes.Value
+		require.NoError(t, got.As(&list))
+		require.Len(t, list, 2)
+	})
+
+	t.Run("non-empty plan list survives missing config", func(t *testing.T) {
+		plan := map[string]any{"id": "x", "tags": []any{"a"}}
+		config := map[string]any{"id": "x"}
+
+		got := attr(t, encode(t, plan, config), "tags")
+		var list []tftypes.Value
+		require.NoError(t, got.As(&list))
+		require.Len(t, list, 1)
+	})
+
+	t.Run("scalar fields are untouched", func(t *testing.T) {
+		plan := map[string]any{"id": "x"}
+		config := map[string]any{"id": "x"}
+
+		got := attr(t, encode(t, plan, config), "id")
+		var s string
+		require.NoError(t, got.As(&s))
+		require.Equal(t, "x", s)
+	})
 }

--- a/internal/plugin/adapter/schema.go
+++ b/internal/plugin/adapter/schema.go
@@ -13,6 +13,14 @@ const (
 	SchemaTypeObject SchemaType = "object"
 )
 
+func (s SchemaType) IsPrimitive() bool {
+	switch s {
+	case SchemaTypeBool, SchemaTypeString, SchemaTypeInt, SchemaTypeFloat:
+		return true
+	}
+	return false
+}
+
 // Schema simplified schema similar to OpenAPI spec.
 // Used internally to perform data normalization and validation,
 // because TF schemas have different types for resource and datasource,

--- a/internal/plugin/service/organization/project/project_test.go
+++ b/internal/plugin/service/organization/project/project_test.go
@@ -269,6 +269,26 @@ resource "aiven_organization_project" "foo" {
 				),
 			},
 			{
+				// set technical_emails = []
+				Config: baseConfig + fmt.Sprintf(`
+resource "aiven_organization_project" "foo" {
+  project_id       = "%s"
+  organization_id  = aiven_organization.foo.id
+  billing_group_id = aiven_billing_group.foo.id
+  parent_id        = aiven_organizational_unit.foo.id
+  technical_emails = []
+}
+`, projectID),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "project_id", projectID),
+					resource.TestCheckResourceAttrPair(resourceName, "organization_id", "aiven_organization.foo", "id"),
+					resource.TestCheckResourceAttrPair(resourceName, "billing_group_id", "aiven_billing_group.foo", "id"),
+					resource.TestCheckResourceAttrPair(resourceName, "parent_id", "aiven_organizational_unit.foo", "id"),
+					resource.TestCheckResourceAttrSet(resourceName, "ca_cert"),
+					resource.TestCheckResourceAttr(resourceName, "technical_emails.#", "0"),
+				),
+			},
+			{
 				// change parent_id which belongs to the same organization, should succeed. Also, remove technical_emails
 				Config: baseConfig + fmt.Sprintf(`
 resource "aiven_organization_project" "foo" {


### PR DESCRIPTION
Resolves NEX-2491.

- Lift `[]` / `{}` from config when missing in plan.
- Drop empty `[]` / `{}` from plan when missing in config.

