### PR TITLE
fix(ci): checkout passed ref in lint jobs

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -59,6 +59,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
         with:
+          ref: ${{ github.event.pull_request.head.sha || inputs.ref }}
           fetch-depth: 0
       - uses: actions/setup-go@v7
         with:
@@ -78,6 +79,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
         with:
+          ref: ${{ github.event.pull_request.head.sha || inputs.ref }}
           fetch-depth: 0
       - uses: actions/setup-go@v7
         with:
@@ -97,6 +99,7 @@ jobs:
     steps:
     - uses: actions/checkout@v7
       with:
+        ref: ${{ github.event.pull_request.head.sha || inputs.ref }}
         fetch-depth: 0
     - uses: actions/setup-go@v7
       with:

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -99,7 +99,7 @@ jobs:
   # Run all linting-related checks
   run_lint_checks:
     needs: create_release_pr
-    if: needs.create_release_pr.outputs.pr_created
+    if: needs.create_release_pr.outputs.pr_created == 'true'
     uses: ./.github/workflows/lint.yml
     with:
       ref: ${{ needs.create_release_pr.outputs.pr_head_sha }}
@@ -107,7 +107,7 @@ jobs:
   # Run unit tests
   run_unit_tests:
     needs: create_release_pr
-    if: needs.create_release_pr.outputs.pr_created
+    if: needs.create_release_pr.outputs.pr_created == 'true'
     uses: ./.github/workflows/unit-tests.yml
     with:
       ref: ${{ needs.create_release_pr.outputs.pr_head_sha }}
@@ -115,7 +115,7 @@ jobs:
   # Run dependency review
   run_dependency_review:
     needs: create_release_pr
-    if: needs.create_release_pr.outputs.pr_created
+    if: needs.create_release_pr.outputs.pr_created == 'true'
     uses: ./.github/workflows/dependency-review.yml
     with:
       head_ref: ${{ needs.create_release_pr.outputs.pr_head_sha }}
@@ -124,7 +124,7 @@ jobs:
   # Run acceptance tests
   run_acceptance_tests:
     needs: create_release_pr
-    if: needs.create_release_pr.outputs.pr_created && inputs.run_acceptance_tests
+    if: needs.create_release_pr.outputs.pr_created == 'true' && inputs.run_acceptance_tests
     uses: ./.github/workflows/reusable-acceptance-tests.yml
     with:
       ref: ${{ needs.create_release_pr.outputs.pr_head_sha }}

--- a/.github/workflows/update-schemas.yml
+++ b/.github/workflows/update-schemas.yml
@@ -60,7 +60,7 @@ jobs:
   # Run all linting-related checks
   run_lint_checks:
     needs: create_update_pr
-    if: needs.create_update_pr.outputs.pr_created
+    if: needs.create_update_pr.outputs.pr_created == 'true'
     uses: ./.github/workflows/lint.yml
     with:
       ref: ${{ needs.create_update_pr.outputs.pr_head_sha }}
@@ -68,7 +68,7 @@ jobs:
   # Run unit tests
   run_unit_tests:
     needs: create_update_pr
-    if: needs.create_update_pr.outputs.pr_created
+    if: needs.create_update_pr.outputs.pr_created == 'true'
     uses: ./.github/workflows/unit-tests.yml
     with:
       ref: ${{ needs.create_update_pr.outputs.pr_head_sha }}
@@ -76,7 +76,7 @@ jobs:
   # Run dependency review
   run_dependency_review:
     needs: create_update_pr
-    if: needs.create_update_pr.outputs.pr_created
+    if: needs.create_update_pr.outputs.pr_created == 'true'
     uses: ./.github/workflows/dependency-review.yml
     with:
       head_ref: ${{ needs.create_update_pr.outputs.pr_head_sha }}


### PR DESCRIPTION
Resolves: NEX-2798

Prevent `Update Schemas` and `Prepare Release` workflows from validating main and reporting false failures. Otherwise we have such problems: https://github.com/aiven/terraform-provider-aiven/actions/runs/31463076571/job/93690888921
