### PR TITLE
fix(plugin): handle timeout blocks without default

### DIFF
--- a/internal/plugin/adapter/timeouts.go
+++ b/internal/plugin/adapter/timeouts.go
@@ -37,11 +37,12 @@ func withTimeout(ctx context.Context, d resourceDataTimeouts, timeoutKey timeout
 
 type resourceDataTimeouts interface {
 	GetOk(key string) (any, bool)
+	Schema() *Schema
 }
 
-// getTimeoutValue retrieves the timeout value in SDKv2 legacy manner (the plugin framework doesn't have "default" key):
+// getTimeoutValue retrieves the timeout value:
 // 1. The specific timeout value for the given key (e.g. "create", "read", "update", "delete")
-// 2. The "default" timeout value if specific one not found
+// 2. The legacy "default" timeout value if the schema supports it and specific one not found
 // 3. The provided fallback duration if no timeouts configured
 // Returns the resolved duration and any validation diagnostics.
 func getTimeoutValue(
@@ -55,10 +56,17 @@ func getTimeoutValue(
 	if ok {
 		tflog.Info(ctx, fmt.Sprintf("Using user %q timeout: %s", timeoutKey, v))
 	} else {
-		v, ok = d.GetOk(fmt.Sprintf("timeouts.%s", timeoutDefault))
-		if ok {
-			tflog.Info(ctx, fmt.Sprintf("Using %q value for %q timeout: %s", timeoutDefault, timeoutKey, v))
-		} else {
+		if schema := d.Schema(); schema != nil {
+			if timeouts, hasTimeouts := schema.Properties["timeouts"]; hasTimeouts && timeouts != nil {
+				if _, hasTimeoutDefault := timeouts.Properties[string(timeoutDefault)]; hasTimeoutDefault {
+					v, ok = d.GetOk(fmt.Sprintf("timeouts.%s", timeoutDefault))
+					if ok {
+						tflog.Info(ctx, fmt.Sprintf("Using %q value for %q timeout: %s", timeoutDefault, timeoutKey, v))
+					}
+				}
+			}
+		}
+		if !ok {
 			tflog.Info(ctx, fmt.Sprintf("Using fallback timeout for %q: %s", timeoutKey, fallback))
 			return fallback, nil
 		}

--- a/internal/plugin/adapter/timeouts_test.go
+++ b/internal/plugin/adapter/timeouts_test.go
@@ -128,3 +128,40 @@ func TestGetTimeoutValue(t *testing.T) {
 		})
 	}
 }
+
+// Plugin Framework timeout blocks don't expose the legacy SDKv2 `timeouts.default` field.
+// The timeout resolver must only read that field when the current schema supports it.
+func TestTimeoutWithDefault(t *testing.T) {
+	t.Parallel()
+
+	const fallbackTimeout = 5 * time.Minute
+
+	t.Run("falls back when schema doesn't support default", func(t *testing.T) {
+		schema := timeoutsTestSchema()
+		delete(schema.Properties["timeouts"].Properties, string(timeoutDefault))
+
+		plan := map[string]any{
+			"id":       "test-id",
+			"timeouts": map[string]any{"update": "45s"},
+		}
+		d, err := NewResourceData(schema, []string{"id"}, WithTestPlan(plan))
+		require.NoError(t, err)
+
+		got, err := getTimeoutValue(t.Context(), d, timeoutCreate, fallbackTimeout)
+		require.NoError(t, err)
+		require.Equal(t, fallbackTimeout, got)
+	})
+
+	t.Run("uses default when schema supports it", func(t *testing.T) {
+		plan := map[string]any{
+			"id":       "test-id",
+			"timeouts": map[string]any{"update": "45s", "default": "90s"},
+		}
+		d, err := NewResourceData(timeoutsTestSchema(), []string{"id"}, WithTestPlan(plan))
+		require.NoError(t, err)
+
+		got, err := getTimeoutValue(t.Context(), d, timeoutCreate, fallbackTimeout)
+		require.NoError(t, err)
+		require.Equal(t, 90*time.Second, got)
+	})
+}

--- a/internal/plugin/service/planlist/plan_list_test.go
+++ b/internal/plugin/service/planlist/plan_list_test.go
@@ -61,3 +61,39 @@ data "aiven_service_plan_list" "plans" {
 		},
 	})
 }
+
+// This test is about the shared timeout adapter. `aiven_service_plan_list` is used because it's a cheap data source whose read path runs during plan.
+func TestAccAivenPlanListDataSourceTimeouts(t *testing.T) {
+	var (
+		projectName = acc.ProjectName()
+		serviceType = "kafka"
+	)
+
+	config := func(timeouts string) string {
+		return fmt.Sprintf(`
+data "aiven_service_plan_list" "plans" {
+  project      = %q
+  service_type = %q
+
+  timeouts {
+%s
+  }
+}
+`, projectName, serviceType, timeouts)
+	}
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acc.TestAccPreCheck(t) },
+		ProtoV6ProviderFactories: acc.TestProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config:   config(""),
+				PlanOnly: true,
+			},
+			{
+				Config:   config(`    read = "5m"`),
+				PlanOnly: true,
+			},
+		},
+	})
+}


### PR DESCRIPTION
Resolves: NEX-2594

Terraform accepted a valid block like timeouts `{ update = "10m" }`, but when another operation needed a timeout, the provider could look for the fallback field `timeouts.default`.

Plugin Framework timeout schemas don't have that default field, so instead of falling back to the normal timeout, the provider could panic. The fix checks whether the schema actually supports default before reading it.