### PR TITLE
feat(plugin): add `datasourceOnly` attribute flag

### DIFF
--- a/definitions/.schema.yml
+++ b/definitions/.schema.yml
@@ -289,6 +289,10 @@ definitions:
         type: boolean
         $comment: |
           Set to true if this attribute is write-only. See https://developer.hashicorp.com/terraform/plugin/sdkv2/resources/write-only-arguments
+      datasourceOnly:
+        type: boolean
+        $comment: |
+          Set to true if this attribute should appear only in the datasource schema and be omitted from the resource schema.
       properties:
         type: object
         additionalProperties:

--- a/generators/plugin/examples.go
+++ b/generators/plugin/examples.go
@@ -31,11 +31,7 @@ func exampleRoot(def *Definition, entity entityType, item *Item) ([]byte, error)
 }
 
 func sortedKeysPriority(def *Definition, entity entityType, item *Item) []string {
-	props := item.Properties
-	if !entity.isResource() {
-		props = item.PropertiesWithoutWO()
-	}
-
+	props := item.PropertiesByEntity(entity)
 	keys := lo.Keys(props)
 	slices.SortFunc(keys, func(i, j string) int {
 		itemI := props[i]

--- a/generators/plugin/item.go
+++ b/generators/plugin/item.go
@@ -187,6 +187,7 @@ type Item struct {
 	OverrideForceNew   *bool `yaml:"forceNew"`
 	UseStateForUnknown bool  `yaml:"useStateForUnknown"`
 	WriteOnly          bool  `yaml:"writeOnly"`
+	DatasourceOnly     bool  `yaml:"datasourceOnly"`
 
 	// TF Validators
 	// https://developer.hashicorp.com/terraform/plugin/framework/migrating/attributes-blocks/validators-predefined#background
@@ -311,10 +312,10 @@ func (item *Item) IsReadOnly(def *Definition, entity entityType) bool {
 	return !item.IsRequired(def, entity) && !item.IsOptional(def, entity)
 }
 
-func (item *Item) PropertiesWithoutWO() map[string]*Item {
+func (item *Item) PropertiesByEntity(entity entityType) map[string]*Item {
 	props := maps.Clone(item.Properties)
 	for k, v := range item.Properties {
-		if v.WriteOnly {
+		if entity == resourceType && v.DatasourceOnly || entity == datasourceType && v.WriteOnly {
 			delete(props, k)
 			for _, a := range v.AlsoRequires {
 				delete(props, a)

--- a/generators/plugin/main.go
+++ b/generators/plugin/main.go
@@ -776,6 +776,7 @@ func mergeItem(parent, a, b *Item) (*Item, error) {
 	a.OverrideForceNew = or(b.OverrideForceNew, a.OverrideForceNew)
 	a.UseStateForUnknown = a.UseStateForUnknown || b.UseStateForUnknown
 	a.WriteOnly = a.WriteOnly || b.WriteOnly
+	a.DatasourceOnly = a.DatasourceOnly || b.DatasourceOnly
 
 	if a.Name == "" {
 		return nil, fmt.Errorf("node doesn't have name set, parent: %q", parent.Name)

--- a/generators/plugin/schemas.go
+++ b/generators/plugin/schemas.go
@@ -70,13 +70,9 @@ func genAttributes(def *Definition, entity entityType, item *Item) (jen.Dict, er
 	attrs := make(jen.Dict)
 	blocks := make(jen.Dict)
 
-	for _, k := range sortedKeys(item.Properties) {
-		v := item.Properties[k]
-		if !entity.isResource() && isWriteOnly(v) {
-			// Don't add WriteOnly to datasource (read-only resource)
-			continue
-		}
-
+	properties := item.PropertiesByEntity(entity)
+	for _, k := range sortedKeys(properties) {
+		v := properties[k]
 		key := jen.Lit(k)
 		switch {
 		case v.IsMapNested():
@@ -292,11 +288,7 @@ func genSchemaInternal(def *Definition, entity entityType, item *Item) (jen.Code
 	}
 
 	properties := make(jen.Dict)
-	for k, v := range item.Properties {
-		if !entity.isResource() && isWriteOnly(v) {
-			continue
-		}
-
+	for k, v := range item.PropertiesByEntity(entity) {
 		prop, err := genSchemaInternal(def, entity, v)
 		if err != nil {
 			return nil, err
@@ -354,24 +346,4 @@ func genSchemaInternal(def *Definition, entity entityType, item *Item) (jen.Code
 		Params().Op("*").Qual(adapterPackage, "Schema").
 		Block(jen.Return(sch))
 	return f, nil
-}
-
-// isWriteOnly returns true if Item.WriteOnly or required with Item.WriteOnly.
-func isWriteOnly(item *Item) bool {
-	if item.IsRoot() {
-		// Root can't be write-only
-		return false
-	}
-
-	if item.WriteOnly {
-		return true
-	}
-
-	// Item might be linked to a write-only field
-	for _, k := range item.AlsoRequires {
-		if isWriteOnly(item.Parent.Properties[k]) {
-			return true
-		}
-	}
-	return false
 }


### PR DESCRIPTION
Adds a `datasourceOnly` field option that omits an attribute from the resource schema while keeping it in the datasource schema.

Resolves NEX-2514.
