### PR TITLE
feat(plugin): infer `useStateForUnknown` for assigned-once attributes

### DIFF
--- a/definitions/.schema.yml
+++ b/definitions/.schema.yml
@@ -316,6 +316,8 @@ definitions:
         $comment: |
           During the planning phase Terraform shows "known after apply" for computed attributes.
           Set this to true if the attribute's value should be taken from the current state during planning.
+          Computed-only "*_id", "uuid", "created_at", "created_by" and "create_time" root attributes get
+          this automatically. Set it to false to opt them out.
       default:
         type: any
         $comment: Default value for this attribute

--- a/definitions/aiven_flink_application_deployment.yml
+++ b/definitions/aiven_flink_application_deployment.yml
@@ -34,9 +34,3 @@ schema:
     forceNew: true
   application_id:
     forceNew: true
-  created_at:
-    useStateForUnknown: true
-  created_by:
-    useStateForUnknown: true
-  deployment_id:
-    useStateForUnknown: true

--- a/definitions/aiven_kafka_acl.yml
+++ b/definitions/aiven_kafka_acl.yml
@@ -40,7 +40,5 @@ operations:
     type: delete
     resultKey: acl
 schema:
-  acl_id:
-    useStateForUnknown: true
   username:
     pattern: ^[-._*?A-Za-z0-9]+$

--- a/definitions/aiven_organization_vpc.yml
+++ b/definitions/aiven_organization_vpc.yml
@@ -43,7 +43,6 @@ schema:
     forceNew: true
     description: Network address range used by the VPC. For example, `192.168.0.0/24`.
   organization_vpc_id:
-    useStateForUnknown: true
     description: The ID of the Aiven Organization VPC.
   state:
     description: State of the VPC.

--- a/definitions/aiven_project_vpc.yml
+++ b/definitions/aiven_project_vpc.yml
@@ -53,6 +53,3 @@ remove:
   - peering_connections
   - pending_build_only_peering_connections
   - update_time
-schema:
-  project_vpc_id:
-    useStateForUnknown: true

--- a/generators/plugin/item.go
+++ b/generators/plugin/item.go
@@ -277,13 +277,16 @@ type Item struct {
 	AdditionalProperties *Item `yaml:"additionalProperties,omitempty"`
 
 	// User-defined fields for YAML generation
-	OverrideRequired   *bool `yaml:"required,omitempty"`
-	OverrideComputed   *bool `yaml:"computed,omitempty"`
-	OverrideOptional   *bool `yaml:"optional,omitempty"`
-	OverrideSensitive  *bool `yaml:"sensitive,omitempty"`
-	OverrideForceNew   *bool `yaml:"forceNew,omitempty"`
-	UseStateForUnknown bool  `yaml:"useStateForUnknown,omitempty"`
-	WriteOnly          bool  `yaml:"writeOnly,omitempty"`
+	OverrideRequired  *bool `yaml:"required,omitempty"`
+	OverrideComputed  *bool `yaml:"computed,omitempty"`
+	OverrideOptional  *bool `yaml:"optional,omitempty"`
+	OverrideSensitive *bool `yaml:"sensitive,omitempty"`
+	OverrideForceNew  *bool `yaml:"forceNew,omitempty"`
+
+	// Overrides what UsesStateForUnknown infers.
+	OverrideUseStateForUnknown *bool `yaml:"useStateForUnknown,omitempty"`
+
+	WriteOnly bool `yaml:"writeOnly,omitempty"`
 
 	// FromSchemaOverride is an internal flag set during datasource.schemaOverride
 	// merging on every item the overlay touched. The datasource branch of
@@ -431,6 +434,28 @@ func (item *Item) IsComputed(def *Definition, entity entityType) bool {
 
 func (item *Item) IsReadOnly(def *Definition, entity entityType) bool {
 	return !item.IsRequired(def, entity) && !item.IsOptional(def, entity)
+}
+
+// assignedOnceAttributes are values the API assigns at creation and never changes.
+// Matched exactly: the API also names configuration after creation, e.g. "create_table".
+var assignedOnceAttributes = []string{"uuid", "created_at", "created_by", "create_time"}
+
+// UsesStateForUnknown reports whether the attribute keeps its state value instead of
+// planning as "known after apply", which would cascade unknowns into everything
+// referencing it. The definition wins when set, otherwise root "*_id" and
+// assignedOnceAttributes qualify. Nested ones don't: a child entity (e.g. the current
+// deployment) is replaced over its parent's lifetime.
+// Unrelated to the spec's "createOnly", which means ForceNew.
+func (item *Item) UsesStateForUnknown() bool {
+	if item.OverrideUseStateForUnknown != nil {
+		return *item.OverrideUseStateForUnknown
+	}
+
+	if !item.IsRootProperty() || !item.Computed || item.Optional || item.Required {
+		return false
+	}
+
+	return strings.HasSuffix(item.Name, "_id") || slices.Contains(assignedOnceAttributes, item.Name)
 }
 
 func (item *Item) PropertiesByEntity(entity entityType) map[string]*Item {

--- a/generators/plugin/item_test.go
+++ b/generators/plugin/item_test.go
@@ -13,6 +13,91 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestUsesStateForUnknown(t *testing.T) {
+	t.Parallel()
+
+	root := &Item{
+		Name: "root",
+		Type: SchemaTypeObject,
+		Properties: map[string]*Item{
+			// Server assigned, never sent back: inferred.
+			"application_id": {Computed: true},
+			"created_at":     {Computed: true},
+			"created_by":     {Computed: true},
+			"create_time":    {Computed: true},
+			"uuid":           {Computed: true},
+			// Configuration named after creation, not creation metadata.
+			"create_table":     {Computed: true},
+			"created_manually": {Computed: true},
+			// Configurable, so the new value is known from the plan.
+			"version_id":  {Required: true},
+			"instance_id": {Optional: true},
+			// Optional with a server side default: the plan can't assume the
+			// state value, the user may have just set it.
+			"parent_id": {Optional: true, Computed: true},
+			// Changes over the resource's lifetime, so the state value is stale.
+			"updated_at":     {Computed: true},
+			"updated_by":     {Computed: true},
+			"update_time":    {Computed: true},
+			"state":          {Computed: true},
+			"status":         {Computed: true},
+			"last_used_time": {Computed: true},
+			// Rotated by password resets and CA renewals.
+			"access_cert": {Computed: true},
+			"access_key":  {Computed: true},
+			// The definition wins over the inference, in both directions.
+			"opted_out_id": {Computed: true, OverrideUseStateForUnknown: new(false)},
+			"host":         {Computed: true, OverrideUseStateForUnknown: new(true)},
+			// A nested "*_id" belongs to a child entity that is replaced over
+			// the lifetime of its parent.
+			"current_deployment": {
+				Computed:   true,
+				Type:       SchemaTypeObject,
+				Properties: map[string]*Item{"deployment_id": {Computed: true}},
+			},
+		},
+	}
+
+	for name, item := range root.Properties {
+		item.Name = name
+		item.Parent = root
+		for nested, child := range item.Properties {
+			child.Name = nested
+			child.Parent = item
+		}
+	}
+
+	expect := map[string]bool{
+		"application_id":   true,
+		"created_at":       true,
+		"created_by":       true,
+		"create_time":      true,
+		"uuid":             true,
+		"host":             true,
+		"create_table":     false,
+		"created_manually": false,
+		"version_id":       false,
+		"instance_id":      false,
+		"parent_id":        false,
+		"updated_at":       false,
+		"updated_by":       false,
+		"update_time":      false,
+		"state":            false,
+		"status":           false,
+		"last_used_time":   false,
+		"access_cert":      false,
+		"access_key":       false,
+		"opted_out_id":     false,
+	}
+
+	for name, want := range expect {
+		assert.Equal(t, want, root.Properties[name].UsesStateForUnknown(), name)
+	}
+
+	nested := root.Properties["current_deployment"].Properties["deployment_id"]
+	assert.False(t, nested.UsesStateForUnknown(), "nested deployment_id")
+}
+
 func TestItemPath(t *testing.T) {
 	items := &Item{
 		Name: "array",
@@ -557,19 +642,19 @@ func TestDeepCopyItem(t *testing.T) {
 		Items:    leaf,
 	}
 	root := &Item{
-		Name:               "root",
-		JSONName:           "root",
-		Type:               SchemaTypeObject,
-		Description:        "root description",
-		DeprecationMessage: "deprecated",
-		OverrideOptional:   lo.ToPtr(true),
-		OverrideRequired:   lo.ToPtr(false),
-		ConflictsWith:      []string{"a", "b"},
-		FromSchemaOverride: true,
-		UseStateForUnknown: true,
-		MinLength:          3,
-		MaxLength:          64,
-		Enum:               []any{"x", "y"},
+		Name:                       "root",
+		JSONName:                   "root",
+		Type:                       SchemaTypeObject,
+		Description:                "root description",
+		DeprecationMessage:         "deprecated",
+		OverrideOptional:           lo.ToPtr(true),
+		OverrideRequired:           lo.ToPtr(false),
+		OverrideUseStateForUnknown: new(true),
+		ConflictsWith:              []string{"a", "b"},
+		FromSchemaOverride:         true,
+		MinLength:                  3,
+		MaxLength:                  64,
+		Enum:                       []any{"x", "y"},
 		Properties: map[string]*Item{
 			"items":     arr,
 			"id":        {Name: "id", JSONName: "id", Type: SchemaTypeString, IDAttribute: true, IDAttributePosition: 0},

--- a/generators/plugin/main.go
+++ b/generators/plugin/main.go
@@ -423,9 +423,10 @@ func createRootItem(scope *Scope) (*Item, error) {
 		return nil, err
 	}
 
-	// Marks ID fields
+	// Marks ID fields.
+	// The virtual "id" is not inferred by UsesStateForUnknown, so it is set here.
 	isMutable := scope.Definition.Operations.AppearsInHandler(OperationUpdate, RequestBody)
-	idField.UseStateForUnknown = true
+	idField.OverrideUseStateForUnknown = or(idField.OverrideUseStateForUnknown, new(true))
 	for i, v := range pkg.IDAttributeComposed {
 		if _, ok := root.Properties[v]; !ok {
 			keys := sortedKeys(root.Properties)
@@ -440,7 +441,7 @@ func createRootItem(scope *Scope) (*Item, error) {
 		// because custom id (e.g. "organization_id") has already been calculated
 		// or modified using "UseStateForUnknown" field.
 		if root.Properties[v].AppearsIn.Contains(isMutable) {
-			idField.UseStateForUnknown = false
+			idField.OverrideUseStateForUnknown = new(false)
 		}
 	}
 
@@ -906,7 +907,7 @@ func mergeItem(parent, a, b *Item) (*Item, error) {
 	a.OverrideComputed = or(b.OverrideComputed, a.OverrideComputed)
 	a.OverrideOptional = or(b.OverrideOptional, a.OverrideOptional)
 	a.OverrideForceNew = or(b.OverrideForceNew, a.OverrideForceNew)
-	a.UseStateForUnknown = a.UseStateForUnknown || b.UseStateForUnknown
+	a.OverrideUseStateForUnknown = or(b.OverrideUseStateForUnknown, a.OverrideUseStateForUnknown)
 	a.WriteOnly = a.WriteOnly || b.WriteOnly
 	a.FromSchemaOverride = a.FromSchemaOverride || b.FromSchemaOverride
 
@@ -978,7 +979,7 @@ func recalcDeep(def *Definition, item *Item) error {
 	for k, v := range item.Properties {
 		// If parent is computed, child must be computed too
 		v.Computed = v.Computed || item.Computed
-		v.UseStateForUnknown = v.UseStateForUnknown || item.UseStateForUnknown
+		v.OverrideUseStateForUnknown = or(v.OverrideUseStateForUnknown, item.OverrideUseStateForUnknown)
 		err := recalcDeep(def, v)
 		if err != nil {
 			return fmt.Errorf("%s property: %w", k, err)
@@ -988,7 +989,7 @@ func recalcDeep(def *Definition, item *Item) error {
 	if item.Items != nil {
 		// If parent is computed, child must be computed too
 		item.Items.Computed = item.Items.Computed || item.Computed
-		item.Items.UseStateForUnknown = item.Items.UseStateForUnknown || item.UseStateForUnknown
+		item.Items.OverrideUseStateForUnknown = or(item.Items.OverrideUseStateForUnknown, item.OverrideUseStateForUnknown)
 		err := recalcDeep(def, item.Items)
 		if err != nil {
 			return fmt.Errorf("%s items: %w", item.Name, err)

--- a/generators/plugin/schemas.go
+++ b/generators/plugin/schemas.go
@@ -183,7 +183,7 @@ func genAttributeValues(def *Definition, entity entityType, item *Item) (map[str
 				planModifiers = append(planModifiers, jen.Qual(typedPlanmodifier, "RequiresReplace").Call())
 			}
 
-			if item.UseStateForUnknown {
+			if item.UsesStateForUnknown() {
 				planModifiers = append(planModifiers, jen.Qual(typedPlanmodifier, "UseStateForUnknown").Call())
 			}
 

--- a/generators/plugin/views.go
+++ b/generators/plugin/views.go
@@ -331,7 +331,7 @@ func genGenericViewOperation(g *jen.Group, funcIndex, funcCount int, def *Defini
 			// Some resources might change the ID fields during Update operation,
 			// so we need to use get values from the state instead of the plan.
 			method := "Get"
-			if operation.Type == OperationUpdate && !item.Properties["id"].UseStateForUnknown {
+			if operation.Type == OperationUpdate && !item.Properties["id"].UsesStateForUnknown() {
 				method = "GetState"
 			}
 

--- a/internal/plugin/service/billinggroup/zz_resource.go
+++ b/internal/plugin/service/billinggroup/zz_resource.go
@@ -60,6 +60,7 @@ func resourceSchema(ctx context.Context) schema.Schema {
 			"billing_group_id": schema.StringAttribute{
 				Computed:            true,
 				MarkdownDescription: "The [ID of the billing group](https://aiven.io/docs/platform/reference/get-resource-IDs#get-a-billing-group-id). To set up proper dependencies please refer to this variable as a reference.",
+				PlanModifiers:       []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
 			},
 			"card_id": schema.StringAttribute{
 				MarkdownDescription: "Credit card ID. Maximum length: `64`.",

--- a/internal/plugin/service/byoc/aws_entity/zz_resource.go
+++ b/internal/plugin/service/byoc/aws_entity/zz_resource.go
@@ -28,6 +28,7 @@ func resourceSchema(ctx context.Context) schema.Schema {
 			"aiven_aws_assume_role_external_id": schema.StringAttribute{
 				Computed:            true,
 				MarkdownDescription: "External ID for assuming the IAM role for controlling the BYOC account.",
+				PlanModifiers:       []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
 			},
 			"aiven_aws_object_storage_credentials_creator_arn": schema.StringAttribute{
 				Computed:            true,
@@ -85,6 +86,7 @@ func resourceSchema(ctx context.Context) schema.Schema {
 			"custom_cloud_environment_id": schema.StringAttribute{
 				Computed:            true,
 				MarkdownDescription: "ID of a custom cloud environment.",
+				PlanModifiers:       []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
 			},
 			"deployment_model": schema.StringAttribute{
 				MarkdownDescription: "Deployment model for the BYOC cloud. The possible values are `direct_ipsec_ingress`, `hipaa`, `ipsec_ingress`, `pci_dss`, `standard` and `standard_public`. Changing this property forces recreation of the resource.",

--- a/internal/plugin/service/byoc/aws_provision/zz_resource.go
+++ b/internal/plugin/service/byoc/aws_provision/zz_resource.go
@@ -27,6 +27,7 @@ func resourceSchema(ctx context.Context) schema.Schema {
 			"aiven_aws_assume_role_external_id": schema.StringAttribute{
 				Computed:            true,
 				MarkdownDescription: "External ID for assuming the IAM role for controlling the BYOC account.",
+				PlanModifiers:       []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
 			},
 			"aws_iam_role_arn": schema.StringAttribute{
 				MarkdownDescription: "Amazon Resource Name. Maximum length: `2048`. Changing this property forces recreation of the resource.",

--- a/internal/plugin/service/clickhouse/user/zz_resource.go
+++ b/internal/plugin/service/clickhouse/user/zz_resource.go
@@ -68,6 +68,7 @@ func resourceSchema(ctx context.Context) schema.Schema {
 			"uuid": schema.StringAttribute{
 				Computed:            true,
 				MarkdownDescription: "User identifier.",
+				PlanModifiers:       []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
 			},
 		},
 		Blocks:              map[string]schema.Block{"timeouts": legacytimeouts.BlockAll(ctx)},

--- a/internal/plugin/service/cmk/zz_resource.go
+++ b/internal/plugin/service/cmk/zz_resource.go
@@ -22,6 +22,7 @@ func resourceSchema(ctx context.Context) schema.Schema {
 			"cmk_id": schema.StringAttribute{
 				Computed:            true,
 				MarkdownDescription: "Customer Managed Key identifier (CMK ID).",
+				PlanModifiers:       []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
 			},
 			"cmk_provider": schema.StringAttribute{
 				MarkdownDescription: "The cloud provider hosting the key management service (KMS). The possible values are `aws`, `azure`, `gcp` and `oci`. Changing this property forces recreation of the resource.",
@@ -32,6 +33,7 @@ func resourceSchema(ctx context.Context) schema.Schema {
 			"created_at": schema.StringAttribute{
 				Computed:            true,
 				MarkdownDescription: "Created At.",
+				PlanModifiers:       []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
 			},
 			"default_cmk": schema.BoolAttribute{
 				MarkdownDescription: "Mark the created CMK as default for all newly created services.",

--- a/internal/plugin/service/flink/application/zz_resource.go
+++ b/internal/plugin/service/flink/application/zz_resource.go
@@ -22,14 +22,17 @@ func resourceSchema(ctx context.Context) schema.Schema {
 			"application_id": schema.StringAttribute{
 				Computed:            true,
 				MarkdownDescription: "Application ID.",
+				PlanModifiers:       []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
 			},
 			"created_at": schema.StringAttribute{
 				Computed:            true,
 				MarkdownDescription: "The creation timestamp of this entity in ISO 8601 format, always in UTC.",
+				PlanModifiers:       []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
 			},
 			"created_by": schema.StringAttribute{
 				Computed:            true,
 				MarkdownDescription: "The creator of this entity.",
+				PlanModifiers:       []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
 			},
 			"id": schema.StringAttribute{
 				Computed:            true,

--- a/internal/plugin/service/governance/access/zz_resource.go
+++ b/internal/plugin/service/governance/access/zz_resource.go
@@ -24,6 +24,7 @@ func resourceSchema(ctx context.Context) schema.Schema {
 			"access_id": schema.StringAttribute{
 				Computed:            true,
 				MarkdownDescription: "The ID of the access.",
+				PlanModifiers:       []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
 			},
 			"access_name": schema.StringAttribute{
 				MarkdownDescription: "Label to describe the access. Changing this property forces recreation of the resource.",

--- a/internal/plugin/service/kafka/nativeacl/zz_resource.go
+++ b/internal/plugin/service/kafka/nativeacl/zz_resource.go
@@ -22,6 +22,7 @@ func resourceSchema(ctx context.Context) schema.Schema {
 			"acl_id": schema.StringAttribute{
 				Computed:            true,
 				MarkdownDescription: "Kafka ACL ID.",
+				PlanModifiers:       []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
 			},
 			"host": schema.StringAttribute{
 				Computed:            true,

--- a/internal/plugin/service/kafkaschema/registryacl/zz_resource.go
+++ b/internal/plugin/service/kafkaschema/registryacl/zz_resource.go
@@ -22,6 +22,7 @@ func resourceSchema(ctx context.Context) schema.Schema {
 			"acl_id": schema.StringAttribute{
 				Computed:            true,
 				MarkdownDescription: "Kafka Schema Registry ACL ID.",
+				PlanModifiers:       []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
 			},
 			"id": schema.StringAttribute{
 				Computed:            true,

--- a/internal/plugin/service/organization/address/zz_resource.go
+++ b/internal/plugin/service/organization/address/zz_resource.go
@@ -24,6 +24,7 @@ func resourceSchema(ctx context.Context) schema.Schema {
 			"address_id": schema.StringAttribute{
 				Computed:            true,
 				MarkdownDescription: "Address ID.",
+				PlanModifiers:       []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
 			},
 			"address_lines": schema.ListAttribute{
 				ElementType:         types.StringType,
@@ -44,6 +45,7 @@ func resourceSchema(ctx context.Context) schema.Schema {
 			"create_time": schema.StringAttribute{
 				Computed:            true,
 				MarkdownDescription: "Create Time.",
+				PlanModifiers:       []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
 			},
 			"id": schema.StringAttribute{
 				Computed:            true,

--- a/internal/plugin/service/organization/applicationuser/zz_resource.go
+++ b/internal/plugin/service/organization/applicationuser/zz_resource.go
@@ -21,6 +21,7 @@ func resourceSchema(ctx context.Context) schema.Schema {
 			"create_time": schema.StringAttribute{
 				Computed:            true,
 				MarkdownDescription: "Time this application user was created.",
+				PlanModifiers:       []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
 			},
 			"email": schema.StringAttribute{
 				Computed:            true,
@@ -50,6 +51,7 @@ func resourceSchema(ctx context.Context) schema.Schema {
 			"user_id": schema.StringAttribute{
 				Computed:            true,
 				MarkdownDescription: "User ID.",
+				PlanModifiers:       []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
 			},
 		},
 		Blocks:              map[string]schema.Block{"timeouts": timeouts.BlockAll(ctx)},

--- a/internal/plugin/service/organization/applicationusertoken/zz_resource.go
+++ b/internal/plugin/service/organization/applicationusertoken/zz_resource.go
@@ -29,6 +29,7 @@ func resourceSchema(ctx context.Context) schema.Schema {
 			"create_time": schema.StringAttribute{
 				Computed:            true,
 				MarkdownDescription: "Create Time.",
+				PlanModifiers:       []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
 			},
 			"created_manually": schema.BoolAttribute{
 				Computed:            true,

--- a/internal/plugin/service/organization/billinggroup/zz_resource.go
+++ b/internal/plugin/service/organization/billinggroup/zz_resource.go
@@ -29,6 +29,7 @@ func resourceSchema(ctx context.Context) schema.Schema {
 			"billing_group_id": schema.StringAttribute{
 				Computed:            true,
 				MarkdownDescription: "Billing group ID.",
+				PlanModifiers:       []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
 			},
 			"billing_group_name": schema.StringAttribute{
 				MarkdownDescription: "Billing Group Name. Length must be between `1` and `128`.",
@@ -38,6 +39,7 @@ func resourceSchema(ctx context.Context) schema.Schema {
 			"create_time": schema.StringAttribute{
 				Computed:            true,
 				MarkdownDescription: "The date when this billing group was created.",
+				PlanModifiers:       []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
 			},
 			"custom_invoice_text": schema.StringAttribute{
 				MarkdownDescription: "Extra billing text. Maximum length: `256`.",

--- a/internal/plugin/service/organization/organization/zz_resource.go
+++ b/internal/plugin/service/organization/organization/zz_resource.go
@@ -22,6 +22,7 @@ func resourceSchema(ctx context.Context) schema.Schema {
 			"create_time": schema.StringAttribute{
 				Computed:            true,
 				MarkdownDescription: "Timestamp in ISO 8601 format, always in UTC.",
+				PlanModifiers:       []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
 			},
 			"id": schema.StringAttribute{
 				Computed:            true,
@@ -37,6 +38,7 @@ func resourceSchema(ctx context.Context) schema.Schema {
 				Computed:            true,
 				DeprecationMessage:  "This field is deprecated and will be removed in the next major release.",
 				MarkdownDescription: "Tenant identifier. **Deprecated**: This field is deprecated and will be removed in the next major release.",
+				PlanModifiers:       []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
 			},
 			"update_time": schema.StringAttribute{
 				Computed:            true,

--- a/internal/plugin/service/organization/unit/zz_resource.go
+++ b/internal/plugin/service/organization/unit/zz_resource.go
@@ -22,6 +22,7 @@ func resourceSchema(ctx context.Context) schema.Schema {
 			"create_time": schema.StringAttribute{
 				Computed:            true,
 				MarkdownDescription: "Timestamp in ISO 8601 format, always in UTC.",
+				PlanModifiers:       []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
 			},
 			"id": schema.StringAttribute{
 				Computed:            true,
@@ -41,6 +42,7 @@ func resourceSchema(ctx context.Context) schema.Schema {
 			"tenant_id": schema.StringAttribute{
 				Computed:            true,
 				MarkdownDescription: "Tenant identifier.",
+				PlanModifiers:       []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
 			},
 			"update_time": schema.StringAttribute{
 				Computed:            true,

--- a/internal/plugin/service/organization/usergroup/zz_resource.go
+++ b/internal/plugin/service/organization/usergroup/zz_resource.go
@@ -22,6 +22,7 @@ func resourceSchema(ctx context.Context) schema.Schema {
 			"create_time": schema.StringAttribute{
 				Computed:            true,
 				MarkdownDescription: "User group creation time.",
+				PlanModifiers:       []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
 			},
 			"description": schema.StringAttribute{
 				MarkdownDescription: "Description. Maximum length: `4096`.",
@@ -31,6 +32,7 @@ func resourceSchema(ctx context.Context) schema.Schema {
 			"group_id": schema.StringAttribute{
 				Computed:            true,
 				MarkdownDescription: "ID of the user group.",
+				PlanModifiers:       []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
 			},
 			"id": schema.StringAttribute{
 				Computed:            true,

--- a/internal/plugin/service/staticip/zz_resource.go
+++ b/internal/plugin/service/staticip/zz_resource.go
@@ -51,6 +51,7 @@ func resourceSchema(ctx context.Context) schema.Schema {
 			"static_ip_address_id": schema.StringAttribute{
 				Computed:            true,
 				MarkdownDescription: "Static IP address identifier.",
+				PlanModifiers:       []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
 			},
 			"termination_protection": schema.BoolAttribute{
 				Computed:            true,

--- a/internal/plugin/service/upgradepipeline/step/zz_resource.go
+++ b/internal/plugin/service/upgradepipeline/step/zz_resource.go
@@ -58,6 +58,7 @@ func resourceSchema(ctx context.Context) schema.Schema {
 			"step_id": schema.StringAttribute{
 				Computed:            true,
 				MarkdownDescription: "Upgrade step ID. The possible value is `550e8400-e29b-41d4-a716-446655440000`.",
+				PlanModifiers:       []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
 			},
 		},
 		Blocks:              map[string]schema.Block{"timeouts": timeouts.BlockAll(ctx)},

--- a/internal/plugin/service/vpc/awsprivatelink/zz_resource.go
+++ b/internal/plugin/service/vpc/awsprivatelink/zz_resource.go
@@ -23,6 +23,7 @@ func resourceSchema(ctx context.Context) schema.Schema {
 			"aws_service_id": schema.StringAttribute{
 				Computed:            true,
 				MarkdownDescription: "AWS VPC endpoint service ID.",
+				PlanModifiers:       []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
 			},
 			"aws_service_name": schema.StringAttribute{
 				Computed:            true,

--- a/internal/plugin/service/vpc/azureprivatelink/zz_resource.go
+++ b/internal/plugin/service/vpc/azureprivatelink/zz_resource.go
@@ -27,6 +27,7 @@ func resourceSchema(ctx context.Context) schema.Schema {
 			"azure_service_id": schema.StringAttribute{
 				Computed:            true,
 				MarkdownDescription: "Azure Privatelink service ID.",
+				PlanModifiers:       []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
 			},
 			"id": schema.StringAttribute{
 				Computed:            true,

--- a/internal/plugin/service/vpc/organizationvpc/zz_resource.go
+++ b/internal/plugin/service/vpc/organizationvpc/zz_resource.go
@@ -28,6 +28,7 @@ func resourceSchema(ctx context.Context) schema.Schema {
 			"create_time": schema.StringAttribute{
 				Computed:            true,
 				MarkdownDescription: "VPC creation timestamp.",
+				PlanModifiers:       []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
 			},
 			"display_name": schema.StringAttribute{
 				Computed:            true,


### PR DESCRIPTION
Computed-only root attributes that the backend assigns at creation and never changes ("*_id", "uuid", "created_at", "created_by", "create_time") now get the UseStateForUnknown plan modifier automatically. Without it an update plans them as unknown, which cascades "known after apply" into every attribute and resource referencing them.

Item.UseStateForUnknown becomes a pointer, so a definition can still opt an attribute in or out explicitly, and the value is resolved when the schema is rendered rather than when the definition is parsed.
