### PR TITLE
fix(database): enable pagination in pg and mysql database

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ nav_order: 1
   for the InnoDB FULLTEXT search query result cache
 - Add `aiven_mysql` field `mysql_user_config.mysql.innodb_ft_user_stopword_table`: This option is used to specify your
   own InnoDB FULLTEXT index stopword list for specific InnoDB tables
+- Fix `aiven_pg_database`: paginate the service database list so services with more than one page of databases are read and looked up correctly.
 
 ## [4.60.0] - 2026-07-02
 

--- a/internal/plugin/service/pg/database/database.go
+++ b/internal/plugin/service/pg/database/database.go
@@ -37,13 +37,28 @@ func create(ctx context.Context, client avngen.Client, d adapter.ResourceData) e
 	return err
 }
 
+// read the database list is fetched with cursor pagination.
 func read(ctx context.Context, client avngen.Client, d adapter.ResourceData) error {
-	err := schemautil.CheckServiceIsPowered(ctx, client, d.Get("project").(string), d.Get("service_name").(string))
+	project := d.Get("project").(string)
+	serviceName := d.Get("service_name").(string)
+
+	err := schemautil.CheckServiceIsPowered(ctx, client, project, serviceName)
 	if err != nil {
 		return fmt.Errorf("service is powered off: %w", err)
 	}
 
-	return readView(ctx, client, d)
+	databases, err := schemautil.ListServiceDatabases(ctx, client, project, serviceName)
+	if err != nil {
+		return err
+	}
+
+	match, err := adapter.FindOne(databases, func(i int) bool {
+		return adapter.Equal(databases[i].DatabaseName, d.Get("database_name"))
+	})
+	if err != nil {
+		return fmt.Errorf("lookup `%s` by `database_name`: %w", typeName, err)
+	}
+	return d.Flatten(&match)
 }
 
 func delete(ctx context.Context, client avngen.Client, d adapter.ResourceData) error {
@@ -83,14 +98,14 @@ func findDatabaseByName(ctx context.Context, client avngen.Client, project, serv
 		return nil, err
 	}
 
-	list, err := client.ServiceDatabaseList(ctx, project, serviceName)
+	databases, err := schemautil.ListServiceDatabases(ctx, client, project, serviceName)
 	if err != nil {
 		return nil, err
 	}
 
-	for _, db := range list.Databases {
-		if db.DatabaseName == dbName {
-			return &db, nil
+	for i := range databases {
+		if databases[i].DatabaseName == dbName {
+			return &databases[i], nil
 		}
 	}
 

--- a/internal/plugin/service/pg/database/database_unit_test.go
+++ b/internal/plugin/service/pg/database/database_unit_test.go
@@ -1,0 +1,245 @@
+package database
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	avngen "github.com/aiven/go-client-codegen"
+	"github.com/aiven/go-client-codegen/handler/service"
+	"github.com/stretchr/testify/require"
+
+	"github.com/aiven/terraform-provider-aiven/internal/plugin/adapter"
+)
+
+// newReadResourceData builds an adapter.ResourceData for a Read operation, seeded with the identifiers.
+func newReadResourceData(t *testing.T, project, serviceName, databaseName string) adapter.ResourceData {
+	t.Helper()
+
+	d, err := adapter.NewResourceData(
+		resourceSchemaInternal(),
+		idFields(),
+		adapter.WithTestState(map[string]any{
+			"project":       project,
+			"service_name":  serviceName,
+			"database_name": databaseName,
+		}),
+	)
+	require.NoError(t, err)
+	return d
+}
+
+// TestRead_Pagination drives the read override with a mocked client that returns two pages,
+// asserting the page-2-only database is found and the cursor is threaded.
+func TestRead_Pagination(t *testing.T) {
+	t.Parallel()
+
+	const (
+		project     = "test-project-pg-read-pagination"
+		serviceName = "test-service-pg-read-pagination"
+		target      = "page-2-db"
+	)
+
+	ctx := context.Background()
+	mockClient := avngen.NewMockClient(t)
+	expectPoweredCheck(ctx, mockClient, project, serviceName)
+
+	nextCursor := "page-1-db"
+	lcCollate := "en_US.UTF-8"
+	// Page 1 returns databases and a cursor to the next page.
+	mockClient.EXPECT().
+		ServiceDatabaseList(ctx, project, serviceName, [][2]string{service.ServiceDatabaseListMaxItems(250)}).
+		Return(&service.ServiceDatabaseListOut{
+			Databases: []service.DatabaseOut{{DatabaseName: "page-1-db"}},
+			Next:      &nextCursor,
+		}, nil).
+		Once()
+	// Page 2 must be requested with the After cursor carrying the page-1 Next value.
+	mockClient.EXPECT().
+		ServiceDatabaseList(
+			ctx, project, serviceName,
+			[][2]string{
+				service.ServiceDatabaseListMaxItems(250),
+				service.ServiceDatabaseListAfter(nextCursor),
+			},
+		).
+		Return(&service.ServiceDatabaseListOut{
+			Databases: []service.DatabaseOut{{DatabaseName: target, LcCollate: &lcCollate}},
+			Next:      nil,
+		}, nil).
+		Once()
+
+	d := newReadResourceData(t, project, serviceName, target)
+
+	err := read(ctx, mockClient, d)
+	require.NoError(t, err)
+
+	// The ID proves the page-2-only element was matched and flattened; lc_collate is a
+	// non-seeded field, so its presence proves the matched element's data (not the seeded
+	// state) was written into state by the read path.
+	require.Equal(t, fmt.Sprintf("%s/%s/%s", project, serviceName, target), d.ID())
+	require.Equal(t, lcCollate, d.Get("lc_collate"))
+}
+
+// TestRead_SinglePage asserts a response with Next == nil issues exactly one list call.
+func TestRead_SinglePage(t *testing.T) {
+	t.Parallel()
+
+	const (
+		project     = "test-project-pg-read-single"
+		serviceName = "test-service-pg-read-single"
+		target      = "only-db"
+	)
+
+	ctx := context.Background()
+	mockClient := avngen.NewMockClient(t)
+	expectPoweredCheck(ctx, mockClient, project, serviceName)
+
+	// A single call with no After cursor and Next == nil terminates the loop immediately.
+	mockClient.EXPECT().
+		ServiceDatabaseList(ctx, project, serviceName, [][2]string{service.ServiceDatabaseListMaxItems(250)}).
+		Return(&service.ServiceDatabaseListOut{
+			Databases: []service.DatabaseOut{{DatabaseName: target}},
+			Next:      nil,
+		}, nil).
+		Once()
+
+	d := newReadResourceData(t, project, serviceName, target)
+
+	err := read(ctx, mockClient, d)
+	require.NoError(t, err)
+	require.Equal(t, target, d.Get("database_name"))
+}
+
+// TestRead_ErrorOnSecondPage asserts a failure fetching page 2 is propagated to the caller.
+func TestRead_ErrorOnSecondPage(t *testing.T) {
+	t.Parallel()
+
+	const (
+		project     = "test-project-pg-read-error-page2"
+		serviceName = "test-service-pg-read-error-page2"
+	)
+
+	ctx := context.Background()
+	mockClient := avngen.NewMockClient(t)
+	expectPoweredCheck(ctx, mockClient, project, serviceName)
+
+	nextCursor := "cursor-2"
+	mockClient.EXPECT().
+		ServiceDatabaseList(ctx, project, serviceName, [][2]string{service.ServiceDatabaseListMaxItems(250)}).
+		Return(&service.ServiceDatabaseListOut{
+			Databases: []service.DatabaseOut{{DatabaseName: "first-page-db"}},
+			Next:      &nextCursor,
+		}, nil).
+		Once()
+	mockClient.EXPECT().
+		ServiceDatabaseList(
+			ctx, project, serviceName,
+			[][2]string{
+				service.ServiceDatabaseListMaxItems(250),
+				service.ServiceDatabaseListAfter(nextCursor),
+			},
+		).
+		Return(nil, fmt.Errorf("boom")).
+		Once()
+
+	d := newReadResourceData(t, project, serviceName, "some-db")
+
+	err := read(ctx, mockClient, d)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "boom")
+}
+
+// TestRead_NotFoundAfterPagination asserts that when the target database is absent
+// from every page, the FindOne returns adapter.ErrNotFound to the caller.
+func TestRead_NotFoundAfterPagination(t *testing.T) {
+	t.Parallel()
+
+	const (
+		project     = "test-project-pg-read-notfound"
+		serviceName = "test-service-pg-read-notfound"
+	)
+
+	ctx := context.Background()
+	mockClient := avngen.NewMockClient(t)
+	expectPoweredCheck(ctx, mockClient, project, serviceName)
+
+	nextCursor := "page-1-db"
+	mockClient.EXPECT().
+		ServiceDatabaseList(ctx, project, serviceName, [][2]string{service.ServiceDatabaseListMaxItems(250)}).
+		Return(&service.ServiceDatabaseListOut{
+			Databases: []service.DatabaseOut{{DatabaseName: "page-1-db"}},
+			Next:      &nextCursor,
+		}, nil).
+		Once()
+	mockClient.EXPECT().
+		ServiceDatabaseList(
+			ctx, project, serviceName,
+			[][2]string{
+				service.ServiceDatabaseListMaxItems(250),
+				service.ServiceDatabaseListAfter(nextCursor),
+			},
+		).
+		Return(&service.ServiceDatabaseListOut{
+			Databases: []service.DatabaseOut{{DatabaseName: "page-2-db"}},
+			Next:      nil,
+		}, nil).
+		Once()
+
+	// The target is present on no page: FindOne over the accumulated slice must not match.
+	d := newReadResourceData(t, project, serviceName, "missing-db")
+
+	err := read(ctx, mockClient, d)
+	require.ErrorIs(t, err, adapter.ErrNotFound)
+}
+
+// TestRead_EmptyFirstPage asserts accumulation starting from an empty page-1 slice:
+// page 1 has no databases but a non-nil Next, and the target appears on page 2.
+func TestRead_EmptyFirstPage(t *testing.T) {
+	t.Parallel()
+
+	const (
+		project     = "test-project-pg-read-emptyfirst"
+		serviceName = "test-service-pg-read-emptyfirst"
+		target      = "page-2-db"
+	)
+
+	ctx := context.Background()
+	mockClient := avngen.NewMockClient(t)
+	expectPoweredCheck(ctx, mockClient, project, serviceName)
+
+	nextCursor := "cursor-1"
+	mockClient.EXPECT().
+		ServiceDatabaseList(ctx, project, serviceName, [][2]string{service.ServiceDatabaseListMaxItems(250)}).
+		Return(&service.ServiceDatabaseListOut{
+			Databases: []service.DatabaseOut{},
+			Next:      &nextCursor,
+		}, nil).
+		Once()
+	mockClient.EXPECT().
+		ServiceDatabaseList(
+			ctx, project, serviceName,
+			[][2]string{
+				service.ServiceDatabaseListMaxItems(250),
+				service.ServiceDatabaseListAfter(nextCursor),
+			},
+		).
+		Return(&service.ServiceDatabaseListOut{
+			Databases: []service.DatabaseOut{{DatabaseName: target}},
+			Next:      nil,
+		}, nil).
+		Once()
+
+	d := newReadResourceData(t, project, serviceName, target)
+
+	err := read(ctx, mockClient, d)
+	require.NoError(t, err)
+	require.Equal(t, fmt.Sprintf("%s/%s/%s", project, serviceName, target), d.ID())
+}
+
+func expectPoweredCheck(ctx context.Context, mockClient *avngen.MockClient, project, serviceName string) {
+	mockClient.EXPECT().
+		ServiceGet(ctx, project, serviceName).
+		Return(&service.ServiceGetOut{State: service.ServiceStateTypeRunning}, nil).
+		Once()
+}

--- a/internal/schemautil/database.go
+++ b/internal/schemautil/database.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/aiven/aiven-go-client/v2"
 	avngen "github.com/aiven/go-client-codegen"
+	"github.com/aiven/go-client-codegen/handler/service"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 
 	"github.com/aiven/terraform-provider-aiven/internal/common"
@@ -47,6 +48,9 @@ func (w *DatabaseDeleteWaiter) Conf(timeout time.Duration) *retry.StateChangeCon
 	}
 }
 
+// serviceDatabaseListPageSize is the page cap for the cursor-pagination (API max is 250).
+const serviceDatabaseListPageSize = 250
+
 var (
 	seenDatabases       sync.Map
 	serviceDatabaseList DoOnce[bool]
@@ -56,6 +60,34 @@ var (
 func ForgetDatabase(projectName, serviceName, dbName string) {
 	dbKey := filepath.Join(projectName, serviceName, dbName)
 	seenDatabases.Delete(dbKey)
+}
+
+// ListServiceDatabases returns all databases of a service. The ServiceDatabaseList
+// endpoint is cursor-paginated (page cap 250), so this follows the Next cursor and
+// accumulates every page. It returns all databases or an error; on error nothing is
+// returned, so callers never observe a partial list.
+func ListServiceDatabases(ctx context.Context, client avngen.Client, projectName, serviceName string) ([]service.DatabaseOut, error) {
+	maxItems := service.ServiceDatabaseListMaxItems(serviceDatabaseListPageSize)
+	query := [][2]string{maxItems}
+	var databases []service.DatabaseOut
+	seen := make(map[string]struct{})
+	for {
+		rsp, err := client.ServiceDatabaseList(ctx, projectName, serviceName, query...)
+		if err != nil {
+			return nil, err
+		}
+		databases = append(databases, rsp.Databases...)
+		if rsp.Next == nil || *rsp.Next == "" {
+			break
+		}
+		// Guard against an API returning a non-advancing or cycling cursor.
+		if _, ok := seen[*rsp.Next]; ok {
+			return nil, fmt.Errorf("database list pagination cursor repeated, aborting to avoid an infinite loop: %q", *rsp.Next)
+		}
+		seen[*rsp.Next] = struct{}{}
+		query = [][2]string{maxItems, service.ServiceDatabaseListAfter(*rsp.Next)}
+	}
+	return databases, nil
 }
 
 // CheckDbConflict sometimes the API might return 5xx, but it actually creates the database.
@@ -71,13 +103,15 @@ func CheckDbConflict(ctx context.Context, client avngen.Client, projectName, ser
 	// First loads the remote state to share this data across all resources.
 	serviceKey := filepath.Join(projectName, serviceName)
 	_, err = serviceDatabaseList.Do(func() (bool, error) {
-		list, err := client.ServiceDatabaseList(ctx, projectName, serviceName)
+		// Accumulate every page so conflicts past page 1 are detected.
+		databases, err := ListServiceDatabases(ctx, client, projectName, serviceName)
 		if err != nil {
 			return false, err
 		}
-		for _, db := range list.Databases {
-			k := filepath.Join(serviceKey, db.DatabaseName)
-			seenDatabases.Store(k, true)
+		// Publish into the shared map only after the full list succeeded, so a
+		// mid-pagination error never leaves seenDatabases in a partial state.
+		for _, db := range databases {
+			seenDatabases.Store(filepath.Join(serviceKey, db.DatabaseName), true)
 		}
 		return true, nil
 	}, serviceKey)

--- a/internal/schemautil/database_test.go
+++ b/internal/schemautil/database_test.go
@@ -3,6 +3,7 @@ package schemautil
 import (
 	"context"
 	"fmt"
+	"path/filepath"
 	"testing"
 
 	avngen "github.com/aiven/go-client-codegen"
@@ -60,7 +61,7 @@ func TestCheckDbConflict(t *testing.T) {
 				Return(&service.ServiceGetOut{State: service.ServiceStateTypeRunning}, nil).
 				Once()
 			mockClient.EXPECT().
-				ServiceDatabaseList(ctx, projectName, serviceName).
+				ServiceDatabaseList(ctx, projectName, serviceName, [][2]string{service.ServiceDatabaseListMaxItems(250)}).
 				Return(&service.ServiceDatabaseListOut{Databases: tt.remoteDBs}, nil).
 				Once()
 
@@ -87,7 +88,7 @@ func TestCheckDbConflict_ConcurrentCalls(t *testing.T) {
 		Once()
 
 	mockClient.EXPECT().
-		ServiceDatabaseList(ctx, projectName, serviceName).
+		ServiceDatabaseList(ctx, projectName, serviceName, [][2]string{service.ServiceDatabaseListMaxItems(250)}).
 		Return(&service.ServiceDatabaseListOut{Databases: make([]service.DatabaseOut, 0)}, nil).
 		Once()
 
@@ -111,4 +112,254 @@ func TestCheckDbConflict_ConcurrentCalls(t *testing.T) {
 
 	// Should get 2 errors out of 3 calls due to singleflight behavior
 	assert.Equal(t, 2, errorCount)
+}
+
+func TestCheckDbConflict_Pagination(t *testing.T) {
+	const projectName = "test-project-db-pagination"
+	const serviceName = "test-service-db-pagination"
+
+	ctx := context.Background()
+	mockClient := avngen.NewMockClient(t)
+	mockClient.EXPECT().
+		ServiceGet(ctx, projectName, serviceName).
+		Return(&service.ServiceGetOut{State: service.ServiceStateTypeRunning}, nil).
+		Once()
+
+	nextCursor := "page-1-db-2"
+	// Page 1 returns databases and a cursor to the next page.
+	mockClient.EXPECT().
+		ServiceDatabaseList(ctx, projectName, serviceName, [][2]string{service.ServiceDatabaseListMaxItems(250)}).
+		Return(&service.ServiceDatabaseListOut{
+			Databases: []service.DatabaseOut{
+				{DatabaseName: "page-1-db-1"},
+				{DatabaseName: "page-1-db-2"},
+			},
+			Next: &nextCursor,
+		}, nil).
+		Once()
+	// Page 2 is requested with the After cursor and has no further pages.
+	mockClient.EXPECT().
+		ServiceDatabaseList(
+			ctx, projectName, serviceName,
+			[][2]string{
+				service.ServiceDatabaseListMaxItems(250),
+				service.ServiceDatabaseListAfter(nextCursor),
+			},
+		).
+		Return(&service.ServiceDatabaseListOut{
+			Databases: []service.DatabaseOut{
+				{DatabaseName: "page-2-db-1"},
+				{DatabaseName: "page-2-db-2"},
+			},
+			Next: nil,
+		}, nil).
+		Once()
+
+	// A brand-new database name must not conflict and triggers the full paginated fetch.
+	err := CheckDbConflict(ctx, mockClient, projectName, serviceName, "brand-new-db")
+	require.NoError(t, err)
+
+	// Every database from both pages must be registered in seenDatabases.
+	for _, db := range []string{"page-1-db-1", "page-1-db-2", "page-2-db-1", "page-2-db-2"} {
+		_, ok := seenDatabases.Load(filepath.Join(projectName, serviceName, db))
+		assert.True(t, ok, "expected %q to be registered as seen", db)
+	}
+}
+
+func TestCheckDbConflict_ConflictOnSecondPage(t *testing.T) {
+	const projectName = "test-project-db-conflict-page2"
+	const serviceName = "test-service-db-conflict-page2"
+
+	ctx := context.Background()
+	mockClient := avngen.NewMockClient(t)
+	mockClient.EXPECT().
+		ServiceGet(ctx, projectName, serviceName).
+		Return(&service.ServiceGetOut{State: service.ServiceStateTypeRunning}, nil).
+		Once()
+
+	nextCursor := "cursor-2"
+	mockClient.EXPECT().
+		ServiceDatabaseList(ctx, projectName, serviceName, [][2]string{service.ServiceDatabaseListMaxItems(250)}).
+		Return(&service.ServiceDatabaseListOut{
+			Databases: []service.DatabaseOut{{DatabaseName: "first-page-db"}},
+			Next:      &nextCursor,
+		}, nil).
+		Once()
+	mockClient.EXPECT().
+		ServiceDatabaseList(
+			ctx, projectName, serviceName,
+			[][2]string{
+				service.ServiceDatabaseListMaxItems(250),
+				service.ServiceDatabaseListAfter(nextCursor),
+			},
+		).
+		Return(&service.ServiceDatabaseListOut{
+			Databases: []service.DatabaseOut{{DatabaseName: "second-page-db"}},
+			Next:      nil,
+		}, nil).
+		Once()
+
+	// The database only appears on page 2, but the conflict must still be detected.
+	err := CheckDbConflict(ctx, mockClient, projectName, serviceName, "second-page-db")
+	require.ErrorIs(t, err, ErrDbAlreadyExists)
+	assert.Contains(t, err.Error(), "second-page-db")
+}
+
+func TestCheckDbConflict_ErrorOnSecondPage(t *testing.T) {
+	const projectName = "test-project-db-error-page2"
+	const serviceName = "test-service-db-error-page2"
+
+	ctx := context.Background()
+	mockClient := avngen.NewMockClient(t)
+	mockClient.EXPECT().
+		ServiceGet(ctx, projectName, serviceName).
+		Return(&service.ServiceGetOut{State: service.ServiceStateTypeRunning}, nil).
+		Once()
+
+	nextCursor := "cursor-2"
+	mockClient.EXPECT().
+		ServiceDatabaseList(ctx, projectName, serviceName, [][2]string{service.ServiceDatabaseListMaxItems(250)}).
+		Return(&service.ServiceDatabaseListOut{
+			Databases: []service.DatabaseOut{{DatabaseName: "first-page-db"}},
+			Next:      &nextCursor,
+		}, nil).
+		Once()
+	mockClient.EXPECT().
+		ServiceDatabaseList(
+			ctx, projectName, serviceName,
+			[][2]string{
+				service.ServiceDatabaseListMaxItems(250),
+				service.ServiceDatabaseListAfter(nextCursor),
+			},
+		).
+		Return(nil, fmt.Errorf("boom")).
+		Once()
+
+	err := CheckDbConflict(ctx, mockClient, projectName, serviceName, "some-db")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "error checking databases for conflict")
+	assert.Contains(t, err.Error(), "boom")
+}
+
+func TestListServiceDatabases_AggregatesAllPages(t *testing.T) {
+	const projectName = "test-project-list-all"
+	const serviceName = "test-service-list-all"
+
+	ctx := context.Background()
+	mockClient := avngen.NewMockClient(t)
+
+	nextCursor := "cursor-2"
+	mockClient.EXPECT().
+		ServiceDatabaseList(ctx, projectName, serviceName, [][2]string{service.ServiceDatabaseListMaxItems(250)}).
+		Return(&service.ServiceDatabaseListOut{
+			Databases: []service.DatabaseOut{{DatabaseName: "db-1"}},
+			Next:      &nextCursor,
+		}, nil).
+		Once()
+	mockClient.EXPECT().
+		ServiceDatabaseList(
+			ctx, projectName, serviceName,
+			[][2]string{
+				service.ServiceDatabaseListMaxItems(250),
+				service.ServiceDatabaseListAfter(nextCursor),
+			},
+		).
+		Return(&service.ServiceDatabaseListOut{
+			Databases: []service.DatabaseOut{{DatabaseName: "db-2"}},
+			Next:      nil,
+		}, nil).
+		Once()
+
+	databases, err := ListServiceDatabases(ctx, mockClient, projectName, serviceName)
+	require.NoError(t, err)
+	require.Len(t, databases, 2)
+	assert.Equal(t, "db-1", databases[0].DatabaseName)
+	assert.Equal(t, "db-2", databases[1].DatabaseName)
+}
+
+func TestListServiceDatabases_NonAdvancingCursorGuard(t *testing.T) {
+	const projectName = "test-project-list-stuck-cursor"
+	const serviceName = "test-service-list-stuck-cursor"
+
+	ctx := context.Background()
+	mockClient := avngen.NewMockClient(t)
+
+	stuckCursor := "stuck"
+	// Page 1 returns a cursor; page 2 returns the SAME cursor. The guard must
+	// stop after the second call rather than loop forever.
+	mockClient.EXPECT().
+		ServiceDatabaseList(ctx, projectName, serviceName, [][2]string{service.ServiceDatabaseListMaxItems(250)}).
+		Return(&service.ServiceDatabaseListOut{
+			Databases: []service.DatabaseOut{{DatabaseName: "db-1"}},
+			Next:      &stuckCursor,
+		}, nil).
+		Once()
+	mockClient.EXPECT().
+		ServiceDatabaseList(
+			ctx, projectName, serviceName,
+			[][2]string{
+				service.ServiceDatabaseListMaxItems(250),
+				service.ServiceDatabaseListAfter(stuckCursor),
+			},
+		).
+		Return(&service.ServiceDatabaseListOut{
+			Databases: []service.DatabaseOut{{DatabaseName: "db-2"}},
+			Next:      &stuckCursor,
+		}, nil).
+		Once()
+
+	_, err := ListServiceDatabases(ctx, mockClient, projectName, serviceName)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "cursor repeated")
+}
+
+func TestListServiceDatabases_CyclingCursorGuard(t *testing.T) {
+	const projectName = "test-project-list-cycling-cursor"
+	const serviceName = "test-service-list-cycling-cursor"
+
+	ctx := context.Background()
+	mockClient := avngen.NewMockClient(t)
+
+	cursorA := "cursor-a"
+	cursorB := "cursor-b"
+	// Page 1 -> cursor-a, page 2 -> cursor-b, page 3 -> cursor-a again. The two
+	// cursors alternate, so the immediate-previous check would never trip; the
+	// seen-set guard must stop once cursor-a reappears.
+	mockClient.EXPECT().
+		ServiceDatabaseList(ctx, projectName, serviceName, [][2]string{service.ServiceDatabaseListMaxItems(250)}).
+		Return(&service.ServiceDatabaseListOut{
+			Databases: []service.DatabaseOut{{DatabaseName: "db-1"}},
+			Next:      &cursorA,
+		}, nil).
+		Once()
+	mockClient.EXPECT().
+		ServiceDatabaseList(
+			ctx, projectName, serviceName,
+			[][2]string{
+				service.ServiceDatabaseListMaxItems(250),
+				service.ServiceDatabaseListAfter(cursorA),
+			},
+		).
+		Return(&service.ServiceDatabaseListOut{
+			Databases: []service.DatabaseOut{{DatabaseName: "db-2"}},
+			Next:      &cursorB,
+		}, nil).
+		Once()
+	mockClient.EXPECT().
+		ServiceDatabaseList(
+			ctx, projectName, serviceName,
+			[][2]string{
+				service.ServiceDatabaseListMaxItems(250),
+				service.ServiceDatabaseListAfter(cursorB),
+			},
+		).
+		Return(&service.ServiceDatabaseListOut{
+			Databases: []service.DatabaseOut{{DatabaseName: "db-3"}},
+			Next:      &cursorA,
+		}, nil).
+		Once()
+
+	_, err := ListServiceDatabases(ctx, mockClient, projectName, serviceName)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "cursor repeated")
 }


### PR DESCRIPTION
<!-- All contributors, please complete these sections, including maintainers. -->

## About this change—what it does

<!-- Provide a small sentence that summarizes the change. -->

<!-- Provide the issue number below, if it exists. -->
-  Fixed `aiven_pg_database` to correctly read databases from services that have more than one page of databases.

Resolves: NEX-2683

<!-- Provide a small explanation on why this is the approach you took for solving this problem. -->
