### PR TITLE
feat(aiven_project): deprecate estimated_balance and available_credits on resource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ nav_order: 1
 ## [MAJOR.MINOR.PATCH] - YYYY-MM-DD
 
 - Fix: timeouts block values are now properly supported for resources implemented with the Plugin Framework
+- Deprecate `aiven_project` resource fields `estimated_balance` and `available_credits`, they are no longer populated on the resource. Use the `aiven_project` data source
+  to read them.
 - Promote `aiven_organization_billing_group` resource and data source, and `aiven_organization_billing_group_list` data
   source to general availability.
 - Deprecate `aiven_billing_group` resource and data source: use `aiven_organization_billing_group` instead.

--- a/docs/resources/project.md
+++ b/docs/resources/project.md
@@ -48,9 +48,9 @@ resource "aiven_project" "example_project" {
 
 ### Read-Only
 
-- `available_credits` (String) The number of trial or promotional credits remaining for this project.
+- `available_credits` (String, Deprecated) The number of trial or promotional credits remaining for this project.
 - `ca_cert` (String, Sensitive) The CA certificate for the project. This is required for configuring clients that connect to certain services like Kafka.
-- `estimated_balance` (String) The monthly running estimate for this project for the current billing period.
+- `estimated_balance` (String, Deprecated) The monthly running estimate for this project for the current billing period.
 - `id` (String) The ID of this resource.
 - `payment_method` (String) The payment type used for this project. For example,`card`.
 

--- a/internal/sdkprovider/service/project/project.go
+++ b/internal/sdkprovider/service/project/project.go
@@ -118,11 +118,15 @@ var aivenProjectSchema = map[string]*schema.Schema{
 		Type:        schema.TypeString,
 		Computed:    true,
 		Description: "The number of trial or promotional credits remaining for this project.",
+		Deprecated: "This field is deprecated on the resource and is no longer populated. " +
+			"Use the `aiven_project` data source to read this value. It will be removed in the next major release.",
 	},
 	"estimated_balance": {
 		Type:        schema.TypeString,
 		Computed:    true,
 		Description: "The monthly running estimate for this project for the current billing period.",
+		Deprecated: "This field is deprecated on the resource and is no longer populated. " +
+			"Use the `aiven_project` data source to read this value. It will be removed in the next major release.",
 	},
 }
 
@@ -456,12 +460,6 @@ func setProjectTerraformProperties(
 	if err := d.Set("default_cloud", project.DefaultCloud); err != nil {
 		return diag.FromErr(err)
 	}
-	if err := d.Set("available_credits", project.AvailableCredits); err != nil {
-		return diag.FromErr(err)
-	}
-	if err := d.Set("estimated_balance", project.EstimatedBalance); err != nil {
-		return diag.FromErr(err)
-	}
 	if err := d.Set("payment_method", project.PaymentMethod); err != nil {
 		return diag.FromErr(err)
 	}
@@ -472,6 +470,17 @@ func setProjectTerraformProperties(
 		return diag.FromErr(err)
 	}
 
+	return nil
+}
+
+// setProjectBillingProperties sets the deprecated billing fields
+func setProjectBillingProperties(d *schema.ResourceData, project *aiven.Project) diag.Diagnostics {
+	if err := d.Set("available_credits", project.AvailableCredits); err != nil {
+		return diag.FromErr(err)
+	}
+	if err := d.Set("estimated_balance", project.EstimatedBalance); err != nil {
+		return diag.FromErr(err)
+	}
 	return nil
 }
 

--- a/internal/sdkprovider/service/project/project_data_source.go
+++ b/internal/sdkprovider/service/project/project_data_source.go
@@ -31,7 +31,11 @@ func datasourceProjectRead(ctx context.Context, d *schema.ResourceData, m any) d
 	for _, project := range projects {
 		if project.Name == projectName {
 			d.SetId(projectName)
-			return resourceProjectRead(ctx, d, m)
+			if diags := resourceProjectRead(ctx, d, m); diags.HasError() {
+				return diags
+			}
+			// populate billing fields
+			return setProjectBillingProperties(d, project)
 		}
 	}
 

--- a/internal/sdkprovider/service/project/project_test.go
+++ b/internal/sdkprovider/service/project/project_test.go
@@ -33,6 +33,11 @@ func TestAccAivenProject_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "project", fmt.Sprintf("test-acc-pr-%s", rName)),
 					resource.TestCheckResourceAttrSet(resourceName, "default_cloud"),
 					resource.TestCheckResourceAttrSet(resourceName, "ca_cert"),
+					// estimated_balance is deprecated and not populated on the resource, but available on the data source
+					resource.TestCheckNoResourceAttr(resourceName, "estimated_balance"),
+					resource.TestCheckNoResourceAttr(resourceName, "available_credits"),
+					resource.TestCheckResourceAttrSet("data.aiven_project.project", "estimated_balance"),
+					resource.TestCheckResourceAttrSet("data.aiven_project.project", "available_credits"),
 				),
 			},
 			{


### PR DESCRIPTION
<!-- All contributors, please complete these sections, including maintainers. -->

## About this change—what it does

<!-- Provide a small sentence that summarizes the change. -->

<!-- Provide the issue number below, if it exists. -->
- Deprecate `estimated_balance` and `available_credits` on the `aiven_project` **resource** and stop populating them
- Both fields remain available on the `aiven_project` **data source**

Resolves: NEX-2604 && #2908 

<!-- Provide a small explanation on why this is the approach you took for solving this problem. -->
