### PR TITLE
test(clickhouse): pin the clickhouse version in the tests

### DIFF
--- a/internal/sdkprovider/service/clickhouse/clickhouse_grant_test.go
+++ b/internal/sdkprovider/service/clickhouse/clickhouse_grant_test.go
@@ -28,6 +28,10 @@ resource "aiven_clickhouse" "bar" {
   service_name            = "%s"
   maintenance_window_dow  = "monday"
   maintenance_window_time = "10:00:00"
+
+  clickhouse_user_config {
+    clickhouse_version = "25.3"
+  }
 }
 
 resource "aiven_clickhouse_database" "testdb" {


### PR DESCRIPTION
<!-- All contributors, please complete these sections, including maintainers. -->

## About this change—what it does

<!-- Provide a small sentence that summarizes the change. -->

<!-- Provide the issue number below, if it exists. -->
- Pin `aiven_clickhouse` in `TestAccAivenClickhouseGrant` to `clickhouse_version = "25.3"`.
- Unblocks the nightly acceptance pipeline, which has been redContributes to: NEX-2506

<!-- Provide a small explanation on why this is the approach you took for solving this problem. -->
