### PR TITLE
feat(plugin): add  `RefreshStateDesired` resource option

### DIFF
--- a/definitions/.schema.yml
+++ b/definitions/.schema.yml
@@ -54,10 +54,16 @@ properties:
           So we sleep for a few seconds to give the backend time to catch up.
         dependencies:
           - refreshState
-      refreshStateWaiter:
-        type: boolean
+      refreshStateDesired:
+        type: object
+        additionalProperties:
+          type: string
         $comment: |
-          Set to true to generate a function placeholder that waits for the resource to be in the desired state before calling refreshState.
+          Map of Terraform attribute names to the desired value the adapter must observe before
+          treating the post-Create/Update Read as successful. Each entry is checked after a Read
+          attempt during refreshState; mismatches retry under the same backoff as the standard
+          404/403 cases. Use this for resources whose API reports a transient state
+          (e.g. `state: ACTIVE`) without custom waiter logic.
         dependencies:
           - refreshState
       removeMissing:

--- a/definitions/aiven_project_vpc.yml
+++ b/definitions/aiven_project_vpc.yml
@@ -2,7 +2,8 @@
 location: internal/plugin/service/vpc/projectvpc
 resource:
   refreshState: true
-  refreshStateWaiter: true
+  refreshStateDesired:
+    state: ACTIVE
   removeMissing: true
   description: Creates and manages a VPC for an Aiven project.
 datasource:

--- a/definitions/aiven_static_ip.yml
+++ b/definitions/aiven_static_ip.yml
@@ -6,7 +6,8 @@ resource:
     Please note that once a static ip is in the 'assigned' state it is bound to the node it is assigned to and cannot be deleted or disassociated until the node is recycled.
     Plans that would delete static ips that are in the assigned state will be blocked.
   refreshState: true
-  refreshStateWaiter: true
+  refreshStateDesired:
+    state: created
 clientHandler: staticip
 idAttributeComposed: [project, static_ip_address_id]
 legacyTimeouts: true

--- a/generators/plugin/item.go
+++ b/generators/plugin/item.go
@@ -133,17 +133,17 @@ type Scope struct {
 // SchemaMeta contains fields to override.
 // Extend this struct if you need to override more fields and update the usage.
 type SchemaMeta struct {
-	Description           string        `yaml:"description"`
-	DeprecationMessage    string        `yaml:"deprecationMessage,omitempty"`
-	TerminationProtection bool          `yaml:"terminationProtection,omitempty"`
-	RefreshState          bool          `yaml:"refreshState,omitempty"`
-	RefreshStateDelay     time.Duration `yaml:"refreshStateDelay,omitempty"`
-	RefreshStateWaiter    bool          `yaml:"refreshStateWaiter,omitempty"`
-	RemoveMissing         bool          `yaml:"removeMissing,omitempty"`
-	IgnoreAlreadyExists   bool          `yaml:"ignoreAlreadyExists,omitempty"`
-	DisableExample        bool          `yaml:"disableExample,omitempty"`
-	ValidateConfig        bool          `yaml:"validateConfig,omitempty"`
-	ModifyPlan            bool          `yaml:"modifyPlan,omitempty"`
+	Description           string            `yaml:"description"`
+	DeprecationMessage    string            `yaml:"deprecationMessage,omitempty"`
+	TerminationProtection bool              `yaml:"terminationProtection,omitempty"`
+	RefreshState          bool              `yaml:"refreshState,omitempty"`
+	RefreshStateDelay     time.Duration     `yaml:"refreshStateDelay,omitempty"`
+	RefreshStateDesired   map[string]string `yaml:"refreshStateDesired,omitempty"`
+	RemoveMissing         bool              `yaml:"removeMissing,omitempty"`
+	IgnoreAlreadyExists   bool              `yaml:"ignoreAlreadyExists,omitempty"`
+	DisableExample        bool              `yaml:"disableExample,omitempty"`
+	ValidateConfig        bool              `yaml:"validateConfig,omitempty"`
+	ModifyPlan            bool              `yaml:"modifyPlan,omitempty"`
 
 	// SchemaOverride is a datasource-only schema overlay merged on top of the
 	// base Definition.Schema when generating the datasource. Resource

--- a/generators/plugin/item_test.go
+++ b/generators/plugin/item_test.go
@@ -65,8 +65,11 @@ func TestLimitedAvailabilitySchemaDescription(t *testing.T) {
 }
 
 func TestLimitedAvailabilityViewOptions(t *testing.T) {
+	code, err := genNewResource(resourceType, &Definition{LimitedAvailability: lo.ToPtr(true), Resource: &SchemaMeta{}}, &Item{}, false)
+	require.NoError(t, err)
+
 	file := jen.NewFile("test")
-	file.Add(genNewResource(resourceType, &Definition{LimitedAvailability: lo.ToPtr(true), Resource: &SchemaMeta{}}, false))
+	file.Add(code)
 
 	var b bytes.Buffer
 	require.NoError(t, file.Render(&b))

--- a/generators/plugin/views.go
+++ b/generators/plugin/views.go
@@ -23,7 +23,6 @@ const (
 	renameFieldsModifier       = "RenameFields"
 	flattenModifier            = "flattenModifier"
 	expandModifier             = "expandModifier"
-	refreshStateWaiter         = "refreshStateWaiter"
 )
 
 // genViews generates CRUD views for the resource, skips disabled or undefined operations.
@@ -41,7 +40,11 @@ func genViews(def *Definition, item *Item) ([]jen.Code, error) {
 
 	builders := make([]jen.Code, 0)
 	if def.Resource != nil {
-		builders = append(builders, genNewResource(resourceType, def, false))
+		v, err := genNewResource(resourceType, def, item, false)
+		if err != nil {
+			return nil, fmt.Errorf("resource builder error: %w", err)
+		}
+		builders = append(builders, v)
 	}
 
 	if def.Datasource != nil {
@@ -52,14 +55,18 @@ func genViews(def *Definition, item *Item) ([]jen.Code, error) {
 			codes = append(codes, datasourceLookupValidators(def))
 		}
 
-		builders = append(builders, genNewResource(datasourceType, def, hasConfigValidators))
+		v, err := genNewResource(datasourceType, def, item, hasConfigValidators)
+		if err != nil {
+			return nil, fmt.Errorf("datasource builder error: %w", err)
+		}
+		builders = append(builders, v)
 	}
 
 	return append(builders, codes...), nil
 }
 
 // genNewResource generates NewResource or NewDatasource function
-func genNewResource(entity entityType, def *Definition, hasConfigValidators bool) jen.Code {
+func genNewResource(entity entityType, def *Definition, item *Item, hasConfigValidators bool) (jen.Code, error) {
 	// Resource might have multiple read operations.
 	// We use here a dict, so we don't need to handle duplicates.
 	values := map[string]jen.Code{
@@ -98,8 +105,20 @@ func genNewResource(entity entityType, def *Definition, hasConfigValidators bool
 				values["RefreshStateDelay"] = jen.Qual(adapterPackage, "MustParseDuration").Call(jen.Lit(def.Resource.RefreshStateDelay.String()))
 			}
 
-			if def.Resource.RefreshStateWaiter {
-				values["RefreshStateWaiter"] = jen.Id(refreshStateWaiter)
+			if len(def.Resource.RefreshStateDesired) > 0 {
+				dict := make(jen.Dict, len(def.Resource.RefreshStateDesired))
+				for _, k := range sortedKeys(def.Resource.RefreshStateDesired) {
+					want := def.Resource.RefreshStateDesired[k]
+					prop, ok := item.Properties[k]
+					if !ok {
+						return nil, fmt.Errorf("refreshStateDesired: unknown field %q (not present in schema)", k)
+					}
+					if prop.IsEnum() && !enumContainsString(prop.Enum, want) {
+						return nil, fmt.Errorf("refreshStateDesired: field %q has enum %v but desired value %q is not allowed", k, prop.Enum, want)
+					}
+					dict[jen.Lit(k)] = jen.Lit(want)
+				}
+				values["RefreshStateDesired"] = jen.Map(jen.String()).String().Values(dict)
 			}
 		}
 
@@ -130,7 +149,14 @@ func genNewResource(entity entityType, def *Definition, hasConfigValidators bool
 
 	title := entity.Title() + optionsSuffix
 	returnValue := jen.Qual(adapterPackage, title).Values(dictFromMap(values, false))
-	return jen.Var().Id(title).Op("=").Add(returnValue)
+	return jen.Var().Id(title).Op("=").Add(returnValue), nil
+}
+
+// enumContainsString reports whether enum contains want under fmt.Sprint comparison.
+// Matches the runtime semantics of adapter.Equal so generator-time validation and
+// the runtime RefreshStateDesired check agree on equality.
+func enumContainsString(enum []any, want string) bool {
+	return slices.ContainsFunc(enum, func(v any) bool { return fmt.Sprint(v) == want })
 }
 
 func genGenericView(def *Definition, item *Item, operation OperationType) (jen.Code, error) {

--- a/generators/plugin/views_test.go
+++ b/generators/plugin/views_test.go
@@ -1,0 +1,113 @@
+package main
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/dave/jennifer/jen"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGenNewResourceRefreshStateDesiredValidation(t *testing.T) {
+	// newDef builds the minimum Definition that genNewResource needs to walk into the
+	// RefreshState branch: a Resource with RefreshState=true and the desired map under test.
+	newDef := func(desired map[string]string) *Definition {
+		return &Definition{
+			Resource: &SchemaMeta{
+				RefreshState:        true,
+				RefreshStateDesired: desired,
+			},
+		}
+	}
+
+	t.Run("accepts a desired key that exists and has no enum", func(t *testing.T) {
+		item := &Item{
+			Properties: map[string]*Item{
+				"state": {Name: "state", Type: SchemaTypeString},
+			},
+		}
+
+		code, err := genNewResource(resourceType, newDef(map[string]string{"state": "ACTIVE"}), item, false)
+		require.NoError(t, err)
+		got := renderCode(t, code)
+		require.Contains(t, got, `RefreshStateDesired: map[string]string{"state": "ACTIVE"},`)
+	})
+
+	t.Run("accepts a desired value that is in the field's enum", func(t *testing.T) {
+		item := &Item{
+			Properties: map[string]*Item{
+				"state": {
+					Name: "state",
+					Type: SchemaTypeString,
+					Enum: []any{"ACTIVE", "APPROVED", "DELETED", "DELETING"},
+				},
+			},
+		}
+
+		code, err := genNewResource(resourceType, newDef(map[string]string{"state": "ACTIVE"}), item, false)
+		require.NoError(t, err)
+		got := renderCode(t, code)
+		require.Contains(t, got, `RefreshStateDesired: map[string]string{"state": "ACTIVE"},`)
+	})
+
+	t.Run("rejects a desired key that does not exist in the schema", func(t *testing.T) {
+		item := &Item{
+			Properties: map[string]*Item{
+				"state": {Name: "state", Type: SchemaTypeString},
+			},
+		}
+
+		_, err := genNewResource(resourceType, newDef(map[string]string{"missing": "ACTIVE"}), item, false)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), `refreshStateDesired: unknown field "missing"`)
+	})
+
+	t.Run("rejects a desired value that is not in the field's enum", func(t *testing.T) {
+		item := &Item{
+			Properties: map[string]*Item{
+				"state": {
+					Name: "state",
+					Type: SchemaTypeString,
+					Enum: []any{"ACTIVE", "APPROVED"},
+				},
+			},
+		}
+
+		_, err := genNewResource(resourceType, newDef(map[string]string{"state": "PENDING"}), item, false)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), `refreshStateDesired: field "state"`)
+		require.Contains(t, err.Error(), `desired value "PENDING" is not allowed`)
+	})
+
+	t.Run("compares enum values via fmt.Sprint so non-string enums match string desired", func(t *testing.T) {
+		// Mirrors adapter.Equal's runtime comparison: fmt.Sprint(7) == "7".
+		item := &Item{
+			Properties: map[string]*Item{
+				"phase": {
+					Name: "phase",
+					Type: SchemaTypeInteger,
+					Enum: []any{1, 7, 42},
+				},
+			},
+		}
+
+		code, err := genNewResource(resourceType, newDef(map[string]string{"phase": "7"}), item, false)
+		require.NoError(t, err)
+		got := renderCode(t, code)
+		require.Contains(t, got, `RefreshStateDesired: map[string]string{"phase": "7"},`)
+	})
+}
+
+func renderCode(t *testing.T, code ...jen.Code) string {
+	t.Helper()
+
+	file := jen.NewFile("projectvpc")
+	for _, c := range code {
+		file.Add(c)
+	}
+
+	var buf bytes.Buffer
+	require.NoError(t, file.Render(&buf))
+
+	return buf.String()
+}

--- a/internal/plugin/adapter/resource.go
+++ b/internal/plugin/adapter/resource.go
@@ -38,15 +38,25 @@ type ResourceOptions struct {
 	IDFields []string
 
 	// Whether to call Read after Create and Update operations.
-	// Retries common errors like 404 and 403 (see the implementation for details).
+	// Implemented by refreshState; see that function for retry behavior.
 	RefreshState bool
 
 	// Time to wait after creating or updating the resource to let the backend catch up.
 	RefreshStateDelay time.Duration
 
-	// RefreshStateWaiter is a function that waits for the resource to be in the desired state.
-	// It is called after the resource is created/updated and before the state is refreshed.
-	RefreshStateWaiter func(ctx context.Context, client avngen.Client, d ResourceData) error
+	// Attribute names and values that must match after Read before refreshState succeeds.
+	// Mismatches return ErrRefreshStateDesired and are retried with the same backoff as transient Read errors.
+	RefreshStateDesired map[string]string
+
+	// refreshStateRetryDelay is the base delay used by retry-go's BackOff between Read attempts in refreshState.
+	// Zero falls back to the package default (defaultRefreshStateRetryDelay). Unexported: intended for tests
+	// inside the adapter package only; not wired through the YAML schema or the generator.
+	refreshStateRetryDelay time.Duration
+
+	// refreshStateMaxAttempts caps the number of Read attempts in refreshState.
+	// Zero falls back to the package default (defaultRefreshStateMaxAttempts). Unexported: intended for tests
+	// inside the adapter package only; not wired through the YAML schema or the generator.
+	refreshStateMaxAttempts uint
 
 	// RemoveMissing removes the resource from the state if it's missing (i.e., if Read() returns an IsNotFound error).
 	// This is useful for resources that Aiven may automatically delete,
@@ -223,7 +233,7 @@ func (a *resourceAdapter) Read(
 	ctx, drainWarnings := withWarnings(ctx, diags)
 	defer drainWarnings()
 
-	// When RemoveResource is enabled, we remove the resource from the state if it's missing.
+	// When RemoveMissing is enabled, we remove the resource from the state if it's missing.
 	// See ResourceOptions.RemoveMissing for more details.
 	err = a.resource.Read(ctx, a.client, d)
 	if a.resource.RemoveMissing && IsNotFound(err) {
@@ -240,10 +250,38 @@ func (a *resourceAdapter) Read(
 	rsp.State.Raw = d.tfValue()
 }
 
-// refreshState reads the resource state after Create or Update operation.
-// Optionally waits RefreshStateDelay before reading. In rare cases, the backend might be
-// inconsistent right after the operation; retries known errors.
+// ErrRefreshStateDesired indicates a RefreshStateDesired attribute did not match after Read.
+var ErrRefreshStateDesired = errors.New("resource is not in the desired state")
+
+const (
+	// defaultRefreshStateRetryDelay is the fallback base delay used by retry-go's BackOff between Read
+	// attempts in refreshState when ResourceOptions.refreshStateRetryDelay is zero.
+	defaultRefreshStateRetryDelay = time.Second * 5
+	// defaultRefreshStateMaxAttempts is the fallback cap on the number of Read attempts in
+	// refreshState when ResourceOptions.refreshStateMaxAttempts is zero.
+	defaultRefreshStateMaxAttempts uint = 10
+)
+
+// refreshState reads the resource state after Create or Update with retries, then validates the
+// resulting state against ResourceOptions.RefreshStateDesired.
+//
+// When ResourceOptions.RefreshStateDelay is non-zero, it waits that duration before the first
+// attempt (honoring ctx). Each attempt installs a child warning collector so attempt warnings are
+// buffered separately; only the last attempt's warnings are merged into the outer warning
+// collector in ctx. retry-go's BackOff uses ResourceOptions.refreshStateRetryDelay as the base
+// delay between attempts and ResourceOptions.refreshStateMaxAttempts as the total attempt cap;
+// zero values fall back to defaultRefreshStateRetryDelay / defaultRefreshStateMaxAttempts
+// respectively. Retries are limited to the errors accepted by isRefreshStateRetryable.
 func (a *resourceAdapter) refreshState(ctx context.Context, rd ResourceData) error {
+	retryDelay := a.resource.refreshStateRetryDelay
+	if retryDelay == 0 {
+		retryDelay = defaultRefreshStateRetryDelay
+	}
+	attempts := a.resource.refreshStateMaxAttempts
+	if attempts == 0 {
+		attempts = defaultRefreshStateMaxAttempts
+	}
+
 	if a.resource.RefreshStateDelay != 0 {
 		delay := time.NewTimer(a.resource.RefreshStateDelay)
 		defer delay.Stop()
@@ -251,13 +289,6 @@ func (a *resourceAdapter) refreshState(ctx context.Context, rd ResourceData) err
 		case <-ctx.Done():
 			return ctx.Err()
 		case <-delay.C:
-		}
-	}
-
-	if a.resource.RefreshStateWaiter != nil {
-		err := a.resource.RefreshStateWaiter(ctx, a.client, rd)
-		if err != nil {
-			return fmt.Errorf("failed to wait for resource to be in desired state: %w", err)
 		}
 	}
 
@@ -272,22 +303,41 @@ func (a *resourceAdapter) refreshState(ctx context.Context, rd ResourceData) err
 			err := a.resource.Read(ctx, a.client, rd)
 			drainWarnings()
 			lastAttemptWarnings = attemptWarnings
-			return err
+
+			if err != nil {
+				return err
+			}
+
+			for key, want := range a.resource.RefreshStateDesired {
+				state := rd.Get(key)
+				if !Equal(state, want) {
+					return fmt.Errorf("%w: expected %q to be `%v`, got `%v`", ErrRefreshStateDesired, key, want, state)
+				}
+			}
+			return nil
 		},
-		retry.Delay(time.Second*5),
-		retry.Attempts(10),
+		retry.Delay(retryDelay),
+		retry.Attempts(attempts),
 		retry.LastErrorOnly(true),
 		retry.Context(ctx),
-		retry.RetryIf(func(err error) bool {
-			// 404: The API is inconsistent, returns 404 after Create/Update
-			// 403: Eventual consistency might cause permission errors, for instance for "organization_project"
-			return IsNotFound(err) || isAivenError(err, http.StatusForbidden)
-		}),
+		retry.RetryIf(isRefreshStateRetryable),
 	)
 
 	AddWarnings(ctx, lastAttemptWarnings...)
 
 	return err
+}
+
+// isRefreshStateRetryable reports whether refreshState should retry after err.
+//
+// Retry on:
+//   - 404 Not Found (including ErrNotFound): API may not immediately reflect new/updated resources;
+//     resource might not be present in list or direct GET call.
+//   - 403 Forbidden: Temporary permission issues can occur due to eventual consistency
+//     (e.g., "organization_project").
+//   - ErrRefreshStateDesired: A RefreshStateDesired attribute did not match after Read.
+func isRefreshStateRetryable(err error) bool {
+	return IsNotFound(err) || isAivenError(err, http.StatusForbidden) || errors.Is(err, ErrRefreshStateDesired)
 }
 
 func (a *resourceAdapter) Update(

--- a/internal/plugin/adapter/resource_test.go
+++ b/internal/plugin/adapter/resource_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 	"testing"
+	"time"
 
 	avngen "github.com/aiven/go-client-codegen"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
@@ -13,6 +14,33 @@ import (
 )
 
 func TestResourceAdapter_refreshState(t *testing.T) {
+	// Use short retry delays so retry-go's exponential backoff stays in the microsecond range.
+	const (
+		fastRetryDelay = time.Microsecond
+		fastAttempts   = uint(5)
+	)
+
+	// fastAdapter builds a *resourceAdapter wired for fast tests: short retry delay and a low
+	// attempt cap. Per-test config (RefreshStateDelay, RefreshStateDesired, etc.) is layered on
+	// top of the returned adapter's resource by the caller.
+	fastAdapter := func(read func(ctx context.Context, client avngen.Client, rd ResourceData) error) *resourceAdapter {
+		return &resourceAdapter{
+			resource: ResourceOptions{
+				Read:                    read,
+				refreshStateRetryDelay:  fastRetryDelay,
+				refreshStateMaxAttempts: fastAttempts,
+			},
+		}
+	}
+
+	// statusSchema is a minimal schema used by tests that exercise RefreshStateDesired.
+	statusSchema := &Schema{
+		Type: SchemaTypeObject,
+		Properties: map[string]*Schema{
+			"status": {Type: SchemaTypeString},
+		},
+	}
+
 	warning := func(summary string) diag.Diagnostic {
 		return diag.NewWarningDiagnostic(summary, "detail")
 	}
@@ -61,6 +89,217 @@ func TestResourceAdapter_refreshState(t *testing.T) {
 		require.False(t, target.Contains(warning("try-1-a")))
 		require.False(t, target.Contains(warning("try-1-b")))
 	})
+
+	t.Run("returns nil when read succeeds on the first try", func(t *testing.T) {
+		t.Parallel()
+
+		attempts := 0
+		a := fastAdapter(func(_ context.Context, _ avngen.Client, _ ResourceData) error {
+			attempts++
+			return nil
+		})
+
+		err := a.refreshState(t.Context(), nil)
+
+		require.NoError(t, err)
+		require.Equal(t, 1, attempts)
+	})
+
+	t.Run("does not retry on a non-retryable error", func(t *testing.T) {
+		t.Parallel()
+
+		boom := errors.New("boom")
+		attempts := 0
+		a := fastAdapter(func(_ context.Context, _ avngen.Client, _ ResourceData) error {
+			attempts++
+			return boom
+		})
+
+		err := a.refreshState(t.Context(), nil)
+
+		require.ErrorIs(t, err, boom)
+		require.Equal(t, 1, attempts, "non-retryable errors must not trigger retries")
+	})
+
+	t.Run("retries on 404 then succeeds", func(t *testing.T) {
+		t.Parallel()
+
+		attempts := 0
+		a := fastAdapter(func(_ context.Context, _ avngen.Client, _ ResourceData) error {
+			attempts++
+			if attempts < 3 {
+				return avngen.Error{Status: http.StatusNotFound, Message: "not ready"}
+			}
+			return nil
+		})
+
+		err := a.refreshState(t.Context(), nil)
+
+		require.NoError(t, err)
+		require.Equal(t, 3, attempts)
+	})
+
+	t.Run("retries on wrapped ErrNotFound then succeeds", func(t *testing.T) {
+		t.Parallel()
+
+		attempts := 0
+		a := fastAdapter(func(_ context.Context, _ avngen.Client, _ ResourceData) error {
+			attempts++
+			if attempts == 1 {
+				return fmt.Errorf("lookup: %w", ErrNotFound)
+			}
+			return nil
+		})
+
+		err := a.refreshState(t.Context(), nil)
+
+		require.NoError(t, err)
+		require.Equal(t, 2, attempts)
+	})
+
+	t.Run("retries on 403 then succeeds", func(t *testing.T) {
+		t.Parallel()
+
+		attempts := 0
+		a := fastAdapter(func(_ context.Context, _ avngen.Client, _ ResourceData) error {
+			attempts++
+			if attempts == 1 {
+				return avngen.Error{Status: http.StatusForbidden, Message: "eventual consistency"}
+			}
+			return nil
+		})
+
+		err := a.refreshState(t.Context(), nil)
+
+		require.NoError(t, err)
+		require.Equal(t, 2, attempts)
+	})
+
+	t.Run("retries when desired attribute does not match, then succeeds", func(t *testing.T) {
+		t.Parallel()
+
+		// rd starts with status "PENDING" and flips to "ACTIVE" after the first Read.
+		rd, err := NewResourceDataFromMaps(
+			statusSchema,
+			nil,
+			nil,
+			map[string]any{"status": "PENDING"},
+			nil,
+		)
+		require.NoError(t, err)
+
+		attempts := 0
+		a := fastAdapter(func(_ context.Context, _ avngen.Client, rd ResourceData) error {
+			attempts++
+			if attempts >= 2 {
+				require.NoError(t, rd.Set("status", "ACTIVE"))
+			}
+			return nil
+		})
+		a.resource.RefreshStateDesired = map[string]string{"status": "ACTIVE"}
+
+		err = a.refreshState(t.Context(), rd)
+
+		require.NoError(t, err)
+		require.Equal(t, 2, attempts)
+		require.Equal(t, "ACTIVE", rd.Get("status"))
+	})
+
+	t.Run("returns ErrRefreshStateDesired after exhausting retries", func(t *testing.T) {
+		t.Parallel()
+
+		rd, err := NewResourceDataFromMaps(
+			statusSchema,
+			nil,
+			nil,
+			map[string]any{"status": "PENDING"},
+			nil,
+		)
+		require.NoError(t, err)
+
+		attempts := 0
+		a := fastAdapter(func(_ context.Context, _ avngen.Client, _ ResourceData) error {
+			attempts++
+			return nil
+		})
+		a.resource.RefreshStateDesired = map[string]string{"status": "ACTIVE"}
+		a.resource.refreshStateMaxAttempts = 3
+
+		err = a.refreshState(t.Context(), rd)
+
+		require.ErrorIs(t, err, ErrRefreshStateDesired)
+		require.Equal(t, 3, attempts)
+	})
+
+	t.Run("returns ctx error when RefreshStateDelay is interrupted by ctx cancellation", func(t *testing.T) {
+		t.Parallel()
+
+		ctx, cancel := context.WithCancel(t.Context())
+		cancel()
+
+		attempts := 0
+		a := fastAdapter(func(_ context.Context, _ avngen.Client, _ ResourceData) error {
+			attempts++
+			return nil
+		})
+		a.resource.RefreshStateDelay = time.Hour
+
+		err := a.refreshState(ctx, nil)
+
+		require.ErrorIs(t, err, context.Canceled)
+		require.Equal(t, 0, attempts, "read must not be called when ctx is cancelled during RefreshStateDelay")
+	})
+
+	t.Run("applies RefreshStateDelay before the first attempt", func(t *testing.T) {
+		t.Parallel()
+
+		const refreshStateDelay = 25 * time.Millisecond
+
+		attempts := 0
+		a := fastAdapter(func(_ context.Context, _ avngen.Client, _ ResourceData) error {
+			attempts++
+			return nil
+		})
+		a.resource.RefreshStateDelay = refreshStateDelay
+
+		start := time.Now()
+		err := a.refreshState(t.Context(), nil)
+		elapsed := time.Since(start)
+
+		require.NoError(t, err)
+		require.Equal(t, 1, attempts)
+		require.GreaterOrEqual(t, elapsed, refreshStateDelay)
+	})
+}
+
+func TestIsRefreshStateRetryable(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{name: "nil error", err: nil, want: false},
+		{name: "ErrNotFound sentinel", err: ErrNotFound, want: true},
+		{name: "wrapped ErrNotFound", err: fmt.Errorf("lookup: %w", ErrNotFound), want: true},
+		{name: "avngen 404", err: avngen.Error{Status: http.StatusNotFound}, want: true},
+		{name: "wrapped avngen 404", err: fmt.Errorf("api: %w", avngen.Error{Status: http.StatusNotFound}), want: true},
+		{name: "avngen 403", err: avngen.Error{Status: http.StatusForbidden}, want: true},
+		{name: "wrapped avngen 403", err: fmt.Errorf("api: %w", avngen.Error{Status: http.StatusForbidden}), want: true},
+		{name: "ErrRefreshStateDesired sentinel", err: ErrRefreshStateDesired, want: true},
+		{name: "wrapped ErrRefreshStateDesired", err: fmt.Errorf("mismatch: %w", ErrRefreshStateDesired), want: true},
+		{name: "avngen 500", err: avngen.Error{Status: http.StatusInternalServerError}, want: false},
+		{name: "avngen 400", err: avngen.Error{Status: http.StatusBadRequest}, want: false},
+		{name: "unrelated error", err: errors.New("boom"), want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, tt.want, isRefreshStateRetryable(tt.err))
+		})
+	}
 }
 
 func TestEqual(t *testing.T) {

--- a/internal/plugin/service/staticip/staticip.go
+++ b/internal/plugin/service/staticip/staticip.go
@@ -1,46 +1,16 @@
-// Package staticip provides custom create (with wait) and delete (list, dissociate if available, then StaticIPDelete) for aiven_static_ip.
+// Package staticip provides custom delete (dissociate then delete) for aiven_static_ip.
 package staticip
 
 import (
 	"context"
-	"fmt"
 
 	avngen "github.com/aiven/go-client-codegen"
-	"github.com/aiven/go-client-codegen/handler/staticip"
-	"github.com/avast/retry-go"
 
-	"github.com/aiven/terraform-provider-aiven/internal/common"
 	"github.com/aiven/terraform-provider-aiven/internal/plugin/adapter"
 )
 
 func init() {
 	ResourceOptions.Delete = deleteWithDissociate
-}
-
-func refreshStateWaiter(ctx context.Context, client avngen.Client, d adapter.ResourceData) error {
-	project := d.Get("project").(string)
-	staticIPAddressID := d.Get("static_ip_address_id").(string)
-	return retry.Do(
-		func() error {
-			list, err := client.StaticIPList(ctx, project)
-			if err != nil {
-				return retry.Unrecoverable(err)
-			}
-			for _, sip := range list {
-				if sip.StaticIPAddressId != d.Get("static_ip_address_id").(string) {
-					continue
-				}
-				if sip.State == staticip.StaticIPStateTypeCreated {
-					return nil
-				}
-				return fmt.Errorf("static ip %s in state %s, waiting for created", staticIPAddressID, sip.State)
-			}
-			return fmt.Errorf("static ip %s not found in project", staticIPAddressID)
-		},
-		retry.Context(ctx),
-		retry.Delay(common.DefaultStateChangeDelay),
-		retry.LastErrorOnly(true),
-	)
 }
 
 // deleteWithDissociate first attempts to dissociate the static IP before deleting it.

--- a/internal/plugin/service/staticip/zz_view.go
+++ b/internal/plugin/service/staticip/zz_view.go
@@ -27,7 +27,7 @@ var ResourceOptions = adapter.ResourceOptions{
 	IDFields:              idFields(),
 	Read:                  readView,
 	RefreshState:          true,
-	RefreshStateWaiter:    refreshStateWaiter,
+	RefreshStateDesired:   map[string]string{"state": "created"},
 	Schema:                resourceSchema,
 	SchemaInternal:        resourceSchemaInternal(),
 	TerminationProtection: true,

--- a/internal/plugin/service/vpc/projectvpc/projectvpc.go
+++ b/internal/plugin/service/vpc/projectvpc/projectvpc.go
@@ -26,36 +26,6 @@ func expandModifier(_ context.Context, _ avngen.Client) adapter.MapModifier {
 	}
 }
 
-func refreshStateWaiter(ctx context.Context, client avngen.Client, d adapter.ResourceData) error {
-	project := d.Get("project").(string)
-	vpcID := d.Get("project_vpc_id").(string)
-
-	return retry.Do(
-		func() error {
-			rsp, err := client.VpcGet(ctx, project, vpcID)
-			if err != nil {
-				if avngen.IsNotFound(err) {
-					// The resource may not be available immediately after creation; retry.
-					return err
-				}
-
-				// Do not retry on client errors such as 401.
-				// 5xx errors are already retried by the client.
-				return retry.Unrecoverable(err)
-			}
-
-			if rsp.State == vpc.VpcStateTypeActive {
-				return nil
-			}
-
-			return fmt.Errorf("project VPC %s in state %s, waiting for ACTIVE", vpcID, rsp.State)
-		},
-		retry.Context(ctx),
-		retry.Delay(common.DefaultStateChangeDelay),
-		retry.LastErrorOnly(true),
-	)
-}
-
 // deleteViewInternal deletes an Aiven project VPC and waits until it reaches the DELETED state or VpcGet returns 404.
 func deleteViewInternal(ctx context.Context, client avngen.Client, d adapter.ResourceData, retryDelay time.Duration) error {
 	project := d.Get("project").(string)

--- a/internal/plugin/service/vpc/projectvpc/zz_view.go
+++ b/internal/plugin/service/vpc/projectvpc/zz_view.go
@@ -25,16 +25,16 @@ func idFields() []string {
 }
 
 var ResourceOptions = adapter.ResourceOptions{
-	Create:             createView,
-	Delete:             deleteView,
-	IDFields:           idFields(),
-	Read:               readView,
-	RefreshState:       true,
-	RefreshStateWaiter: refreshStateWaiter,
-	RemoveMissing:      true,
-	Schema:             resourceSchema,
-	SchemaInternal:     resourceSchemaInternal(),
-	TypeName:           typeName,
+	Create:              createView,
+	Delete:              deleteView,
+	IDFields:            idFields(),
+	Read:                readView,
+	RefreshState:        true,
+	RefreshStateDesired: map[string]string{"state": "ACTIVE"},
+	RemoveMissing:       true,
+	Schema:              resourceSchema,
+	SchemaInternal:      resourceSchemaInternal(),
+	TypeName:            typeName,
 }
 
 var DataSourceOptions = adapter.DataSourceOptions{

--- a/tools/agents/skills/tf-resource-generator/SKILL.md
+++ b/tools/agents/skills/tf-resource-generator/SKILL.md
@@ -172,11 +172,15 @@ Common fields:
 resource:
   description: "..."
   deprecationMessage: "..."
-  terminationProtection: true       # Check field before delete
-  refreshState: true                # Call Read after Create/Update
-  refreshStateDelay: "15s"          # Wait before Read
-  removeMissing: true               # Remove from state on 404
+  terminationProtection: true # Check field before delete
+  refreshState: true # Call Read after Create/Update
+  refreshStateDelay: "15s" # Wait before Read
+  refreshStateDesired: # Retry Read until fields match desired values
+    state: ACTIVE
+  removeMissing: true # Remove from state on 404
 ```
+
+`refreshStateDesired` replaces ad-hoc refresh waiters for simple state transitions. Use it when the resource should settle into a known value after create/update (for example, `state: ACTIVE`).
 
 ### Datasource Configuration
 
@@ -269,6 +273,7 @@ var ResourceOptions = adapter.ResourceOptions{
     Read:              readView,
     RefreshState:      true,
     RefreshStateDelay: adapter.MustParseDuration("15s"),
+    RefreshStateDesired: map[string]string{"state": "ACTIVE"},
     RemoveMissing:     true,
     Schema:            resourceSchema,
     SchemaInternal:    resourceSchemaInternal(),


### PR DESCRIPTION
Resolves NEX-2563.

- Adds `RefreshStateDesired` resource option
- Validates the desired state field exists and the value is presented on the enum list (when possible)
- Moves the state refresher into a standalone function, adds tests
- Replaces handwritten pollers for `project_vpc` and `static_ip`
