### PR TITLE
ci: bump cron minutes to reassign scheduled run ownership

### DIFF
--- a/.github/workflows/acceptance-tests.yml
+++ b/.github/workflows/acceptance-tests.yml
@@ -2,7 +2,7 @@ name: Acceptance Tests
 
 on:
   schedule:
-    - cron: "0 0 * * *"
+    - cron: "15 0 * * *"
   workflow_dispatch:
   pull_request:
     types: [opened, synchronize, reopened, labeled]

--- a/.github/workflows/examples-tests.yml
+++ b/.github/workflows/examples-tests.yml
@@ -2,7 +2,7 @@ name: Examples Tests
 
 on:
   schedule:
-    - cron: "0 13 * * *"
+    - cron: "15 13 * * *"
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/sweep.yml
+++ b/.github/workflows/sweep.yml
@@ -2,7 +2,7 @@ name: Sweep
 
 on:
   schedule:
-    - cron: "0 3 * * *"
+    - cron: "15 3 * * *"
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
Scheduled runs are attributed to whoever last changed the cron line, which pointed at a maintainer who has left.
