### PR TITLE
refactor(plugin): flatten resource state polling YAML

### DIFF
--- a/definitions/.schema.yml
+++ b/definitions/.schema.yml
@@ -39,57 +39,66 @@ properties:
         description: |
           Set to true to enable termination protection validation for this resource.
           The `termination_protection` attribute generated automatically.
-      refreshState:
-        type: object
-        additionalProperties: false
-        properties:
-          attribute:
-            type: string
-            minLength: 1
-            default: state
-          desired:
-            type: array
-            minItems: 1
-            uniqueItems: true
-            items:
-              type: string
-          failed:
-            type: array
-            minItems: 1
-            uniqueItems: true
-            items:
-              type: string
-        dependentRequired:
-          attribute:
-            - desired
-          failed:
-            - desired
+      stateAttribute:
+        type: string
+        minLength: 1
         $comment: |
-          Refreshes state after Create and Update. An empty object performs one successful Read,
-          retrying transient 404/403 errors. When conditions are configured, `attribute` selects
-          the computed-only Terraform attribute to check and defaults to `state`. The attribute must
-          reach one of the `desired` values. A match against any `failed` value fails immediately.
-          Values outside both lists are treated as pending and retried until the operation timeout.
+          Terraform attribute polled by refreshStateDesired and deleteStateDesired.
+          Required when either list is set. Must be computed-only when used with refreshStateDesired.
+      refreshStateExists:
+        type: boolean
+        const: true
+        $comment: |
+          Enables a post-Create/Update Read that completes on the first successful Read,
+          retrying transient 404/403 errors. Omit this when refreshStateDesired is set: desired
+          already retries those errors until the resource exists, then waits for the attribute value.
+      refreshStateDesired:
+        type: array
+        minItems: 1
+        uniqueItems: true
+        items:
+          type: string
+        $comment: |
+          Enables a post-Create/Update Read that waits until `stateAttribute` matches any of
+          these values. Transient 404/403 errors are retried until the resource exists
+          (refreshStateExists is implied). Values in neither this list nor refreshStateFailed
+          are treated as pending and retried until the operation timeout.
+      refreshStateFailed:
+        type: array
+        minItems: 1
+        uniqueItems: true
+        items:
+          type: string
+        $comment: |
+          Terminal failure values for `stateAttribute`. A match against any value fails refresh
+          immediately. Requires refreshStateDesired.
       refreshStateDelay:
         type: string
         example: 10s
         $comment: |
-          The duration to sleep after the resource is created/updated.
+          The duration to sleep after the resource is created/updated, before the first refresh Read.
           This is useful to avoid race conditions with the backend.
           For instance, when a new user is created, the backend might hit a read-replica.
           So we sleep for a few seconds to give the backend time to catch up.
+          Requires refreshStateExists or refreshStateDesired.
+      deleteStateGone:
+        type: boolean
+        const: true
+        $comment: |
+          Enables the delete poller and completes when Read returns 404. Delete is re-issued while
+          it errors (for example 409 from dependents still detaching); once Delete succeeds, only
+          Read is polled. Omit this when deleteStateDesired is set: a 404 already completes desired.
       deleteStateDesired:
-        type: object
-        additionalProperties:
+        type: array
+        minItems: 1
+        uniqueItems: true
+        items:
           type: string
         $comment: |
-          Enables the delete poller. Its presence (even as an empty map, `{}`) makes the adapter
-          re-issue Delete on every attempt (ignoring the delete error, so a 409 Conflict from
-          detaching dependents resolves on its own) and poll Read until the resource is gone (404) or
-          every entry here matches. Each entry maps a Terraform attribute name to the terminal value
-          the adapter must observe before treating a Delete as complete; with an empty map a 404 is
-          the only terminal. Values are validated against the field's enum when one is declared.
-          Omit it entirely to delete without polling.
+          Enables the delete poller and completes when `stateAttribute` matches any value here, or
+          when Read returns 404 (deleteStateGone is implied). Delete is re-issued while it errors
+          (for example 409); once Delete succeeds, only Read is polled. Values are validated against
+          the field's enum when one is declared. Omit both to delete without polling.
       removeMissing:
         type: boolean
         $comment: |
@@ -100,7 +109,7 @@ properties:
         $comment: |
           Set to true to treat a 409 Conflict ("already exists") response from Create as success.
           Useful for one-shot provisioning actions that should adopt an existing entity rather than fail on re-run.
-          Requires `refreshState` so the state is populated by the subsequent Read.
+          Requires `refreshStateExists` or `refreshStateDesired` so the state is populated by the subsequent Read.
           Does NOT work for resources whose ID is returned only in the Create response (e.g. server-assigned IDs):
           on conflict there is no response to read the ID from and the subsequent Read has nothing to look up.
       disableExample:
@@ -124,10 +133,34 @@ properties:
           need access to prior state (e.g. forbidding a decrease in a numeric attribute).
           https://developer.hashicorp.com/terraform/plugin/framework/resources/plan-modification#resource-plan-modification
     dependentRequired:
+      refreshStateFailed:
+        - refreshStateDesired
+        - stateAttribute
+      refreshStateDesired:
+        - stateAttribute
+      deleteStateDesired:
+        - stateAttribute
+    dependentSchemas:
       refreshStateDelay:
-        - refreshState
+        anyOf:
+          - required: [refreshStateExists]
+          - required: [refreshStateDesired]
       ignoreAlreadyExists:
-        - refreshState
+        anyOf:
+          - required: [refreshStateExists]
+          - required: [refreshStateDesired]
+      stateAttribute:
+        anyOf:
+          - required: [refreshStateDesired]
+          - required: [deleteStateDesired]
+      refreshStateExists:
+        not:
+          anyOf:
+            - required: [refreshStateDesired]
+            - required: [refreshStateFailed]
+      deleteStateGone:
+        not:
+          required: [deleteStateDesired]
     $comment: |
       Documentation and configuration specific to this resource type.
       Use this to provide clear descriptions for your resource in the Terraform registry.

--- a/definitions/aiven_aws_privatelink.yml
+++ b/definitions/aiven_aws_privatelink.yml
@@ -1,8 +1,8 @@
 # yaml-language-server: $schema=.schema.yml
 location: internal/plugin/service/vpc/awsprivatelink
 resource:
-  refreshState:
-    desired: [active]
+  stateAttribute: state
+  refreshStateDesired: [active]
   removeMissing: true
   description: Creates and manages an [AWS PrivateLink for Aiven services](https://aiven.io/docs/platform/howto/use-aws-privatelinks) in a VPC.
 datasource:

--- a/definitions/aiven_azure_privatelink.yml
+++ b/definitions/aiven_azure_privatelink.yml
@@ -1,11 +1,11 @@
 # yaml-language-server: $schema=.schema.yml
 location: internal/plugin/service/vpc/azureprivatelink
 resource:
-  refreshState:
-    desired: [active]
+  stateAttribute: state
+  refreshStateDesired: [active]
   # ServicePrivatelinkAzureGet never returns state=deleted (the backend filters deleted rows and 404s
   # instead, see privatelink_get), so there is no terminal state to match on: wait until gone (404).
-  deleteStateDesired: {}
+  deleteStateGone: true
   removeMissing: true
   description: Creates and manages an Azure Private Link for [selected Aiven services](https://aiven.io/docs/platform/howto/use-azure-privatelink) in a VPC.
 datasource:

--- a/definitions/aiven_byoc_aws_provision.yml
+++ b/definitions/aiven_byoc_aws_provision.yml
@@ -10,10 +10,9 @@ resource:
 
     Create this resource after the customer-side AWS infrastructure
     (IAM role, VPC, subnets, security groups, buckets) has been defined.
-  refreshState:
-    desired: [active]
-  deleteStateDesired:
-    state: deleted
+  stateAttribute: state
+  refreshStateDesired: [active]
+  deleteStateDesired: [deleted]
 clientHandler: byoc
 idAttributeComposed: [organization_id, custom_cloud_environment_id]
 operations:

--- a/definitions/aiven_byoc_permissions.yml
+++ b/definitions/aiven_byoc_permissions.yml
@@ -11,7 +11,7 @@ resource:
 
     Create this resource after `aiven_byoc_aws_entity` and `aiven_byoc_aws_provision` so the custom cloud environment
     is active before permissions are granted.
-  refreshState: {}
+  refreshStateExists: true
   removeMissing: true
 clientHandler: byoc
 idAttributeComposed: [organization_id, custom_cloud_environment_id]

--- a/definitions/aiven_clickhouse_database.yml
+++ b/definitions/aiven_clickhouse_database.yml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=.schema.yml
 location: internal/plugin/service/clickhouse/database
 resource:
-  refreshState: {}
+  refreshStateExists: true
   removeMissing: true
   terminationProtection: true
   description: |

--- a/definitions/aiven_clickhouse_user.yml
+++ b/definitions/aiven_clickhouse_user.yml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=.schema.yml
 location: internal/plugin/service/clickhouse/user
 resource:
-  refreshState: {}
+  refreshStateExists: true
   removeMissing: true
   description: Creates and manages an Aiven for ClickHouse user.
 datasource:

--- a/definitions/aiven_connection_pool.yml
+++ b/definitions/aiven_connection_pool.yml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=.schema.yml
 location: internal/plugin/service/pg/connectionpool
 resource:
-  refreshState: {}
+  refreshStateExists: true
   removeMissing: true
   description: Creates and manages a [connection pool](https://aiven.io/docs/products/postgresql/concepts/pg-connection-pooling) in an Aiven for PostgreSQL® service.
 datasource:

--- a/definitions/aiven_flink_application.yml
+++ b/definitions/aiven_flink_application.yml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=.schema.yml
 location: internal/plugin/service/flink/application
 resource:
-  refreshState: {}
+  refreshStateExists: true
   removeMissing: true
   description: |
     Creates and manages an [Aiven for Apache Flink® application](https://aiven.io/docs/products/flink/concepts/flink-applications).

--- a/definitions/aiven_flink_application_deployment.yml
+++ b/definitions/aiven_flink_application_deployment.yml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=.schema.yml
 location: internal/plugin/service/flink/deployment
 resource:
-  refreshState: {}
+  refreshStateExists: true
   removeMissing: true
   disableExample: true
   description: Creates and manages the deployment of an Aiven for Apache Flink® application.

--- a/definitions/aiven_flink_jar_application.yml
+++ b/definitions/aiven_flink_jar_application.yml
@@ -3,7 +3,7 @@ location: internal/plugin/service/flink/jarapplication
 beta: true
 limitedAvailability: true
 resource:
-  refreshState: {}
+  refreshStateExists: true
   removeMissing: true
   description: |
     Creates and manages an [Aiven for Apache Flink® jar application](https://aiven.io/docs/products/flink/howto/create-jar-application).

--- a/definitions/aiven_gcp_privatelink.yml
+++ b/definitions/aiven_gcp_privatelink.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=.schema.yml
 location: internal/plugin/service/vpc/gcpprivatelink
 resource:
-  refreshState:
-    desired: [active]
-  deleteStateDesired: {}
+  stateAttribute: state
+  refreshStateDesired: [active]
+  deleteStateGone: true
   removeMissing: true
   description: Creates and manages a Google Private Service Connect for an Aiven service in a VPC.
 datasource:

--- a/definitions/aiven_kafka_acl.yml
+++ b/definitions/aiven_kafka_acl.yml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=.schema.yml
 location: internal/plugin/service/kafka/acl
 resource:
-  refreshState: {}
+  refreshStateExists: true
   removeMissing: true
   description: |
     Creates and manages Aiven [access control lists](https://aiven.io/docs/products/kafka/concepts/acl) (ACLs) for an Aiven for Apache Kafka® service. ACLs control access to Kafka topics, consumer groups, clusters, and Schema Registry.

--- a/definitions/aiven_kafka_native_acl.yml
+++ b/definitions/aiven_kafka_native_acl.yml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=.schema.yml
 location: internal/plugin/service/kafka/nativeacl
 resource:
-  refreshState: {}
+  refreshStateExists: true
   removeMissing: true
   description: |
     Creates and manages Kafka-native [access control lists](https://aiven.io/docs/products/kafka/concepts/acl) (ACLs) for an Aiven for Apache Kafka® service. ACLs control access to Kafka topics, consumer groups, clusters, and Schema Registry.

--- a/definitions/aiven_kafka_schema_registry_acl.yml
+++ b/definitions/aiven_kafka_schema_registry_acl.yml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=.schema.yml
 location: internal/plugin/service/kafkaschema/registryacl
 resource:
-  refreshState: {}
+  refreshStateExists: true
   removeMissing: true
   description: Creates and manages an Aiven for Apache Kafka® Schema Registry ACL entry.
 datasource:

--- a/definitions/aiven_kafka_user.yml
+++ b/definitions/aiven_kafka_user.yml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=.schema.yml
 location: internal/plugin/service/kafka/user
 resource:
-  refreshState: {}
+  refreshStateExists: true
   removeMissing: true
   description: Creates and manages an Aiven for Apache Kafka® service user.
 datasource:

--- a/definitions/aiven_mirrormaker_replication_flow.yml
+++ b/definitions/aiven_mirrormaker_replication_flow.yml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=.schema.yml
 location: internal/plugin/service/kafka/mirrormakerreplicationflow
 resource:
-  refreshState: {}
+  refreshStateExists: true
   removeMissing: true
   description: Creates and manages an [Aiven for Apache Kafka® MirrorMaker 2](https://aiven.io/docs/products/kafka/kafka-mirrormaker) replication flow.
 datasource:

--- a/definitions/aiven_mysql_database.yml
+++ b/definitions/aiven_mysql_database.yml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=.schema.yml
 location: internal/plugin/service/mysql/database
 resource:
-  refreshState: {}
+  refreshStateExists: true
   removeMissing: true
   terminationProtection: true
   description: Creates and manages an [Aiven for MySQL®](https://aiven.io/docs/products/mysql) database.

--- a/definitions/aiven_mysql_user.yml
+++ b/definitions/aiven_mysql_user.yml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=.schema.yml
 location: internal/plugin/service/mysql/user
 resource:
-  refreshState: {}
+  refreshStateExists: true
   removeMissing: true
   description: Creates and manages an Aiven for MySQL® service user.
 datasource:

--- a/definitions/aiven_opensearch_security_plugin_config.yml
+++ b/definitions/aiven_opensearch_security_plugin_config.yml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=.schema.yml
 location: internal/plugin/service/opensearch/securitypluginconfig
 resource:
-  refreshState: {}
+  refreshStateExists: true
   removeMissing: true
   description: |
     Enables and manages [OpenSearch Security for an Aiven for OpenSearch® service](https://aiven.io/docs/products/opensearch/concepts/os-security).

--- a/definitions/aiven_opensearch_user.yml
+++ b/definitions/aiven_opensearch_user.yml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=.schema.yml
 location: internal/plugin/service/opensearch/user
 resource:
-  refreshState: {}
+  refreshStateExists: true
   removeMissing: true
   description: Creates and manages an Aiven for OpenSearch® service user.
 datasource:

--- a/definitions/aiven_organization_application_user_token.yml
+++ b/definitions/aiven_organization_application_user_token.yml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=.schema.yml
 location: internal/plugin/service/organization/applicationusertoken
 resource:
-  refreshState: {}
+  refreshStateExists: true
   description: |
     Creates and manages an application user token.
     Review the [best practices](https://aiven.io/docs/platform/concepts/application-users#security-best-practices) for securing application users and their tokens.

--- a/definitions/aiven_organization_project.yml
+++ b/definitions/aiven_organization_project.yml
@@ -2,7 +2,7 @@
 beta: false # Endpoints are still Experimental in Aiven API
 location: internal/plugin/service/organization/project
 resource:
-  refreshState: {}
+  refreshStateExists: true
   description: Creates and manages an [Aiven project](https://aiven.io/docs/platform/concepts/orgs-units-projects#projects).
 datasource:
   description: Gets information about an Aiven project.

--- a/definitions/aiven_organization_user_group_member.yml
+++ b/definitions/aiven_organization_user_group_member.yml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=.schema.yml
 location: internal/plugin/service/organization/usergroupmember
 resource:
-  refreshState: {} # create and update operations have no response.
+  refreshStateExists: true # create and update operations have no response.
   description: |
     Adds and manages users in a [user group](https://registry.terraform.io/providers/aiven/aiven/latest/docs/resources/organization_user_group).
     You can add organization users and application users to groups.

--- a/definitions/aiven_organization_vpc.yml
+++ b/definitions/aiven_organization_vpc.yml
@@ -1,10 +1,9 @@
 # yaml-language-server: $schema=.schema.yml
 location: internal/plugin/service/vpc/organizationvpc
 resource:
-  refreshState:
-    desired: [ACTIVE]
-  deleteStateDesired:
-    state: DELETED
+  stateAttribute: state
+  refreshStateDesired: [ACTIVE]
+  deleteStateDesired: [DELETED]
   removeMissing: true
   description: Creates and manages a VPC for an Aiven organization.
 datasource:

--- a/definitions/aiven_pg_database.yml
+++ b/definitions/aiven_pg_database.yml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=.schema.yml
 location: internal/plugin/service/pg/database
 resource:
-  refreshState: {}
+  refreshStateExists: true
   removeMissing: true
   terminationProtection: true
   description: Creates and manages an [Aiven for PostgreSQL®](https://aiven.io/docs/products/postgresql) database.

--- a/definitions/aiven_pg_user.yml
+++ b/definitions/aiven_pg_user.yml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=.schema.yml
 location: internal/plugin/service/pg/user
 resource:
-  refreshState: {}
+  refreshStateExists: true
   removeMissing: true
   description: Creates and manages an Aiven for PostgreSQL® service user. The built-in admin user belongs to the service itself. Write-only password management is not supported.
 datasource:

--- a/definitions/aiven_project_vpc.yml
+++ b/definitions/aiven_project_vpc.yml
@@ -1,10 +1,9 @@
 # yaml-language-server: $schema=.schema.yml
 location: internal/plugin/service/vpc/projectvpc
 resource:
-  refreshState:
-    desired: [ACTIVE]
-  deleteStateDesired:
-    state: DELETED
+  stateAttribute: state
+  refreshStateDesired: [ACTIVE]
+  deleteStateDesired: [DELETED]
   removeMissing: true
   description: Creates and manages a VPC for an Aiven project.
 datasource:

--- a/definitions/aiven_static_ip.yml
+++ b/definitions/aiven_static_ip.yml
@@ -5,8 +5,8 @@ resource:
     The aiven_static_ip resource allows the creation and deletion of static ips.
     Please note that once a static ip is in the 'assigned' state it is bound to the node it is assigned to and cannot be deleted or disassociated until the node is recycled.
     Plans that would delete static ips that are in the assigned state will be blocked.
-  refreshState:
-    desired: [created]
+  stateAttribute: state
+  refreshStateDesired: [created]
 clientHandler: staticip
 idAttributeComposed: [project, static_ip_address_id]
 legacyTimeouts: true

--- a/definitions/aiven_valkey_user.yml
+++ b/definitions/aiven_valkey_user.yml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=.schema.yml
 location: internal/plugin/service/valkey/user
 resource:
-  refreshState: {}
+  refreshStateExists: true
   removeMissing: true
   description: Creates and manages an [Aiven for Valkey™](https://aiven.io/docs/products/valkey) service user.
 datasource:

--- a/generators/plugin/item.go
+++ b/generators/plugin/item.go
@@ -131,29 +131,35 @@ type Scope struct {
 	CurrentMeta *SchemaMeta
 }
 
-type RefreshStateCondition struct {
-	Attribute *string  `yaml:"attribute,omitempty"`
-	Desired   []string `yaml:"desired,omitempty"`
-	Failed    []string `yaml:"failed,omitempty"`
-}
-
 // SchemaMeta contains fields to override.
 // Extend this struct if you need to override more fields and update the usage.
 type SchemaMeta struct {
-	Description           string                 `yaml:"description"`
-	DeprecationMessage    string                 `yaml:"deprecationMessage,omitempty"`
-	TerminationProtection bool                   `yaml:"terminationProtection,omitempty"`
-	RefreshState          *RefreshStateCondition `yaml:"refreshState,omitempty"`
-	RefreshStateDelay     time.Duration          `yaml:"refreshStateDelay,omitempty"`
-	// DeleteStateDesired, when non-nil (even as an empty map), enables the delete poller. It maps
-	// Terraform attribute names to the terminal value the poller must observe. See
-	// adapter.DeleteStateOptions.
-	DeleteStateDesired  map[string]string `yaml:"deleteStateDesired,omitempty"`
-	RemoveMissing       bool              `yaml:"removeMissing,omitempty"`
-	IgnoreAlreadyExists bool              `yaml:"ignoreAlreadyExists,omitempty"`
-	DisableExample      bool              `yaml:"disableExample,omitempty"`
-	ValidateConfig      bool              `yaml:"validateConfig,omitempty"`
-	ModifyPlan          bool              `yaml:"modifyPlan,omitempty"`
+	Description           string `yaml:"description"`
+	DeprecationMessage    string `yaml:"deprecationMessage,omitempty"`
+	TerminationProtection bool   `yaml:"terminationProtection,omitempty"`
+	// StateAttribute is the Terraform attribute polled by refreshStateDesired and
+	// deleteStateDesired. Required when either list is set.
+	StateAttribute string `yaml:"stateAttribute,omitempty"`
+	// RefreshStateExists enables a post-Create/Update Read that completes on the first
+	// successful Read. Implied by RefreshStateDesired; omit this when waiting for an attribute value.
+	RefreshStateExists bool `yaml:"refreshStateExists,omitempty"`
+	// RefreshStateDesired enables a post-Create/Update Read that waits until StateAttribute
+	// matches any value. Transient 404/403 errors are retried until the resource exists.
+	// See adapter.RefreshStateCondition.
+	RefreshStateDesired []string      `yaml:"refreshStateDesired,omitempty"`
+	RefreshStateFailed  []string      `yaml:"refreshStateFailed,omitempty"`
+	RefreshStateDelay   time.Duration `yaml:"refreshStateDelay,omitempty"`
+	// DeleteStateGone enables the delete poller and completes when Read returns 404.
+	// Implied by DeleteStateDesired (a 404 also completes); omit this when waiting for an attribute value.
+	DeleteStateGone bool `yaml:"deleteStateGone,omitempty"`
+	// DeleteStateDesired enables the delete poller and waits until StateAttribute matches any
+	// value. A 404 also completes. See adapter.DeleteStateOptions.
+	DeleteStateDesired  []string `yaml:"deleteStateDesired,omitempty"`
+	RemoveMissing       bool     `yaml:"removeMissing,omitempty"`
+	IgnoreAlreadyExists bool     `yaml:"ignoreAlreadyExists,omitempty"`
+	DisableExample      bool     `yaml:"disableExample,omitempty"`
+	ValidateConfig      bool     `yaml:"validateConfig,omitempty"`
+	ModifyPlan          bool     `yaml:"modifyPlan,omitempty"`
 
 	// SchemaOverride is a datasource-only schema overlay merged on top of the
 	// base Definition.Schema when generating the datasource. Resource

--- a/generators/plugin/views.go
+++ b/generators/plugin/views.go
@@ -13,17 +13,16 @@ import (
 )
 
 const (
-	viewSuffix                   = "View"
-	optionsSuffix                = "Options"
-	configValidatorsFuncSuffix   = "ConfigValidators"
-	planModifier                 = "planModifier"
-	validateConfig               = "validateConfig"
-	modifyPlan                   = "modifyPlan"
-	resourceData                 = "ResourceData"
-	renameFieldsModifier         = "RenameFields"
-	flattenModifier              = "flattenModifier"
-	expandModifier               = "expandModifier"
-	defaultRefreshStateAttribute = "state"
+	viewSuffix                 = "View"
+	optionsSuffix              = "Options"
+	configValidatorsFuncSuffix = "ConfigValidators"
+	planModifier               = "planModifier"
+	validateConfig             = "validateConfig"
+	modifyPlan                 = "modifyPlan"
+	resourceData               = "ResourceData"
+	renameFieldsModifier       = "RenameFields"
+	flattenModifier            = "flattenModifier"
+	expandModifier             = "expandModifier"
 )
 
 // genViews generates CRUD views for the resource, skips disabled or undefined operations.
@@ -99,56 +98,82 @@ func genNewResource(entity entityType, def *Definition, item *Item, hasConfigVal
 	}
 
 	if entity.isResource() {
-		if refreshState := def.Resource.RefreshState; refreshState != nil {
-			fields := jen.Dict{}
-			hasCondition := refreshState.Desired != nil || refreshState.Failed != nil
-			if refreshState.Attribute != nil && *refreshState.Attribute == "" {
-				return nil, errors.New("refreshState: attribute cannot be empty")
-			}
-			if refreshState.Attribute != nil && !hasCondition {
-				return nil, errors.New("refreshState: attribute requires desired")
-			}
-			if hasCondition {
-				attribute := defaultRefreshStateAttribute
-				if refreshState.Attribute != nil {
-					attribute = *refreshState.Attribute
-				}
+		res := def.Resource
+		if res.RefreshStateDesired != nil && len(res.RefreshStateDesired) == 0 {
+			return nil, errors.New("refreshStateDesired must not be empty; use refreshStateExists")
+		}
+		if res.RefreshStateFailed != nil && len(res.RefreshStateFailed) == 0 {
+			return nil, errors.New("refreshStateFailed must not be empty")
+		}
+		if res.DeleteStateDesired != nil && len(res.DeleteStateDesired) == 0 {
+			return nil, errors.New("deleteStateDesired must not be empty; use deleteStateGone")
+		}
+		if res.RefreshStateExists && len(res.RefreshStateDesired) > 0 {
+			return nil, errors.New("refreshStateExists is implied by refreshStateDesired; omit refreshStateExists")
+		}
+		if res.DeleteStateGone && len(res.DeleteStateDesired) > 0 {
+			return nil, errors.New("deleteStateGone is implied by deleteStateDesired; omit deleteStateGone")
+		}
 
-				prop, ok := item.Properties[attribute]
-				if !ok {
-					return nil, fmt.Errorf("refreshState: unknown attribute %q (not present in schema)", attribute)
+		hasRefresh := res.RefreshStateExists || len(res.RefreshStateDesired) > 0
+		hasDelete := res.DeleteStateGone || len(res.DeleteStateDesired) > 0
+		if len(res.RefreshStateFailed) > 0 && len(res.RefreshStateDesired) == 0 {
+			return nil, errors.New("refreshStateFailed requires refreshStateDesired")
+		}
+		if !hasRefresh {
+			if res.RefreshStateDelay != 0 {
+				return nil, errors.New("refreshStateDelay requires refreshStateExists or refreshStateDesired")
+			}
+			if res.IgnoreAlreadyExists {
+				return nil, errors.New("ignoreAlreadyExists requires refreshStateExists or refreshStateDesired")
+			}
+		}
+
+		needsStateAttribute := len(res.RefreshStateDesired) > 0 || len(res.RefreshStateFailed) > 0 || len(res.DeleteStateDesired) > 0
+		if res.StateAttribute != "" && !needsStateAttribute {
+			return nil, errors.New("stateAttribute requires refreshStateDesired or deleteStateDesired")
+		}
+		if needsStateAttribute && res.StateAttribute == "" {
+			return nil, errors.New("stateAttribute is required")
+		}
+
+		var stateProp *Item
+		if res.StateAttribute != "" {
+			var ok bool
+			stateProp, ok = item.Properties[res.StateAttribute]
+			if !ok {
+				return nil, fmt.Errorf("stateAttribute %q is not present in schema", res.StateAttribute)
+			}
+		}
+
+		if hasRefresh {
+			fields := jen.Dict{}
+			if len(res.RefreshStateDesired) > 0 {
+				if !stateProp.IsComputed(def, entity) || !stateProp.IsReadOnly(def, entity) {
+					return nil, fmt.Errorf("stateAttribute %q must be computed-only", res.StateAttribute)
 				}
-				if !prop.IsComputed(def, entity) || !prop.IsReadOnly(def, entity) {
-					return nil, fmt.Errorf("refreshState: attribute %q must be computed-only", attribute)
-				}
-				if len(refreshState.Desired) == 0 {
-					return nil, fmt.Errorf("refreshState: attribute %q must define at least one desired value", attribute)
-				}
-				if refreshState.Failed != nil && len(refreshState.Failed) == 0 {
-					return nil, fmt.Errorf("refreshState: attribute %q has an empty failed list", attribute)
-				}
-				if err := validateRefreshStateValues(attribute, "desired", refreshState.Desired, prop); err != nil {
+				if err := validateStateAttributeValues(res.StateAttribute, "refreshStateDesired", res.RefreshStateDesired, stateProp); err != nil {
 					return nil, err
 				}
-				if err := validateRefreshStateValues(attribute, "failed", refreshState.Failed, prop); err != nil {
+				if err := validateStateAttributeValues(res.StateAttribute, "refreshStateFailed", res.RefreshStateFailed, stateProp); err != nil {
 					return nil, err
 				}
-				for _, failed := range refreshState.Failed {
-					if slices.Contains(refreshState.Desired, failed) {
+				for _, failed := range res.RefreshStateFailed {
+					if slices.Contains(res.RefreshStateDesired, failed) {
 						return nil, fmt.Errorf(
-							"refreshState: attribute %q value %q cannot be both desired and failed",
-							attribute,
+							"stateAttribute %q value %q cannot be both refreshStateDesired and refreshStateFailed",
+							res.StateAttribute,
 							failed,
 						)
 					}
 				}
 
 				fields = jen.Dict{
-					jen.Id("Attribute"): jen.Lit(attribute),
-					jen.Id("Desired"):   stringSliceLiteral(refreshState.Desired),
+					jen.Id("Attribute"): jen.Lit(res.StateAttribute),
+					jen.Id("Desired"):   stringSliceLiteral(res.RefreshStateDesired),
 				}
-				if len(refreshState.Failed) > 0 {
-					fields[jen.Id("Failed")] = stringSliceLiteral(refreshState.Failed)
+				if len(res.RefreshStateFailed) > 0 {
+					fields[jen.Id("Failed")] = stringSliceLiteral(res.RefreshStateFailed)
 				}
 			}
 
@@ -156,36 +181,19 @@ func genNewResource(entity entityType, def *Definition, item *Item, hasConfigVal
 				Qual(adapterPackage, "RefreshStateCondition").
 				Values(fields)
 
-			if def.Resource.RefreshStateDelay != 0 {
-				values["RefreshStateDelay"] = jen.Qual(adapterPackage, "MustParseDuration").Call(jen.Lit(def.Resource.RefreshStateDelay.String()))
-			}
-		} else {
-			if def.Resource.RefreshStateDelay != 0 {
-				return nil, errors.New("refreshStateDelay requires refreshState")
-			}
-			if def.Resource.IgnoreAlreadyExists {
-				return nil, errors.New("ignoreAlreadyExists requires refreshState")
+			if res.RefreshStateDelay != 0 {
+				values["RefreshStateDelay"] = jen.Qual(adapterPackage, "MustParseDuration").Call(jen.Lit(res.RefreshStateDelay.String()))
 			}
 		}
 
-		// A non-nil deleteStateDesired (even an empty map) enables the delete poller.
-		if dsd := def.Resource.DeleteStateDesired; dsd != nil {
-			desired := make(jen.Dict, len(dsd))
-			for _, k := range sortedKeys(dsd) {
-				want := dsd[k]
-				prop, ok := item.Properties[k]
-				if !ok {
-					return nil, fmt.Errorf("deleteStateDesired: unknown field %q (not present in schema)", k)
-				}
-				if prop.IsEnum() && !enumContainsString(prop.Enum, want) {
-					return nil, fmt.Errorf("deleteStateDesired: field %q has enum %v but desired value %q is not allowed", k, prop.Enum, want)
-				}
-				desired[jen.Lit(k)] = jen.Lit(want)
-			}
-
+		if hasDelete {
 			fields := jen.Dict{}
-			if len(desired) > 0 {
-				fields[jen.Id("Desired")] = jen.Map(jen.String()).String().Values(desired)
+			if len(res.DeleteStateDesired) > 0 {
+				if err := validateStateAttributeValues(res.StateAttribute, "deleteStateDesired", res.DeleteStateDesired, stateProp); err != nil {
+					return nil, err
+				}
+				fields[jen.Id("Attribute")] = jen.Lit(res.StateAttribute)
+				fields[jen.Id("Desired")] = stringSliceLiteral(res.DeleteStateDesired)
 			}
 			values["DeleteState"] = jen.Op("&").Qual(adapterPackage, "DeleteStateOptions").Values(fields)
 		}
@@ -220,20 +228,20 @@ func genNewResource(entity entityType, def *Definition, item *Item, hasConfigVal
 	return jen.Var().Id(title).Op("=").Add(returnValue), nil
 }
 
-func validateRefreshStateValues(attribute, kind string, values []string, prop *Item) error {
+func validateStateAttributeValues(field, kind string, values []string, prop *Item) error {
 	seen := make(map[string]struct{}, len(values))
 	for _, value := range values {
 		if _, ok := seen[value]; ok {
-			return fmt.Errorf("refreshState: attribute %q has duplicate %s value %q", attribute, kind, value)
+			return fmt.Errorf("%s: %q has duplicate value %q", kind, field, value)
 		}
 		seen[value] = struct{}{}
 
 		if prop.IsEnum() && !enumContainsString(prop.Enum, value) {
 			return fmt.Errorf(
-				"refreshState: attribute %q has enum %v but %s value %q is not allowed",
-				attribute,
-				prop.Enum,
+				"%s: %q has enum %v but value %q is not allowed",
 				kind,
+				field,
+				prop.Enum,
 				value,
 			)
 		}

--- a/generators/plugin/views_test.go
+++ b/generators/plugin/views_test.go
@@ -12,13 +12,8 @@ import (
 )
 
 func TestGenNewResourceRefreshStateValidation(t *testing.T) {
-	attribute := func(value string) *string { return &value }
-	newDef := func(refreshState *RefreshStateCondition) *Definition {
-		return &Definition{
-			Resource: &SchemaMeta{
-				RefreshState: refreshState,
-			},
-		}
+	newDef := func(meta SchemaMeta) *Definition {
+		return &Definition{Resource: &meta}
 	}
 	newItem := func(properties map[string]*Item) *Item {
 		item := &Item{Properties: properties}
@@ -38,8 +33,8 @@ func TestGenNewResourceRefreshStateValidation(t *testing.T) {
 		require.NotContains(t, renderCode(t, code), "RefreshState:")
 	})
 
-	t.Run("an empty refreshState enables refresh without conditions", func(t *testing.T) {
-		code, err := genNewResource(resourceType, newDef(&RefreshStateCondition{}), newItem(nil), false)
+	t.Run("refreshStateExists enables refresh without conditions", func(t *testing.T) {
+		code, err := genNewResource(resourceType, newDef(SchemaMeta{RefreshStateExists: true}), newItem(nil), false)
 		require.NoError(t, err)
 		require.Contains(t, renderCode(t, code), "&adapter.RefreshStateCondition{}")
 	})
@@ -54,9 +49,10 @@ func TestGenNewResourceRefreshStateValidation(t *testing.T) {
 			},
 		})
 
-		code, err := genNewResource(resourceType, newDef(&RefreshStateCondition{
-			Desired: []string{"ACTIVE", "PENDING_PEER"},
-			Failed:  []string{"ERROR"},
+		code, err := genNewResource(resourceType, newDef(SchemaMeta{
+			StateAttribute:      "state",
+			RefreshStateDesired: []string{"ACTIVE", "PENDING_PEER"},
+			RefreshStateFailed:  []string{"ERROR"},
 		}), item, false)
 		require.NoError(t, err)
 		got := renderCode(t, code)
@@ -68,14 +64,14 @@ func TestGenNewResourceRefreshStateValidation(t *testing.T) {
 		require.Contains(t, got, `[]string{"ERROR"}`)
 	})
 
-	t.Run("generates a custom attribute", func(t *testing.T) {
+	t.Run("generates a custom state field", func(t *testing.T) {
 		item := newItem(map[string]*Item{
 			"status": {Name: "status", Type: SchemaTypeString, Computed: true},
 		})
 
-		code, err := genNewResource(resourceType, newDef(&RefreshStateCondition{
-			Attribute: attribute("status"),
-			Desired:   []string{"ACTIVE"},
+		code, err := genNewResource(resourceType, newDef(SchemaMeta{
+			StateAttribute:      "status",
+			RefreshStateDesired: []string{"ACTIVE"},
 		}), item, false)
 		require.NoError(t, err)
 		got := renderCode(t, code)
@@ -84,12 +80,20 @@ func TestGenNewResourceRefreshStateValidation(t *testing.T) {
 		require.Contains(t, got, `[]string{"ACTIVE"}`)
 	})
 
-	t.Run("rejects conditions when the default attribute is missing", func(t *testing.T) {
-		_, err := genNewResource(resourceType, newDef(&RefreshStateCondition{
-			Desired: []string{"ACTIVE"},
+	t.Run("rejects conditions without stateAttribute", func(t *testing.T) {
+		_, err := genNewResource(resourceType, newDef(SchemaMeta{
+			RefreshStateDesired: []string{"ACTIVE"},
+		}), stringItem(), false)
+		require.EqualError(t, err, "stateAttribute is required")
+	})
+
+	t.Run("rejects an unknown stateAttribute", func(t *testing.T) {
+		_, err := genNewResource(resourceType, newDef(SchemaMeta{
+			StateAttribute:      "state",
+			RefreshStateDesired: []string{"ACTIVE"},
 		}), newItem(nil), false)
 		require.Error(t, err)
-		require.Contains(t, err.Error(), `refreshState: unknown attribute "state"`)
+		require.Contains(t, err.Error(), `stateAttribute "state" is not present in schema`)
 	})
 
 	t.Run("rejects configurable fields", func(t *testing.T) {
@@ -108,41 +112,54 @@ func TestGenNewResourceRefreshStateValidation(t *testing.T) {
 		} {
 			t.Run(name, func(t *testing.T) {
 				item := newItem(map[string]*Item{"state": field})
-				_, err := genNewResource(resourceType, newDef(&RefreshStateCondition{
-					Desired: []string{"ACTIVE"},
+				_, err := genNewResource(resourceType, newDef(SchemaMeta{
+					StateAttribute:      "state",
+					RefreshStateDesired: []string{"ACTIVE"},
 				}), item, false)
-				require.EqualError(t, err, `refreshState: attribute "state" must be computed-only`)
+				require.EqualError(t, err, `stateAttribute "state" must be computed-only`)
 			})
 		}
 	})
 
-	t.Run("rejects an empty or unused attribute", func(t *testing.T) {
-		_, err := genNewResource(resourceType, newDef(&RefreshStateCondition{
-			Attribute: attribute(""),
-			Desired:   []string{"ACTIVE"},
+	t.Run("rejects an unused stateAttribute", func(t *testing.T) {
+		_, err := genNewResource(resourceType, newDef(SchemaMeta{
+			StateAttribute:     "state",
+			RefreshStateExists: true,
 		}), stringItem(), false)
-		require.EqualError(t, err, "refreshState: attribute cannot be empty")
-
-		_, err = genNewResource(resourceType, newDef(&RefreshStateCondition{
-			Attribute: attribute("status"),
-		}), stringItem(), false)
-		require.EqualError(t, err, "refreshState: attribute requires desired")
+		require.EqualError(t, err, "stateAttribute requires refreshStateDesired or deleteStateDesired")
 	})
 
 	t.Run("rejects a condition without desired values", func(t *testing.T) {
-		_, err := genNewResource(resourceType, newDef(&RefreshStateCondition{
-			Failed: []string{"ERROR"},
+		_, err := genNewResource(resourceType, newDef(SchemaMeta{
+			StateAttribute:     "state",
+			RefreshStateFailed: []string{"ERROR"},
 		}), stringItem(), false)
-		require.Error(t, err)
-		require.Contains(t, err.Error(), `attribute "state" must define at least one desired value`)
+		require.EqualError(t, err, "refreshStateFailed requires refreshStateDesired")
+	})
+
+	t.Run("rejects an empty desired list", func(t *testing.T) {
+		_, err := genNewResource(resourceType, newDef(SchemaMeta{
+			RefreshStateDesired: []string{},
+		}), stringItem(), false)
+		require.EqualError(t, err, "refreshStateDesired must not be empty; use refreshStateExists")
+	})
+
+	t.Run("rejects combining exists with desired", func(t *testing.T) {
+		_, err := genNewResource(resourceType, newDef(SchemaMeta{
+			StateAttribute:      "state",
+			RefreshStateExists:  true,
+			RefreshStateDesired: []string{"ACTIVE"},
+		}), stringItem(), false)
+		require.EqualError(t, err, "refreshStateExists is implied by refreshStateDesired; omit refreshStateExists")
 	})
 
 	t.Run("rejects an explicitly empty failed list", func(t *testing.T) {
-		_, err := genNewResource(resourceType, newDef(&RefreshStateCondition{
-			Desired: []string{"ACTIVE"}, Failed: []string{},
+		_, err := genNewResource(resourceType, newDef(SchemaMeta{
+			StateAttribute:      "state",
+			RefreshStateDesired: []string{"ACTIVE"},
+			RefreshStateFailed:  []string{},
 		}), stringItem(), false)
-		require.Error(t, err)
-		require.Contains(t, err.Error(), `attribute "state" has an empty failed list`)
+		require.EqualError(t, err, "refreshStateFailed must not be empty")
 	})
 
 	t.Run("rejects desired and failed values outside the field enum", func(t *testing.T) {
@@ -155,38 +172,47 @@ func TestGenNewResourceRefreshStateValidation(t *testing.T) {
 			},
 		})
 
-		_, err := genNewResource(resourceType, newDef(&RefreshStateCondition{
-			Desired: []string{"PENDING"},
+		_, err := genNewResource(resourceType, newDef(SchemaMeta{
+			StateAttribute:      "state",
+			RefreshStateDesired: []string{"PENDING"},
 		}), item, false)
 		require.Error(t, err)
-		require.Contains(t, err.Error(), `refreshState: attribute "state"`)
-		require.Contains(t, err.Error(), `desired value "PENDING" is not allowed`)
+		require.Contains(t, err.Error(), `refreshStateDesired: "state"`)
+		require.Contains(t, err.Error(), `value "PENDING" is not allowed`)
 
-		_, err = genNewResource(resourceType, newDef(&RefreshStateCondition{
-			Desired: []string{"ACTIVE"}, Failed: []string{"ERROR"},
+		_, err = genNewResource(resourceType, newDef(SchemaMeta{
+			StateAttribute:      "state",
+			RefreshStateDesired: []string{"ACTIVE"},
+			RefreshStateFailed:  []string{"ERROR"},
 		}), item, false)
 		require.Error(t, err)
-		require.Contains(t, err.Error(), `failed value "ERROR" is not allowed`)
+		require.Contains(t, err.Error(), `refreshStateFailed: "state"`)
+		require.Contains(t, err.Error(), `value "ERROR" is not allowed`)
 	})
 
 	t.Run("rejects duplicate and overlapping values", func(t *testing.T) {
-		_, err := genNewResource(resourceType, newDef(&RefreshStateCondition{
-			Desired: []string{"ACTIVE", "ACTIVE"},
+		_, err := genNewResource(resourceType, newDef(SchemaMeta{
+			StateAttribute:      "state",
+			RefreshStateDesired: []string{"ACTIVE", "ACTIVE"},
 		}), stringItem(), false)
 		require.Error(t, err)
-		require.Contains(t, err.Error(), `duplicate desired value "ACTIVE"`)
+		require.Contains(t, err.Error(), `duplicate value "ACTIVE"`)
 
-		_, err = genNewResource(resourceType, newDef(&RefreshStateCondition{
-			Desired: []string{"ACTIVE"}, Failed: []string{"ERROR", "ERROR"},
+		_, err = genNewResource(resourceType, newDef(SchemaMeta{
+			StateAttribute:      "state",
+			RefreshStateDesired: []string{"ACTIVE"},
+			RefreshStateFailed:  []string{"ERROR", "ERROR"},
 		}), stringItem(), false)
 		require.Error(t, err)
-		require.Contains(t, err.Error(), `duplicate failed value "ERROR"`)
+		require.Contains(t, err.Error(), `duplicate value "ERROR"`)
 
-		_, err = genNewResource(resourceType, newDef(&RefreshStateCondition{
-			Desired: []string{"ACTIVE"}, Failed: []string{"ACTIVE"},
+		_, err = genNewResource(resourceType, newDef(SchemaMeta{
+			StateAttribute:      "state",
+			RefreshStateDesired: []string{"ACTIVE"},
+			RefreshStateFailed:  []string{"ACTIVE"},
 		}), stringItem(), false)
 		require.Error(t, err)
-		require.Contains(t, err.Error(), `value "ACTIVE" cannot be both desired and failed`)
+		require.Contains(t, err.Error(), `value "ACTIVE" cannot be both refreshStateDesired and refreshStateFailed`)
 	})
 
 	t.Run("compares enum values via fmt.Sprint so non-string enums match string desired", func(t *testing.T) {
@@ -200,8 +226,10 @@ func TestGenNewResourceRefreshStateValidation(t *testing.T) {
 			},
 		})
 
-		code, err := genNewResource(resourceType, newDef(&RefreshStateCondition{
-			Desired: []string{"7"}, Failed: []string{"42"},
+		code, err := genNewResource(resourceType, newDef(SchemaMeta{
+			StateAttribute:      "state",
+			RefreshStateDesired: []string{"7"},
+			RefreshStateFailed:  []string{"42"},
 		}), item, false)
 		require.NoError(t, err)
 		got := renderCode(t, code)
@@ -211,25 +239,28 @@ func TestGenNewResourceRefreshStateValidation(t *testing.T) {
 		require.Contains(t, got, `[]string{"42"}`)
 	})
 
-	t.Run("generates refreshStateDelay with refreshState", func(t *testing.T) {
-		def := newDef(&RefreshStateCondition{Desired: []string{"ACTIVE"}})
-		def.Resource.RefreshStateDelay = 15 * time.Second
+	t.Run("generates refreshStateDelay with refreshStateDesired", func(t *testing.T) {
+		def := newDef(SchemaMeta{
+			StateAttribute:      "state",
+			RefreshStateDesired: []string{"ACTIVE"},
+			RefreshStateDelay:   15 * time.Second,
+		})
 
 		code, err := genNewResource(resourceType, def, stringItem(), false)
 		require.NoError(t, err)
 		require.Contains(t, renderCode(t, code), `RefreshStateDelay: adapter.MustParseDuration("15s")`)
 	})
 
-	t.Run("rejects dependent settings without refreshState", func(t *testing.T) {
+	t.Run("rejects dependent settings without a refresh", func(t *testing.T) {
 		_, err := genNewResource(resourceType, &Definition{
 			Resource: &SchemaMeta{RefreshStateDelay: 10},
 		}, stringItem(), false)
-		require.EqualError(t, err, "refreshStateDelay requires refreshState")
+		require.EqualError(t, err, "refreshStateDelay requires refreshStateExists or refreshStateDesired")
 
 		_, err = genNewResource(resourceType, &Definition{
 			Resource: &SchemaMeta{IgnoreAlreadyExists: true},
 		}, stringItem(), false)
-		require.EqualError(t, err, "ignoreAlreadyExists requires refreshState")
+		require.EqualError(t, err, "ignoreAlreadyExists requires refreshStateExists or refreshStateDesired")
 	})
 }
 
@@ -245,36 +276,36 @@ func TestSchemaMetaRefreshStateYAML(t *testing.T) {
 	t.Run("omitted", func(t *testing.T) {
 		def, err := decode(t, "resource: {}\n")
 		require.NoError(t, err)
-		require.Nil(t, def.Resource.RefreshState)
+		require.False(t, def.Resource.RefreshStateExists)
+		require.Nil(t, def.Resource.RefreshStateDesired)
+		require.Nil(t, def.Resource.RefreshStateFailed)
+		require.Empty(t, def.Resource.StateAttribute)
 	})
 
-	t.Run("empty", func(t *testing.T) {
-		def, err := decode(t, "resource:\n  refreshState: {}\n")
+	t.Run("exists", func(t *testing.T) {
+		def, err := decode(t, "resource:\n  refreshStateExists: true\n")
 		require.NoError(t, err)
-		require.NotNil(t, def.Resource.RefreshState)
-		require.Nil(t, def.Resource.RefreshState.Attribute)
-		require.Nil(t, def.Resource.RefreshState.Desired)
-		require.Nil(t, def.Resource.RefreshState.Failed)
+		require.True(t, def.Resource.RefreshStateExists)
+		require.Nil(t, def.Resource.RefreshStateDesired)
 	})
 
 	t.Run("configured", func(t *testing.T) {
-		def, err := decode(t, "resource:\n  refreshState:\n    desired: [ACTIVE]\n    failed: [ERROR]\n")
+		def, err := decode(t, "resource:\n  stateAttribute: state\n  refreshStateDesired: [ACTIVE]\n  refreshStateFailed: [ERROR]\n")
 		require.NoError(t, err)
-		require.Nil(t, def.Resource.RefreshState.Attribute)
-		require.Equal(t, []string{"ACTIVE"}, def.Resource.RefreshState.Desired)
-		require.Equal(t, []string{"ERROR"}, def.Resource.RefreshState.Failed)
+		require.Equal(t, "state", def.Resource.StateAttribute)
+		require.Equal(t, []string{"ACTIVE"}, def.Resource.RefreshStateDesired)
+		require.Equal(t, []string{"ERROR"}, def.Resource.RefreshStateFailed)
 	})
 
-	t.Run("custom attribute", func(t *testing.T) {
-		def, err := decode(t, "resource:\n  refreshState:\n    attribute: status\n    desired: [ACTIVE]\n")
+	t.Run("custom state field", func(t *testing.T) {
+		def, err := decode(t, "resource:\n  stateAttribute: status\n  refreshStateDesired: [ACTIVE]\n")
 		require.NoError(t, err)
-		require.NotNil(t, def.Resource.RefreshState.Attribute)
-		require.Equal(t, "status", *def.Resource.RefreshState.Attribute)
+		require.Equal(t, "status", def.Resource.StateAttribute)
 	})
 
 	t.Run("rejects the old nested form", func(t *testing.T) {
-		_, err := decode(t, "resource:\n  refreshState:\n    state:\n      desired: [ACTIVE]\n")
-		require.ErrorContains(t, err, "field state not found")
+		_, err := decode(t, "resource:\n  refreshState:\n    attribute: state\n    desired: [ACTIVE]\n")
+		require.ErrorContains(t, err, "field refreshState not found")
 	})
 }
 
@@ -287,20 +318,25 @@ func TestGenNewResourceDeleteStateValidation(t *testing.T) {
 			"state": {Name: "state", Type: SchemaTypeString, Enum: vals},
 		}}
 	}
-	newDef := func(dsd map[string]string) *Definition {
-		return &Definition{Resource: &SchemaMeta{DeleteStateDesired: dsd}}
+	newDef := func(desired []string) *Definition {
+		meta := SchemaMeta{DeleteStateDesired: desired}
+		if len(desired) > 0 {
+			meta.StateAttribute = "state"
+		}
+		return &Definition{Resource: &meta}
 	}
 
 	t.Run("desired conditions generate the poller", func(t *testing.T) {
-		code, err := genNewResource(resourceType, newDef(map[string]string{"state": "DELETED"}), stringItem(), false)
+		code, err := genNewResource(resourceType, newDef([]string{"DELETED"}), stringItem(), false)
 		require.NoError(t, err)
 		got := renderCode(t, code)
 		require.Contains(t, got, "DeleteStateOptions{")
-		require.Contains(t, got, `map[string]string{"state": "DELETED"}`)
+		require.Contains(t, got, `Attribute: "state"`)
+		require.Contains(t, got, `[]string{"DELETED"}`)
 	})
 
-	t.Run("an empty map enables the poller (404-only)", func(t *testing.T) {
-		code, err := genNewResource(resourceType, newDef(map[string]string{}), stringItem(), false)
+	t.Run("deleteStateGone enables the poller (404-only)", func(t *testing.T) {
+		code, err := genNewResource(resourceType, &Definition{Resource: &SchemaMeta{DeleteStateGone: true}}, stringItem(), false)
 		require.NoError(t, err)
 		got := renderCode(t, code)
 		require.Contains(t, got, "&adapter.DeleteStateOptions{}")
@@ -315,23 +351,49 @@ func TestGenNewResourceDeleteStateValidation(t *testing.T) {
 	})
 
 	t.Run("accepts a desired value that is in the field's enum", func(t *testing.T) {
-		code, err := genNewResource(resourceType, newDef(map[string]string{"state": "DELETED"}), enumItem("ACTIVE", "DELETING", "DELETED"), false)
+		code, err := genNewResource(resourceType, newDef([]string{"DELETED"}), enumItem("ACTIVE", "DELETING", "DELETED"), false)
 		require.NoError(t, err)
 		got := renderCode(t, code)
-		require.Contains(t, got, `map[string]string{"state": "DELETED"}`)
+		require.Contains(t, got, `[]string{"DELETED"}`)
 	})
 
 	t.Run("rejects a desired value outside the field's enum", func(t *testing.T) {
-		_, err := genNewResource(resourceType, newDef(map[string]string{"state": "deleted"}), enumItem("active", "creating", "deleting"), false)
+		_, err := genNewResource(resourceType, newDef([]string{"deleted"}), enumItem("active", "creating", "deleting"), false)
 		require.Error(t, err)
-		require.Contains(t, err.Error(), `deleteStateDesired: field "state"`)
-		require.Contains(t, err.Error(), `desired value "deleted" is not allowed`)
+		require.Contains(t, err.Error(), `deleteStateDesired: "state"`)
+		require.Contains(t, err.Error(), `value "deleted" is not allowed`)
 	})
 
-	t.Run("rejects a desired key that does not exist in the schema", func(t *testing.T) {
-		_, err := genNewResource(resourceType, newDef(map[string]string{"missing": "DELETED"}), stringItem(), false)
+	t.Run("rejects a stateAttribute that does not exist in the schema", func(t *testing.T) {
+		_, err := genNewResource(resourceType, &Definition{Resource: &SchemaMeta{
+			StateAttribute:     "missing",
+			DeleteStateDesired: []string{"DELETED"},
+		}}, stringItem(), false)
 		require.Error(t, err)
-		require.Contains(t, err.Error(), `deleteStateDesired: unknown field "missing"`)
+		require.Contains(t, err.Error(), `stateAttribute "missing" is not present in schema`)
+	})
+
+	t.Run("rejects delete values without stateAttribute", func(t *testing.T) {
+		_, err := genNewResource(resourceType, &Definition{Resource: &SchemaMeta{
+			DeleteStateDesired: []string{"DELETED"},
+		}}, stringItem(), false)
+		require.EqualError(t, err, "stateAttribute is required")
+	})
+
+	t.Run("rejects an empty desired list", func(t *testing.T) {
+		_, err := genNewResource(resourceType, &Definition{Resource: &SchemaMeta{
+			DeleteStateDesired: []string{},
+		}}, stringItem(), false)
+		require.EqualError(t, err, "deleteStateDesired must not be empty; use deleteStateGone")
+	})
+
+	t.Run("rejects combining gone with desired", func(t *testing.T) {
+		_, err := genNewResource(resourceType, &Definition{Resource: &SchemaMeta{
+			StateAttribute:     "state",
+			DeleteStateGone:    true,
+			DeleteStateDesired: []string{"DELETED"},
+		}}, stringItem(), false)
+		require.EqualError(t, err, "deleteStateGone is implied by deleteStateDesired; omit deleteStateGone")
 	})
 }
 

--- a/internal/plugin/adapter/resource.go
+++ b/internal/plugin/adapter/resource.go
@@ -48,9 +48,9 @@ type ResourceOptions struct {
 	// Example: ["project_id", "instance_name"] == "project-123/instance-456"
 	IDFields []string
 
-	// RefreshState enables Read after Create and Update when non-nil. An empty condition performs a
-	// post-operation Read without checking an attribute. Otherwise, Attribute must reach one of its
-	// Desired values; any Failed value terminates refresh with an error.
+	// RefreshState enables Read after Create and Update when non-nil. 404/403 are retried until
+	// the resource exists. An empty condition then completes; otherwise Attribute must reach one
+	// of its Desired values, and any Failed value terminates refresh with an error.
 	RefreshState *RefreshStateCondition
 
 	// Time to wait after creating or updating the resource to let the backend catch up.
@@ -530,13 +530,16 @@ func (a *resourceAdapter) Delete(
 	}
 }
 
-// DeleteStateOptions configures the delete poller. When set (non-nil) on ResourceOptions, Delete
-// re-issues Delete on every attempt (ignoring its error) and polls Read until the resource reaches
-// its terminal state. See deleteState.
+// DeleteStateOptions configures the delete poller. When non-nil, Delete runs deleteState:
+// Delete is issued until it succeeds once, then Read is polled until 404 or a Desired value.
+// See deleteState.
 type DeleteStateOptions struct {
-	// Desired maps attribute names to the terminal value the poller must observe after Delete. Empty
-	// means there are no attribute conditions, so the poll completes only once the resource is gone (404).
-	Desired map[string]string
+	// Attribute is the Terraform attribute to check after Delete. Required when Desired is non-empty.
+	Attribute string
+	// Desired contains successful terminal attribute values. A match against any value completes
+	// the delete. Empty means there are no attribute conditions, so the poll completes only once
+	// the resource is gone (404).
+	Desired []string
 
 	// retryDelay is the fixed delay between attempts. Zero falls back to defaultDeleteStateRetryDelay.
 	// Unexported: intended for tests inside the adapter package only.
@@ -551,8 +554,8 @@ var ErrDeleteStateDesired = errors.New("resource has not reached the desired del
 const defaultDeleteStateRetryDelay = time.Second * 5
 
 // deleteState deletes the resource and polls until it reaches its terminal state: the API reports it
-// gone (404), or every DeleteStateOptions.Desired entry matches (with no Desired, a 404 is the only
-// terminal).
+// gone (404), or Attribute matches any DeleteStateOptions.Desired value (with no Desired, a 404 is
+// the only terminal).
 //
 // Delete is issued until it succeeds once, then each attempt only reads. While Delete errors
 // (404 = already gone, 409 = dependents still detaching) it is re-issued, but its error is not fatal
@@ -568,6 +571,10 @@ const defaultDeleteStateRetryDelay = time.Second * 5
 // Each Read's warnings are buffered so only the last attempt's are merged into the outer collector.
 func (a *resourceAdapter) deleteState(ctx context.Context, rd ResourceData) error {
 	opts := a.resource.DeleteState
+	if len(opts.Desired) > 0 && opts.Attribute == "" {
+		return errors.New("delete state condition has no attribute")
+	}
+
 	retryDelay := opts.retryDelay
 	if retryDelay == 0 {
 		retryDelay = defaultDeleteStateRetryDelay
@@ -603,14 +610,21 @@ func (a *resourceAdapter) deleteState(ctx context.Context, rd ResourceData) erro
 			}
 
 			// Still present: with no Desired the only terminal is a 404, so keep polling; otherwise
-			// every entry must match. The last Delete error is attached after the loop.
+			// Attribute must match any Desired value. The last Delete error is attached after the loop.
 			if len(opts.Desired) == 0 {
 				return fmt.Errorf("%w: waiting for the resource to be gone", ErrDeleteStateDesired)
 			}
-			for key, want := range opts.Desired {
-				if state := rd.Get(key); !Equal(state, want) {
-					return fmt.Errorf("%w: expected %q to be `%v`, got `%v`", ErrDeleteStateDesired, key, want, state)
-				}
+			attributeValue, ok := rd.GetOk(opts.Attribute)
+			if !ok || !slices.ContainsFunc(opts.Desired, func(desired string) bool {
+				return Equal(attributeValue, desired)
+			}) {
+				return fmt.Errorf(
+					"%w: expected %q to be one of `%v`, got `%v`",
+					ErrDeleteStateDesired,
+					opts.Attribute,
+					opts.Desired,
+					attributeValue,
+				)
 			}
 			return nil
 		},

--- a/internal/plugin/adapter/resource_test.go
+++ b/internal/plugin/adapter/resource_test.go
@@ -712,6 +712,28 @@ func TestResourceAdapter_deleteState(t *testing.T) {
 		return diag.NewWarningDiagnostic(summary, "detail")
 	}
 
+	t.Run("rejects desired values without an attribute before deleting", func(t *testing.T) {
+		t.Parallel()
+
+		deletes, reads := 0, 0
+		a := fastAdapter(
+			func(_ context.Context, _ avngen.Client, _ ResourceData) error {
+				deletes++
+				return nil
+			},
+			func(_ context.Context, _ avngen.Client, _ ResourceData) error {
+				reads++
+				return nil
+			},
+		)
+		a.resource.DeleteState.Desired = []string{"DELETED"}
+
+		err := a.deleteState(t.Context(), nil)
+		require.EqualError(t, err, "delete state condition has no attribute")
+		require.Zero(t, deletes)
+		require.Zero(t, reads)
+	})
+
 	t.Run("deletes once then surfaces the 404 when read reports the resource gone", func(t *testing.T) {
 		t.Parallel()
 
@@ -726,7 +748,8 @@ func TestResourceAdapter_deleteState(t *testing.T) {
 				return avngen.Error{Status: http.StatusNotFound}
 			},
 		)
-		a.resource.DeleteState.Desired = map[string]string{"status": "DELETED"}
+		a.resource.DeleteState.Attribute = "status"
+		a.resource.DeleteState.Desired = []string{"DELETED"}
 
 		// A 404 bubbles up; Delete's outer guard ignores it as a successful deletion.
 		require.True(t, IsNotFound(a.deleteState(t.Context(), nil)))
@@ -754,11 +777,30 @@ func TestResourceAdapter_deleteState(t *testing.T) {
 				return nil
 			},
 		)
-		a.resource.DeleteState.Desired = map[string]string{"status": "DELETED"}
+		a.resource.DeleteState.Attribute = "status"
+		a.resource.DeleteState.Desired = []string{"DELETED"}
 
 		require.NoError(t, a.deleteState(t.Context(), rd))
 		require.Equal(t, 3, reads)
 		require.Equal(t, 1, deletes, "delete must be issued once after it succeeds; only read polls after")
+	})
+
+	t.Run("completes when the attribute matches any desired value", func(t *testing.T) {
+		t.Parallel()
+
+		rd, err := NewResourceData(statusSchema, nil, WithTestState(map[string]any{"status": "DELETING"}))
+		require.NoError(t, err)
+
+		a := fastAdapter(
+			func(_ context.Context, _ avngen.Client, _ ResourceData) error { return nil },
+			func(_ context.Context, _ avngen.Client, rd ResourceData) error {
+				return rd.Set("status", "DELETED_BY_PEER")
+			},
+		)
+		a.resource.DeleteState.Attribute = "status"
+		a.resource.DeleteState.Desired = []string{"DELETED", "DELETED_BY_PEER"}
+
+		require.NoError(t, a.deleteState(t.Context(), rd))
 	})
 
 	t.Run("not-found-only polls read until the resource is gone", func(t *testing.T) {
@@ -801,7 +843,8 @@ func TestResourceAdapter_deleteState(t *testing.T) {
 				return nil
 			},
 		)
-		a.resource.DeleteState.Desired = map[string]string{"status": "DELETED"}
+		a.resource.DeleteState.Attribute = "status"
+		a.resource.DeleteState.Desired = []string{"DELETED"}
 
 		require.NoError(t, a.deleteState(t.Context(), rd))
 		require.Equal(t, 3, deletes, "delete must be re-issued on every attempt, its error ignored")
@@ -854,7 +897,8 @@ func TestResourceAdapter_deleteState(t *testing.T) {
 				return nil
 			},
 		)
-		a.resource.DeleteState.Desired = map[string]string{"status": "DELETED"}
+		a.resource.DeleteState.Attribute = "status"
+		a.resource.DeleteState.Desired = []string{"DELETED"}
 
 		require.NoError(t, a.deleteState(t.Context(), rd))
 		require.Equal(t, 3, deletes, "delete is re-issued only until it succeeds, then read polls alone")
@@ -904,7 +948,8 @@ func TestResourceAdapter_deleteState(t *testing.T) {
 				return nil // Never transitions to DELETED, so the poll runs until ctx is cancelled.
 			},
 		)
-		a.resource.DeleteState.Desired = map[string]string{"status": "DELETED"}
+		a.resource.DeleteState.Attribute = "status"
+		a.resource.DeleteState.Desired = []string{"DELETED"}
 
 		// The fixed retry delay is fastRetryDelay (1µs), so a 300ms window comfortably allows many
 		// polls before the deadline.
@@ -954,7 +999,8 @@ func TestResourceAdapter_deleteState(t *testing.T) {
 				return boom
 			},
 		)
-		a.resource.DeleteState.Desired = map[string]string{"status": "DELETED"}
+		a.resource.DeleteState.Attribute = "status"
+		a.resource.DeleteState.Desired = []string{"DELETED"}
 
 		err := a.deleteState(t.Context(), nil)
 		require.ErrorIs(t, err, boom)
@@ -988,7 +1034,8 @@ func TestResourceAdapter_deleteState(t *testing.T) {
 					return nil
 				},
 				DeleteState: &DeleteStateOptions{
-					Desired:    map[string]string{"status": "DELETED"},
+					Attribute:  "status",
+					Desired:    []string{"DELETED"},
 					retryDelay: fastRetryDelay,
 				},
 			},

--- a/internal/plugin/service/byoc/aws_provision/zz_view.go
+++ b/internal/plugin/service/byoc/aws_provision/zz_view.go
@@ -21,10 +21,13 @@ func idFields() []string {
 }
 
 var ResourceOptions = adapter.ResourceOptions{
-	Beta:                true,
-	Create:              createView,
-	Delete:              deleteView,
-	DeleteState:         &adapter.DeleteStateOptions{Desired: map[string]string{"state": "deleted"}},
+	Beta:   true,
+	Create: createView,
+	Delete: deleteView,
+	DeleteState: &adapter.DeleteStateOptions{
+		Attribute: "state",
+		Desired:   []string{"deleted"},
+	},
 	IDFields:            idFields(),
 	IgnoreAlreadyExists: true,
 	Read:                readView,

--- a/internal/plugin/service/vpc/organizationvpc/zz_view.go
+++ b/internal/plugin/service/vpc/organizationvpc/zz_view.go
@@ -21,11 +21,14 @@ func idFields() []string {
 }
 
 var ResourceOptions = adapter.ResourceOptions{
-	Create:      createView,
-	Delete:      deleteView,
-	DeleteState: &adapter.DeleteStateOptions{Desired: map[string]string{"state": "DELETED"}},
-	IDFields:    idFields(),
-	Read:        readView,
+	Create: createView,
+	Delete: deleteView,
+	DeleteState: &adapter.DeleteStateOptions{
+		Attribute: "state",
+		Desired:   []string{"DELETED"},
+	},
+	IDFields: idFields(),
+	Read:     readView,
 	RefreshState: &adapter.RefreshStateCondition{
 		Attribute: "state",
 		Desired:   []string{"ACTIVE"},

--- a/internal/plugin/service/vpc/projectvpc/zz_view.go
+++ b/internal/plugin/service/vpc/projectvpc/zz_view.go
@@ -25,11 +25,14 @@ func idFields() []string {
 }
 
 var ResourceOptions = adapter.ResourceOptions{
-	Create:      createView,
-	Delete:      deleteView,
-	DeleteState: &adapter.DeleteStateOptions{Desired: map[string]string{"state": "DELETED"}},
-	IDFields:    idFields(),
-	Read:        readView,
+	Create: createView,
+	Delete: deleteView,
+	DeleteState: &adapter.DeleteStateOptions{
+		Attribute: "state",
+		Desired:   []string{"DELETED"},
+	},
+	IDFields: idFields(),
+	Read:     readView,
 	RefreshState: &adapter.RefreshStateCondition{
 		Attribute: "state",
 		Desired:   []string{"ACTIVE"},

--- a/tools/agents/skills/tf-resource-generator/SKILL.md
+++ b/tools/agents/skills/tf-resource-generator/SKILL.md
@@ -173,42 +173,45 @@ resource:
   description: "..."
   deprecationMessage: "..."
   terminationProtection: true # Check field before delete
-  refreshState: # Call Read after Create/Update and wait for state convergence
-    attribute: state # Optional; defaults to state
-    desired: [ACTIVE, PENDING_PEER]
-    failed: [ERROR, DELETED]
+  stateAttribute: state # Terraform attribute polled after Create/Update/Delete
+  refreshStateDesired: [ACTIVE, PENDING_PEER] # Call Read after Create/Update and wait for state convergence
+  refreshStateFailed: [ERROR, DELETED]
   refreshStateDelay: "15s" # Wait before Read
   removeMissing: true # Remove from state on 404
-  deleteStateDesired: # Poll Read after Delete until the resource reaches its terminal state
-    state: DELETED
+  deleteStateDesired: [DELETED] # Poll Read after Delete until the resource reaches its terminal state
 ```
 
-`refreshState` enables a post-Create/Update Read. Use `refreshState: {}` when the first successful
-Read is sufficient. To wait for state convergence, configure `desired` values and optional `failed`
-values for a computed-only Terraform attribute. The optional `attribute` setting defaults to `state`.
-Values within each list use OR semantics. A desired value completes the refresh, and any failed value
-stops it immediately. Values in neither list are treated as pending and retried, which safely
-accommodates new intermediate backend states.
+`refreshStateExists: true` enables a post-Create/Update Read that completes on the first
+successful Read, retrying transient 404/403 errors. To also wait for an attribute value, set
+`stateAttribute` plus `refreshStateDesired` and optional `refreshStateFailed` instead — desired
+already includes that exists retry. Values within each list use OR semantics. A desired value
+completes the refresh, and any failed value stops it immediately. Values in neither list are
+treated as pending and retried until the operation timeout.
 
-`deleteStateDesired` replaces custom delete waiters. It is a map, and its presence (even as an empty map, `{}`) enables the delete poller: on every attempt the adapter re-issues `Delete` (ignoring its error) and polls `Read` until the resource is gone (404) or reaches its terminal state, then returns. A 404 always completes the delete. Because `Delete` is re-issued each attempt and its error is ignored, a 409 Conflict from dependents still detaching resolves on its own — no extra configuration is needed.
+`deleteStateGone: true` enables the delete poller and completes when Read returns 404.
+`deleteStateDesired` waits until `stateAttribute` matches any listed value; a 404 also
+completes (gone is implied). Delete is re-issued while it errors (for example 409 from
+dependents still detaching); once Delete succeeds, only Read is polled. Omit both to delete
+without polling.
 
-The map's entries are attribute names mapped to the terminal value the poller must observe (e.g. `state: DELETED`). The poll finishes when every entry matches or the API 404s, whichever comes first. Values are validated against the field's enum when one is declared. Use an empty map for APIs whose Read never surfaces a terminal state (it just 404s).
+Values are validated against the field's enum when one is declared. `stateAttribute` is required
+when `refreshStateDesired` or `deleteStateDesired` is set.
 
 Examples:
 
 ```yaml
 # Wait until the API 404s; no observable terminal state (e.g. aiven_azure_privatelink).
-deleteStateDesired: {}
+deleteStateGone: true
 ```
 
 ```yaml
 # Soft-delete API reports state: DELETED, and dependents may still be detaching
-# (e.g. aiven_project_vpc, aiven_organization_vpc). Delete is re-issued each attempt.
-deleteStateDesired:
-  state: DELETED
+# (e.g. aiven_project_vpc, aiven_organization_vpc).
+stateAttribute: state
+deleteStateDesired: [DELETED]
 ```
 
-Prefer `deleteStateDesired` over a hand-written delete `disableView` + custom poller whenever the terminal condition is "gone (404)" and/or a fixed attribute value. Keep a custom delete view only for genuinely bespoke flows (e.g. a cancel-then-delete state machine).
+Prefer `deleteStateGone` or `deleteStateDesired` over a hand-written delete `disableView` + custom poller whenever the terminal condition is "gone (404)" and/or a fixed attribute value. Keep a custom delete view only for genuinely bespoke flows (e.g. a cancel-then-delete state machine).
 
 ### Datasource Configuration
 


### PR DESCRIPTION
Replace nested refreshState and deleteStateDesired maps with stateAttribute, refreshStateExists/Desired/Failed, and deleteStateGone/Desired so exists vs value waits are explicit and 404 handling is implied by the desired lists.

Resolves NEX-2808.

