### PR TITLE
feat(plugin): support desired and failed refresh states

### DIFF
--- a/definitions/.schema.yml
+++ b/definitions/.schema.yml
@@ -40,10 +40,36 @@ properties:
           Set to true to enable termination protection validation for this resource.
           The `termination_protection` attribute generated automatically.
       refreshState:
-        type: boolean
+        type: object
+        additionalProperties: false
+        properties:
+          attribute:
+            type: string
+            minLength: 1
+            default: state
+          desired:
+            type: array
+            minItems: 1
+            uniqueItems: true
+            items:
+              type: string
+          failed:
+            type: array
+            minItems: 1
+            uniqueItems: true
+            items:
+              type: string
+        dependentRequired:
+          attribute:
+            - desired
+          failed:
+            - desired
         $comment: |
-          Set to true to refresh the state after the resource is created/updated/deleted.
-          Example: refreshState: true
+          Refreshes state after Create and Update. An empty object performs one successful Read,
+          retrying transient 404/403 errors. When conditions are configured, `attribute` selects
+          the computed-only Terraform attribute to check and defaults to `state`. The attribute must
+          reach one of the `desired` values. A match against any `failed` value fails immediately.
+          Values outside both lists are treated as pending and retried until the operation timeout.
       refreshStateDelay:
         type: string
         example: 10s
@@ -52,20 +78,6 @@ properties:
           This is useful to avoid race conditions with the backend.
           For instance, when a new user is created, the backend might hit a read-replica.
           So we sleep for a few seconds to give the backend time to catch up.
-        dependencies:
-          - refreshState
-      refreshStateDesired:
-        type: object
-        additionalProperties:
-          type: string
-        $comment: |
-          Map of Terraform attribute names to the desired value the adapter must observe before
-          treating the post-Create/Update Read as successful. Each entry is checked after a Read
-          attempt during refreshState; mismatches retry under the same backoff as the standard
-          404/403 cases. Use this for resources whose API reports a transient state
-          (e.g. `state: ACTIVE`) without custom waiter logic.
-        dependencies:
-          - refreshState
       deleteStateDesired:
         type: object
         additionalProperties:
@@ -76,8 +88,8 @@ properties:
           detaching dependents resolves on its own) and poll Read until the resource is gone (404) or
           every entry here matches. Each entry maps a Terraform attribute name to the terminal value
           the adapter must observe before treating a Delete as complete; with an empty map a 404 is
-          the only terminal. Values are validated against the field's enum (when declared), as for
-          refreshStateDesired. Omit it entirely to delete without polling.
+          the only terminal. Values are validated against the field's enum when one is declared.
+          Omit it entirely to delete without polling.
       removeMissing:
         type: boolean
         $comment: |
@@ -88,11 +100,9 @@ properties:
         $comment: |
           Set to true to treat a 409 Conflict ("already exists") response from Create as success.
           Useful for one-shot provisioning actions that should adopt an existing entity rather than fail on re-run.
-          Requires `refreshState: true` so the state is populated by the subsequent Read.
+          Requires `refreshState` so the state is populated by the subsequent Read.
           Does NOT work for resources whose ID is returned only in the Create response (e.g. server-assigned IDs):
           on conflict there is no response to read the ID from and the subsequent Read has nothing to look up.
-        dependencies:
-          - refreshState
       disableExample:
         type: boolean
         $comment: |
@@ -113,6 +123,11 @@ properties:
           adapter.ResourceOptions.ModifyPlan signature. Use this for plan-time checks that
           need access to prior state (e.g. forbidding a decrease in a numeric attribute).
           https://developer.hashicorp.com/terraform/plugin/framework/resources/plan-modification#resource-plan-modification
+    dependentRequired:
+      refreshStateDelay:
+        - refreshState
+      ignoreAlreadyExists:
+        - refreshState
     $comment: |
       Documentation and configuration specific to this resource type.
       Use this to provide clear descriptions for your resource in the Terraform registry.

--- a/definitions/aiven_aws_privatelink.yml
+++ b/definitions/aiven_aws_privatelink.yml
@@ -1,9 +1,8 @@
 # yaml-language-server: $schema=.schema.yml
 location: internal/plugin/service/vpc/awsprivatelink
 resource:
-  refreshState: true
-  refreshStateDesired:
-    state: active
+  refreshState:
+    desired: [active]
   removeMissing: true
   description: Creates and manages an [AWS PrivateLink for Aiven services](https://aiven.io/docs/platform/howto/use-aws-privatelinks) in a VPC.
 datasource:

--- a/definitions/aiven_azure_privatelink.yml
+++ b/definitions/aiven_azure_privatelink.yml
@@ -1,9 +1,8 @@
 # yaml-language-server: $schema=.schema.yml
 location: internal/plugin/service/vpc/azureprivatelink
 resource:
-  refreshState: true
-  refreshStateDesired:
-    state: active
+  refreshState:
+    desired: [active]
   # ServicePrivatelinkAzureGet never returns state=deleted (the backend filters deleted rows and 404s
   # instead, see privatelink_get), so there is no terminal state to match on: wait until gone (404).
   deleteStateDesired: {}

--- a/definitions/aiven_byoc_aws_provision.yml
+++ b/definitions/aiven_byoc_aws_provision.yml
@@ -10,9 +10,8 @@ resource:
 
     Create this resource after the customer-side AWS infrastructure
     (IAM role, VPC, subnets, security groups, buckets) has been defined.
-  refreshState: true
-  refreshStateDesired:
-    state: active
+  refreshState:
+    desired: [active]
   deleteStateDesired:
     state: deleted
 clientHandler: byoc

--- a/definitions/aiven_byoc_permissions.yml
+++ b/definitions/aiven_byoc_permissions.yml
@@ -11,7 +11,7 @@ resource:
 
     Create this resource after \`aiven_byoc_aws_entity\` and \`aiven_byoc_aws_provision\` so the custom cloud environment
     is active before permissions are granted.
-  refreshState: true
+  refreshState: {}
   removeMissing: true
 clientHandler: byoc
 idAttributeComposed: [organization_id, custom_cloud_environment_id]

--- a/definitions/aiven_clickhouse_database.yml
+++ b/definitions/aiven_clickhouse_database.yml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=.schema.yml
 location: internal/plugin/service/clickhouse/database
 resource:
-  refreshState: true
+  refreshState: {}
   removeMissing: true
   terminationProtection: true
   description: |

--- a/definitions/aiven_clickhouse_user.yml
+++ b/definitions/aiven_clickhouse_user.yml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=.schema.yml
 location: internal/plugin/service/clickhouse/user
 resource:
-  refreshState: true
+  refreshState: {}
   removeMissing: true
   description: Creates and manages an Aiven for ClickHouse user.
 datasource:

--- a/definitions/aiven_connection_pool.yml
+++ b/definitions/aiven_connection_pool.yml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=.schema.yml
 location: internal/plugin/service/pg/connectionpool
 resource:
-  refreshState: true
+  refreshState: {}
   removeMissing: true
   description: Creates and manages a [connection pool](https://aiven.io/docs/products/postgresql/concepts/pg-connection-pooling) in an Aiven for PostgreSQL® service.
 datasource:

--- a/definitions/aiven_flink_application.yml
+++ b/definitions/aiven_flink_application.yml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=.schema.yml
 location: internal/plugin/service/flink/application
 resource:
-  refreshState: true
+  refreshState: {}
   removeMissing: true
   description: |
     Creates and manages an [Aiven for Apache Flink® application](https://aiven.io/docs/products/flink/concepts/flink-applications).

--- a/definitions/aiven_flink_application_deployment.yml
+++ b/definitions/aiven_flink_application_deployment.yml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=.schema.yml
 location: internal/plugin/service/flink/deployment
 resource:
-  refreshState: true
+  refreshState: {}
   removeMissing: true
   disableExample: true
   description: Creates and manages the deployment of an Aiven for Apache Flink® application.

--- a/definitions/aiven_gcp_privatelink.yml
+++ b/definitions/aiven_gcp_privatelink.yml
@@ -1,9 +1,8 @@
 # yaml-language-server: $schema=.schema.yml
 location: internal/plugin/service/vpc/gcpprivatelink
 resource:
-  refreshState: true
-  refreshStateDesired:
-    state: active
+  refreshState:
+    desired: [active]
   deleteStateDesired: {}
   removeMissing: true
   description: Creates and manages a Google Private Service Connect for an Aiven service in a VPC.

--- a/definitions/aiven_kafka_acl.yml
+++ b/definitions/aiven_kafka_acl.yml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=.schema.yml
 location: internal/plugin/service/kafka/acl
 resource:
-  refreshState: true
+  refreshState: {}
   removeMissing: true
   description: |
     Creates and manages Aiven [access control lists](https://aiven.io/docs/products/kafka/concepts/acl) (ACLs) for an Aiven for Apache Kafka® service. ACLs control access to Kafka topics, consumer groups, clusters, and Schema Registry.

--- a/definitions/aiven_kafka_native_acl.yml
+++ b/definitions/aiven_kafka_native_acl.yml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=.schema.yml
 location: internal/plugin/service/kafka/nativeacl
 resource:
-  refreshState: true
+  refreshState: {}
   removeMissing: true
   description: |
     Creates and manages Kafka-native [access control lists](https://aiven.io/docs/products/kafka/concepts/acl) (ACLs) for an Aiven for Apache Kafka® service. ACLs control access to Kafka topics, consumer groups, clusters, and Schema Registry.

--- a/definitions/aiven_kafka_schema_registry_acl.yml
+++ b/definitions/aiven_kafka_schema_registry_acl.yml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=.schema.yml
 location: internal/plugin/service/kafkaschema/registryacl
 resource:
-  refreshState: true
+  refreshState: {}
   removeMissing: true
   description: Creates and manages an Aiven for Apache Kafka® Schema Registry ACL entry.
 datasource:

--- a/definitions/aiven_kafka_user.yml
+++ b/definitions/aiven_kafka_user.yml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=.schema.yml
 location: internal/plugin/service/kafka/user
 resource:
-  refreshState: true
+  refreshState: {}
   removeMissing: true
   description: Creates and manages an Aiven for Apache Kafka® service user.
 datasource:

--- a/definitions/aiven_mirrormaker_replication_flow.yml
+++ b/definitions/aiven_mirrormaker_replication_flow.yml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=.schema.yml
 location: internal/plugin/service/kafka/mirrormakerreplicationflow
 resource:
-  refreshState: true
+  refreshState: {}
   removeMissing: true
   description: Creates and manages an [Aiven for Apache Kafka® MirrorMaker 2](https://aiven.io/docs/products/kafka/kafka-mirrormaker) replication flow.
 datasource:

--- a/definitions/aiven_mysql_database.yml
+++ b/definitions/aiven_mysql_database.yml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=.schema.yml
 location: internal/plugin/service/mysql/database
 resource:
-  refreshState: true
+  refreshState: {}
   removeMissing: true
   terminationProtection: true
   description: Creates and manages an [Aiven for MySQL®](https://aiven.io/docs/products/mysql) database.

--- a/definitions/aiven_mysql_user.yml
+++ b/definitions/aiven_mysql_user.yml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=.schema.yml
 location: internal/plugin/service/mysql/user
 resource:
-  refreshState: true
+  refreshState: {}
   removeMissing: true
   description: Creates and manages an Aiven for MySQL® service user.
 datasource:

--- a/definitions/aiven_opensearch_security_plugin_config.yml
+++ b/definitions/aiven_opensearch_security_plugin_config.yml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=.schema.yml
 location: internal/plugin/service/opensearch/securitypluginconfig
 resource:
-  refreshState: true
+  refreshState: {}
   removeMissing: true
   description: |
     Enables and manages [OpenSearch Security for an Aiven for OpenSearch® service](https://aiven.io/docs/products/opensearch/concepts/os-security).

--- a/definitions/aiven_opensearch_user.yml
+++ b/definitions/aiven_opensearch_user.yml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=.schema.yml
 location: internal/plugin/service/opensearch/user
 resource:
-  refreshState: true
+  refreshState: {}
   removeMissing: true
   description: Creates and manages an Aiven for OpenSearch® service user.
 datasource:

--- a/definitions/aiven_organization_application_user_token.yml
+++ b/definitions/aiven_organization_application_user_token.yml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=.schema.yml
 location: internal/plugin/service/organization/applicationusertoken
 resource:
-  refreshState: true
+  refreshState: {}
   description: |
     Creates and manages an application user token.
     Review the [best practices](https://aiven.io/docs/platform/concepts/application-users#security-best-practices) for securing application users and their tokens.

--- a/definitions/aiven_organization_project.yml
+++ b/definitions/aiven_organization_project.yml
@@ -2,7 +2,7 @@
 beta: false # Endpoints are still Experimental in Aiven API
 location: internal/plugin/service/organization/project
 resource:
-  refreshState: true
+  refreshState: {}
   description: Creates and manages an [Aiven project](https://aiven.io/docs/platform/concepts/orgs-units-projects#projects).
 datasource:
   description: Gets information about an Aiven project.

--- a/definitions/aiven_organization_user_group_member.yml
+++ b/definitions/aiven_organization_user_group_member.yml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=.schema.yml
 location: internal/plugin/service/organization/usergroupmember
 resource:
-  refreshState: true # create and update operations have no response.
+  refreshState: {} # create and update operations have no response.
   description: |
     Adds and manages users in a [user group](https://registry.terraform.io/providers/aiven/aiven/latest/docs/resources/organization_user_group).
     You can add organization users and application users to groups.

--- a/definitions/aiven_organization_vpc.yml
+++ b/definitions/aiven_organization_vpc.yml
@@ -1,9 +1,8 @@
 # yaml-language-server: $schema=.schema.yml
 location: internal/plugin/service/vpc/organizationvpc
 resource:
-  refreshState: true
-  refreshStateDesired:
-    state: ACTIVE
+  refreshState:
+    desired: [ACTIVE]
   deleteStateDesired:
     state: DELETED
   removeMissing: true

--- a/definitions/aiven_pg_database.yml
+++ b/definitions/aiven_pg_database.yml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=.schema.yml
 location: internal/plugin/service/pg/database
 resource:
-  refreshState: true
+  refreshState: {}
   removeMissing: true
   terminationProtection: true
   description: Creates and manages an [Aiven for PostgreSQL®](https://aiven.io/docs/products/postgresql) database.

--- a/definitions/aiven_pg_user.yml
+++ b/definitions/aiven_pg_user.yml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=.schema.yml
 location: internal/plugin/service/pg/user
 resource:
-  refreshState: true
+  refreshState: {}
   removeMissing: true
   description: Creates and manages an Aiven for PostgreSQL® service user. The built-in admin user belongs to the service itself. Write-only password management is not supported.
 datasource:

--- a/definitions/aiven_project_vpc.yml
+++ b/definitions/aiven_project_vpc.yml
@@ -1,9 +1,8 @@
 # yaml-language-server: $schema=.schema.yml
 location: internal/plugin/service/vpc/projectvpc
 resource:
-  refreshState: true
-  refreshStateDesired:
-    state: ACTIVE
+  refreshState:
+    desired: [ACTIVE]
   deleteStateDesired:
     state: DELETED
   removeMissing: true

--- a/definitions/aiven_static_ip.yml
+++ b/definitions/aiven_static_ip.yml
@@ -5,9 +5,8 @@ resource:
     The aiven_static_ip resource allows the creation and deletion of static ips.
     Please note that once a static ip is in the 'assigned' state it is bound to the node it is assigned to and cannot be deleted or disassociated until the node is recycled.
     Plans that would delete static ips that are in the assigned state will be blocked.
-  refreshState: true
-  refreshStateDesired:
-    state: created
+  refreshState:
+    desired: [created]
 clientHandler: staticip
 idAttributeComposed: [project, static_ip_address_id]
 legacyTimeouts: true

--- a/definitions/aiven_valkey_user.yml
+++ b/definitions/aiven_valkey_user.yml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=.schema.yml
 location: internal/plugin/service/valkey/user
 resource:
-  refreshState: true
+  refreshState: {}
   removeMissing: true
   description: Creates and manages an [Aiven for Valkey™](https://aiven.io/docs/products/valkey) service user.
 datasource:

--- a/generators/plugin/item.go
+++ b/generators/plugin/item.go
@@ -131,15 +131,20 @@ type Scope struct {
 	CurrentMeta *SchemaMeta
 }
 
+type RefreshStateCondition struct {
+	Attribute *string  `yaml:"attribute,omitempty"`
+	Desired   []string `yaml:"desired,omitempty"`
+	Failed    []string `yaml:"failed,omitempty"`
+}
+
 // SchemaMeta contains fields to override.
 // Extend this struct if you need to override more fields and update the usage.
 type SchemaMeta struct {
-	Description           string            `yaml:"description"`
-	DeprecationMessage    string            `yaml:"deprecationMessage,omitempty"`
-	TerminationProtection bool              `yaml:"terminationProtection,omitempty"`
-	RefreshState          bool              `yaml:"refreshState,omitempty"`
-	RefreshStateDelay     time.Duration     `yaml:"refreshStateDelay,omitempty"`
-	RefreshStateDesired   map[string]string `yaml:"refreshStateDesired,omitempty"`
+	Description           string                 `yaml:"description"`
+	DeprecationMessage    string                 `yaml:"deprecationMessage,omitempty"`
+	TerminationProtection bool                   `yaml:"terminationProtection,omitempty"`
+	RefreshState          *RefreshStateCondition `yaml:"refreshState,omitempty"`
+	RefreshStateDelay     time.Duration          `yaml:"refreshStateDelay,omitempty"`
 	// DeleteStateDesired, when non-nil (even as an empty map), enables the delete poller. It maps
 	// Terraform attribute names to the terminal value the poller must observe. See
 	// adapter.DeleteStateOptions.

--- a/generators/plugin/views.go
+++ b/generators/plugin/views.go
@@ -13,16 +13,17 @@ import (
 )
 
 const (
-	viewSuffix                 = "View"
-	optionsSuffix              = "Options"
-	configValidatorsFuncSuffix = "ConfigValidators"
-	planModifier               = "planModifier"
-	validateConfig             = "validateConfig"
-	modifyPlan                 = "modifyPlan"
-	resourceData               = "ResourceData"
-	renameFieldsModifier       = "RenameFields"
-	flattenModifier            = "flattenModifier"
-	expandModifier             = "expandModifier"
+	viewSuffix                   = "View"
+	optionsSuffix                = "Options"
+	configValidatorsFuncSuffix   = "ConfigValidators"
+	planModifier                 = "planModifier"
+	validateConfig               = "validateConfig"
+	modifyPlan                   = "modifyPlan"
+	resourceData                 = "ResourceData"
+	renameFieldsModifier         = "RenameFields"
+	flattenModifier              = "flattenModifier"
+	expandModifier               = "expandModifier"
+	defaultRefreshStateAttribute = "state"
 )
 
 // genViews generates CRUD views for the resource, skips disabled or undefined operations.
@@ -98,27 +99,72 @@ func genNewResource(entity entityType, def *Definition, item *Item, hasConfigVal
 	}
 
 	if entity.isResource() {
-		if def.Resource.RefreshState {
-			values["RefreshState"] = jen.True()
+		if refreshState := def.Resource.RefreshState; refreshState != nil {
+			fields := jen.Dict{}
+			hasCondition := refreshState.Desired != nil || refreshState.Failed != nil
+			if refreshState.Attribute != nil && *refreshState.Attribute == "" {
+				return nil, errors.New("refreshState: attribute cannot be empty")
+			}
+			if refreshState.Attribute != nil && !hasCondition {
+				return nil, errors.New("refreshState: attribute requires desired")
+			}
+			if hasCondition {
+				attribute := defaultRefreshStateAttribute
+				if refreshState.Attribute != nil {
+					attribute = *refreshState.Attribute
+				}
+
+				prop, ok := item.Properties[attribute]
+				if !ok {
+					return nil, fmt.Errorf("refreshState: unknown attribute %q (not present in schema)", attribute)
+				}
+				if !prop.IsComputed(def, entity) || !prop.IsReadOnly(def, entity) {
+					return nil, fmt.Errorf("refreshState: attribute %q must be computed-only", attribute)
+				}
+				if len(refreshState.Desired) == 0 {
+					return nil, fmt.Errorf("refreshState: attribute %q must define at least one desired value", attribute)
+				}
+				if refreshState.Failed != nil && len(refreshState.Failed) == 0 {
+					return nil, fmt.Errorf("refreshState: attribute %q has an empty failed list", attribute)
+				}
+				if err := validateRefreshStateValues(attribute, "desired", refreshState.Desired, prop); err != nil {
+					return nil, err
+				}
+				if err := validateRefreshStateValues(attribute, "failed", refreshState.Failed, prop); err != nil {
+					return nil, err
+				}
+				for _, failed := range refreshState.Failed {
+					if slices.Contains(refreshState.Desired, failed) {
+						return nil, fmt.Errorf(
+							"refreshState: attribute %q value %q cannot be both desired and failed",
+							attribute,
+							failed,
+						)
+					}
+				}
+
+				fields = jen.Dict{
+					jen.Id("Attribute"): jen.Lit(attribute),
+					jen.Id("Desired"):   stringSliceLiteral(refreshState.Desired),
+				}
+				if len(refreshState.Failed) > 0 {
+					fields[jen.Id("Failed")] = stringSliceLiteral(refreshState.Failed)
+				}
+			}
+
+			values["RefreshState"] = jen.Op("&").
+				Qual(adapterPackage, "RefreshStateCondition").
+				Values(fields)
 
 			if def.Resource.RefreshStateDelay != 0 {
 				values["RefreshStateDelay"] = jen.Qual(adapterPackage, "MustParseDuration").Call(jen.Lit(def.Resource.RefreshStateDelay.String()))
 			}
-
-			if len(def.Resource.RefreshStateDesired) > 0 {
-				dict := make(jen.Dict, len(def.Resource.RefreshStateDesired))
-				for _, k := range sortedKeys(def.Resource.RefreshStateDesired) {
-					want := def.Resource.RefreshStateDesired[k]
-					prop, ok := item.Properties[k]
-					if !ok {
-						return nil, fmt.Errorf("refreshStateDesired: unknown field %q (not present in schema)", k)
-					}
-					if prop.IsEnum() && !enumContainsString(prop.Enum, want) {
-						return nil, fmt.Errorf("refreshStateDesired: field %q has enum %v but desired value %q is not allowed", k, prop.Enum, want)
-					}
-					dict[jen.Lit(k)] = jen.Lit(want)
-				}
-				values["RefreshStateDesired"] = jen.Map(jen.String()).String().Values(dict)
+		} else {
+			if def.Resource.RefreshStateDelay != 0 {
+				return nil, errors.New("refreshStateDelay requires refreshState")
+			}
+			if def.Resource.IgnoreAlreadyExists {
+				return nil, errors.New("ignoreAlreadyExists requires refreshState")
 			}
 		}
 
@@ -174,9 +220,37 @@ func genNewResource(entity entityType, def *Definition, item *Item, hasConfigVal
 	return jen.Var().Id(title).Op("=").Add(returnValue), nil
 }
 
-// enumContainsString reports whether enum contains want under fmt.Sprint comparison.
-// Matches the runtime semantics of adapter.Equal so generator-time validation and
-// the runtime RefreshStateDesired check agree on equality.
+func validateRefreshStateValues(attribute, kind string, values []string, prop *Item) error {
+	seen := make(map[string]struct{}, len(values))
+	for _, value := range values {
+		if _, ok := seen[value]; ok {
+			return fmt.Errorf("refreshState: attribute %q has duplicate %s value %q", attribute, kind, value)
+		}
+		seen[value] = struct{}{}
+
+		if prop.IsEnum() && !enumContainsString(prop.Enum, value) {
+			return fmt.Errorf(
+				"refreshState: attribute %q has enum %v but %s value %q is not allowed",
+				attribute,
+				prop.Enum,
+				kind,
+				value,
+			)
+		}
+	}
+	return nil
+}
+
+func stringSliceLiteral(values []string) *jen.Statement {
+	items := make([]jen.Code, len(values))
+	for i, value := range values {
+		items[i] = jen.Lit(value)
+	}
+	return jen.Index().String().Values(items...)
+}
+
+// enumContainsString reports whether enum contains want under fmt.Sprint comparison. Matches the
+// runtime semantics of adapter.Equal so generator-time validation and runtime state checks agree.
 func enumContainsString(enum []any, want string) bool {
 	return slices.ContainsFunc(enum, func(v any) bool { return fmt.Sprint(v) == want })
 }

--- a/generators/plugin/views_test.go
+++ b/generators/plugin/views_test.go
@@ -2,99 +2,279 @@ package main
 
 import (
 	"bytes"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/dave/jennifer/jen"
 	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
 )
 
-func TestGenNewResourceRefreshStateDesiredValidation(t *testing.T) {
-	// newDef builds the minimum Definition that genNewResource needs to walk into the
-	// RefreshState branch: a Resource with RefreshState=true and the desired map under test.
-	newDef := func(desired map[string]string) *Definition {
+func TestGenNewResourceRefreshStateValidation(t *testing.T) {
+	attribute := func(value string) *string { return &value }
+	newDef := func(refreshState *RefreshStateCondition) *Definition {
 		return &Definition{
 			Resource: &SchemaMeta{
-				RefreshState:        true,
-				RefreshStateDesired: desired,
+				RefreshState: refreshState,
 			},
 		}
 	}
+	newItem := func(properties map[string]*Item) *Item {
+		item := &Item{Properties: properties}
+		setParents(item, nil)
+		return item
+	}
 
-	t.Run("accepts a desired key that exists and has no enum", func(t *testing.T) {
-		item := &Item{
-			Properties: map[string]*Item{
-				"state": {Name: "state", Type: SchemaTypeString},
+	stringItem := func() *Item {
+		return newItem(map[string]*Item{
+			"state": {Name: "state", Type: SchemaTypeString, Computed: true},
+		})
+	}
+
+	t.Run("an absent config disables refresh", func(t *testing.T) {
+		code, err := genNewResource(resourceType, &Definition{Resource: &SchemaMeta{}}, stringItem(), false)
+		require.NoError(t, err)
+		require.NotContains(t, renderCode(t, code), "RefreshState:")
+	})
+
+	t.Run("an empty refreshState enables refresh without conditions", func(t *testing.T) {
+		code, err := genNewResource(resourceType, newDef(&RefreshStateCondition{}), newItem(nil), false)
+		require.NoError(t, err)
+		require.Contains(t, renderCode(t, code), "&adapter.RefreshStateCondition{}")
+	})
+
+	t.Run("generates desired and failed values", func(t *testing.T) {
+		item := newItem(map[string]*Item{
+			"state": {
+				Name:     "state",
+				Type:     SchemaTypeString,
+				Computed: true,
+				Enum:     []any{"ACTIVE", "PENDING_PEER", "ERROR"},
 			},
-		}
+		})
 
-		code, err := genNewResource(resourceType, newDef(map[string]string{"state": "ACTIVE"}), item, false)
+		code, err := genNewResource(resourceType, newDef(&RefreshStateCondition{
+			Desired: []string{"ACTIVE", "PENDING_PEER"},
+			Failed:  []string{"ERROR"},
+		}), item, false)
 		require.NoError(t, err)
 		got := renderCode(t, code)
-		require.Contains(t, got, `RefreshStateDesired: map[string]string{"state": "ACTIVE"},`)
+		require.Contains(t, got, "&adapter.RefreshStateCondition{")
+		require.Contains(t, got, `Attribute: "state"`)
+		require.Contains(t, got, "Desired:")
+		require.Contains(t, got, `[]string{"ACTIVE", "PENDING_PEER"}`)
+		require.Contains(t, got, "Failed:")
+		require.Contains(t, got, `[]string{"ERROR"}`)
 	})
 
-	t.Run("accepts a desired value that is in the field's enum", func(t *testing.T) {
-		item := &Item{
-			Properties: map[string]*Item{
-				"state": {
-					Name: "state",
-					Type: SchemaTypeString,
-					Enum: []any{"ACTIVE", "APPROVED", "DELETED", "DELETING"},
-				},
-			},
-		}
+	t.Run("generates a custom attribute", func(t *testing.T) {
+		item := newItem(map[string]*Item{
+			"status": {Name: "status", Type: SchemaTypeString, Computed: true},
+		})
 
-		code, err := genNewResource(resourceType, newDef(map[string]string{"state": "ACTIVE"}), item, false)
+		code, err := genNewResource(resourceType, newDef(&RefreshStateCondition{
+			Attribute: attribute("status"),
+			Desired:   []string{"ACTIVE"},
+		}), item, false)
 		require.NoError(t, err)
 		got := renderCode(t, code)
-		require.Contains(t, got, `RefreshStateDesired: map[string]string{"state": "ACTIVE"},`)
+		require.Contains(t, got, `Attribute: "status"`)
+		require.Contains(t, got, "Desired:")
+		require.Contains(t, got, `[]string{"ACTIVE"}`)
 	})
 
-	t.Run("rejects a desired key that does not exist in the schema", func(t *testing.T) {
-		item := &Item{
-			Properties: map[string]*Item{
-				"state": {Name: "state", Type: SchemaTypeString},
-			},
-		}
-
-		_, err := genNewResource(resourceType, newDef(map[string]string{"missing": "ACTIVE"}), item, false)
+	t.Run("rejects conditions when the default attribute is missing", func(t *testing.T) {
+		_, err := genNewResource(resourceType, newDef(&RefreshStateCondition{
+			Desired: []string{"ACTIVE"},
+		}), newItem(nil), false)
 		require.Error(t, err)
-		require.Contains(t, err.Error(), `refreshStateDesired: unknown field "missing"`)
+		require.Contains(t, err.Error(), `refreshState: unknown attribute "state"`)
 	})
 
-	t.Run("rejects a desired value that is not in the field's enum", func(t *testing.T) {
-		item := &Item{
-			Properties: map[string]*Item{
-				"state": {
-					Name: "state",
-					Type: SchemaTypeString,
-					Enum: []any{"ACTIVE", "APPROVED"},
-				},
+	t.Run("rejects configurable fields", func(t *testing.T) {
+		for name, field := range map[string]*Item{
+			"required": {
+				Name:     "state",
+				Type:     SchemaTypeString,
+				Required: true,
 			},
+			"optional and computed": {
+				Name:     "state",
+				Type:     SchemaTypeString,
+				Optional: true,
+				Computed: true,
+			},
+		} {
+			t.Run(name, func(t *testing.T) {
+				item := newItem(map[string]*Item{"state": field})
+				_, err := genNewResource(resourceType, newDef(&RefreshStateCondition{
+					Desired: []string{"ACTIVE"},
+				}), item, false)
+				require.EqualError(t, err, `refreshState: attribute "state" must be computed-only`)
+			})
 		}
+	})
 
-		_, err := genNewResource(resourceType, newDef(map[string]string{"state": "PENDING"}), item, false)
+	t.Run("rejects an empty or unused attribute", func(t *testing.T) {
+		_, err := genNewResource(resourceType, newDef(&RefreshStateCondition{
+			Attribute: attribute(""),
+			Desired:   []string{"ACTIVE"},
+		}), stringItem(), false)
+		require.EqualError(t, err, "refreshState: attribute cannot be empty")
+
+		_, err = genNewResource(resourceType, newDef(&RefreshStateCondition{
+			Attribute: attribute("status"),
+		}), stringItem(), false)
+		require.EqualError(t, err, "refreshState: attribute requires desired")
+	})
+
+	t.Run("rejects a condition without desired values", func(t *testing.T) {
+		_, err := genNewResource(resourceType, newDef(&RefreshStateCondition{
+			Failed: []string{"ERROR"},
+		}), stringItem(), false)
 		require.Error(t, err)
-		require.Contains(t, err.Error(), `refreshStateDesired: field "state"`)
+		require.Contains(t, err.Error(), `attribute "state" must define at least one desired value`)
+	})
+
+	t.Run("rejects an explicitly empty failed list", func(t *testing.T) {
+		_, err := genNewResource(resourceType, newDef(&RefreshStateCondition{
+			Desired: []string{"ACTIVE"}, Failed: []string{},
+		}), stringItem(), false)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), `attribute "state" has an empty failed list`)
+	})
+
+	t.Run("rejects desired and failed values outside the field enum", func(t *testing.T) {
+		item := newItem(map[string]*Item{
+			"state": {
+				Name:     "state",
+				Type:     SchemaTypeString,
+				Computed: true,
+				Enum:     []any{"ACTIVE", "APPROVED"},
+			},
+		})
+
+		_, err := genNewResource(resourceType, newDef(&RefreshStateCondition{
+			Desired: []string{"PENDING"},
+		}), item, false)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), `refreshState: attribute "state"`)
 		require.Contains(t, err.Error(), `desired value "PENDING" is not allowed`)
+
+		_, err = genNewResource(resourceType, newDef(&RefreshStateCondition{
+			Desired: []string{"ACTIVE"}, Failed: []string{"ERROR"},
+		}), item, false)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), `failed value "ERROR" is not allowed`)
+	})
+
+	t.Run("rejects duplicate and overlapping values", func(t *testing.T) {
+		_, err := genNewResource(resourceType, newDef(&RefreshStateCondition{
+			Desired: []string{"ACTIVE", "ACTIVE"},
+		}), stringItem(), false)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), `duplicate desired value "ACTIVE"`)
+
+		_, err = genNewResource(resourceType, newDef(&RefreshStateCondition{
+			Desired: []string{"ACTIVE"}, Failed: []string{"ERROR", "ERROR"},
+		}), stringItem(), false)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), `duplicate failed value "ERROR"`)
+
+		_, err = genNewResource(resourceType, newDef(&RefreshStateCondition{
+			Desired: []string{"ACTIVE"}, Failed: []string{"ACTIVE"},
+		}), stringItem(), false)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), `value "ACTIVE" cannot be both desired and failed`)
 	})
 
 	t.Run("compares enum values via fmt.Sprint so non-string enums match string desired", func(t *testing.T) {
 		// Mirrors adapter.Equal's runtime comparison: fmt.Sprint(7) == "7".
-		item := &Item{
-			Properties: map[string]*Item{
-				"phase": {
-					Name: "phase",
-					Type: SchemaTypeInteger,
-					Enum: []any{1, 7, 42},
-				},
+		item := newItem(map[string]*Item{
+			"state": {
+				Name:     "state",
+				Type:     SchemaTypeInteger,
+				Computed: true,
+				Enum:     []any{1, 7, 42},
 			},
-		}
+		})
 
-		code, err := genNewResource(resourceType, newDef(map[string]string{"phase": "7"}), item, false)
+		code, err := genNewResource(resourceType, newDef(&RefreshStateCondition{
+			Desired: []string{"7"}, Failed: []string{"42"},
+		}), item, false)
 		require.NoError(t, err)
 		got := renderCode(t, code)
-		require.Contains(t, got, `RefreshStateDesired: map[string]string{"phase": "7"},`)
+		require.Contains(t, got, "Desired:")
+		require.Contains(t, got, `[]string{"7"}`)
+		require.Contains(t, got, "Failed:")
+		require.Contains(t, got, `[]string{"42"}`)
+	})
+
+	t.Run("generates refreshStateDelay with refreshState", func(t *testing.T) {
+		def := newDef(&RefreshStateCondition{Desired: []string{"ACTIVE"}})
+		def.Resource.RefreshStateDelay = 15 * time.Second
+
+		code, err := genNewResource(resourceType, def, stringItem(), false)
+		require.NoError(t, err)
+		require.Contains(t, renderCode(t, code), `RefreshStateDelay: adapter.MustParseDuration("15s")`)
+	})
+
+	t.Run("rejects dependent settings without refreshState", func(t *testing.T) {
+		_, err := genNewResource(resourceType, &Definition{
+			Resource: &SchemaMeta{RefreshStateDelay: 10},
+		}, stringItem(), false)
+		require.EqualError(t, err, "refreshStateDelay requires refreshState")
+
+		_, err = genNewResource(resourceType, &Definition{
+			Resource: &SchemaMeta{IgnoreAlreadyExists: true},
+		}, stringItem(), false)
+		require.EqualError(t, err, "ignoreAlreadyExists requires refreshState")
+	})
+}
+
+func TestSchemaMetaRefreshStateYAML(t *testing.T) {
+	decode := func(t *testing.T, source string) (*Definition, error) {
+		t.Helper()
+		var def Definition
+		decoder := yaml.NewDecoder(strings.NewReader(source))
+		decoder.KnownFields(true)
+		return &def, decoder.Decode(&def)
+	}
+
+	t.Run("omitted", func(t *testing.T) {
+		def, err := decode(t, "resource: {}\n")
+		require.NoError(t, err)
+		require.Nil(t, def.Resource.RefreshState)
+	})
+
+	t.Run("empty", func(t *testing.T) {
+		def, err := decode(t, "resource:\n  refreshState: {}\n")
+		require.NoError(t, err)
+		require.NotNil(t, def.Resource.RefreshState)
+		require.Nil(t, def.Resource.RefreshState.Attribute)
+		require.Nil(t, def.Resource.RefreshState.Desired)
+		require.Nil(t, def.Resource.RefreshState.Failed)
+	})
+
+	t.Run("configured", func(t *testing.T) {
+		def, err := decode(t, "resource:\n  refreshState:\n    desired: [ACTIVE]\n    failed: [ERROR]\n")
+		require.NoError(t, err)
+		require.Nil(t, def.Resource.RefreshState.Attribute)
+		require.Equal(t, []string{"ACTIVE"}, def.Resource.RefreshState.Desired)
+		require.Equal(t, []string{"ERROR"}, def.Resource.RefreshState.Failed)
+	})
+
+	t.Run("custom attribute", func(t *testing.T) {
+		def, err := decode(t, "resource:\n  refreshState:\n    attribute: status\n    desired: [ACTIVE]\n")
+		require.NoError(t, err)
+		require.NotNil(t, def.Resource.RefreshState.Attribute)
+		require.Equal(t, "status", *def.Resource.RefreshState.Attribute)
+	})
+
+	t.Run("rejects the old nested form", func(t *testing.T) {
+		_, err := decode(t, "resource:\n  refreshState:\n    state:\n      desired: [ACTIVE]\n")
+		require.ErrorContains(t, err, "field state not found")
 	})
 }
 

--- a/internal/plugin/adapter/resource.go
+++ b/internal/plugin/adapter/resource.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 	"reflect"
+	"slices"
 	"time"
 
 	avngen "github.com/aiven/go-client-codegen"
@@ -22,6 +23,16 @@ import (
 	"github.com/aiven/terraform-provider-aiven/internal/schemautil"
 )
 
+// RefreshStateCondition describes the terminal values for a Terraform attribute.
+type RefreshStateCondition struct {
+	// Attribute is the Terraform attribute to check after Read.
+	Attribute string
+	// Desired contains successful attribute values. A match against any value succeeds.
+	Desired []string
+	// Failed contains terminal failure attribute values. A match against any value fails refresh immediately.
+	Failed []string
+}
+
 type ResourceOptions struct {
 	// TypeName is the name of resource,
 	// for instance, "aiven_organization_address"
@@ -37,21 +48,19 @@ type ResourceOptions struct {
 	// Example: ["project_id", "instance_name"] == "project-123/instance-456"
 	IDFields []string
 
-	// Whether to call Read after Create and Update operations.
-	// Implemented by refreshState; see that function for retry behavior.
-	RefreshState bool
+	// RefreshState enables Read after Create and Update when non-nil. An empty condition performs a
+	// post-operation Read without checking an attribute. Otherwise, Attribute must reach one of its
+	// Desired values; any Failed value terminates refresh with an error.
+	RefreshState *RefreshStateCondition
 
 	// Time to wait after creating or updating the resource to let the backend catch up.
 	RefreshStateDelay time.Duration
 
-	// Attribute names and values that must match after Read before refreshState succeeds.
-	// Mismatches return ErrRefreshStateDesired and are retried with the same backoff as transient Read errors.
-	RefreshStateDesired map[string]string
-
 	// RefreshStateCheck validates the freshly read state after Read succeeds in refreshState,
-	// for conditions that RefreshStateDesired can't express.
-	// A non-nil error means the backend hasn't converged yet: it is wrapped in
-	// ErrRefreshStateDesired and retried with the same backoff as transient Read errors.
+	// for conditions that declarative RefreshState conditions can't express.
+	// ErrRefreshStateFailed terminates refresh immediately. Any other non-nil error means the
+	// backend hasn't converged yet: it is wrapped in ErrRefreshStateDesired and retried with the
+	// same backoff as transient Read errors.
 	// Runs only during the post-Create/Update refresh, never during plain Read, import,
 	// or datasource reads.
 	// The check validates the same Read() that populates state.
@@ -75,7 +84,7 @@ type ResourceOptions struct {
 	// IgnoreAlreadyExists treats a 409 Conflict ("already exists") response from Create as success.
 	// This is useful when the resource being managed is a one-shot provisioning action whose effect is
 	// idempotent from Terraform's perspective — re-running it should adopt the existing entity rather
-	// than fail. Requires RefreshState=true so that the full state is populated by the subsequent Read.
+	// than fail. Requires non-nil RefreshState so the full state is populated by the subsequent Read.
 	// NOTE: This does NOT work for resources whose ID is returned only in the Create response
 	// (e.g. server-assigned IDs), because on conflict there is no response to read the ID from and
 	// the subsequent Read has nothing to look up.
@@ -94,7 +103,7 @@ type ResourceOptions struct {
 	// CRUD operations.
 	// Each CRUD operation should return diag.Diagnostics (rather than taking it as an argument)
 	// This design allows internal retry logic for operations that can fail transiently.
-	// NOTE: Create and Update must NOT invoke Read themselves; set RefreshState=true to trigger a post-operation Read.
+	// NOTE: Create and Update must NOT invoke Read themselves; set RefreshState to trigger a post-operation Read.
 	// NOTE2: Delete ignores 404 errors since resources may already be deleted after client retries.
 
 	Create func(ctx context.Context, client avngen.Client, d ResourceData) error
@@ -205,20 +214,62 @@ func (a *resourceAdapter) Create(
 	defer drainWarnings()
 
 	err = a.resource.Create(ctx, a.client, d)
+	createSucceeded := err == nil
 	if err != nil && !(a.resource.IgnoreAlreadyExists && avngen.IsAlreadyExists(err)) {
 		diags.AddError("failed to create resource", err.Error())
 		return
 	}
 
-	if a.resource.RefreshState {
+	if a.resource.RefreshState != nil {
+		// Terraform persists state returned with an error diagnostic and marks the resource as
+		// tainted. Checkpoint a successfully created resource before polling so it remains
+		// manageable when the post-Create refresh fails. Do not checkpoint a failed
+		// AlreadyExists adoption.
+		stateCheckpointed := createSucceeded && ensurePostCreateID(d, a.resource.IDFields)
+		if stateCheckpointed {
+			rsp.State.Raw = d.tfValue()
+		}
+
 		err = a.refreshState(ctx, d)
 		if err != nil {
+			// A successful Read may populate a server-assigned ID that was unavailable before
+			// polling. Preserve it without replacing an earlier, known-good checkpoint.
+			if createSucceeded && !stateCheckpointed && ensurePostCreateID(d, a.resource.IDFields) {
+				rsp.State.Raw = d.tfValue()
+			}
 			diags.AddError("failed to refresh state", err.Error())
 			return
 		}
 	}
 
 	rsp.State.Raw = d.tfValue()
+}
+
+// ensurePostCreateID reports whether d has a complete ID that is safe to checkpoint. Generated
+// Create operations without a response rely on the subsequent Read to set the ID, even when every
+// component is already known from configuration. Build that ID here so a refresh failure does not
+// lose an otherwise successful Create.
+func ensurePostCreateID(d ResourceData, idFields []string) bool {
+	if d.ID() != "" {
+		return true
+	}
+	if len(idFields) == 0 {
+		return false
+	}
+
+	parts := make([]string, len(idFields))
+	for i, field := range idFields {
+		value, ok := d.GetOk(field)
+		if !ok {
+			return false
+		}
+		parts[i], ok = value.(string)
+		if !ok || parts[i] == "" {
+			return false
+		}
+	}
+
+	return d.SetID(parts...) == nil
 }
 
 func (a *resourceAdapter) Read(
@@ -263,15 +314,18 @@ func (a *resourceAdapter) Read(
 	rsp.State.Raw = d.tfValue()
 }
 
-// ErrRefreshStateDesired indicates a RefreshStateDesired attribute did not match after Read.
+// ErrRefreshStateDesired indicates a refresh attribute did not match any configured desired value.
 var ErrRefreshStateDesired = errors.New("resource is not in the desired state")
+
+// ErrRefreshStateFailed indicates a refresh attribute reached a configured terminal failure value.
+var ErrRefreshStateFailed = errors.New("resource reached a failed state")
 
 // defaultRefreshStateRetryDelay is the fixed delay between Read attempts when
 // ResourceOptions.refreshStateRetryDelay is zero.
 const defaultRefreshStateRetryDelay = time.Second * 5
 
 // refreshState reads the resource after Create or Update with retries, then validates the state
-// against ResourceOptions.RefreshStateDesired and ResourceOptions.RefreshStateCheck.
+// against ResourceOptions.RefreshState and ResourceOptions.RefreshStateCheck.
 //
 // A non-zero ResourceOptions.RefreshStateDelay is waited out before the first attempt (honoring
 // ctx). The delay is fixed (refreshStateRetryDelay, default defaultRefreshStateRetryDelay) and there
@@ -279,6 +333,15 @@ const defaultRefreshStateRetryDelay = time.Second * 5
 // or ctx (the create/update timeout) is cancelled. On timeout ctx.Err() is returned wrapped with the
 // last attempt's error, so the user sees why the state never settled rather than a bare deadline.
 func (a *resourceAdapter) refreshState(ctx context.Context, rd ResourceData) error {
+	condition := a.resource.RefreshState
+	hasAttributeCondition := condition.Attribute != "" || condition.Desired != nil || condition.Failed != nil
+	if hasAttributeCondition && len(condition.Desired) == 0 {
+		return fmt.Errorf("refresh state condition for %q has no desired values", condition.Attribute)
+	}
+	if hasAttributeCondition && condition.Attribute == "" {
+		return errors.New("refresh state condition has no attribute")
+	}
+
 	retryDelay := a.resource.refreshStateRetryDelay
 	if retryDelay == 0 {
 		retryDelay = defaultRefreshStateRetryDelay
@@ -310,15 +373,32 @@ func (a *resourceAdapter) refreshState(ctx context.Context, rd ResourceData) err
 				return err
 			}
 
-			for key, want := range a.resource.RefreshStateDesired {
-				state := rd.Get(key)
-				if !Equal(state, want) {
-					return fmt.Errorf("%w: expected %q to be `%v`, got `%v`", ErrRefreshStateDesired, key, want, state)
+			if hasAttributeCondition {
+				attributeValue, ok := rd.GetOk(condition.Attribute)
+				if ok && slices.ContainsFunc(condition.Failed, func(failed string) bool {
+					return Equal(attributeValue, failed)
+				}) {
+					return fmt.Errorf("%w: %q is `%v`", ErrRefreshStateFailed, condition.Attribute, attributeValue)
+				}
+
+				if !ok || !slices.ContainsFunc(condition.Desired, func(desired string) bool {
+					return Equal(attributeValue, desired)
+				}) {
+					return fmt.Errorf(
+						"%w: expected %q to be one of `%v`, got `%v`",
+						ErrRefreshStateDesired,
+						condition.Attribute,
+						condition.Desired,
+						attributeValue,
+					)
 				}
 			}
 
 			if a.resource.RefreshStateCheck != nil {
 				if err := a.resource.RefreshStateCheck(rd); err != nil {
+					if errors.Is(err, ErrRefreshStateFailed) {
+						return err
+					}
 					return fmt.Errorf("%w: %w", ErrRefreshStateDesired, err)
 				}
 			}
@@ -331,8 +411,8 @@ func (a *resourceAdapter) refreshState(ctx context.Context, rd ResourceData) err
 		retry.Attempts(0),
 		retry.LastErrorOnly(true),
 		retry.Context(ctx),
-		// On timeout, wrap ctx.Err() with the last attempt's error so the user sees why the state
-		// never settled (e.g. the unmet RefreshStateDesired).
+		// On timeout, wrap ctx.Err() with the last attempt's error so the user sees why refresh
+		// did not converge.
 		retry.WrapContextErrorWithLastError(true),
 		retry.RetryIf(isRefreshStateRetryable),
 	)
@@ -349,7 +429,9 @@ func (a *resourceAdapter) refreshState(ctx context.Context, rd ResourceData) err
 //     resource might not be present in list or direct GET call.
 //   - 403 Forbidden: Temporary permission issues can occur due to eventual consistency
 //     (e.g., "organization_project").
-//   - ErrRefreshStateDesired: A RefreshStateDesired attribute did not match after Read.
+//   - ErrRefreshStateDesired: A refresh attribute did not match any desired value after Read.
+//
+// ErrRefreshStateFailed is terminal and intentionally non-retryable.
 func isRefreshStateRetryable(err error) bool {
 	return IsNotFound(err) || isAivenError(err, http.StatusForbidden) || errors.Is(err, ErrRefreshStateDesired)
 }
@@ -392,7 +474,7 @@ func (a *resourceAdapter) Update(
 		}
 	}
 
-	if a.resource.RefreshState {
+	if a.resource.RefreshState != nil {
 		err = a.refreshState(ctx, d)
 		if err != nil {
 			diags.AddError("failed to refresh state", err.Error())

--- a/internal/plugin/adapter/resource_test.go
+++ b/internal/plugin/adapter/resource_test.go
@@ -10,30 +10,186 @@ import (
 
 	avngen "github.com/aiven/go-client-codegen"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
 	"github.com/stretchr/testify/require"
 )
 
+func TestResourceAdapterCreatePreservesStateAfterRefreshError(t *testing.T) {
+	schema := &Schema{
+		Type: SchemaTypeObject,
+		Properties: map[string]*Schema{
+			"id":        {Type: SchemaTypeString, Computed: true},
+			"name":      {Type: SchemaTypeString},
+			"project":   {Type: SchemaTypeString},
+			"server_id": {Type: SchemaTypeString, Computed: true},
+			"state":     {Type: SchemaTypeString, Computed: true},
+			"timeouts": {
+				Type: SchemaTypeObject,
+				Properties: map[string]*Schema{
+					"create": {Type: SchemaTypeString},
+				},
+			},
+		},
+	}
+
+	refreshError := errors.New("refresh failed")
+	alreadyExistsError := avngen.Error{Status: http.StatusConflict, Message: "resource already exists"}
+	tests := []struct {
+		name                string
+		idFields            []string
+		plan                map[string]any
+		createID            string
+		createError         error
+		readID              []string
+		readState           string
+		readError           error
+		refreshState        *RefreshStateCondition
+		ignoreAlreadyExists bool
+		wantError           bool
+		wantID              string
+	}{
+		{
+			name:      "keeps an ID set by Create",
+			idFields:  []string{"server_id"},
+			plan:      map[string]any{"name": "example"},
+			createID:  "created-id",
+			readError: refreshError,
+			wantError: true,
+			wantID:    "created-id",
+		},
+		{
+			name:      "builds a composite ID from known plan fields",
+			idFields:  []string{"project", "name"},
+			plan:      map[string]any{"project": "project", "name": "example"},
+			readError: refreshError,
+			wantError: true,
+			wantID:    "project/example",
+		},
+		{
+			name:      "does not save state without a complete ID",
+			idFields:  []string{"project", "server_id"},
+			plan:      map[string]any{"project": "project"},
+			readError: refreshError,
+			wantError: true,
+		},
+		{
+			name:      "keeps an ID learned by Read before refresh fails",
+			idFields:  []string{"project", "server_id"},
+			plan:      map[string]any{"project": "project"},
+			readID:    []string{"project", "server-id"},
+			readState: "ERROR",
+			wantError: true,
+			wantID:    "project/server-id",
+			refreshState: &RefreshStateCondition{
+				Attribute: "state",
+				Desired:   []string{"ACTIVE"},
+				Failed:    []string{"ERROR"},
+			},
+		},
+		{
+			name:                "does not save state when AlreadyExists adoption fails",
+			idFields:            []string{"project", "name"},
+			plan:                map[string]any{"project": "project", "name": "example"},
+			createError:         alreadyExistsError,
+			readError:           refreshError,
+			ignoreAlreadyExists: true,
+			wantError:           true,
+		},
+		{
+			name:                "saves state when AlreadyExists adoption succeeds",
+			idFields:            []string{"project", "name"},
+			plan:                map[string]any{"project": "project", "name": "example"},
+			createError:         alreadyExistsError,
+			readID:              []string{"project", "example"},
+			ignoreAlreadyExists: true,
+			wantID:              "project/example",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			raw, err := toTFValue(schema, tt.plan)
+			require.NoError(t, err)
+			refreshState := tt.refreshState
+			if refreshState == nil {
+				refreshState = &RefreshStateCondition{}
+			}
+
+			a := &resourceAdapter{
+				resource: ResourceOptions{
+					SchemaInternal:      schema,
+					IDFields:            tt.idFields,
+					RefreshState:        refreshState,
+					IgnoreAlreadyExists: tt.ignoreAlreadyExists,
+					Create: func(_ context.Context, _ avngen.Client, d ResourceData) error {
+						if tt.createID != "" {
+							return d.SetID(tt.createID)
+						}
+						return tt.createError
+					},
+					Read: func(_ context.Context, _ avngen.Client, d ResourceData) error {
+						if tt.readID != nil {
+							if err := d.SetID(tt.readID...); err != nil {
+								return err
+							}
+						}
+						if tt.readState != "" {
+							if err := d.Set("state", tt.readState); err != nil {
+								return err
+							}
+						}
+						return tt.readError
+					},
+				},
+			}
+			req := resource.CreateRequest{
+				Plan:   tfsdk.Plan{Raw: raw},
+				Config: tfsdk.Config{Raw: raw},
+			}
+			rsp := resource.CreateResponse{
+				State: tfsdk.State{Raw: tftypes.NewValue(raw.Type(), nil)},
+			}
+
+			a.Create(t.Context(), req, &rsp)
+
+			require.Equal(t, tt.wantError, rsp.Diagnostics.HasError())
+			if tt.wantID == "" {
+				require.True(t, rsp.State.Raw.IsNull())
+				return
+			}
+
+			require.False(t, rsp.State.Raw.IsNull())
+			state, err := fromTFValue(schema, rsp.State.Raw, false)
+			require.NoError(t, err)
+			require.Equal(t, tt.wantID, state["id"])
+		})
+	}
+}
+
 func TestResourceAdapter_refreshState(t *testing.T) {
-	// Use short retry delays so retry-go's exponential backoff stays in the microsecond range.
+	// Use short retry delays so retry-go's fixed delay stays in the microsecond range.
 	const fastRetryDelay = time.Microsecond
 
 	// fastAdapter builds a *resourceAdapter wired for fast tests: short retry delay. Per-test config
-	// (RefreshStateDelay, RefreshStateDesired, etc.) is layered on top of the returned adapter's
+	// (RefreshState, RefreshStateDelay, etc.) is layered on top of the returned adapter's
 	// resource by the caller.
 	fastAdapter := func(read func(ctx context.Context, client avngen.Client, rd ResourceData) error) *resourceAdapter {
 		return &resourceAdapter{
 			resource: ResourceOptions{
 				Read:                   read,
+				RefreshState:           &RefreshStateCondition{},
 				refreshStateRetryDelay: fastRetryDelay,
 			},
 		}
 	}
 
-	// statusSchema is a minimal schema used by tests that exercise RefreshStateDesired.
-	statusSchema := &Schema{
+	// stateSchema is a minimal schema used by tests that exercise RefreshState conditions.
+	stateSchema := &Schema{
 		Type: SchemaTypeObject,
 		Properties: map[string]*Schema{
-			"status": {Type: SchemaTypeString},
+			"state": {Type: SchemaTypeString},
 		},
 	}
 
@@ -59,6 +215,7 @@ func TestResourceAdapter_refreshState(t *testing.T) {
 		attempts := 0
 		a := &resourceAdapter{
 			resource: ResourceOptions{
+				RefreshState: &RefreshStateCondition{},
 				Read: func(ctx context.Context, _ avngen.Client, _ ResourceData) error {
 					attempts++
 					AddWarnings(ctx, warningsByTry[attempts-1]...)
@@ -171,14 +328,14 @@ func TestResourceAdapter_refreshState(t *testing.T) {
 		require.Equal(t, 2, attempts)
 	})
 
-	t.Run("retries when desired attribute does not match, then succeeds", func(t *testing.T) {
+	t.Run("retries an unknown value until a desired value is reached", func(t *testing.T) {
 		t.Parallel()
 
-		// rd starts with status "PENDING" and flips to "ACTIVE" after the first Read.
+		// An unlisted backend state is pending rather than an implicit failure.
 		rd, err := NewResourceData(
-			statusSchema,
+			stateSchema,
 			nil,
-			WithTestState(map[string]any{"status": "PENDING"}),
+			WithTestState(map[string]any{"state": "FUTURE_STATE"}),
 		)
 		require.NoError(t, err)
 
@@ -186,26 +343,214 @@ func TestResourceAdapter_refreshState(t *testing.T) {
 		a := fastAdapter(func(_ context.Context, _ avngen.Client, rd ResourceData) error {
 			attempts++
 			if attempts >= 2 {
-				require.NoError(t, rd.Set("status", "ACTIVE"))
+				require.NoError(t, rd.Set("state", "ACTIVE"))
 			}
 			return nil
 		})
-		a.resource.RefreshStateDesired = map[string]string{"status": "ACTIVE"}
+		a.resource.RefreshState = &RefreshStateCondition{Attribute: "state", Desired: []string{"ACTIVE"}}
 
 		err = a.refreshState(t.Context(), rd)
 
 		require.NoError(t, err)
 		require.Equal(t, 2, attempts)
-		require.Equal(t, "ACTIVE", rd.Get("status"))
+		require.Equal(t, "ACTIVE", rd.Get("state"))
+	})
+
+	t.Run("accepts any desired value", func(t *testing.T) {
+		t.Parallel()
+
+		rd, err := NewResourceData(
+			stateSchema,
+			nil,
+			WithTestState(map[string]any{"state": "PENDING_PEER"}),
+		)
+		require.NoError(t, err)
+
+		a := fastAdapter(func(_ context.Context, _ avngen.Client, _ ResourceData) error {
+			return nil
+		})
+		a.resource.RefreshState = &RefreshStateCondition{Attribute: "state", Desired: []string{"ACTIVE", "PENDING_PEER"}}
+
+		err = a.refreshState(t.Context(), rd)
+
+		require.NoError(t, err)
+	})
+
+	t.Run("checks the configured attribute", func(t *testing.T) {
+		t.Parallel()
+
+		statusSchema := &Schema{
+			Type: SchemaTypeObject,
+			Properties: map[string]*Schema{
+				"status": {Type: SchemaTypeString},
+			},
+		}
+		rd, err := NewResourceData(
+			statusSchema,
+			nil,
+			WithTestState(map[string]any{"status": "ACTIVE"}),
+		)
+		require.NoError(t, err)
+
+		a := fastAdapter(func(_ context.Context, _ avngen.Client, _ ResourceData) error {
+			return nil
+		})
+		a.resource.RefreshState = &RefreshStateCondition{Attribute: "status", Desired: []string{"ACTIVE"}}
+
+		err = a.refreshState(t.Context(), rd)
+
+		require.NoError(t, err)
+	})
+
+	t.Run("keeps a missing attribute pending even when desired contains its zero value", func(t *testing.T) {
+		t.Parallel()
+
+		rd, err := NewResourceData(
+			stateSchema,
+			nil,
+			WithTestState(map[string]any{}),
+		)
+		require.NoError(t, err)
+
+		ctx, cancel := context.WithCancel(t.Context())
+		attempts := 0
+		a := fastAdapter(func(_ context.Context, _ avngen.Client, _ ResourceData) error {
+			attempts++
+			cancel()
+			return nil
+		})
+		a.resource.RefreshState = &RefreshStateCondition{Attribute: "state", Desired: []string{""}}
+
+		err = a.refreshState(ctx, rd)
+
+		require.ErrorIs(t, err, context.Canceled)
+		require.GreaterOrEqual(t, attempts, 1)
+	})
+
+	t.Run("fails immediately on a configured failed value", func(t *testing.T) {
+		t.Parallel()
+
+		rd, err := NewResourceData(
+			stateSchema,
+			nil,
+			WithTestState(map[string]any{"state": "ERROR"}),
+		)
+		require.NoError(t, err)
+
+		attempts := 0
+		a := fastAdapter(func(_ context.Context, _ avngen.Client, _ ResourceData) error {
+			attempts++
+			return nil
+		})
+		a.resource.RefreshState = &RefreshStateCondition{
+			Attribute: "state",
+			Desired:   []string{"ACTIVE"},
+			Failed:    []string{"ERROR"},
+		}
+
+		err = a.refreshState(t.Context(), rd)
+
+		require.ErrorIs(t, err, ErrRefreshStateFailed)
+		require.Equal(t, 1, attempts)
+		require.Contains(t, err.Error(), "\"state\" is `ERROR`")
+	})
+
+	t.Run("failed values take precedence over desired values", func(t *testing.T) {
+		t.Parallel()
+
+		rd, err := NewResourceData(
+			stateSchema,
+			nil,
+			WithTestState(map[string]any{"state": "ERROR"}),
+		)
+		require.NoError(t, err)
+
+		a := fastAdapter(func(_ context.Context, _ avngen.Client, _ ResourceData) error {
+			return nil
+		})
+		a.resource.RefreshState = &RefreshStateCondition{
+			Attribute: "state",
+			Desired:   []string{"ACTIVE", "ERROR"},
+			Failed:    []string{"ERROR"},
+		}
+
+		err = a.refreshState(t.Context(), rd)
+
+		require.ErrorIs(t, err, ErrRefreshStateFailed)
+		require.Contains(t, err.Error(), `"state"`)
+	})
+
+	t.Run("rejects failed values without desired values before reading", func(t *testing.T) {
+		t.Parallel()
+
+		attempts := 0
+		a := fastAdapter(func(_ context.Context, _ avngen.Client, _ ResourceData) error {
+			attempts++
+			return nil
+		})
+		a.resource.RefreshState = &RefreshStateCondition{Attribute: "state", Failed: []string{"ERROR"}}
+
+		err := a.refreshState(t.Context(), nil)
+
+		require.EqualError(t, err, `refresh state condition for "state" has no desired values`)
+		require.Zero(t, attempts)
+	})
+
+	t.Run("rejects an explicitly empty desired list before reading", func(t *testing.T) {
+		t.Parallel()
+
+		attempts := 0
+		a := fastAdapter(func(_ context.Context, _ avngen.Client, _ ResourceData) error {
+			attempts++
+			return nil
+		})
+		a.resource.RefreshState = &RefreshStateCondition{Attribute: "state", Desired: []string{}}
+
+		err := a.refreshState(t.Context(), nil)
+
+		require.EqualError(t, err, `refresh state condition for "state" has no desired values`)
+		require.Zero(t, attempts)
+	})
+
+	t.Run("rejects an attribute without desired values before reading", func(t *testing.T) {
+		t.Parallel()
+
+		attempts := 0
+		a := fastAdapter(func(_ context.Context, _ avngen.Client, _ ResourceData) error {
+			attempts++
+			return nil
+		})
+		a.resource.RefreshState = &RefreshStateCondition{Attribute: "state"}
+
+		err := a.refreshState(t.Context(), nil)
+
+		require.EqualError(t, err, `refresh state condition for "state" has no desired values`)
+		require.Zero(t, attempts)
+	})
+
+	t.Run("rejects a condition without an attribute before reading", func(t *testing.T) {
+		t.Parallel()
+
+		attempts := 0
+		a := fastAdapter(func(_ context.Context, _ avngen.Client, _ ResourceData) error {
+			attempts++
+			return nil
+		})
+		a.resource.RefreshState = &RefreshStateCondition{Desired: []string{"ACTIVE"}}
+
+		err := a.refreshState(t.Context(), nil)
+
+		require.EqualError(t, err, "refresh state condition has no attribute")
+		require.Zero(t, attempts)
 	})
 
 	t.Run("retries until the context deadline when the desired state is never reached", func(t *testing.T) {
 		t.Parallel()
 
 		rd, err := NewResourceData(
-			statusSchema,
+			stateSchema,
 			nil,
-			WithTestState(map[string]any{"status": "PENDING"}),
+			WithTestState(map[string]any{"state": "PENDING"}),
 		)
 		require.NoError(t, err)
 
@@ -214,7 +559,7 @@ func TestResourceAdapter_refreshState(t *testing.T) {
 			attempts++
 			return nil // Never transitions to ACTIVE, so the poll runs until ctx is cancelled.
 		})
-		a.resource.RefreshStateDesired = map[string]string{"status": "ACTIVE"}
+		a.resource.RefreshState = &RefreshStateCondition{Attribute: "state", Desired: []string{"ACTIVE"}}
 
 		// The fixed retry delay is fastRetryDelay (1µs), so a 300ms window comfortably allows many
 		// attempts before the deadline.
@@ -246,6 +591,30 @@ func TestResourceAdapter_refreshState(t *testing.T) {
 
 		require.NoError(t, err)
 		require.Equal(t, 3, attempts)
+	})
+
+	t.Run("stops when RefreshStateCheck reports a failed state", func(t *testing.T) {
+		t.Parallel()
+
+		unexpectedRetry := errors.New("unexpected retry")
+		attempts := 0
+		a := fastAdapter(func(_ context.Context, _ avngen.Client, _ ResourceData) error {
+			attempts++
+			if attempts > 1 {
+				return unexpectedRetry
+			}
+			return nil
+		})
+		a.resource.RefreshStateCheck = func(_ ResourceData) error {
+			return fmt.Errorf("custom check: %w", ErrRefreshStateFailed)
+		}
+
+		err := a.refreshState(t.Context(), nil)
+
+		require.ErrorIs(t, err, ErrRefreshStateFailed)
+		require.NotErrorIs(t, err, ErrRefreshStateDesired)
+		require.NotErrorIs(t, err, unexpectedRetry)
+		require.Equal(t, 1, attempts)
 	})
 
 	t.Run("retries until the context deadline when RefreshStateCheck never passes", func(t *testing.T) {
@@ -653,6 +1022,8 @@ func TestIsRefreshStateRetryable(t *testing.T) {
 		{name: "wrapped avngen 403", err: fmt.Errorf("api: %w", avngen.Error{Status: http.StatusForbidden}), want: true},
 		{name: "ErrRefreshStateDesired sentinel", err: ErrRefreshStateDesired, want: true},
 		{name: "wrapped ErrRefreshStateDesired", err: fmt.Errorf("mismatch: %w", ErrRefreshStateDesired), want: true},
+		{name: "ErrRefreshStateFailed sentinel", err: ErrRefreshStateFailed, want: false},
+		{name: "wrapped ErrRefreshStateFailed", err: fmt.Errorf("failed: %w", ErrRefreshStateFailed), want: false},
 		{name: "avngen 500", err: avngen.Error{Status: http.StatusInternalServerError}, want: false},
 		{name: "avngen 400", err: avngen.Error{Status: http.StatusBadRequest}, want: false},
 		{name: "unrelated error", err: errors.New("boom"), want: false},

--- a/internal/plugin/service/byoc/aws_provision/zz_view.go
+++ b/internal/plugin/service/byoc/aws_provision/zz_view.go
@@ -28,11 +28,13 @@ var ResourceOptions = adapter.ResourceOptions{
 	IDFields:            idFields(),
 	IgnoreAlreadyExists: true,
 	Read:                readView,
-	RefreshState:        true,
-	RefreshStateDesired: map[string]string{"state": "active"},
-	Schema:              resourceSchema,
-	SchemaInternal:      resourceSchemaInternal(),
-	TypeName:            typeName,
+	RefreshState: &adapter.RefreshStateCondition{
+		Attribute: "state",
+		Desired:   []string{"active"},
+	},
+	Schema:         resourceSchema,
+	SchemaInternal: resourceSchemaInternal(),
+	TypeName:       typeName,
 }
 
 func createView(ctx context.Context, client avngen.Client, d adapter.ResourceData) error {

--- a/internal/plugin/service/byoc/permissions/zz_view.go
+++ b/internal/plugin/service/byoc/permissions/zz_view.go
@@ -25,7 +25,7 @@ var ResourceOptions = adapter.ResourceOptions{
 	Create:         createView,
 	IDFields:       idFields(),
 	Read:           readView,
-	RefreshState:   true,
+	RefreshState:   &adapter.RefreshStateCondition{},
 	RemoveMissing:  true,
 	Schema:         resourceSchema,
 	SchemaInternal: resourceSchemaInternal(),

--- a/internal/plugin/service/clickhouse/database/zz_view.go
+++ b/internal/plugin/service/clickhouse/database/zz_view.go
@@ -26,7 +26,7 @@ var ResourceOptions = adapter.ResourceOptions{
 	Delete:                deleteView,
 	IDFields:              idFields(),
 	Read:                  readView,
-	RefreshState:          true,
+	RefreshState:          &adapter.RefreshStateCondition{},
 	RemoveMissing:         true,
 	Schema:                resourceSchema,
 	SchemaInternal:        resourceSchemaInternal(),

--- a/internal/plugin/service/clickhouse/user/zz_view.go
+++ b/internal/plugin/service/clickhouse/user/zz_view.go
@@ -29,7 +29,7 @@ var ResourceOptions = adapter.ResourceOptions{
 	Delete:         deleteView,
 	IDFields:       idFields(),
 	Read:           readView,
-	RefreshState:   true,
+	RefreshState:   &adapter.RefreshStateCondition{},
 	RemoveMissing:  true,
 	Schema:         resourceSchema,
 	SchemaInternal: resourceSchemaInternal(),

--- a/internal/plugin/service/flink/application/zz_view.go
+++ b/internal/plugin/service/flink/application/zz_view.go
@@ -29,7 +29,7 @@ var ResourceOptions = adapter.ResourceOptions{
 	Delete:         deleteView,
 	IDFields:       idFields(),
 	Read:           readView,
-	RefreshState:   true,
+	RefreshState:   &adapter.RefreshStateCondition{},
 	RemoveMissing:  true,
 	Schema:         resourceSchema,
 	SchemaInternal: resourceSchemaInternal(),

--- a/internal/plugin/service/flink/deployment/zz_view.go
+++ b/internal/plugin/service/flink/deployment/zz_view.go
@@ -24,7 +24,7 @@ var ResourceOptions = adapter.ResourceOptions{
 	Create:         createView,
 	IDFields:       idFields(),
 	Read:           readView,
-	RefreshState:   true,
+	RefreshState:   &adapter.RefreshStateCondition{},
 	RemoveMissing:  true,
 	Schema:         resourceSchema,
 	SchemaInternal: resourceSchemaInternal(),

--- a/internal/plugin/service/kafka/acl/zz_view.go
+++ b/internal/plugin/service/kafka/acl/zz_view.go
@@ -29,7 +29,7 @@ var ResourceOptions = adapter.ResourceOptions{
 	Delete:         deleteView,
 	IDFields:       idFields(),
 	Read:           readView,
-	RefreshState:   true,
+	RefreshState:   &adapter.RefreshStateCondition{},
 	RemoveMissing:  true,
 	Schema:         resourceSchema,
 	SchemaInternal: resourceSchemaInternal(),

--- a/internal/plugin/service/kafka/mirrormakerreplicationflow/zz_view.go
+++ b/internal/plugin/service/kafka/mirrormakerreplicationflow/zz_view.go
@@ -25,7 +25,7 @@ var ResourceOptions = adapter.ResourceOptions{
 	Delete:         deleteView,
 	IDFields:       idFields(),
 	Read:           readView,
-	RefreshState:   true,
+	RefreshState:   &adapter.RefreshStateCondition{},
 	RemoveMissing:  true,
 	Schema:         resourceSchema,
 	SchemaInternal: resourceSchemaInternal(),

--- a/internal/plugin/service/kafka/nativeacl/zz_view.go
+++ b/internal/plugin/service/kafka/nativeacl/zz_view.go
@@ -25,7 +25,7 @@ var ResourceOptions = adapter.ResourceOptions{
 	Delete:         deleteView,
 	IDFields:       idFields(),
 	Read:           readView,
-	RefreshState:   true,
+	RefreshState:   &adapter.RefreshStateCondition{},
 	RemoveMissing:  true,
 	Schema:         resourceSchema,
 	SchemaInternal: resourceSchemaInternal(),

--- a/internal/plugin/service/kafka/user/zz_view.go
+++ b/internal/plugin/service/kafka/user/zz_view.go
@@ -24,7 +24,7 @@ var ResourceOptions = adapter.ResourceOptions{
 	Delete:         deleteView,
 	IDFields:       idFields(),
 	Read:           readView,
-	RefreshState:   true,
+	RefreshState:   &adapter.RefreshStateCondition{},
 	RemoveMissing:  true,
 	Schema:         resourceSchema,
 	SchemaInternal: resourceSchemaInternal(),

--- a/internal/plugin/service/kafkaschema/registryacl/zz_view.go
+++ b/internal/plugin/service/kafkaschema/registryacl/zz_view.go
@@ -29,7 +29,7 @@ var ResourceOptions = adapter.ResourceOptions{
 	Delete:         deleteView,
 	IDFields:       idFields(),
 	Read:           readView,
-	RefreshState:   true,
+	RefreshState:   &adapter.RefreshStateCondition{},
 	RemoveMissing:  true,
 	Schema:         resourceSchema,
 	SchemaInternal: resourceSchemaInternal(),

--- a/internal/plugin/service/mysql/database/zz_view.go
+++ b/internal/plugin/service/mysql/database/zz_view.go
@@ -26,7 +26,7 @@ var ResourceOptions = adapter.ResourceOptions{
 	Delete:                deleteView,
 	IDFields:              idFields(),
 	Read:                  readView,
-	RefreshState:          true,
+	RefreshState:          &adapter.RefreshStateCondition{},
 	RemoveMissing:         true,
 	Schema:                resourceSchema,
 	SchemaInternal:        resourceSchemaInternal(),

--- a/internal/plugin/service/mysql/user/zz_view.go
+++ b/internal/plugin/service/mysql/user/zz_view.go
@@ -24,7 +24,7 @@ var ResourceOptions = adapter.ResourceOptions{
 	Delete:         deleteView,
 	IDFields:       idFields(),
 	Read:           readView,
-	RefreshState:   true,
+	RefreshState:   &adapter.RefreshStateCondition{},
 	RemoveMissing:  true,
 	Schema:         resourceSchema,
 	SchemaInternal: resourceSchemaInternal(),

--- a/internal/plugin/service/opensearch/securitypluginconfig/zz_view.go
+++ b/internal/plugin/service/opensearch/securitypluginconfig/zz_view.go
@@ -24,7 +24,7 @@ var ResourceOptions = adapter.ResourceOptions{
 	Create:         createView,
 	IDFields:       idFields(),
 	Read:           readView,
-	RefreshState:   true,
+	RefreshState:   &adapter.RefreshStateCondition{},
 	RemoveMissing:  true,
 	Schema:         resourceSchema,
 	SchemaInternal: resourceSchemaInternal(),

--- a/internal/plugin/service/opensearch/user/zz_view.go
+++ b/internal/plugin/service/opensearch/user/zz_view.go
@@ -24,7 +24,7 @@ var ResourceOptions = adapter.ResourceOptions{
 	Delete:         deleteView,
 	IDFields:       idFields(),
 	Read:           readView,
-	RefreshState:   true,
+	RefreshState:   &adapter.RefreshStateCondition{},
 	RemoveMissing:  true,
 	Schema:         resourceSchema,
 	SchemaInternal: resourceSchemaInternal(),

--- a/internal/plugin/service/organization/applicationusertoken/zz_view.go
+++ b/internal/plugin/service/organization/applicationusertoken/zz_view.go
@@ -26,7 +26,7 @@ var ResourceOptions = adapter.ResourceOptions{
 	Delete:         deleteView,
 	IDFields:       idFields(),
 	Read:           readView,
-	RefreshState:   true,
+	RefreshState:   &adapter.RefreshStateCondition{},
 	Schema:         resourceSchema,
 	SchemaInternal: resourceSchemaInternal(),
 	TypeName:       typeName,

--- a/internal/plugin/service/organization/organization/organization.go
+++ b/internal/plugin/service/organization/organization/organization.go
@@ -24,7 +24,7 @@ func NewResource() resource.Resource {
 		IDFields:       idFields(),
 		Schema:         resourceSchema,
 		SchemaInternal: resourceSchemaInternal(),
-		RefreshState:   true,
+		RefreshState:   &adapter.RefreshStateCondition{},
 		Read:           readOrganization,
 		Create:         createOrganization,
 		Update:         updateOrganization,

--- a/internal/plugin/service/organization/project/zz_view.go
+++ b/internal/plugin/service/organization/project/zz_view.go
@@ -25,7 +25,7 @@ var ResourceOptions = adapter.ResourceOptions{
 	Delete:         deleteView,
 	IDFields:       idFields(),
 	Read:           readView,
-	RefreshState:   true,
+	RefreshState:   &adapter.RefreshStateCondition{},
 	Schema:         resourceSchema,
 	SchemaInternal: resourceSchemaInternal(),
 	TypeName:       typeName,

--- a/internal/plugin/service/organization/usergroupmember/zz_view.go
+++ b/internal/plugin/service/organization/usergroupmember/zz_view.go
@@ -25,7 +25,7 @@ var ResourceOptions = adapter.ResourceOptions{
 	Delete:         deleteView,
 	IDFields:       idFields(),
 	Read:           readView,
-	RefreshState:   true,
+	RefreshState:   &adapter.RefreshStateCondition{},
 	Schema:         resourceSchema,
 	SchemaInternal: resourceSchemaInternal(),
 	TypeName:       typeName,

--- a/internal/plugin/service/pg/connectionpool/zz_view.go
+++ b/internal/plugin/service/pg/connectionpool/zz_view.go
@@ -26,7 +26,7 @@ var ResourceOptions = adapter.ResourceOptions{
 	Delete:         deleteView,
 	IDFields:       idFields(),
 	Read:           readView,
-	RefreshState:   true,
+	RefreshState:   &adapter.RefreshStateCondition{},
 	RemoveMissing:  true,
 	Schema:         resourceSchema,
 	SchemaInternal: resourceSchemaInternal(),

--- a/internal/plugin/service/pg/database/zz_view.go
+++ b/internal/plugin/service/pg/database/zz_view.go
@@ -26,7 +26,7 @@ var ResourceOptions = adapter.ResourceOptions{
 	Delete:                deleteView,
 	IDFields:              idFields(),
 	Read:                  readView,
-	RefreshState:          true,
+	RefreshState:          &adapter.RefreshStateCondition{},
 	RemoveMissing:         true,
 	Schema:                resourceSchema,
 	SchemaInternal:        resourceSchemaInternal(),

--- a/internal/plugin/service/pg/user/zz_view.go
+++ b/internal/plugin/service/pg/user/zz_view.go
@@ -24,7 +24,7 @@ var ResourceOptions = adapter.ResourceOptions{
 	Delete:         deleteView,
 	IDFields:       idFields(),
 	Read:           readView,
-	RefreshState:   true,
+	RefreshState:   &adapter.RefreshStateCondition{},
 	RemoveMissing:  true,
 	Schema:         resourceSchema,
 	SchemaInternal: resourceSchemaInternal(),

--- a/internal/plugin/service/staticip/zz_view.go
+++ b/internal/plugin/service/staticip/zz_view.go
@@ -22,12 +22,14 @@ func idFields() []string {
 }
 
 var ResourceOptions = adapter.ResourceOptions{
-	Create:                createView,
-	Delete:                deleteView,
-	IDFields:              idFields(),
-	Read:                  readView,
-	RefreshState:          true,
-	RefreshStateDesired:   map[string]string{"state": "created"},
+	Create:   createView,
+	Delete:   deleteView,
+	IDFields: idFields(),
+	Read:     readView,
+	RefreshState: &adapter.RefreshStateCondition{
+		Attribute: "state",
+		Desired:   []string{"created"},
+	},
 	Schema:                resourceSchema,
 	SchemaInternal:        resourceSchemaInternal(),
 	TerminationProtection: true,

--- a/internal/plugin/service/valkey/user/zz_view.go
+++ b/internal/plugin/service/valkey/user/zz_view.go
@@ -24,7 +24,7 @@ var ResourceOptions = adapter.ResourceOptions{
 	Delete:         deleteView,
 	IDFields:       idFields(),
 	Read:           readView,
-	RefreshState:   true,
+	RefreshState:   &adapter.RefreshStateCondition{},
 	RemoveMissing:  true,
 	Schema:         resourceSchema,
 	SchemaInternal: resourceSchemaInternal(),

--- a/internal/plugin/service/vpc/awsprivatelink/zz_view.go
+++ b/internal/plugin/service/vpc/awsprivatelink/zz_view.go
@@ -21,17 +21,19 @@ func idFields() []string {
 }
 
 var ResourceOptions = adapter.ResourceOptions{
-	Create:              createView,
-	Delete:              deleteView,
-	IDFields:            idFields(),
-	Read:                readView,
-	RefreshState:        true,
-	RefreshStateDesired: map[string]string{"state": "active"},
-	RemoveMissing:       true,
-	Schema:              resourceSchema,
-	SchemaInternal:      resourceSchemaInternal(),
-	TypeName:            typeName,
-	Update:              updateView,
+	Create:   createView,
+	Delete:   deleteView,
+	IDFields: idFields(),
+	Read:     readView,
+	RefreshState: &adapter.RefreshStateCondition{
+		Attribute: "state",
+		Desired:   []string{"active"},
+	},
+	RemoveMissing:  true,
+	Schema:         resourceSchema,
+	SchemaInternal: resourceSchemaInternal(),
+	TypeName:       typeName,
+	Update:         updateView,
 }
 
 var DataSourceOptions = adapter.DataSourceOptions{

--- a/internal/plugin/service/vpc/azureprivatelink/zz_view.go
+++ b/internal/plugin/service/vpc/azureprivatelink/zz_view.go
@@ -21,18 +21,20 @@ func idFields() []string {
 }
 
 var ResourceOptions = adapter.ResourceOptions{
-	Create:              createView,
-	Delete:              deleteView,
-	DeleteState:         &adapter.DeleteStateOptions{},
-	IDFields:            idFields(),
-	Read:                readView,
-	RefreshState:        true,
-	RefreshStateDesired: map[string]string{"state": "active"},
-	RemoveMissing:       true,
-	Schema:              resourceSchema,
-	SchemaInternal:      resourceSchemaInternal(),
-	TypeName:            typeName,
-	Update:              updateView,
+	Create:      createView,
+	Delete:      deleteView,
+	DeleteState: &adapter.DeleteStateOptions{},
+	IDFields:    idFields(),
+	Read:        readView,
+	RefreshState: &adapter.RefreshStateCondition{
+		Attribute: "state",
+		Desired:   []string{"active"},
+	},
+	RemoveMissing:  true,
+	Schema:         resourceSchema,
+	SchemaInternal: resourceSchemaInternal(),
+	TypeName:       typeName,
+	Update:         updateView,
 }
 
 var DataSourceOptions = adapter.DataSourceOptions{

--- a/internal/plugin/service/vpc/gcpprivatelink/zz_view.go
+++ b/internal/plugin/service/vpc/gcpprivatelink/zz_view.go
@@ -20,17 +20,19 @@ func idFields() []string {
 }
 
 var ResourceOptions = adapter.ResourceOptions{
-	Create:              createView,
-	Delete:              deleteView,
-	DeleteState:         &adapter.DeleteStateOptions{},
-	IDFields:            idFields(),
-	Read:                readView,
-	RefreshState:        true,
-	RefreshStateDesired: map[string]string{"state": "active"},
-	RemoveMissing:       true,
-	Schema:              resourceSchema,
-	SchemaInternal:      resourceSchemaInternal(),
-	TypeName:            typeName,
+	Create:      createView,
+	Delete:      deleteView,
+	DeleteState: &adapter.DeleteStateOptions{},
+	IDFields:    idFields(),
+	Read:        readView,
+	RefreshState: &adapter.RefreshStateCondition{
+		Attribute: "state",
+		Desired:   []string{"active"},
+	},
+	RemoveMissing:  true,
+	Schema:         resourceSchema,
+	SchemaInternal: resourceSchemaInternal(),
+	TypeName:       typeName,
 }
 
 var DataSourceOptions = adapter.DataSourceOptions{

--- a/internal/plugin/service/vpc/organizationvpc/zz_view.go
+++ b/internal/plugin/service/vpc/organizationvpc/zz_view.go
@@ -21,18 +21,20 @@ func idFields() []string {
 }
 
 var ResourceOptions = adapter.ResourceOptions{
-	Create:              createView,
-	Delete:              deleteView,
-	DeleteState:         &adapter.DeleteStateOptions{Desired: map[string]string{"state": "DELETED"}},
-	IDFields:            idFields(),
-	Read:                readView,
-	RefreshState:        true,
-	RefreshStateDesired: map[string]string{"state": "ACTIVE"},
-	RemoveMissing:       true,
-	Schema:              resourceSchema,
-	SchemaInternal:      resourceSchemaInternal(),
-	TypeName:            typeName,
-	Update:              updateView,
+	Create:      createView,
+	Delete:      deleteView,
+	DeleteState: &adapter.DeleteStateOptions{Desired: map[string]string{"state": "DELETED"}},
+	IDFields:    idFields(),
+	Read:        readView,
+	RefreshState: &adapter.RefreshStateCondition{
+		Attribute: "state",
+		Desired:   []string{"ACTIVE"},
+	},
+	RemoveMissing:  true,
+	Schema:         resourceSchema,
+	SchemaInternal: resourceSchemaInternal(),
+	TypeName:       typeName,
+	Update:         updateView,
 }
 
 var DataSourceOptions = adapter.DataSourceOptions{

--- a/internal/plugin/service/vpc/projectvpc/zz_view.go
+++ b/internal/plugin/service/vpc/projectvpc/zz_view.go
@@ -25,17 +25,19 @@ func idFields() []string {
 }
 
 var ResourceOptions = adapter.ResourceOptions{
-	Create:              createView,
-	Delete:              deleteView,
-	DeleteState:         &adapter.DeleteStateOptions{Desired: map[string]string{"state": "DELETED"}},
-	IDFields:            idFields(),
-	Read:                readView,
-	RefreshState:        true,
-	RefreshStateDesired: map[string]string{"state": "ACTIVE"},
-	RemoveMissing:       true,
-	Schema:              resourceSchema,
-	SchemaInternal:      resourceSchemaInternal(),
-	TypeName:            typeName,
+	Create:      createView,
+	Delete:      deleteView,
+	DeleteState: &adapter.DeleteStateOptions{Desired: map[string]string{"state": "DELETED"}},
+	IDFields:    idFields(),
+	Read:        readView,
+	RefreshState: &adapter.RefreshStateCondition{
+		Attribute: "state",
+		Desired:   []string{"ACTIVE"},
+	},
+	RemoveMissing:  true,
+	Schema:         resourceSchema,
+	SchemaInternal: resourceSchemaInternal(),
+	TypeName:       typeName,
 }
 
 var DataSourceOptions = adapter.DataSourceOptions{

--- a/tools/agents/skills/tf-resource-generator/SKILL.md
+++ b/tools/agents/skills/tf-resource-generator/SKILL.md
@@ -173,20 +173,26 @@ resource:
   description: "..."
   deprecationMessage: "..."
   terminationProtection: true # Check field before delete
-  refreshState: true # Call Read after Create/Update
+  refreshState: # Call Read after Create/Update and wait for state convergence
+    attribute: state # Optional; defaults to state
+    desired: [ACTIVE, PENDING_PEER]
+    failed: [ERROR, DELETED]
   refreshStateDelay: "15s" # Wait before Read
-  refreshStateDesired: # Retry Read until fields match desired values
-    state: ACTIVE
   removeMissing: true # Remove from state on 404
   deleteStateDesired: # Poll Read after Delete until the resource reaches its terminal state
     state: DELETED
 ```
 
-`refreshStateDesired` replaces ad-hoc refresh waiters for simple state transitions. Use it when the resource should settle into a known value after create/update (for example, `state: ACTIVE`).
+`refreshState` enables a post-Create/Update Read. Use `refreshState: {}` when the first successful
+Read is sufficient. To wait for state convergence, configure `desired` values and optional `failed`
+values for a computed-only Terraform attribute. The optional `attribute` setting defaults to `state`.
+Values within each list use OR semantics. A desired value completes the refresh, and any failed value
+stops it immediately. Values in neither list are treated as pending and retried, which safely
+accommodates new intermediate backend states.
 
 `deleteStateDesired` replaces custom delete waiters. It is a map, and its presence (even as an empty map, `{}`) enables the delete poller: on every attempt the adapter re-issues `Delete` (ignoring its error) and polls `Read` until the resource is gone (404) or reaches its terminal state, then returns. A 404 always completes the delete. Because `Delete` is re-issued each attempt and its error is ignored, a 409 Conflict from dependents still detaching resolves on its own — no extra configuration is needed.
 
-The map's entries are attribute names mapped to the terminal value the poller must observe (e.g. `state: DELETED`). The poll finishes when every entry matches or the API 404s, whichever comes first. Values are validated against the field's enum when one is declared, as for `refreshStateDesired`. Use an empty map for APIs whose Read never surfaces a terminal state (it just 404s).
+The map's entries are attribute names mapped to the terminal value the poller must observe (e.g. `state: DELETED`). The poll finishes when every entry matches or the API 404s, whichever comes first. Values are validated against the field's enum when one is declared. Use an empty map for APIs whose Read never surfaces a terminal state (it just 404s).
 
 Examples:
 
@@ -321,13 +327,16 @@ func idFields() []string {
 }
 
 var ResourceOptions = adapter.ResourceOptions{
-    Create:            createView,
-    Delete:            deleteView,
-    IDFields:          idFields(),
-    Read:              readView,
-    RefreshState:      true,
+    Create:   createView,
+    Delete:   deleteView,
+    IDFields: idFields(),
+    Read:     readView,
+    RefreshState: &adapter.RefreshStateCondition{
+        Attribute: "state",
+        Desired: []string{"ACTIVE", "PENDING_PEER"},
+        Failed:  []string{"ERROR", "DELETED"},
+    },
     RefreshStateDelay: adapter.MustParseDuration("15s"),
-    RefreshStateDesired: map[string]string{"state": "ACTIVE"},
     RemoveMissing:     true,
     Schema:            resourceSchema,
     SchemaInternal:    resourceSchemaInternal(),


### PR DESCRIPTION
Resolves: NEX-2789

This PR replaces `refreshState` and `refreshStateDesired` with one `refreshState` block. By default, the block checks the Terraform `state` field, but a resource can choose another read-only field. It can define several desired and failed values. A desired value completes the refresh, a failed value stops it with an error, and all other values stay pending.

Existing resources are moved to the new format. The adapter also keeps the resource state after a successful `Create` when the following refresh fails, so Terraform doesn't lose the created resource. Custom refresh checks can return `ErrRefreshStateFailed` to stop polling immediately.

