### PR TITLE
chore(serviceuser): fixing password issues

### DIFF
--- a/.github/workflows/slack-notify.yml
+++ b/.github/workflows/slack-notify.yml
@@ -34,6 +34,8 @@ jobs:
         with:
           webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
           webhook-type: webhook-trigger
+          # Disable retries: the Workflow Builder trigger returns a response the action treats as a failure.
+          retries: "0"
           payload: |
             {
               "blocks": [
@@ -81,6 +83,8 @@ jobs:
         with:
           webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
           webhook-type: webhook-trigger
+          # Disable retries: the Workflow Builder trigger returns a response the action treats as a failure.
+          retries: "0"
           payload: |
             {
               "blocks": [

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ nav_order: 1
 ## [MAJOR.MINOR.PATCH] - YYYY-MM-DD
 
 - Migrate `aiven_kafka_acl` resource and data source to the Plugin Framework.
+- Fix `aiven_kafka_user`, `aiven_mysql_user`, `aiven_pg_user` and `aiven_opensearch_user` intermittently storing an empty
+  `password` in the state after a password reset.
 - Migrate `aiven_organization_user_group` resource and data source to the Plugin Framework.
 - Change `aiven_organization_user_group`: `name` and `description` can now be updated in place instead of forcing resource recreation.
 - Migrate `aiven_gcp_privatelink` resource and data source to the Plugin Framework.

--- a/definitions/aiven_kafka_user.yml
+++ b/definitions/aiven_kafka_user.yml
@@ -2,7 +2,6 @@
 location: internal/plugin/service/kafka/user
 resource:
   refreshState: true
-  refreshStateDelay: 15s
   removeMissing: true
   description: Creates and manages an Aiven for Apache Kafka® service user.
 datasource:

--- a/definitions/aiven_mysql_user.yml
+++ b/definitions/aiven_mysql_user.yml
@@ -2,7 +2,6 @@
 location: internal/plugin/service/mysql/user
 resource:
   refreshState: true
-  refreshStateDelay: 15s
   removeMissing: true
   description: Creates and manages an Aiven for MySQL® service user.
 datasource:

--- a/definitions/aiven_pg_user.yml
+++ b/definitions/aiven_pg_user.yml
@@ -2,7 +2,6 @@
 location: internal/plugin/service/pg/user
 resource:
   refreshState: true
-  refreshStateDelay: 15s
   removeMissing: true
   description: Creates and manages an Aiven for PostgreSQL® service user. The built-in admin user belongs to the service itself. Write-only password management is not supported.
 datasource:

--- a/internal/plugin/adapter/resource.go
+++ b/internal/plugin/adapter/resource.go
@@ -48,6 +48,15 @@ type ResourceOptions struct {
 	// Mismatches return ErrRefreshStateDesired and are retried with the same backoff as transient Read errors.
 	RefreshStateDesired map[string]string
 
+	// RefreshStateCheck validates the freshly read state after Read succeeds in refreshState,
+	// for conditions that RefreshStateDesired can't express.
+	// A non-nil error means the backend hasn't converged yet: it is wrapped in
+	// ErrRefreshStateDesired and retried with the same backoff as transient Read errors.
+	// Runs only during the post-Create/Update refresh, never during plain Read, import,
+	// or datasource reads.
+	// The check validates the same Read() that populates state.
+	RefreshStateCheck func(d ResourceData) error
+
 	// refreshStateRetryDelay is the base delay used by retry-go's BackOff between Read attempts in refreshState.
 	// Zero falls back to the package default (defaultRefreshStateRetryDelay). Unexported: intended for tests
 	// inside the adapter package only; not wired through the YAML schema or the generator.
@@ -262,7 +271,7 @@ var ErrRefreshStateDesired = errors.New("resource is not in the desired state")
 const defaultRefreshStateRetryDelay = time.Second * 5
 
 // refreshState reads the resource after Create or Update with retries, then validates the state
-// against ResourceOptions.RefreshStateDesired.
+// against ResourceOptions.RefreshStateDesired and ResourceOptions.RefreshStateCheck.
 //
 // A non-zero ResourceOptions.RefreshStateDelay is waited out before the first attempt (honoring
 // ctx). The delay is fixed (refreshStateRetryDelay, default defaultRefreshStateRetryDelay) and there
@@ -305,6 +314,12 @@ func (a *resourceAdapter) refreshState(ctx context.Context, rd ResourceData) err
 				state := rd.Get(key)
 				if !Equal(state, want) {
 					return fmt.Errorf("%w: expected %q to be `%v`, got `%v`", ErrRefreshStateDesired, key, want, state)
+				}
+			}
+
+			if a.resource.RefreshStateCheck != nil {
+				if err := a.resource.RefreshStateCheck(rd); err != nil {
+					return fmt.Errorf("%w: %w", ErrRefreshStateDesired, err)
 				}
 			}
 			return nil

--- a/internal/plugin/adapter/resource_test.go
+++ b/internal/plugin/adapter/resource_test.go
@@ -227,6 +227,49 @@ func TestResourceAdapter_refreshState(t *testing.T) {
 		require.Greater(t, attempts, 1, "must keep polling until the deadline rather than giving up early")
 	})
 
+	t.Run("retries when RefreshStateCheck fails, then succeeds", func(t *testing.T) {
+		t.Parallel()
+
+		attempts := 0
+		a := fastAdapter(func(_ context.Context, _ avngen.Client, _ ResourceData) error {
+			attempts++
+			return nil
+		})
+		a.resource.RefreshStateCheck = func(_ ResourceData) error {
+			if attempts < 3 {
+				return errors.New("not converged")
+			}
+			return nil
+		}
+
+		err := a.refreshState(t.Context(), nil)
+
+		require.NoError(t, err)
+		require.Equal(t, 3, attempts)
+	})
+
+	t.Run("retries until the context deadline when RefreshStateCheck never passes", func(t *testing.T) {
+		t.Parallel()
+
+		attempts := 0
+		a := fastAdapter(func(_ context.Context, _ avngen.Client, _ ResourceData) error {
+			attempts++
+			return nil
+		})
+		a.resource.RefreshStateCheck = func(_ ResourceData) error {
+			return errors.New("password is not available yet")
+		}
+
+		ctx, cancel := context.WithTimeout(t.Context(), 300*time.Millisecond)
+		defer cancel()
+
+		err := a.refreshState(ctx, nil)
+
+		require.ErrorIs(t, err, context.DeadlineExceeded)
+		require.ErrorContains(t, err, "password is not available yet")
+		require.Greater(t, attempts, 1, "must keep polling until the deadline rather than giving up early")
+	})
+
 	t.Run("returns ctx error when RefreshStateDelay is interrupted by ctx cancellation", func(t *testing.T) {
 		t.Parallel()
 

--- a/internal/plugin/service/kafka/user/user.go
+++ b/internal/plugin/service/kafka/user/user.go
@@ -11,6 +11,7 @@ import (
 
 func init() {
 	ResourceOptions.Update = serviceuser.ResetPassword
+	ResourceOptions.RefreshStateCheck = serviceuser.PasswordIsReady
 }
 
 func createView(ctx context.Context, client avngen.Client, d adapter.ResourceData) error {

--- a/internal/plugin/service/kafka/user/zz_view.go
+++ b/internal/plugin/service/kafka/user/zz_view.go
@@ -20,16 +20,15 @@ func idFields() []string {
 }
 
 var ResourceOptions = adapter.ResourceOptions{
-	Create:            createView,
-	Delete:            deleteView,
-	IDFields:          idFields(),
-	Read:              readView,
-	RefreshState:      true,
-	RefreshStateDelay: adapter.MustParseDuration("15s"),
-	RemoveMissing:     true,
-	Schema:            resourceSchema,
-	SchemaInternal:    resourceSchemaInternal(),
-	TypeName:          typeName,
+	Create:         createView,
+	Delete:         deleteView,
+	IDFields:       idFields(),
+	Read:           readView,
+	RefreshState:   true,
+	RemoveMissing:  true,
+	Schema:         resourceSchema,
+	SchemaInternal: resourceSchemaInternal(),
+	TypeName:       typeName,
 }
 
 var DataSourceOptions = adapter.DataSourceOptions{

--- a/internal/plugin/service/mysql/user/user.go
+++ b/internal/plugin/service/mysql/user/user.go
@@ -13,6 +13,7 @@ import (
 
 func init() {
 	ResourceOptions.Update = resetPassword
+	ResourceOptions.RefreshStateCheck = serviceuser.PasswordIsReady
 }
 
 func createView(ctx context.Context, client avngen.Client, d adapter.ResourceData) error {

--- a/internal/plugin/service/mysql/user/zz_view.go
+++ b/internal/plugin/service/mysql/user/zz_view.go
@@ -20,16 +20,15 @@ func idFields() []string {
 }
 
 var ResourceOptions = adapter.ResourceOptions{
-	Create:            createView,
-	Delete:            deleteView,
-	IDFields:          idFields(),
-	Read:              readView,
-	RefreshState:      true,
-	RefreshStateDelay: adapter.MustParseDuration("15s"),
-	RemoveMissing:     true,
-	Schema:            resourceSchema,
-	SchemaInternal:    resourceSchemaInternal(),
-	TypeName:          typeName,
+	Create:         createView,
+	Delete:         deleteView,
+	IDFields:       idFields(),
+	Read:           readView,
+	RefreshState:   true,
+	RemoveMissing:  true,
+	Schema:         resourceSchema,
+	SchemaInternal: resourceSchemaInternal(),
+	TypeName:       typeName,
 }
 
 var DataSourceOptions = adapter.DataSourceOptions{

--- a/internal/plugin/service/opensearch/user/user.go
+++ b/internal/plugin/service/opensearch/user/user.go
@@ -11,6 +11,7 @@ import (
 
 func init() {
 	ResourceOptions.Update = serviceuser.ResetPassword
+	ResourceOptions.RefreshStateCheck = serviceuser.PasswordIsReady
 }
 
 func createView(ctx context.Context, client avngen.Client, d adapter.ResourceData) error {

--- a/internal/plugin/service/pg/connectionpool/connectionpool_test.go
+++ b/internal/plugin/service/pg/connectionpool/connectionpool_test.go
@@ -22,7 +22,7 @@ func TestAccAivenConnectionPool(t *testing.T) {
 		projectName,
 		serviceName,
 		acc.WithServiceType("pg"),
-		acc.WithPlan("startup-4"),
+		acc.WithPlan("startup-8"),
 		acc.WithCloud("google-europe-west1"),
 	)
 

--- a/internal/plugin/service/pg/user/user.go
+++ b/internal/plugin/service/pg/user/user.go
@@ -12,6 +12,7 @@ import (
 
 func init() {
 	ResourceOptions.Update = updateView
+	ResourceOptions.RefreshStateCheck = serviceuser.PasswordIsReady
 }
 
 func createView(ctx context.Context, client avngen.Client, d adapter.ResourceData) error {

--- a/internal/plugin/service/pg/user/zz_view.go
+++ b/internal/plugin/service/pg/user/zz_view.go
@@ -20,16 +20,15 @@ func idFields() []string {
 }
 
 var ResourceOptions = adapter.ResourceOptions{
-	Create:            createView,
-	Delete:            deleteView,
-	IDFields:          idFields(),
-	Read:              readView,
-	RefreshState:      true,
-	RefreshStateDelay: adapter.MustParseDuration("15s"),
-	RemoveMissing:     true,
-	Schema:            resourceSchema,
-	SchemaInternal:    resourceSchemaInternal(),
-	TypeName:          typeName,
+	Create:         createView,
+	Delete:         deleteView,
+	IDFields:       idFields(),
+	Read:           readView,
+	RefreshState:   true,
+	RemoveMissing:  true,
+	Schema:         resourceSchema,
+	SchemaInternal: resourceSchemaInternal(),
+	TypeName:       typeName,
 }
 
 var DataSourceOptions = adapter.DataSourceOptions{

--- a/internal/plugin/serviceuser/serviceuser.go
+++ b/internal/plugin/serviceuser/serviceuser.go
@@ -72,8 +72,10 @@ func ResetPassword(ctx context.Context, client avngen.Client, d adapter.Resource
 }
 
 // PasswordIsReady returns an error if the password is empty while not in write-only mode.
-// The backend resets credentials asynchronously, so a freshly read user may have
-// an empty password until the change is fully propagated.
+// A freshly created service user can briefly be read back before the backend has populated
+// its password, so the first post-create read may observe an empty password. Retrying the
+// read until the password is present lets that settle.
+// Updates may see this as a blip but never a stale or old password.
 //
 // This must run against the same Read() whose result is written to state.
 // It cannot be a standalone pre-check.

--- a/internal/plugin/serviceuser/serviceuser.go
+++ b/internal/plugin/serviceuser/serviceuser.go
@@ -10,6 +10,7 @@ package serviceuser
 
 import (
 	"context"
+	"errors"
 
 	avngen "github.com/aiven/go-client-codegen"
 	"github.com/aiven/go-client-codegen/handler/service"
@@ -68,6 +69,23 @@ func ResetPassword(ctx context.Context, client avngen.Client, d adapter.Resource
 
 	_, err := client.ServiceUserCredentialsModify(ctx, d.Get("project").(string), d.Get("service_name").(string), d.Get("username").(string), req)
 	return err
+}
+
+// PasswordIsReady returns an error if the password is empty while not in write-only mode.
+// The backend resets credentials asynchronously, so a freshly read user may have
+// an empty password until the change is fully propagated.
+//
+// This must run against the same Read() whose result is written to state.
+// It cannot be a standalone pre-check.
+func PasswordIsReady(d adapter.ResourceData) error {
+	if _, ok := d.Schema().Properties["password_wo_version"]; ok && d.Get("password_wo_version").(int) != 0 {
+		// Write-only mode: PasswordFlatten removes the password from the state.
+		return nil
+	}
+	if d.Get("password").(string) == "" {
+		return errors.New("password is not available yet")
+	}
+	return nil
 }
 
 // PasswordFlatten is a MapModifier that reconciles the password in the API

--- a/internal/plugin/serviceuser/serviceuser_test.go
+++ b/internal/plugin/serviceuser/serviceuser_test.go
@@ -203,3 +203,64 @@ func TestResetPassword(t *testing.T) {
 		})
 	}
 }
+
+func TestPasswordIsReady(t *testing.T) {
+	t.Parallel()
+
+	// schemaWithoutWriteOnly mirrors schemaInternal but omits the password_wo_version property.
+	schemaWithoutWriteOnly := func() *adapter.Schema {
+		s := schemaInternal()
+		delete(s.Properties, "password_wo_version")
+		delete(s.Properties, "password_wo")
+		return s
+	}
+
+	tests := []struct {
+		name    string
+		schema  *adapter.Schema
+		state   map[string]any
+		wantErr string
+	}{
+		{
+			name:  "password present in state",
+			state: map[string]any{"password": "SomePass$1"},
+		},
+		{
+			name:    "password empty while backend regenerates",
+			state:   map[string]any{},
+			wantErr: "password is not available yet",
+		},
+		{
+			name:  "write-only mode keeps password out of state",
+			state: map[string]any{"password_wo_version": 1},
+		},
+		{
+			name:   "schema without password_wo_version still checks password",
+			schema: schemaWithoutWriteOnly(),
+			state:  map[string]any{"password": "SomePass$1"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			s := tt.schema
+			if s == nil {
+				s = schemaInternal()
+			}
+
+			d, err := adapter.NewResourceData(s, idFields(),
+				adapter.WithTestState(tt.state),
+			)
+			require.NoError(t, err)
+
+			err = serviceuser.PasswordIsReady(d)
+			if tt.wantErr != "" {
+				require.ErrorContains(t, err, tt.wantErr)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!-- All contributors, please complete these sections, including maintainers. -->

## About this change—what it does

<!-- Provide a small sentence that summarizes the change. -->

<!-- Provide the issue number below, if it exists. -->
## Changes

- Add `RefreshStateCheck` hook to the plugin adapter: a post-Create/Update validator for conditions that can't be expressed as exact attribute values in `RefreshStateDesired`
- Add `serviceuser.PasswordIsReady`: fails while `password` is empty, so the refresh keeps polling until the password propagates
- Wire `PasswordIsReady` into the service user resources
- Remove `refreshStateDelay: 15s` from the `kafka_user`, `mysql_user`, and `pg_user` definitions
- `slack-notify.yml`: set `retries: "0"` to stop the Workflow Builder trigger from re-delivering the webhook and posting duplicate messages
- `pg/connectionpool` acceptance test: bump plan `startup-4` → `startup-8`.

Resolves: NEX-2755

<!-- Provide a small explanation on why this is the approach you took for solving this problem. -->
