### PR TITLE
fix(organization_user): remove incorrect deprecation warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ nav_order: 1
 
 ## [MAJOR.MINOR.PATCH] - YYYY-MM-DD
 
+- Fix `aiven_organization_user` data source incorrectly inheriting the deprecation warning from the deprecated resource
+  of the same name.
+
 ## [4.62.0] - 2026-09-02
 
 - Fix `aiven_valkey_user` intermittently storing an empty `password` in the state after a password reset.

--- a/docs/data-sources/organization_user.md
+++ b/docs/data-sources/organization_user.md
@@ -4,24 +4,11 @@ page_title: "aiven_organization_user Data Source - terraform-provider-aiven"
 subcategory: ""
 description: |-
   The Organization User data source provides information about the existing Aiven Organization User.
-  ~> This resource is deprecated
-  Users cannot be invited to an organization using Terraform.
-  Use the Aiven Console to invite users to your organization https://aiven.io/docs/platform/howto/manage-org-users.
-  After the user accepts the invite you can get their information using the aiven_organization_user data source. You can manage
-  user access to projects with the aiven_organization_user_group, aiven_organization_user_group_member,
-  and aiven_organization_permission resources.
 ---
 
 # aiven_organization_user (Data Source)
 
 The Organization User data source provides information about the existing Aiven Organization User.
-
-~> **This resource is deprecated**
-Users cannot be invited to an organization using Terraform.
-Use the Aiven Console to [invite users to your organization](https://aiven.io/docs/platform/howto/manage-org-users).
-After the user accepts the invite you can get their information using the `aiven_organization_user` data source. You can manage
-user access to projects with the `aiven_organization_user_group`, `aiven_organization_user_group_member`,
-and `aiven_organization_permission` resources.
 
 
 

--- a/internal/sdkprovider/provider/provider.go
+++ b/internal/sdkprovider/provider/provider.go
@@ -191,9 +191,14 @@ func Provider(version string) (*schema.Provider, error) {
 		addBeta(p.DataSourcesMap, betaDataSources)...,
 	)
 
+	// Datasources that stay supported even though the resource with the same name is deprecated.
+	deprecationExemptDataSources := map[string]bool{
+		"aiven_organization_user": true,
+	}
+
 	// Deprecates datasources along with their resources
 	for k, d := range p.DataSourcesMap {
-		if d.DeprecationMessage == "" {
+		if d.DeprecationMessage == "" && !deprecationExemptDataSources[k] {
 			r, ok := p.ResourcesMap[k]
 			if ok && r.DeprecationMessage != "" {
 				d.DeprecationMessage = r.DeprecationMessage


### PR DESCRIPTION
<!-- All contributors, please complete these sections, including maintainers. -->

## About this change—what it does

<!-- Provide a small sentence that summarizes the change. -->

<!-- Provide the issue number below, if it exists. -->
- The data source inherited the resource's deprecation message via the copy-loop added in #2047
- The resource is deprecated because org user invites must go through the Console (#1484), but the data source is the recommended replacement and is not deprecated itself

Resolves: NEX-2832

<!-- Provide a small explanation on why this is the approach you took for solving this problem. -->
