### PR TITLE
feat(plugin): support glob patterns in definition remove lists

### DIFF
--- a/definitions/.schema.yml
+++ b/definitions/.schema.yml
@@ -155,8 +155,20 @@ properties:
   remove:
     $ref: '#/definitions/Remove'
     $comment: |
-      List of attributes to remove from the resource/datasource.
-      Example: remove: ["openapi_name1", "openapi_name2"]
+      List of attributes to remove from the resource/datasource. Entries are matched against the
+      attribute's OpenAPI path, where nested attributes are slash-separated, e.g. "plans/node_count".
+      Example: remove: ["openapi_name1", "nested/openapi_name2"]
+
+      Entries are glob patterns:
+        "*"  matches any run of characters within a single path segment, e.g. "azure_*" drops
+             every top-level attribute with that prefix, and "*google*" drops every top-level
+             attribute containing "google".
+        "?"  matches exactly one character within a single path segment.
+        "**" matches across segments, e.g. "**/errors" drops "errors" at any depth.
+      A pattern without wildcards is an exact match, so plain attribute names keep working.
+
+      Prefer globs over long explicit lists when the removed attributes share an obvious prefix,
+      such as a cloud provider name that the resource does not support.
   idAttributeComposed:
     type: array
     minItems: 1
@@ -210,7 +222,7 @@ definitions:
     type: array
     items:
       type: string
-      $comment: The attribute to remove
+      $comment: The attribute to remove, either an exact path or a glob pattern
 
   Operation:
     type: object

--- a/definitions/aiven_byoc_aws_entity.yml
+++ b/definitions/aiven_byoc_aws_entity.yml
@@ -19,13 +19,13 @@ operations:
   - id: CustomCloudEnvironmentDelete
     type: delete
 remove:
-  - aiven_google_account_principal
-  - google_bastion_cidr
-  - google_privilege_bearing_service_account_id
-  - google_workload_cidr
-  - oracle_compartment_id
-  - oracle_subnet_bastion
-  - oracle_subnet_workload
+  # The API serves every cloud provider from one schema. This resource is AWS
+  # only, so anything named after another provider is dropped, including fields
+  # the API may add later.
+  - "*azure*"
+  - "*gcp*"
+  - "*google*"
+  - "*oracle*"
   - custom_cloud_names
   - errors
   - state

--- a/definitions/aiven_byoc_aws_provision.yml
+++ b/definitions/aiven_byoc_aws_provision.yml
@@ -27,9 +27,17 @@ operations:
   - id: CustomCloudEnvironmentDelete
     type: delete
 remove:
+  # The API serves every cloud provider from one schema. This resource is AWS
+  # only, so anything named after another provider is dropped, including fields
+  # the API may add later.
+  - "*azure*"
+  - "*gcp*"
+  - "*google*"
+  - "*oracle*"
+  # Environment attributes belong to aiven_byoc_aws_entity, which creates the
+  # environment. This resource only hands over the IAM role that activates it.
   - aiven_aws_object_storage_credentials_creator_arn
   - aiven_aws_object_storage_user_arn
-  - aiven_google_account_principal
   - aiven_management_cidr_blocks
   - aiven_object_storage_credentials_creator_user
   - aws_subnets_bastion
@@ -43,12 +51,6 @@ remove:
   - deployment_model
   - display_name
   - errors
-  - google_bastion_cidr
-  - google_privilege_bearing_service_account_id
-  - google_workload_cidr
-  - oracle_compartment_id
-  - oracle_subnet_bastion
-  - oracle_subnet_workload
   - reserved_cidr
   - tags
   - update_time

--- a/generators/plugin/item.go
+++ b/generators/plugin/item.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/bmatcuk/doublestar/v4"
 	"github.com/ettle/strcase"
 )
 
@@ -179,6 +180,24 @@ type Definition struct {
 	PlanModifier        bool              `yaml:"planModifier,omitempty"`
 	ExpandModifier      bool              `yaml:"expandModifier,omitempty"`
 	FlattenModifier     bool              `yaml:"flattenModifier,omitempty"`
+}
+
+// IsRemoved reports whether the given JSON path is excluded by the `remove` list.
+// Entries are glob patterns matched against the slash-separated JSON path:
+// `*` and `?` stay within a single segment, `**` spans segments, and a pattern
+// without wildcards is an exact match.
+func (d *Definition) IsRemoved(jsonPath string) (bool, error) {
+	for _, pattern := range d.Remove {
+		match, err := doublestar.Match(pattern, jsonPath)
+		if err != nil {
+			return false, fmt.Errorf("invalid remove pattern %q: %w", pattern, err)
+		}
+
+		if match {
+			return true, nil
+		}
+	}
+	return false, nil
 }
 
 // DatasourceLookupOp returns the single read op marked `datasourceLookup`, or nil. It

--- a/generators/plugin/item_test.go
+++ b/generators/plugin/item_test.go
@@ -228,6 +228,71 @@ func TestItemRemoveElements(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "glob matches within a segment only",
+			schema: &OASchema{
+				Type: SchemaTypeObject,
+				Properties: map[string]*OASchema{
+					"azure_tenant_id":       {Type: SchemaTypeString},
+					"aiven_azure_principal": {Type: SchemaTypeString},
+					"aws_iam_role_arn":      {Type: SchemaTypeString},
+					"plans": {
+						Type: SchemaTypeArray,
+						Items: &OASchema{
+							Type: SchemaTypeObject,
+							Properties: map[string]*OASchema{
+								"azure_sku": {Type: SchemaTypeString},
+								"name":      {Type: SchemaTypeString},
+							},
+						},
+					},
+				},
+			},
+			remove: []string{"*azure*"},
+			want: map[string]*Item{
+				"aws_iam_role_arn": {Properties: map[string]*Item{}},
+				"plans": {
+					Properties: map[string]*Item{},
+					Items: &Item{
+						Properties: map[string]*Item{
+							// "*" does not cross "/", so the nested field survives
+							"azure_sku": {Properties: map[string]*Item{}},
+							"name":      {Properties: map[string]*Item{}},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "doublestar glob crosses segments",
+			schema: &OASchema{
+				Type: SchemaTypeObject,
+				Properties: map[string]*OASchema{
+					"errors": {Type: SchemaTypeString},
+					"plans": {
+						Type: SchemaTypeArray,
+						Items: &OASchema{
+							Type: SchemaTypeObject,
+							Properties: map[string]*OASchema{
+								"errors": {Type: SchemaTypeString},
+								"name":   {Type: SchemaTypeString},
+							},
+						},
+					},
+				},
+			},
+			remove: []string{"**/errors"},
+			want: map[string]*Item{
+				"plans": {
+					Properties: map[string]*Item{},
+					Items: &Item{
+						Properties: map[string]*Item{
+							"name": {Properties: map[string]*Item{}},
+						},
+					},
+				},
+			},
+		},
 	}
 
 	transformer := cmp.Transformer("Item", func(i *Item) any {

--- a/generators/plugin/main.go
+++ b/generators/plugin/main.go
@@ -673,7 +673,12 @@ func getOperationPath(scope *Scope, operationID OperationID) (*OAPath, error) {
 }
 
 func addProperty(scope *Scope, parent, prop *Item) error {
-	if slices.Contains(scope.Definition.Remove, prop.JSONPath()) {
+	removed, err := scope.Definition.IsRemoved(prop.JSONPath())
+	if err != nil {
+		return err
+	}
+
+	if removed {
 		return nil
 	}
 
@@ -684,7 +689,6 @@ func addProperty(scope *Scope, parent, prop *Item) error {
 
 	// CRUD fields often intersect with each other
 	// Merges duplicated fields
-	var err error
 	parent.Properties[prop.Name], err = mergeItem(parent, parent.Properties[prop.Name], prop)
 	return err
 }

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/aiven/go-client-codegen v0.207.0
 	github.com/avast/retry-go v3.0.0+incompatible
 	github.com/avast/retry-go/v4 v4.7.0
+	github.com/bmatcuk/doublestar/v4 v4.8.1
 	github.com/dave/jennifer v1.7.1
 	github.com/docker/go-units v0.5.0
 	github.com/ettle/strcase v0.2.0
@@ -68,7 +69,6 @@ require (
 	github.com/bitfield/gotestdox v0.2.2 // indirect
 	github.com/bkielbasa/cyclop v1.2.3 // indirect
 	github.com/blizzy78/varnamelen v0.8.0 // indirect
-	github.com/bmatcuk/doublestar/v4 v4.8.1 // indirect
 	github.com/bombsimon/wsl/v4 v4.7.0 // indirect
 	github.com/breml/bidichk v0.3.3 // indirect
 	github.com/breml/errchkjson v0.4.1 // indirect

--- a/tools/agents/skills/tf-resource-generator/SKILL.md
+++ b/tools/agents/skills/tf-resource-generator/SKILL.md
@@ -157,7 +157,7 @@ Common fields:
 - `resource` / `datasource` - Configuration metadata
 - `idAttributeComposed` - Fields that compose the ID (e.g., `[project, service_name]`)
 - `clientHandler` - API client type: `project`, `service`, `organization`, `organizationbilling`, etc.
-- `remove` - Fields to exclude from schema
+- `remove` - Fields to exclude from schema (exact paths or glob patterns)
 - `rename` - Field name mappings (API field -> Terraform field)
 - `schema` - Schema customizations (types, validation, behavior)
 - `expandModifier` / `flattenModifier` / `planModifier` - Enable custom Go modifiers
@@ -246,6 +246,38 @@ operations:
 ```
 
 **Find examples**: `grep -A 5 "operations:" definitions/aiven_*.yml`
+
+### Removing Fields
+
+`remove` drops attributes the resource should not expose. Entries are matched against the
+attribute's OpenAPI path, where nested attributes are slash-separated:
+
+```yaml
+remove:
+  - update_time # top-level attribute
+  - plans/node_count # attribute nested under "plans"
+```
+
+Entries are glob patterns. `*` and `?` match within a single path segment, `**` matches across
+segments, and a pattern with no wildcards is an exact match:
+
+```yaml
+remove:
+  - "azure_*" # every top-level attribute with that prefix
+  - "*google*" # every top-level attribute containing "google"
+  - "**/errors" # "errors" at any depth
+```
+
+Quote glob patterns — an unquoted leading `*` is an alias reference in YAML and fails to parse.
+
+Reach for a glob when the removed attributes share an obvious naming pattern, most often a cloud
+provider that the resource does not support. Some Aiven endpoints serve every provider from one
+schema, so a provider-specific resource has to drop the rest. A glob keeps doing that when the API
+grows new fields, whereas an explicit list silently lets them into the schema on the next
+`task generate`. See `definitions/aiven_byoc_aws_entity.yml` for this pattern.
+
+Globs only match attribute names, not descriptions or enum values, so a `cloud_provider` attribute
+whose enum lists `azure` is unaffected by `"*azure*"`.
 
 ### Schema Customization
 


### PR DESCRIPTION
The Aiven API serves every cloud provider from one custom_cloud_environment schema, so the AWS-only BYOC resources have to drop each field named after another provider. An explicit remove list cannot anticipate new ones: the current spec added four azure_* fields to aiven_byoc_aws_provision, which would otherwise have shipped as part of the resource schema.

Match remove entries as globs against the slash-separated JSON path, so "*azure*" keeps excluding provider fields the API adds later. A pattern without wildcards is still an exact match, leaving every existing entry untouched, and generated output is unchanged.
