### PR TITLE
fix(byoc): fix BYOC resources dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,16 @@ nav_order: 1
 - Change `aiven_service_integration_endpoint` field `datadog_user_config.site` (enum): add `us2.ddog-gov.com`
 - Change `aiven_organization_address`: no longer beta
 - Change `aiven_organization_payment_method_list` datasource: no longer beta
+- Fix `aiven_byoc_aws_provision`: when provisioning a new cloud, the resource will now wait for the custom cloud
+  environment to be `active` before it can be used by service resources. Also when destroying the provisioned custom
+  cloud, it will free its managed cloud resources before the IAM role is destroyed.
+- Remove field `custom_cloud_names` from `aiven_byoc_aws_entity` resource and add it to `aiven_byoc_aws_provision`:
+  the field is only populated after the custom cloud is provisioned.
+- Remove field `aws_iam_role_arn` from `aiven_byoc_aws_entity` resource: it is not used by this resource, and instead
+  it is a required input for provisioning the custom cloud environment.
+- Remove fields `errors`, `state`, `update_time` from `aiven_byoc_aws_entity` resource: they are not useful when only
+  defining the BYOC entity, and would unnecessarily invalidate the resource's state on every update, causing a cascade
+  of unrelated updates to dependent BYOC resources.
 
 ## [4.57.0] - 2026-05-19
 

--- a/definitions/aiven_byoc_aws_entity.yml
+++ b/definitions/aiven_byoc_aws_entity.yml
@@ -4,7 +4,6 @@ location: internal/plugin/service/byoc/aws_entity
 resource:
   description: |
     Creates and manages a BYOC custom cloud environment on AWS.
-
 clientHandler: byoc
 idAttributeComposed: [organization_id, custom_cloud_environment_id]
 operations:
@@ -27,6 +26,11 @@ remove:
   - oracle_compartment_id
   - oracle_subnet_bastion
   - oracle_subnet_workload
+  - custom_cloud_names
+  - errors
+  - state
+  - update_time
+  - aws_iam_role_arn
 schema:
   cloud_provider:
     forceNew: true

--- a/definitions/aiven_byoc_aws_provision.yml
+++ b/definitions/aiven_byoc_aws_provision.yml
@@ -3,19 +3,16 @@ beta: true
 location: internal/plugin/service/byoc/aws_provision
 resource:
   ignoreAlreadyExists: true
-  refreshState: true
   description: |
     Provisions a BYOC custom cloud environment by handing Aiven the IAM role
     ARN created in the customer AWS account. Transitions the environment from
     `draft` to `active` so services can be deployed into it.
 
     Create this resource after the customer-side AWS infrastructure
-    (IAM role, VPC, subnets, security groups, buckets) has been applied, and
-    before `aiven_byoc_permissions`.
-
-    `terraform destroy` on this resource is a state-only operation -- it does
-    not reverse provisioning. To tear down, destroy the underlying
-    `aiven_byoc_aws_entity`.
+    (IAM role, VPC, subnets, security groups, buckets) has been defined.
+  refreshState: true
+  refreshStateDesired:
+    state: active
 clientHandler: byoc
 idAttributeComposed: [organization_id, custom_cloud_environment_id]
 operations:
@@ -25,6 +22,9 @@ operations:
   - id: CustomCloudEnvironmentGet
     type: read
     resultKey: custom_cloud_environment
+  - id: CustomCloudEnvironmentDelete
+    type: delete
+    disableView: true
 remove:
   - aiven_aws_object_storage_credentials_creator_arn
   - aiven_aws_object_storage_user_arn
@@ -39,7 +39,6 @@ remove:
   - cloud_provider
   - cloud_region
   - contact_emails
-  - custom_cloud_names
   - deployment_model
   - display_name
   - errors
@@ -50,7 +49,6 @@ remove:
   - oracle_subnet_bastion
   - oracle_subnet_workload
   - reserved_cidr
-  - state
   - tags
   - update_time
   - use_customer_owned_storage

--- a/docs/resources/byoc_aws_entity.md
+++ b/docs/resources/byoc_aws_entity.md
@@ -27,7 +27,6 @@ resource "aiven_byoc_aws_entity" "example" {
   reserved_cidr    = "192.168.6.0/24" // Force new
 
   // OPTIONAL FIELDS
-  aws_iam_role_arn = "arn:aws:iam::012345678901:root"
   contact_emails {
     email = "jane@example.com"
 
@@ -59,14 +58,7 @@ resource "aiven_byoc_aws_entity" "example" {
   byoc_resource_tags = {
     foo = "foo"
   }
-  byoc_unique_name   = "foo"
-  custom_cloud_names = ["foo"]
-  errors {
-    category = "general_error"
-    message  = "foo"
-  }
-  state                      = "active"
-  update_time                = "2021-01-01T00:00:00Z"
+  byoc_unique_name           = "foo"
   use_customer_owned_storage = true
   */
 }
@@ -86,7 +78,6 @@ resource "aiven_byoc_aws_entity" "example" {
 
 ### Optional
 
-- `aws_iam_role_arn` (String) Amazon Resource Name. Maximum length: `2048`.
 - `contact_emails` (Block Set) Email addresses for notifications and alerts for this BYOC cloud. (see [below for nested schema](#nestedblock--contact_emails))
 - `tags` (Map of String) Set of resource tags.
 - `timeouts` (Block, Optional) (see [below for nested schema](#nestedblock--timeouts))
@@ -105,11 +96,7 @@ resource "aiven_byoc_aws_entity" "example" {
 - `byoc_resource_tags` (Map of String) Set of tags for the resources provisioned on the BYOC account.
 - `byoc_unique_name` (String) Name for all the resources created for the custom cloud environment.
 - `custom_cloud_environment_id` (String) ID of a custom cloud environment.
-- `custom_cloud_names` (Set of String) Cloud names that can be used to provision a service on this BYOC.
-- `errors` (Block Set) List of errors for this custom cloud environment. (see [below for nested schema](#nestedblock--errors))
 - `id` (String) Resource ID composed as: `organization_id/custom_cloud_environment_id`.
-- `state` (String) State of this BYOC cloud. The possible values are `active`, `creating`, `creation_failed`, `deleted`, `deleting`, `deletion_failed`, `disconnected`, `draft`, `reconnecting` and `validating`.
-- `update_time` (String) Custom cloud environment last update timestamp (ISO 8601).
 - `use_customer_owned_storage` (Boolean) True if this BYOC cloud is using customer owned storage.
 
 <a id="nestedblock--contact_emails"></a>
@@ -134,15 +121,6 @@ Optional:
 - `delete` (String) A string that can be [parsed as a duration](https://pkg.go.dev/time#ParseDuration) consisting of numbers and unit suffixes, such as "30s" or "2h45m". Valid time units are "s" (seconds), "m" (minutes), "h" (hours). Setting a timeout for a Delete operation is only applicable if changes are saved into state before the destroy operation occurs.
 - `read` (String) A string that can be [parsed as a duration](https://pkg.go.dev/time#ParseDuration) consisting of numbers and unit suffixes, such as "30s" or "2h45m". Valid time units are "s" (seconds), "m" (minutes), "h" (hours). Read operations occur during any refresh or planning operation when refresh is enabled.
 - `update` (String) A string that can be [parsed as a duration](https://pkg.go.dev/time#ParseDuration) consisting of numbers and unit suffixes, such as "30s" or "2h45m". Valid time units are "s" (seconds), "m" (minutes), "h" (hours).
-
-
-<a id="nestedblock--errors"></a>
-### Nested Schema for `errors`
-
-Read-Only:
-
-- `category` (String) Category of this error. The possible value is `general_error`.
-- `message` (String) Description of this error.
 
 ## Import
 

--- a/docs/resources/byoc_aws_provision.md
+++ b/docs/resources/byoc_aws_provision.md
@@ -3,14 +3,14 @@
 page_title: "aiven_byoc_aws_provision Resource - terraform-provider-aiven"
 subcategory: ""
 description: |-
-  Provisions a BYOC custom cloud environment by handing Aiven the IAM role ARN created in the customer AWS account. Transitions the environment from draft to active so services can be deployed into it. Create this resource after the customer-side AWS infrastructure (IAM role, VPC, subnets, security groups, buckets) has been applied, and before aiven_byoc_permissions. terraform destroy on this resource is a state-only operation -- it does not reverse provisioning. To tear down, destroy the underlying aiven_byoc_aws_entity.
+  Provisions a BYOC custom cloud environment by handing Aiven the IAM role ARN created in the customer AWS account. Transitions the environment from draft to active so services can be deployed into it. Create this resource after the customer-side AWS infrastructure (IAM role, VPC, subnets, security groups, buckets) has been defined.
   This resource is in the beta stage and may change without notice. Set
   the PROVIDER_AIVEN_ENABLE_BETA environment variable to use the resource.
 ---
 
 # aiven_byoc_aws_provision (Resource)
 
-Provisions a BYOC custom cloud environment by handing Aiven the IAM role ARN created in the customer AWS account. Transitions the environment from `draft` to `active` so services can be deployed into it. Create this resource after the customer-side AWS infrastructure (IAM role, VPC, subnets, security groups, buckets) has been applied, and before `aiven_byoc_permissions`. `terraform destroy` on this resource is a state-only operation -- it does not reverse provisioning. To tear down, destroy the underlying `aiven_byoc_aws_entity`.
+Provisions a BYOC custom cloud environment by handing Aiven the IAM role ARN created in the customer AWS account. Transitions the environment from `draft` to `active` so services can be deployed into it. Create this resource after the customer-side AWS infrastructure (IAM role, VPC, subnets, security groups, buckets) has been defined.
 
 **This resource is in the beta stage and may change without notice.** Set
 the `PROVIDER_AIVEN_ENABLE_BETA` environment variable to use the resource.
@@ -26,6 +26,8 @@ resource "aiven_byoc_aws_provision" "example" {
   /* COMPUTED FIELDS
   aiven_aws_assume_role_external_id = "admin"
   aiven_aws_account_principal       = "foo"
+  custom_cloud_names                = ["foo"]
+  state                             = "active"
   */
 }
 ```
@@ -47,7 +49,9 @@ resource "aiven_byoc_aws_provision" "example" {
 
 - `aiven_aws_account_principal` (String) Entity that assumes the IAM role for controlling the BYOC account.
 - `aiven_aws_assume_role_external_id` (String) External ID for assuming the IAM role for controlling the BYOC account.
+- `custom_cloud_names` (Set of String) Cloud names that can be used to provision a service on this BYOC.
 - `id` (String) Resource ID composed as: `organization_id/custom_cloud_environment_id`.
+- `state` (String) State of this BYOC cloud. The possible values are `active`, `creating`, `creation_failed`, `deleted`, `deleting`, `deletion_failed`, `disconnected`, `draft`, `reconnecting` and `validating`.
 
 <a id="nestedblock--timeouts"></a>
 ### Nested Schema for `timeouts`

--- a/examples/resources/aiven_byoc_aws_entity/resource.tf
+++ b/examples/resources/aiven_byoc_aws_entity/resource.tf
@@ -7,7 +7,6 @@ resource "aiven_byoc_aws_entity" "example" {
   reserved_cidr    = "192.168.6.0/24" // Force new
 
   // OPTIONAL FIELDS
-  aws_iam_role_arn = "arn:aws:iam::012345678901:root"
   contact_emails {
     email = "jane@example.com"
 
@@ -39,14 +38,7 @@ resource "aiven_byoc_aws_entity" "example" {
   byoc_resource_tags = {
     foo = "foo"
   }
-  byoc_unique_name   = "foo"
-  custom_cloud_names = ["foo"]
-  errors {
-    category = "general_error"
-    message  = "foo"
-  }
-  state                      = "active"
-  update_time                = "2021-01-01T00:00:00Z"
+  byoc_unique_name           = "foo"
   use_customer_owned_storage = true
   */
 }

--- a/examples/resources/aiven_byoc_aws_provision/resource.tf
+++ b/examples/resources/aiven_byoc_aws_provision/resource.tf
@@ -6,5 +6,7 @@ resource "aiven_byoc_aws_provision" "example" {
   /* COMPUTED FIELDS
   aiven_aws_assume_role_external_id = "admin"
   aiven_aws_account_principal       = "foo"
+  custom_cloud_names                = ["foo"]
+  state                             = "active"
   */
 }

--- a/internal/plugin/service/byoc/aws_entity/aws_entity_test.go
+++ b/internal/plugin/service/byoc/aws_entity/aws_entity_test.go
@@ -13,8 +13,6 @@ import (
 func TestAccAivenBYOCAWSEntity(t *testing.T) {
 	acc.SkipIfNotBeta(t)
 
-	envVars := acc.RequireEnvVars(t, "AIVEN_BYOC_AWS_IAM_ROLE_ARN")
-	iamRoleARN := envVars["AIVEN_BYOC_AWS_IAM_ROLE_ARN"]
 	organizationName := acc.OrganizationName()
 
 	const resourceName = "aiven_byoc_aws_entity.example"
@@ -24,7 +22,7 @@ data "aiven_organization" "org" {
   name = %q
 }`, organizationName)
 
-	initialConfig := baseConfig + fmt.Sprintf(`
+	initialConfig := baseConfig + `
 resource "aiven_byoc_aws_entity" "example" {
   organization_id  = data.aiven_organization.org.id
   display_name     = "test-byoc-acc"
@@ -32,16 +30,15 @@ resource "aiven_byoc_aws_entity" "example" {
   cloud_region     = "aws-eu-west-1"
   deployment_model = "standard"
   reserved_cidr    = "10.0.0.0/16"
-  aws_iam_role_arn = %q
 
   contact_emails {
     email     = "ops@example.com"
     real_name = "Ops Team"
     role      = "admin"
   }
-}`, iamRoleARN)
+}`
 
-	updatedConfig := baseConfig + fmt.Sprintf(`
+	updatedConfig := baseConfig + `
 resource "aiven_byoc_aws_entity" "example" {
   organization_id  = data.aiven_organization.org.id
   display_name     = "test-byoc-acc-updated"
@@ -49,7 +46,6 @@ resource "aiven_byoc_aws_entity" "example" {
   cloud_region     = "aws-eu-west-1"
   deployment_model = "standard"
   reserved_cidr    = "10.0.0.0/16"
-  aws_iam_role_arn = %q
 
   contact_emails {
     email     = "ops@example.com"
@@ -61,9 +57,9 @@ resource "aiven_byoc_aws_entity" "example" {
     email = "devops@example.com"
     role  = "ops"
   }
-}`, iamRoleARN)
+}`
 
-	regionChangeConfig := baseConfig + fmt.Sprintf(`
+	regionChangeConfig := baseConfig + `
 resource "aiven_byoc_aws_entity" "example" {
   organization_id  = data.aiven_organization.org.id
   display_name     = "test-byoc-acc-updated"
@@ -71,7 +67,6 @@ resource "aiven_byoc_aws_entity" "example" {
   cloud_region     = "aws-us-east-1"
   deployment_model = "standard"
   reserved_cidr    = "10.0.0.0/16"
-  aws_iam_role_arn = %q
 
   contact_emails {
     email     = "ops@example.com"
@@ -83,7 +78,7 @@ resource "aiven_byoc_aws_entity" "example" {
     email = "devops@example.com"
     role  = "ops"
   }
-}`, iamRoleARN)
+}`
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acc.TestAccPreCheck(t) },
@@ -100,7 +95,6 @@ resource "aiven_byoc_aws_entity" "example" {
 					resource.TestCheckResourceAttr(resourceName, "cloud_region", "aws-eu-west-1"),
 					resource.TestCheckResourceAttr(resourceName, "deployment_model", "standard"),
 					resource.TestCheckResourceAttr(resourceName, "reserved_cidr", "10.0.0.0/16"),
-					resource.TestCheckResourceAttr(resourceName, "aws_iam_role_arn", iamRoleARN),
 					resource.TestCheckResourceAttr(resourceName, "contact_emails.#", "1"),
 					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "contact_emails.*", map[string]string{
 						"email":     "ops@example.com",
@@ -126,7 +120,6 @@ resource "aiven_byoc_aws_entity" "example" {
 			},
 			{
 				Config:             regionChangeConfig,
-				PlanOnly:           true,
 				ExpectNonEmptyPlan: true,
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PreApply: []plancheck.PlanCheck{

--- a/internal/plugin/service/byoc/aws_entity/zz_resource.go
+++ b/internal/plugin/service/byoc/aws_entity/zz_resource.go
@@ -46,11 +46,6 @@ func resourceSchema(ctx context.Context) schema.Schema {
 				Computed:            true,
 				MarkdownDescription: "Google account identifier.",
 			},
-			"aws_iam_role_arn": schema.StringAttribute{
-				MarkdownDescription: "Amazon Resource Name. Maximum length: `2048`.",
-				Optional:            true,
-				Validators:          []validator.String{stringvalidator.LengthAtMost(2048)},
-			},
 			"aws_subnets_bastion": schema.MapAttribute{
 				Computed:            true,
 				ElementType:         types.StringType,
@@ -91,11 +86,6 @@ func resourceSchema(ctx context.Context) schema.Schema {
 				Computed:            true,
 				MarkdownDescription: "ID of a custom cloud environment.",
 			},
-			"custom_cloud_names": schema.SetAttribute{
-				Computed:            true,
-				ElementType:         types.StringType,
-				MarkdownDescription: "Cloud names that can be used to provision a service on this BYOC.",
-			},
 			"deployment_model": schema.StringAttribute{
 				MarkdownDescription: "Deployment model for the BYOC cloud. The possible values are `direct_ipsec_ingress`, `hipaa`, `ipsec_ingress`, `pci_dss`, `standard` and `standard_public`. Changing this property forces recreation of the resource.",
 				PlanModifiers:       []planmodifier.String{stringplanmodifier.RequiresReplace()},
@@ -123,18 +113,10 @@ func resourceSchema(ctx context.Context) schema.Schema {
 				Required:            true,
 				Validators:          []validator.String{stringvalidator.LengthAtMost(18)},
 			},
-			"state": schema.StringAttribute{
-				Computed:            true,
-				MarkdownDescription: "State of this BYOC cloud. The possible values are `active`, `creating`, `creation_failed`, `deleted`, `deleting`, `deletion_failed`, `disconnected`, `draft`, `reconnecting` and `validating`.",
-			},
 			"tags": schema.MapAttribute{
 				ElementType:         types.StringType,
 				MarkdownDescription: "Set of resource tags.",
 				Optional:            true,
-			},
-			"update_time": schema.StringAttribute{
-				Computed:            true,
-				MarkdownDescription: "Custom cloud environment last update timestamp (ISO 8601).",
 			},
 			"use_customer_owned_storage": schema.BoolAttribute{
 				Computed:            true,
@@ -162,19 +144,6 @@ func resourceSchema(ctx context.Context) schema.Schema {
 					},
 				}},
 				Validators: []validator.Set{setvalidator.SizeBetween(1, 10)},
-			},
-			"errors": schema.SetNestedBlock{
-				MarkdownDescription: "List of errors for this custom cloud environment.",
-				NestedObject: schema.NestedBlockObject{Attributes: map[string]schema.Attribute{
-					"category": schema.StringAttribute{
-						Computed:            true,
-						MarkdownDescription: "Category of this error. The possible value is `general_error`.",
-					},
-					"message": schema.StringAttribute{
-						Computed:            true,
-						MarkdownDescription: "Description of this error.",
-					},
-				}},
 			},
 			"timeouts": timeouts.BlockAll(ctx),
 		},
@@ -213,7 +182,6 @@ func resourceSchemaInternal() *adapter.Schema {
 				Computed: true,
 				Type:     adapter.SchemaTypeString,
 			},
-			"aws_iam_role_arn": &adapter.Schema{Type: adapter.SchemaTypeString},
 			"aws_subnets_bastion": &adapter.Schema{
 				Computed: true,
 				Items: &adapter.Schema{
@@ -269,44 +237,14 @@ func resourceSchemaInternal() *adapter.Schema {
 				Type:           adapter.SchemaTypeString,
 				ZeroNotAllowed: true,
 			},
-			"custom_cloud_names": &adapter.Schema{
-				Computed: true,
-				Items: &adapter.Schema{
-					Computed: true,
-					Type:     adapter.SchemaTypeString,
-				},
-				Type: adapter.SchemaTypeSet,
-			},
 			"deployment_model": &adapter.Schema{Type: adapter.SchemaTypeString},
 			"display_name":     &adapter.Schema{Type: adapter.SchemaTypeString},
-			"errors": &adapter.Schema{
-				Computed: true,
-				Items: &adapter.Schema{
-					Computed: true,
-					Properties: map[string]*adapter.Schema{
-						"category": &adapter.Schema{
-							Computed: true,
-							Type:     adapter.SchemaTypeString,
-						},
-						"message": &adapter.Schema{
-							Computed: true,
-							Type:     adapter.SchemaTypeString,
-						},
-					},
-					Type: adapter.SchemaTypeObject,
-				},
-				Type: adapter.SchemaTypeSet,
-			},
 			"id": &adapter.Schema{
 				Computed: true,
 				Type:     adapter.SchemaTypeString,
 			},
 			"organization_id": &adapter.Schema{Type: adapter.SchemaTypeString},
 			"reserved_cidr":   &adapter.Schema{Type: adapter.SchemaTypeString},
-			"state": &adapter.Schema{
-				Computed: true,
-				Type:     adapter.SchemaTypeString,
-			},
 			"tags": &adapter.Schema{
 				Items: &adapter.Schema{Type: adapter.SchemaTypeString},
 				Type:  adapter.SchemaTypeMap,
@@ -319,10 +257,6 @@ func resourceSchemaInternal() *adapter.Schema {
 					"update": &adapter.Schema{Type: adapter.SchemaTypeString},
 				},
 				Type: adapter.SchemaTypeObject,
-			},
-			"update_time": &adapter.Schema{
-				Computed: true,
-				Type:     adapter.SchemaTypeString,
 			},
 			"use_customer_owned_storage": &adapter.Schema{
 				Computed: true,

--- a/internal/plugin/service/byoc/aws_provision/aws_provision_test.go
+++ b/internal/plugin/service/byoc/aws_provision/aws_provision_test.go
@@ -30,7 +30,6 @@ resource "aiven_byoc_aws_entity" "example" {
   cloud_region     = "aws-eu-west-1"
   deployment_model = "standard"
   reserved_cidr    = "10.0.0.0/16"
-  aws_iam_role_arn = %[2]q
 
   contact_emails {
     email = "ops@example.com"
@@ -41,7 +40,7 @@ resource "aiven_byoc_aws_entity" "example" {
 resource "aiven_byoc_aws_provision" "example" {
   organization_id             = data.aiven_organization.org.id
   custom_cloud_environment_id = aiven_byoc_aws_entity.example.custom_cloud_environment_id
-  aws_iam_role_arn            = %[2]q
+  aws_iam_role_arn            = %q
 }`, organizationName, iamRoleARN)
 
 	resource.ParallelTest(t, resource.TestCase{

--- a/internal/plugin/service/byoc/aws_provision/provision.go
+++ b/internal/plugin/service/byoc/aws_provision/provision.go
@@ -1,0 +1,66 @@
+// Package awsprovision provides custom create (with wait) for aiven_byoc_aws_provision.
+package awsprovision
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	avngen "github.com/aiven/go-client-codegen"
+	"github.com/aiven/go-client-codegen/handler/byoc"
+	"github.com/avast/retry-go"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+
+	"github.com/aiven/terraform-provider-aiven/internal/common"
+	"github.com/aiven/terraform-provider-aiven/internal/plugin/adapter"
+)
+
+// deleteViewInternal deletes a custome cloud enviornmnet nd waits until it reaches the DELETED state or CustomCloudEnvironmentGet returns 404.
+func deleteViewInternal(ctx context.Context, client avngen.Client, d adapter.ResourceData, retryDelay time.Duration) error {
+	organizationID := d.Get("organization_id").(string)
+	customCloudEnvironmentID := d.Get("custom_cloud_environment_id").(string)
+
+	return retry.Do(
+		func() error {
+			cce, err := client.CustomCloudEnvironmentGet(ctx, organizationID, customCloudEnvironmentID)
+			if err != nil {
+				if avngen.IsNotFound(err) {
+					// The CCE is deleted.
+					return nil
+				}
+
+				// Do not retry on client errors such as 401.
+				// 5xx errors are already retried by the client.
+				return retry.Unrecoverable(err)
+			}
+
+			if cce.State == byoc.CustomCloudEnvironmentStateTypeDeleted {
+				// The CCE is deleted.
+				return nil
+			}
+
+			if cce.State != byoc.CustomCloudEnvironmentStateTypeDeleting {
+				// Note: the CCE cannot be deleted while there are services using it,
+				// or while a service deletion is still in progress; in these cases the API returns 409.
+				if err = client.CustomCloudEnvironmentDelete(ctx, organizationID, customCloudEnvironmentID); err != nil {
+					// We don't know exactly which errors this call might return.
+					// If it's a 401, the next GET call will mark it as Unrecoverable.
+					return err
+				}
+			}
+			return fmt.Errorf("custom cloud environment %s in state %s, waiting for %q", customCloudEnvironmentID, cce.State, byoc.CustomCloudEnvironmentStateTypeDeleted)
+		},
+		retry.Context(ctx),
+		retry.Delay(retryDelay),
+		retry.LastErrorOnly(true),
+		retry.OnRetry(func(n uint, err error) {
+			// We can't tell whether a Conflict is caused by Terraform-managed resources that haven't been removed yet
+			// or by unmanaged resources still attached to the CCE. Logging the error provides some visibility in those cases.
+			tflog.Info(ctx, fmt.Sprintf("Retrying to delete custome cloud environment %q: %s", customCloudEnvironmentID, err))
+		}),
+	)
+}
+
+func deleteView(ctx context.Context, client avngen.Client, d adapter.ResourceData) error {
+	return deleteViewInternal(ctx, client, d, common.DefaultStateChangeDelay)
+}

--- a/internal/plugin/service/byoc/aws_provision/zz_resource.go
+++ b/internal/plugin/service/byoc/aws_provision/zz_resource.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
 
 	"github.com/aiven/terraform-provider-aiven/internal/plugin/adapter"
 )
@@ -39,6 +40,11 @@ func resourceSchema(ctx context.Context) schema.Schema {
 				Required:            true,
 				Validators:          []validator.String{stringvalidator.LengthBetween(36, 36)},
 			},
+			"custom_cloud_names": schema.SetAttribute{
+				Computed:            true,
+				ElementType:         types.StringType,
+				MarkdownDescription: "Cloud names that can be used to provision a service on this BYOC.",
+			},
 			"id": schema.StringAttribute{
 				Computed:            true,
 				MarkdownDescription: "Resource ID composed as: `organization_id/custom_cloud_environment_id`.",
@@ -49,9 +55,13 @@ func resourceSchema(ctx context.Context) schema.Schema {
 				PlanModifiers:       []planmodifier.String{stringplanmodifier.RequiresReplace()},
 				Required:            true,
 			},
+			"state": schema.StringAttribute{
+				Computed:            true,
+				MarkdownDescription: "State of this BYOC cloud. The possible values are `active`, `creating`, `creation_failed`, `deleted`, `deleting`, `deletion_failed`, `disconnected`, `draft`, `reconnecting` and `validating`.",
+			},
 		},
 		Blocks:              map[string]schema.Block{"timeouts": timeouts.BlockAll(ctx)},
-		MarkdownDescription: "Provisions a BYOC custom cloud environment by handing Aiven the IAM role ARN created in the customer AWS account. Transitions the environment from `draft` to `active` so services can be deployed into it. Create this resource after the customer-side AWS infrastructure (IAM role, VPC, subnets, security groups, buckets) has been applied, and before `aiven_byoc_permissions`. `terraform destroy` on this resource is a state-only operation -- it does not reverse provisioning. To tear down, destroy the underlying `aiven_byoc_aws_entity`. \n\n**This resource is in the beta stage and may change without notice.** Set\nthe `PROVIDER_AIVEN_ENABLE_BETA` environment variable to use the resource.",
+		MarkdownDescription: "Provisions a BYOC custom cloud environment by handing Aiven the IAM role ARN created in the customer AWS account. Transitions the environment from `draft` to `active` so services can be deployed into it. Create this resource after the customer-side AWS infrastructure (IAM role, VPC, subnets, security groups, buckets) has been defined. \n\n**This resource is in the beta stage and may change without notice.** Set\nthe `PROVIDER_AIVEN_ENABLE_BETA` environment variable to use the resource.",
 	}
 }
 func resourceSchemaInternal() *adapter.Schema {
@@ -71,11 +81,23 @@ func resourceSchemaInternal() *adapter.Schema {
 				Type:           adapter.SchemaTypeString,
 				ZeroNotAllowed: true,
 			},
+			"custom_cloud_names": &adapter.Schema{
+				Computed: true,
+				Items: &adapter.Schema{
+					Computed: true,
+					Type:     adapter.SchemaTypeString,
+				},
+				Type: adapter.SchemaTypeSet,
+			},
 			"id": &adapter.Schema{
 				Computed: true,
 				Type:     adapter.SchemaTypeString,
 			},
 			"organization_id": &adapter.Schema{Type: adapter.SchemaTypeString},
+			"state": &adapter.Schema{
+				Computed: true,
+				Type:     adapter.SchemaTypeString,
+			},
 			"timeouts": &adapter.Schema{
 				Properties: map[string]*adapter.Schema{
 					"create": &adapter.Schema{Type: adapter.SchemaTypeString},

--- a/internal/plugin/service/byoc/aws_provision/zz_view.go
+++ b/internal/plugin/service/byoc/aws_provision/zz_view.go
@@ -23,10 +23,12 @@ func idFields() []string {
 var ResourceOptions = adapter.ResourceOptions{
 	Beta:                true,
 	Create:              createView,
+	Delete:              deleteView,
 	IDFields:            idFields(),
 	IgnoreAlreadyExists: true,
 	Read:                readView,
 	RefreshState:        true,
+	RefreshStateDesired: map[string]string{"state": "active"},
 	Schema:              resourceSchema,
 	SchemaInternal:      resourceSchemaInternal(),
 	TypeName:            typeName,

--- a/internal/plugin/service/byoc/permissions/permissions_test.go
+++ b/internal/plugin/service/byoc/permissions/permissions_test.go
@@ -13,8 +13,6 @@ import (
 func TestAccAivenBYOCPermissions(t *testing.T) {
 	acc.SkipIfNotBeta(t)
 
-	envVars := acc.RequireEnvVars(t, "AIVEN_BYOC_AWS_IAM_ROLE_ARN")
-	iamRoleARN := envVars["AIVEN_BYOC_AWS_IAM_ROLE_ARN"]
 	organizationName := acc.OrganizationName()
 
 	const resourceName = "aiven_byoc_permissions.example"
@@ -31,14 +29,13 @@ resource "aiven_byoc_aws_entity" "example" {
   cloud_region     = "aws-eu-west-1"
   deployment_model = "standard"
   reserved_cidr    = "10.0.0.0/16"
-  aws_iam_role_arn = %q
 
   contact_emails {
     email     = "ops@example.com"
     real_name = "Ops Team"
     role      = "admin"
   }
-}`, organizationName, iamRoleARN)
+}`, organizationName)
 
 	initialConfig := baseConfig + `
 resource "aiven_byoc_permissions" "example" {


### PR DESCRIPTION
Changes to resource `aiven_byoc_aws_provision`:

- When destroying a provisioned custom cloud environment, the CustomCloudEnvironmentDelete endpoint should be called to free the managed cloud resources before the IAM role and other network resources are destroyed. Now this operation is added to the resource.

- A custom cloud should be `active` before it can be used to create services on it, this adds a `refreshStateDesired` to the resource so it waits for the custom cloud environment to be 'active'.

- Add `custom_cloud_names` to this resource and remove it from `aiven_byoc_aws_entity`. The custom cloud names are only populated after provisioning, and services should depend on this resource rather than `aiven_byoc_aws_entity`, in order to attempt cleaning up the managed cloud resources only after all the services are destroyed.

Changes to resource `aiven_byoc_aws_entity`:

- Remove `aws_iam_role_arn` since it is not valid before the entity is defined first, and it is rather an input to provision the custom cloud.

- Also remove computed `errors`, `state`, and `update_time` as they would unncessarily invalidate this resource's state on every update, causing a cascade of unrelated updates to dependent BYOC resources.

Resolves: IP-998