### PR TITLE
feat(plugin): add `resultKeyField`

### DIFF
--- a/definitions/.schema.yml
+++ b/definitions/.schema.yml
@@ -215,9 +215,17 @@ definitions:
         $comment: |
           The key to extract the result object from the response (if the API nests result under a property)
           E.g.: resultKey: "result" retrieves response.result
-      resultListLookup:
+      resultKeyField:
         type: string
-        $comment: The name of the list to lookup the item in the response
+        $comment: |
+          Go field name on the client response struct to drill into before further processing.
+          Use when the API nests the actual resource (or the list of candidates) under an
+          extra wrapper that the Go client does not strip.
+          Examples:
+            - resultKeyField: "Aws" with no resultListLookupKeys -> d.Flatten(rsp.Aws)
+              (single nested object, e.g. {accessors: {aws: {...}}}).
+            - resultKeyField: "ConnectionPools" with resultListLookupKeys -> the list
+              `rsp.ConnectionPools` is searched by the lookup keys to find the item.
       resultListLookupKeys:
         type: object
         additionalProperties:

--- a/definitions/aiven_cmk_accessor_aws.yml
+++ b/definitions/aiven_cmk_accessor_aws.yml
@@ -10,6 +10,7 @@ operations:
   - id: CMKAccessorsList
     type: read
     resultKey: accessors/aws
+    resultKeyField: Aws
 schema:
   principal:
     description: The AWS IAM principal ARN that Aiven uses to access your KMS key.

--- a/definitions/aiven_cmk_accessor_azure.yml
+++ b/definitions/aiven_cmk_accessor_azure.yml
@@ -10,6 +10,7 @@ operations:
   - id: CMKAccessorsList
     type: read
     resultKey: accessors/azure
+    resultKeyField: Azure
 schema:
   app_id:
     description: The Azure application ID that Aiven uses to access your Key Vault.

--- a/definitions/aiven_cmk_accessor_gcp.yml
+++ b/definitions/aiven_cmk_accessor_gcp.yml
@@ -10,6 +10,7 @@ operations:
   - id: CMKAccessorsList
     type: read
     resultKey: accessors/gcp
+    resultKeyField: Gcp
 schema:
   access_group:
     description: The GCP access group that Aiven uses to access your Cloud KMS key.

--- a/definitions/aiven_cmk_accessor_oci.yml
+++ b/definitions/aiven_cmk_accessor_oci.yml
@@ -10,6 +10,7 @@ operations:
   - id: CMKAccessorsList
     type: read
     resultKey: accessors/oci
+    resultKeyField: Oci
 schema:
   access_group:
     description: The OCI access group that Aiven uses to access your OCI Vault key.

--- a/definitions/aiven_connection_pool.yml
+++ b/definitions/aiven_connection_pool.yml
@@ -21,7 +21,7 @@ operations:
   - id: ServiceGet
     type: read
     resultKey: service/connection_pools
-    resultListLookup: ConnectionPools
+    resultKeyField: ConnectionPools
     resultListLookupKeys:
       PoolName: pool_name
 schema:

--- a/generators/plugin/item.go
+++ b/generators/plugin/item.go
@@ -72,7 +72,7 @@ type Operation struct {
 	DatasourceLookup     bool              `yaml:"datasourceLookup"`     // Inline this read op as the data source readView's id-empty branch (lookup by alternative key). Not wired into resource views.
 	ResultIDField        string            `yaml:"resultIDField"`        // Go field name on the lookup result item that holds the primary id. When set on a datasourceLookup op, the lookup resolves the id and control falls through to the canonical read body in the same readView.
 	ResultKey            string            `yaml:"resultKey"`            // E.g.: {errors: [], result: {}} - extract "result"
-	ResultListLookup     string            `yaml:"resultListLookup"`     // The list name to lookup the item in the response
+	ResultKeyField       string            `yaml:"resultKeyField"`       // Go field name on the client response struct to drill into before further processing. Combined with resultListLookupKeys it points at the list to search; otherwise it points at the inner object to flatten. E.g.: "Aws" emits d.Flatten(rsp.Aws).
 	ResultListLookupKeys map[string]string `yaml:"resultListLookupKeys"` // When the response is a list, these keys are used to locate the correct item
 	// When the API response is not an object (e.g., a primitive or array), wrap it into a map using this key.
 	ResultToKey string `yaml:"resultToKey"`

--- a/generators/plugin/views.go
+++ b/generators/plugin/views.go
@@ -331,25 +331,29 @@ func genGenericViewOperation(g *jen.Group, funcIndex, funcCount int, def *Defini
 		return v
 	}
 
+	// rspCode is the response expression, optionally traversed by
+	// ResultKeyField (e.g. rsp.Aws or rsp.ConnectionPools) when the Go
+	// client doesn't strip an extra wrapper exposed by the API.
+	rspCode := jen.Id(rspName)
+	if operation.ResultKeyField != "" {
+		rspCode.Dot(operation.ResultKeyField)
+	}
+
 	// Wraps the result into a map by the specified key
 	if operation.ResultToKey != "" {
 		m := jen.Op("&").Map(jen.String()).Any()
-		g.Add(flatten(m.Values(jen.Dict{jen.Lit(operation.ResultToKey): jen.Id(rspName)})))
+		g.Add(flatten(m.Values(jen.Dict{jen.Lit(operation.ResultToKey): rspCode})))
 		return nil
 	}
 
 	// Flattens the response directly, because it is not a list but an object
 	if len(operation.ResultListLookupKeys) == 0 {
-		g.Add(flatten(jen.Id(rspName)))
+		g.Add(flatten(rspCode))
 		return nil
 	}
 
 	// Finds a match in the list.
 	// E.g. rsp[0].foo == state.Foo && rsp[0].bar == state.Bar ...
-	rspCode := jen.Id(rspName)
-	if operation.ResultListLookup != "" {
-		rspCode.Dot(operation.ResultListLookup)
-	}
 
 	var fieldsMatch jen.Statement
 	for i, key := range sortedKeys(operation.ResultListLookupKeys) {

--- a/internal/plugin/service/cmk/accessor/aws/zz_view.go
+++ b/internal/plugin/service/cmk/accessor/aws/zz_view.go
@@ -32,5 +32,5 @@ func readView(ctx context.Context, client avngen.Client, d adapter.ResourceData)
 	if err != nil {
 		return err
 	}
-	return d.Flatten(rsp)
+	return d.Flatten(rsp.Aws)
 }

--- a/internal/plugin/service/cmk/accessor/azure/zz_view.go
+++ b/internal/plugin/service/cmk/accessor/azure/zz_view.go
@@ -32,5 +32,5 @@ func readView(ctx context.Context, client avngen.Client, d adapter.ResourceData)
 	if err != nil {
 		return err
 	}
-	return d.Flatten(rsp)
+	return d.Flatten(rsp.Azure)
 }

--- a/internal/plugin/service/cmk/accessor/gcp/zz_view.go
+++ b/internal/plugin/service/cmk/accessor/gcp/zz_view.go
@@ -32,5 +32,5 @@ func readView(ctx context.Context, client avngen.Client, d adapter.ResourceData)
 	if err != nil {
 		return err
 	}
-	return d.Flatten(rsp)
+	return d.Flatten(rsp.Gcp)
 }

--- a/internal/plugin/service/cmk/accessor/oci/zz_view.go
+++ b/internal/plugin/service/cmk/accessor/oci/zz_view.go
@@ -32,5 +32,5 @@ func readView(ctx context.Context, client avngen.Client, d adapter.ResourceData)
 	if err != nil {
 		return err
 	}
-	return d.Flatten(rsp)
+	return d.Flatten(rsp.Oci)
 }

--- a/tools/agents/skills/tf-resource-generator/SKILL.md
+++ b/tools/agents/skills/tf-resource-generator/SKILL.md
@@ -195,7 +195,15 @@ operations:
                                     # the id, then control falls through to the canonical
                                     # read body in the same readView. Requires
                                     # datasourceLookup + resultListLookupKeys.
-    resultKey: nested_field          # Extract from response.nested_field
+    resultKey: nested_field          # Extract from response.nested_field (schema/JSON path,
+                                     # used at generation time to scope the OpenAPI schema)
+    resultKeyField: GoField          # Go field name on the client response to drill into at
+                                     # runtime, e.g. d.Flatten(rsp.GoField). Use when the Go
+                                     # client doesn't strip an extra wrapper exposed by the API
+                                     # (response is {accessors: {aws: {...}}} but the client
+                                     # returns *CMKAccessorsListOut, so set resultKeyField: Aws).
+                                     # When combined with resultListLookupKeys, points at the
+                                     # list to search (e.g. resultKeyField: ConnectionPools).
     resultToKey: wrapper_key         # Wrap response as {wrapper_key: ...}
     resultListLookupKeys:            # For list responses
       APIField: terraform_field      # Match items by field


### PR DESCRIPTION
Resolves NEX-2561.

Add an option `resultKeyField` — Go field name on the client response to drill into. Replaces `resultListLookup` which was specifically used with lists.
