### PR TITLE
fix(ci): fix the acceptance-test skip on release PRs

### DIFF
--- a/.github/workflows/acceptance-tests.yml
+++ b/.github/workflows/acceptance-tests.yml
@@ -5,7 +5,7 @@ on:
     - cron: "15 0 * * *"
   workflow_dispatch:
   pull_request:
-    types: [opened, synchronize, reopened, labeled]
+    types: [opened, synchronize, reopened, labeled, unlabeled]
     branches:
       - main
 
@@ -40,7 +40,10 @@ jobs:
             echo "ref_to_test=${{ github.sha }}" >> $GITHUB_OUTPUT
 
           elif [[ "${{ github.event_name }}" == "pull_request" ]]; then
-            if ${{ contains(github.event.pull_request.labels.*.name, 'release') }}; then
+            if ${{ contains(github.event.pull_request.labels.*.name, 'skip-acc-tests') }}; then
+              echo "Pull request has 'skip-acc-tests' label. Skipping."
+              echo "should_run=false" >> $GITHUB_OUTPUT
+            elif ${{ contains(github.event.pull_request.labels.*.name, 'release') }}; then
               echo "Pull request has 'release' label. Testing PR commit."
               echo "should_run=true" >> $GITHUB_OUTPUT
               echo "ref_to_test=${{ github.event.pull_request.head.sha }}" >> $GITHUB_OUTPUT

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -94,6 +94,7 @@ jobs:
             *This PR was created automatically by the release preparation workflow.*
           labels: |
             release
+            ${{ !inputs.run_acceptance_tests && 'skip-acc-tests' || '' }}
           draft: false
 
   # Run all linting-related checks


### PR DESCRIPTION
<!-- All contributors, please complete these sections, including maintainers. -->

## About this change—what it does

<!-- Provide a small sentence that summarizes the change. -->

<!-- Provide the issue number below, if it exists. -->
- **prepare-release.yml** — when `run_acceptance_tests` is unchecked, the release PR is created with a `skip-acc-tests` label
- **acceptance-tests.yml** checks `skip-acc-tests` before the`release` label and skips the suite when present

Resolves: NEX-2834

<!-- Provide a small explanation on why this is the approach you took for solving this problem. -->
